### PR TITLE
Bundle Claude Code command + skill for one-shot install

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Single-file Bash script (`fanout`) plus its design doc (`fanout.README.md`). No build system, no test suite, no lint config. `claude` (the 200MB Mach-O binary at the repo root) is unrelated to this project — leave it alone.
 
+The Claude Code integration files (`claude/commands/fanout.md` slash command and `claude/skills/fanout/SKILL.md` skill) are bundled in the repo as the source-of-truth. `make install` places them under `~/.claude/`. Don't edit copies in `~/.claude/` directly — edit the repo versions and rerun `make install` (or use `make link` during development).
+
 The user-facing surface (CLI flags, prerequisites, troubleshooting) is in `fanout.README.md`. Read it before changing behavior; this file covers only what's not obvious from the README.
 
 ## Working with the script

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,37 @@
-PREFIX ?= $(HOME)/.local
-BINDIR ?= $(PREFIX)/bin
+PREFIX     ?= $(HOME)/.local
+BINDIR     ?= $(PREFIX)/bin
+CLAUDE_DIR ?= $(HOME)/.claude
+CMD_DIR    := $(CLAUDE_DIR)/commands
+SKILL_DIR  := $(CLAUDE_DIR)/skills
 
 .PHONY: install link uninstall
 
 install:
-	@mkdir -p "$(BINDIR)"
+	@mkdir -p "$(BINDIR)" "$(CMD_DIR)" "$(SKILL_DIR)/fanout"
 	install -m 0755 fanout "$(BINDIR)/fanout"
-	@echo "Installed $(BINDIR)/fanout"
+	install -m 0644 claude/commands/fanout.md "$(CMD_DIR)/fanout.md"
+	install -m 0644 claude/skills/fanout/SKILL.md "$(SKILL_DIR)/fanout/SKILL.md"
+	@echo "Installed:"
+	@echo "  $(BINDIR)/fanout"
+	@echo "  $(CMD_DIR)/fanout.md"
+	@echo "  $(SKILL_DIR)/fanout/SKILL.md"
 
 link:
-	@mkdir -p "$(BINDIR)"
+	@mkdir -p "$(BINDIR)" "$(CMD_DIR)" "$(SKILL_DIR)"
 	ln -sf "$(CURDIR)/fanout" "$(BINDIR)/fanout"
-	@echo "Linked $(BINDIR)/fanout -> $(CURDIR)/fanout"
+	ln -sf "$(CURDIR)/claude/commands/fanout.md" "$(CMD_DIR)/fanout.md"
+	rm -rf "$(SKILL_DIR)/fanout"
+	ln -sf "$(CURDIR)/claude/skills/fanout" "$(SKILL_DIR)/fanout"
+	@echo "Linked:"
+	@echo "  $(BINDIR)/fanout -> $(CURDIR)/fanout"
+	@echo "  $(CMD_DIR)/fanout.md -> $(CURDIR)/claude/commands/fanout.md"
+	@echo "  $(SKILL_DIR)/fanout -> $(CURDIR)/claude/skills/fanout"
 
 uninstall:
 	rm -f "$(BINDIR)/fanout"
-	@echo "Removed $(BINDIR)/fanout"
+	rm -f "$(CMD_DIR)/fanout.md"
+	rm -rf "$(SKILL_DIR)/fanout"
+	@echo "Removed:"
+	@echo "  $(BINDIR)/fanout"
+	@echo "  $(CMD_DIR)/fanout.md"
+	@echo "  $(SKILL_DIR)/fanout"

--- a/claude/commands/fanout.md
+++ b/claude/commands/fanout.md
@@ -1,0 +1,43 @@
+---
+description: Fan out a parent GitHub issue's OPEN sub-issues into parallel dmux panes with git worktrees via the fanout CLI.
+argument-hint: "[parent-issue] [--go] [extra fanout flags]"
+---
+
+Invoke the `fanout` CLI to spawn one dmux pane per OPEN sub-issue of a parent GitHub issue. See the `fanout` skill (`~/.claude/skills/fanout/SKILL.md`) for context on when and why to use this.
+
+Arguments: `$ARGUMENTS`
+
+## Steps
+
+1. **Resolve the parent issue number** from `$ARGUMENTS`:
+   - First token matching `^#?\d+$` → that is `N`.
+   - If none: scan the user's opening message / recent context for a `#\d+` reference and use the first match.
+   - Still nothing: ask the user which parent issue to fan out.
+2. **Detect `--go`** in the remaining arguments. Strip it out — it is this command's own bypass flag, not a `fanout` flag. The rest of the arguments are forwarded verbatim to `fanout`.
+3. **Dry-run first** (unless `--go` was passed):
+   - Run `fanout <N> --dry-run <forwarded>` via Bash. cwd is irrelevant; do NOT `cd` first.
+   - Summarize the output: number of targets, child issue numbers and titles, briefing file paths under `/tmp/fanout-<repo>-<N>.md`.
+   - Do not dump the raw `tmux send-keys` lines — they are long and noisy.
+   - Ask the user to confirm.
+4. **Execute**:
+   - Run `fanout <N> <forwarded>` via Bash.
+   - Relay the `created / skipped / deferred / failed` summary.
+5. **On failure**: consult `/Users/butaosuinu/fanout/fanout.README.md` Troubleshooting and surface the most likely fix. Common cases:
+   - dmux not running → tell the user to `cd <target-repo> && dmux` in another shell.
+   - Multiple dmux sessions alive → rerun with `--session <name>`.
+   - 60s timeout → the dmux TUI has a modal open; user presses `Esc` in the dmux pane and retries.
+   - Missing `gh-sub-issue` extension → `gh extension install yahsan2/gh-sub-issue`.
+
+## Notes
+
+- `fanout` never touches the caller's pane; the agent keeps working on the parent issue in the current session.
+- Rerun is safe; idempotency is handled by the `[fanout #<N>]` prompt prefix.
+- Default flags the CLI already applies: `--sleep 4`. Pass `--sleep 8` or higher on slow machines.
+- Multiple agents enabled in dmux → pass `--agent <name>` (e.g. `--agent claude`). With a single enabled agent, no popup appears and `--agent` is ignored.
+
+## Examples
+
+- `/fanout 123` — dry-run preview for parent issue #123, then real run after confirmation.
+- `/fanout 123 --go` — skip confirmation, run immediately.
+- `/fanout 123 --limit 3 --agent claude` — only the first 3 children, force agent picker to `claude`.
+- `/fanout` (no args in a session that started with "work on #456") — extract `456` from context and proceed.

--- a/claude/skills/fanout/SKILL.md
+++ b/claude/skills/fanout/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: fanout
+description: Spawn one dmux pane per OPEN sub-issue of a GitHub parent issue via the fanout CLI. Use when the user is working in a dmux pane on a parent issue and wants to parallelize its children across independent git worktrees/agent sessions.
+---
+
+# fanout
+
+`fanout <parent-issue>` enumerates a GitHub parent issue's OPEN sub-issues and, for each one, asks dmux to create a new pane with its own git worktree and an agent CLI started with a briefing that points at `/tmp/fanout-<repo>-<N>.md`. The caller's pane is not modified, so this is safe to invoke from inside an agent session that is itself running in a dmux pane.
+
+The CLI lives at `/Users/butaosuinu/.local/bin/fanout`; source and docs are in `/Users/butaosuinu/fanout/`.
+
+## When to invoke
+
+Good fits:
+
+- The user is in a dmux-managed pane on a parent issue that has OPEN sub-issues, and asks (explicitly or implicitly) to parallelize the children.
+- The user types `/fanout` or mentions "fan out" / "並列展開".
+
+Do not invoke unprompted just because an issue has sub-issues. Pane creation is visible and the user has to close each pane manually if they change their mind — suggest first, wait for a "yes", and prefer routing through the `/fanout` slash command so there is one consistent entry point.
+
+## Pre-flight
+
+Before running the real command:
+
+1. **Prerequisites** — `gh`, `jq`, `tmux`, and the `gh-sub-issue` extension must be installed. `fanout` validates these on startup and fails with install hints, so you can rely on its error output rather than re-checking.
+2. **Live dmux session** — `tmux list-sessions -F '#{session_name} #{session_id}'` and look for any session whose `@dmux_controller_pid` option is set and alive. If none, tell the user to `cd <target-repo> && dmux` first.
+3. **Single enabled agent** — if dmux has multiple agents enabled, a popup appears that `fanout` can only navigate by sending the first letter of the agent name. Pass `--agent <name>` (commonly `--agent claude`) when in doubt.
+4. **Dry-run** — run `fanout <N> --dry-run <forwarded-flags>` and show the user: how many children, their titles, the briefing paths. This is the confirmation step.
+
+cwd does not matter. `fanout` discovers dmux via tmux session options (`@dmux_controller_pid`, `@dmux_control_pane`, `@dmux_config_path`, `@dmux_project_root`). Do not `cd` before invoking.
+
+## Running
+
+- **Default**: `fanout <N> --dry-run` → summarize → ask user to confirm → `fanout <N>`.
+- **Bypass**: if the user's invocation carries `--go`, skip the confirmation and run directly.
+- **Forward extra flags** (`--agent`, `--limit`, `--session`, `--sleep`) verbatim to both the dry-run and the real run. Strip `--go` before forwarding — it is the slash command's own flag, not a `fanout` flag.
+
+## After running
+
+- Relay the `created / skipped / deferred / failed` summary.
+- The caller's pane is untouched. Continue working on the parent issue's own scope in the current session.
+- Re-invocation is idempotent: already-fanned issues are detected via the `[fanout #<N>]` prompt prefix in `dmux.config.json` and skipped.
+
+## Failure mapping
+
+When `fanout` exits non-zero, point the user at `/Users/butaosuinu/fanout/fanout.README.md` Troubleshooting. Common cases:
+
+- `no active dmux session found` — user needs to `cd <repo> && dmux` first.
+- `multiple dmux sessions active` — rerun with `--session <name>` (list via `tmux list-sessions -F '#{session_name}'`).
+- `timed out after 60s waiting for config.json to grow` — the dmux TUI likely has a modal open. User should press `Esc` in the dmux pane until the list view is visible, then rerun. On slow machines, increase `--sleep`.
+- `gh sub-issue list failed` — install `gh extension install yahsan2/gh-sub-issue` or run `gh auth status`.
+- `no sub-issues on #<N>` is not a failure; fanout exits 0.
+
+## Non-goals
+
+- Do not attempt to modify the dmux TUI state beyond running `fanout`. The script already sends one `Escape` as best-effort recovery; anything more is outside scope.
+- Do not rewrite or wrap the `fanout` script. The approved interface is the CLI as-is.
+- Do not assume an HTTP API on dmux. The CLI drives dmux via `tmux send-keys` because dmux v5.6.3 does not ship the documented HTTP API yet.

--- a/fanout.README.md
+++ b/fanout.README.md
@@ -24,21 +24,29 @@ dmux eventually publishes the HTTP API, this script can be rewritten around
 
 ## Installation
 
-fanout ships as a single Bash script. Put it on your `PATH` via the
+fanout ships as a single Bash script plus its Claude Code integration
+files (slash command + skill). All three are placed in one shot via the
 `Makefile`:
 
 ```bash
-make install        # copies fanout to ~/.local/bin/fanout (mode 0755)
-make link           # symlinks ~/.local/bin/fanout -> ./fanout (use while hacking on fanout)
-make uninstall      # removes ~/.local/bin/fanout
+make install        # copies CLI + command + skill into ~/.local and ~/.claude
+make link           # symlinks the same three paths at the checkout (use while hacking)
+make uninstall      # removes all three
 
-PREFIX=/usr/local sudo make install   # system-wide; overrides BINDIR to $PREFIX/bin
+PREFIX=/usr/local sudo make install     # system-wide CLI; overrides BINDIR to $PREFIX/bin
+CLAUDE_DIR=/path/to/.claude make install # non-default Claude data dir
 ```
 
-`make install` is stable — delete the repo and the copy still works.
+Installed paths:
+
+- `$(BINDIR)/fanout` (default `~/.local/bin/fanout`)
+- `$(CLAUDE_DIR)/commands/fanout.md` (default `~/.claude/commands/fanout.md`)
+- `$(CLAUDE_DIR)/skills/fanout/SKILL.md` (default `~/.claude/skills/fanout/SKILL.md`)
+
+`make install` is stable — delete the repo and the copies still work.
 `make link` points at the checkout, so edits take effect immediately and
-`git pull` is enough to update. Either target creates `$(BINDIR)` if it
-doesn't exist.
+`git pull` is enough to update. Either target creates the parent
+directories if they don't exist.
 
 Confirm `~/.local/bin` is on your `PATH` (`echo $PATH | tr ':' '\n' | grep -F "$HOME/.local/bin"`).
 If not, add `export PATH="$HOME/.local/bin:$PATH"` to your shell rc.
@@ -93,6 +101,31 @@ fanout 123 --sleep 8
 # Hint an agent name when multiple are enabled (best-effort popup navigation)
 fanout 123 --agent claude
 ```
+
+## From inside an agent session
+
+fanout is safe to call from an agent session (Claude Code, Codex, etc.) that
+is itself running in a dmux pane. It discovers dmux via tmux session options,
+not via `$TMUX` or cwd, and it only creates NEW panes for children — the
+caller's pane is never touched.
+
+Recommended integration for Claude Code — both assets are bundled in this
+repo under `claude/` and get placed by `make install`:
+
+- **Slash command** → `claude/commands/fanout.md` is installed to
+  `~/.claude/commands/fanout.md` and invoked as `/fanout [parent-issue]
+  [--go] [extra fanout flags]`. Runs `fanout <N> --dry-run` first, shows
+  the target list, and only fires the real command after the user confirms
+  (or if `--go` was passed).
+- **Skill** → `claude/skills/fanout/SKILL.md` is installed to
+  `~/.claude/skills/fanout/SKILL.md` and lets the agent recognize when
+  fanout is applicable and suggest `/fanout` rather than invoking
+  unprompted.
+
+The CLI prerequisites above still apply: the dmux session must be alive,
+the TUI must be on the pane-list view, and only one agent should be
+enabled (or `--agent` passed). See **Prerequisites** and **Troubleshooting**
+for details.
 
 ## What fanout actually does
 


### PR DESCRIPTION
## Summary

- `/fanout` slash command と `fanout` skill をリポジトリ内 `claude/` 配下に取り込み、`make install` 一発で CLI と一緒に配置できるようにした。
- `Makefile` の `install` / `link` / `uninstall` を全部入りに統一（サブターゲットは作らず 3 ターゲットのみ）。`CLAUDE_DIR` 変数で配置先を上書き可能。
- `fanout.README.md` Installation / "From inside an agent session" と `CLAUDE.md` Project shape を新しい配布形態に合わせて更新。

## Test plan

- [x] `CLAUDE_DIR=/tmp/fake-claude PREFIX=/tmp/fake-local make install` で 3 ファイルが配置される
- [x] 同 env で `make uninstall` が 3 つとも消す
- [x] 同 env で `make link` が symlink を張り、`ls -l` で target 確認
- [x] `shellcheck fanout` クリーン
- [ ] 実環境で `make install` 後に Claude Code を再起動し、`/fanout` と `fanout` skill が引き続き読み込まれる

🤖 Generated with [Claude Code](https://claude.com/claude-code)