### PR TITLE
Parse only the leading #N in body task-list rows

### DIFF
--- a/fanout
+++ b/fanout
@@ -288,11 +288,13 @@ parent_body=$(gh_in_root issue view "$parent" --json body -q .body 2>/dev/null) 
   parent_body=''
 }
 
-# `- [ ]` guard: skip prose mentions. `[^\w/]` guard: skip owner/repo#NUM.
+# Only take the first `#N` immediately after the checkbox — ignore trailing
+# refs like "(blocked by #X, #Y)". Prose-only rows (no leading `#N`) skip
+# naturally because `capture` yields empty on non-match.
 body_nums=$(printf '%s' "$parent_body" | jq -Rrs '
   split("\n")
   | map(select(test("^[[:space:]]*-[[:space:]]+\\[[ xX]\\]")))
-  | map([scan("(?:^|[^\\w/])#([0-9]+)") | .[0]])
+  | map([capture("^[[:space:]]*-[[:space:]]+\\[[ xX]\\][[:space:]]*#(?<n>[0-9]+)").n])
   | flatten | map(tonumber) | unique | .[]
 ')
 


### PR DESCRIPTION
## Summary
- Fixes #10. The parent-body task-list scanner pulled every `#N` on a matching line, so trailing refs like `(blocked by #4, #6)` got enqueued as children.
- Replace the iterating `scan` with a checkbox-anchored `capture` so only the first `#N` per row is taken. `gh sub-issue list` side of the union is unaffected.
- Prose-only rows (no leading `#N`) now skip naturally because `capture` yields empty on non-match, which `map` drops.

## Test plan
- [x] Unit-test the jq snippet against a synthetic body including `(blocked by #X, #Y)`, a prose-only row, a checked row, and a cross-repo `owner/repo#99` ref — only the leading `#N` per row is emitted.
- [x] `shellcheck fanout` clean.
- [ ] End-to-end dry-run (`./fanout <parent> --dry-run`) against a parent with a `(blocked by …)` row to confirm the "added N extra child reference(s)" count drops by the number of blocker refs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)