### PR TITLE
Add before_pane_create hook to base new worktrees on fresh origin/main

### DIFF
--- a/.dmux-hooks/before_pane_create
+++ b/.dmux-hooks/before_pane_create
@@ -49,8 +49,11 @@ if git rev-parse --verify "refs/heads/$default_branch" >/dev/null 2>&1; then
       # but only if its working tree is clean, so we never clobber the
       # user's uncommitted work.
       if ! git branch -f "$default_branch" "$origin_sha" 2>/dev/null; then
+        # `worktree <path>` carries the full path verbatim — paths can
+        # contain spaces (e.g. `~/My Projects/...`), so awk field splitting
+        # would truncate. Strip the literal "worktree " (9 chars) instead.
         checked_out_path=$(git worktree list --porcelain 2>/dev/null | awk -v br="$default_branch" '
-          /^worktree / { w=$2 }
+          /^worktree / { w=substr($0, 10) }
           /^branch refs\/heads\// {
             b=$2; sub(/^refs\/heads\//, "", b)
             if (b == br) { print w; exit }

--- a/.dmux-hooks/before_pane_create
+++ b/.dmux-hooks/before_pane_create
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# dmux before_pane_create hook — refresh the local default branch from origin
+# so new worktrees are created from the freshest possible base.
+#
+# dmux's paneCreation.js does not call `git fetch` before `git worktree add`.
+# If the local default branch (usually `main`) is stale, every new worktree
+# is born on an old commit. This hook closes that gap.
+#
+# Execution note: dmux fires before_pane_create via `spawn` + `child.unref()`
+# (fire-and-forget), so it runs in parallel with dmux's slug generation and
+# worktree creation. In practice the LLM-backed generateSlug() call takes
+# 1-5 seconds, which comfortably exceeds a `git fetch --quiet` round-trip on
+# any reasonable network — so the hook usually finishes first. If the race
+# is lost (slow network + cached slug) the next pane creation recovers.
+#
+# Env vars provided by dmux: DMUX_ROOT, DMUX_PROMPT, DMUX_AGENT.
+
+# -e would abort on the first non-fatal `git` failure; we want best-effort.
+set -u
+
+: "${DMUX_ROOT:?DMUX_ROOT not set; dmux should provide this}"
+cd "$DMUX_ROOT" || exit 0
+
+# 1) Resolve default branch. gh is authoritative; fall back to the remote HEAD
+#    symref; last resort is literal "main".
+default_branch=''
+if command -v gh >/dev/null 2>&1; then
+  default_branch=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name 2>/dev/null) || default_branch=''
+fi
+if [[ -z "$default_branch" ]]; then
+  default_branch=$(git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##') || default_branch=''
+fi
+[[ -z "$default_branch" ]] && default_branch='main'
+
+# 2) Fetch remote-tracking ref. Safe: never touches the working tree.
+git fetch --quiet --no-tags origin "$default_branch" 2>/dev/null || exit 0
+
+origin_sha=$(git rev-parse --verify "refs/remotes/origin/$default_branch" 2>/dev/null) || exit 0
+
+# 3) Fast-forward local branch to origin, if safe.
+if git rev-parse --verify "refs/heads/$default_branch" >/dev/null 2>&1; then
+  local_sha=$(git rev-parse "refs/heads/$default_branch")
+  if [[ "$local_sha" != "$origin_sha" ]]; then
+    merge_base=$(git merge-base "$local_sha" "$origin_sha" 2>/dev/null || true)
+    if [[ "$merge_base" == "$local_sha" ]]; then
+      # FF is safe. First try `git branch -f`, which works when the branch
+      # is not checked out anywhere. If that fails (checked out in some
+      # worktree), locate the worktree and `git merge --ff-only` there —
+      # but only if its working tree is clean, so we never clobber the
+      # user's uncommitted work.
+      if ! git branch -f "$default_branch" "$origin_sha" 2>/dev/null; then
+        checked_out_path=$(git worktree list --porcelain 2>/dev/null | awk -v br="$default_branch" '
+          /^worktree / { w=$2 }
+          /^branch refs\/heads\// {
+            b=$2; sub(/^refs\/heads\//, "", b)
+            if (b == br) { print w; exit }
+          }
+        ')
+        if [[ -n "$checked_out_path" && -d "$checked_out_path" ]]; then
+          if [[ -z "$(git -C "$checked_out_path" status --porcelain 2>/dev/null)" ]]; then
+            git -C "$checked_out_path" merge --ff-only --quiet "$origin_sha" 2>/dev/null || true
+          fi
+          # If working tree is dirty, skip — the user may be mid-edit on main.
+        fi
+      fi
+    fi
+    # If local has diverged (merge_base != local_sha), leave it alone.
+  fi
+else
+  # No local ref yet — create from origin.
+  git branch "$default_branch" "$origin_sha" 2>/dev/null || true
+fi
+
+exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,10 @@ The Claude Code integration files (`claude/commands/fanout.md` slash command and
 
 The user-facing surface (CLI flags, prerequisites, troubleshooting) is in `README.md`. Read it before changing behavior; this file covers only what's not obvious from the README.
 
+## dmux integration outside the script
+
+- **Worktrees branch off a fresh `main`.** `.dmux-hooks/before_pane_create` (version-controlled) runs just before dmux creates a worktree. It `git fetch`es the repo's default branch and fast-forwards the local ref (via `git branch -f` if the branch is unchecked-out, or `git merge --ff-only` in the worktree that has it checked out, only when that worktree is clean). Combined with `settings.baseBranch = "main"` in `.dmux/dmux.config.json`, dmux's `git worktree add -b <new> main` then starts every new worktree from the freshest local `main`. This works around dmux's `paneCreation.js` not calling `git fetch` before `git worktree add`. The hook is fire-and-forget (`spawn`+`unref` in `dist/utils/hooks.js`), so it races against dmux's `generateSlug` LLM call (typically 1-5s) — `git fetch --quiet` normally wins. If local `main` is ahead of `origin/main` (unpushed commits) or diverged, the hook deliberately does nothing, preserving the user's work. `.dmux/dmux.config.json` is gitignored so the `baseBranch` setting is per-machine; the hook file in `.dmux-hooks/` is the portable half.
+
 ## Working with the script
 
 - Run it: `./fanout <parent-issue>` (it's executable; no install step).


### PR DESCRIPTION
## Summary

- Adds `.dmux-hooks/before_pane_create` which `git fetch`es the repo's default branch and fast-forwards the local ref before dmux creates a worktree. Works around dmux's `paneCreation.js` not calling `git fetch` prior to `git worktree add`.
- Pairs the hook with a machine-local `.dmux/dmux.config.json` change: `settings.baseBranch = "main"` so dmux uses the freshened ref as the start point for `git worktree add -b <new> main`. That config file is gitignored, so each clone needs to set it once — the hook file in `.dmux-hooks/` is the portable half.
- Documents both pieces in `CLAUDE.md` under a new "dmux integration outside the script" section, including the race caveat (dmux's hook spawn is fire-and-forget; we rely on `generateSlug`'s 1-5s LLM call being longer than `git fetch --quiet`) and the "don't clobber unpushed work" policy.

## Test plan

- [x] `shellcheck .dmux-hooks/before_pane_create` — clean.
- [x] Standalone hook run: `DMUX_ROOT=$(pwd) ./.dmux-hooks/before_pane_create` — `.git/FETCH_HEAD` timestamp advances, confirming `git fetch` fired.
- [x] `jq '.settings' .dmux/dmux.config.json` → `{"baseBranch": "main"}`.
- [x] Ahead-of-origin case: local `main` ahead of `origin/main` — hook correctly skips the FF update (no clobber of unpushed commits).
- [ ] End-to-end: force local `main` to an older sha (`git branch -f main main~3`), then create a new pane in dmux; verify the new worktree's initial commit matches `origin/main` HEAD.
- [ ] Dirty-worktree case: leave uncommitted changes on a worktree where `main` is checked out; verify the hook's `git merge --ff-only` path is skipped (no clobber).

🤖 Generated with [Claude Code](https://claude.com/claude-code)