### PR TITLE
[codex] Add fanout issue creation skills

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,49 +5,66 @@ CODEX_DIR  ?= $(HOME)/.codex
 CLAUDE_CMD_DIR   := $(CLAUDE_DIR)/commands
 CLAUDE_SKILL_DIR := $(CLAUDE_DIR)/skills
 CODEX_SKILL_DIR  := $(CODEX_DIR)/skills
+CLAUDE_COMMANDS := $(notdir $(wildcard claude/commands/*.md))
+CLAUDE_SKILLS   := $(notdir $(wildcard claude/skills/*))
+CODEX_SKILLS    := $(notdir $(wildcard codex/skills/*))
 
 BATS       ?= bats
 
 .PHONY: install link uninstall test test-tier1 test-tier2 lint check-bats
 
 install:
-	@mkdir -p "$(BINDIR)" "$(CLAUDE_CMD_DIR)" "$(CLAUDE_SKILL_DIR)/fanout" "$(CODEX_SKILL_DIR)/fanout/agents"
+	@mkdir -p "$(BINDIR)" "$(CLAUDE_CMD_DIR)" "$(CLAUDE_SKILL_DIR)" "$(CODEX_SKILL_DIR)"
 	install -m 0755 fanout "$(BINDIR)/fanout"
-	install -m 0644 claude/commands/fanout.md "$(CLAUDE_CMD_DIR)/fanout.md"
-	install -m 0644 claude/skills/fanout/SKILL.md "$(CLAUDE_SKILL_DIR)/fanout/SKILL.md"
-	install -m 0644 codex/skills/fanout/SKILL.md "$(CODEX_SKILL_DIR)/fanout/SKILL.md"
-	install -m 0644 codex/skills/fanout/agents/openai.yaml "$(CODEX_SKILL_DIR)/fanout/agents/openai.yaml"
+	@for cmd in $(CLAUDE_COMMANDS); do \
+		install -m 0644 "claude/commands/$$cmd" "$(CLAUDE_CMD_DIR)/$$cmd"; \
+	done
+	@for skill in $(CLAUDE_SKILLS); do \
+		rm -rf "$(CLAUDE_SKILL_DIR)/$$skill"; \
+		mkdir -p "$(CLAUDE_SKILL_DIR)/$$skill"; \
+		cp -R "claude/skills/$$skill/." "$(CLAUDE_SKILL_DIR)/$$skill/"; \
+	done
+	@for skill in $(CODEX_SKILLS); do \
+		rm -rf "$(CODEX_SKILL_DIR)/$$skill"; \
+		mkdir -p "$(CODEX_SKILL_DIR)/$$skill"; \
+		cp -R "codex/skills/$$skill/." "$(CODEX_SKILL_DIR)/$$skill/"; \
+	done
 	@echo "Installed:"
 	@echo "  $(BINDIR)/fanout"
-	@echo "  $(CLAUDE_CMD_DIR)/fanout.md"
-	@echo "  $(CLAUDE_SKILL_DIR)/fanout/SKILL.md"
-	@echo "  $(CODEX_SKILL_DIR)/fanout/SKILL.md"
-	@echo "  $(CODEX_SKILL_DIR)/fanout/agents/openai.yaml"
+	@for cmd in $(CLAUDE_COMMANDS); do echo "  $(CLAUDE_CMD_DIR)/$$cmd"; done
+	@for skill in $(CLAUDE_SKILLS); do echo "  $(CLAUDE_SKILL_DIR)/$$skill"; done
+	@for skill in $(CODEX_SKILLS); do echo "  $(CODEX_SKILL_DIR)/$$skill"; done
 
 link:
 	@mkdir -p "$(BINDIR)" "$(CLAUDE_CMD_DIR)" "$(CLAUDE_SKILL_DIR)" "$(CODEX_SKILL_DIR)"
 	ln -sf "$(CURDIR)/fanout" "$(BINDIR)/fanout"
-	ln -sf "$(CURDIR)/claude/commands/fanout.md" "$(CLAUDE_CMD_DIR)/fanout.md"
-	rm -rf "$(CLAUDE_SKILL_DIR)/fanout"
-	ln -sf "$(CURDIR)/claude/skills/fanout" "$(CLAUDE_SKILL_DIR)/fanout"
-	rm -rf "$(CODEX_SKILL_DIR)/fanout"
-	ln -sf "$(CURDIR)/codex/skills/fanout" "$(CODEX_SKILL_DIR)/fanout"
+	@for cmd in $(CLAUDE_COMMANDS); do \
+		ln -sf "$(CURDIR)/claude/commands/$$cmd" "$(CLAUDE_CMD_DIR)/$$cmd"; \
+	done
+	@for skill in $(CLAUDE_SKILLS); do \
+		rm -rf "$(CLAUDE_SKILL_DIR)/$$skill"; \
+		ln -sf "$(CURDIR)/claude/skills/$$skill" "$(CLAUDE_SKILL_DIR)/$$skill"; \
+	done
+	@for skill in $(CODEX_SKILLS); do \
+		rm -rf "$(CODEX_SKILL_DIR)/$$skill"; \
+		ln -sf "$(CURDIR)/codex/skills/$$skill" "$(CODEX_SKILL_DIR)/$$skill"; \
+	done
 	@echo "Linked:"
 	@echo "  $(BINDIR)/fanout -> $(CURDIR)/fanout"
-	@echo "  $(CLAUDE_CMD_DIR)/fanout.md -> $(CURDIR)/claude/commands/fanout.md"
-	@echo "  $(CLAUDE_SKILL_DIR)/fanout -> $(CURDIR)/claude/skills/fanout"
-	@echo "  $(CODEX_SKILL_DIR)/fanout -> $(CURDIR)/codex/skills/fanout"
+	@for cmd in $(CLAUDE_COMMANDS); do echo "  $(CLAUDE_CMD_DIR)/$$cmd -> $(CURDIR)/claude/commands/$$cmd"; done
+	@for skill in $(CLAUDE_SKILLS); do echo "  $(CLAUDE_SKILL_DIR)/$$skill -> $(CURDIR)/claude/skills/$$skill"; done
+	@for skill in $(CODEX_SKILLS); do echo "  $(CODEX_SKILL_DIR)/$$skill -> $(CURDIR)/codex/skills/$$skill"; done
 
 uninstall:
 	rm -f "$(BINDIR)/fanout"
-	rm -f "$(CLAUDE_CMD_DIR)/fanout.md"
-	rm -rf "$(CLAUDE_SKILL_DIR)/fanout"
-	rm -rf "$(CODEX_SKILL_DIR)/fanout"
+	@for cmd in $(CLAUDE_COMMANDS); do rm -f "$(CLAUDE_CMD_DIR)/$$cmd"; done
+	@for skill in $(CLAUDE_SKILLS); do rm -rf "$(CLAUDE_SKILL_DIR)/$$skill"; done
+	@for skill in $(CODEX_SKILLS); do rm -rf "$(CODEX_SKILL_DIR)/$$skill"; done
 	@echo "Removed:"
 	@echo "  $(BINDIR)/fanout"
-	@echo "  $(CLAUDE_CMD_DIR)/fanout.md"
-	@echo "  $(CLAUDE_SKILL_DIR)/fanout"
-	@echo "  $(CODEX_SKILL_DIR)/fanout"
+	@for cmd in $(CLAUDE_COMMANDS); do echo "  $(CLAUDE_CMD_DIR)/$$cmd"; done
+	@for skill in $(CLAUDE_SKILLS); do echo "  $(CLAUDE_SKILL_DIR)/$$skill"; done
+	@for skill in $(CODEX_SKILLS); do echo "  $(CODEX_SKILL_DIR)/$$skill"; done
 
 # --- test / lint -------------------------------------------------------------
 # `make test`         — run every tier that's implemented (currently just Tier 1).

--- a/README.ja.md
+++ b/README.ja.md
@@ -47,8 +47,8 @@ resultFile パスを特定し、プロンプトポップアップ用には
 ## インストール
 
 fanout は 1 つの Bash スクリプトに、エージェント連携ファイルを加えた構成で
-配布されます。Claude Code にはスラッシュコマンド + スキル、Codex CLI には
-スキルを用意しています。すべて `Makefile` 経由で一括配置されます:
+配布されます。Claude Code にはスラッシュコマンド + スキル群、Codex CLI には
+スキル群を用意しています。すべて `Makefile` 経由で一括配置されます:
 
 ```bash
 make install        # CLI + Claude/Codex 連携を ~/.local, ~/.claude, ~/.codex にコピー
@@ -64,8 +64,10 @@ CODEX_DIR=/path/to/.codex make install   # 既定以外の Codex データディ
 
 - `$(BINDIR)/fanout`（既定は `~/.local/bin/fanout`）
 - `$(CLAUDE_DIR)/commands/fanout.md`（既定は `~/.claude/commands/fanout.md`）
-- `$(CLAUDE_DIR)/skills/fanout/SKILL.md`（既定は `~/.claude/skills/fanout/SKILL.md`）
-- `$(CODEX_DIR)/skills/fanout/SKILL.md`（既定は `~/.codex/skills/fanout/SKILL.md`）
+- `$(CLAUDE_DIR)/skills/fanout/`（既定は `~/.claude/skills/fanout/`）
+- `$(CLAUDE_DIR)/skills/fanout-issues/`（既定は `~/.claude/skills/fanout-issues/`）
+- `$(CODEX_DIR)/skills/fanout/`（既定は `~/.codex/skills/fanout/`）
+- `$(CODEX_DIR)/skills/fanout-issues/`（既定は `~/.codex/skills/fanout-issues/`）
 
 `make install` は安定しています — リポジトリを消しても、コピー済みのファイルで
 動作し続けます。`make link` はチェックアウトを指すので、編集がすぐ反映され、
@@ -187,7 +189,7 @@ Codex など）から呼び出しても安全です。fanout は `$TMUX` や cwd
 セッションオプションから dmux を検出します。作るのは子用の新規ペインだけなので、
 呼び出し元のペインは一切触りません。
 
-Claude Code 向けの推奨連携 — どちらのアセットもこのリポジトリの `claude/` 配下に
+Claude Code 向けの推奨連携 — これらのアセットはこのリポジトリの `claude/` 配下に
 同梱されており、`make install` で配置されます:
 
 - **スラッシュコマンド** → `claude/commands/fanout.md` が
@@ -203,6 +205,12 @@ Claude Code 向けの推奨連携 — どちらのアセットもこのリポジ
   表現、チェックボックス無しの素の箇条書き (`- #N`)、`#N に関連` / `#N を対応`
   のような日本語の慣用句 — を親本文から読み取り、候補をユーザーに提示して
   承認された番号を `--include` で fanout に渡します。
+- **issue 作成スキル** → `claude/skills/fanout-issues/SKILL.md` が
+  `~/.claude/skills/fanout-issues/SKILL.md` にインストールされ、計画を
+  fanout 向けの GitHub 親 issue + 子 issue 群へ変換する場面で使われます。
+  同一リポジトリ内の子 issue を作成し、GitHub Sub-issues と親本文のタスクリストの
+  両方へ反映し、`fanout --unblocked-only` が読める `## Blocked by` /
+  `(blocked by #N)` 形式で依存関係の wave も記録します。
 
 Codex CLI 向けの推奨連携 — スキルはこのリポジトリの `codex/` 配下に同梱され、
 `make install` で配置されます:
@@ -214,6 +222,12 @@ Codex CLI 向けの推奨連携 — スキルはこのリポジトリの `codex/
   このワークフローを使います。Claude のコマンドと同じく、まず dry-run で
   対象を確認し、ユーザー確認後に本実行します（確認不要と明示された場合を除く）。
   暗黙の子参照の scan と `--name` 生成もスキル側で行います。
+- **issue 作成スキル** → `codex/skills/fanout-issues/SKILL.md` が
+  `~/.codex/skills/fanout-issues/SKILL.md` にインストールされます。Codex に
+  fanout 向けの GitHub issue ツリー作成、計画の親子 issue 化、
+  `fanout --unblocked-only` 用の blocker wave 作成を依頼したときに使います。
+  Claude 版と同じく、同一リポジトリ内の子 issue、GitHub Sub-issues のリンク、
+  親本文のタスクリスト、`## Blocked by` 注記を揃えます。
 
 上記の CLI 前提条件はそのまま適用されます: dmux セッションが生きていること、
 TUI がペイン一覧画面にあること。エージェントは、呼び出し元ペイン自身が

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ can collapse back to `POST /api/panes` in a page.
 ## Installation
 
 fanout ships as a single Bash script plus agent integration files:
-Claude Code gets a slash command + skill, and Codex CLI gets a skill.
+Claude Code gets a slash command + skills, and Codex CLI gets skills.
 All of them are placed in one shot via the `Makefile`:
 
 ```bash
@@ -62,8 +62,10 @@ Installed paths:
 
 - `$(BINDIR)/fanout` (default `~/.local/bin/fanout`)
 - `$(CLAUDE_DIR)/commands/fanout.md` (default `~/.claude/commands/fanout.md`)
-- `$(CLAUDE_DIR)/skills/fanout/SKILL.md` (default `~/.claude/skills/fanout/SKILL.md`)
-- `$(CODEX_DIR)/skills/fanout/SKILL.md` (default `~/.codex/skills/fanout/SKILL.md`)
+- `$(CLAUDE_DIR)/skills/fanout/` (default `~/.claude/skills/fanout/`)
+- `$(CLAUDE_DIR)/skills/fanout-issues/` (default `~/.claude/skills/fanout-issues/`)
+- `$(CODEX_DIR)/skills/fanout/` (default `~/.codex/skills/fanout/`)
+- `$(CODEX_DIR)/skills/fanout-issues/` (default `~/.codex/skills/fanout-issues/`)
 
 `make install` is stable — delete the repo and the copies still work.
 `make link` points at the checkout, so edits take effect immediately and
@@ -198,7 +200,7 @@ is itself running in a dmux pane. It discovers dmux via tmux session options,
 not via `$TMUX` or cwd, and it only creates NEW panes for children — the
 caller's pane is never touched.
 
-Recommended integration for Claude Code — both assets are bundled in this
+Recommended integration for Claude Code — these assets are bundled in this
 repo under `claude/` and get placed by `make install`:
 
 - **Slash command** → `claude/commands/fanout.md` is installed to
@@ -214,6 +216,13 @@ repo under `claude/` and get placed by `make install`:
   (close keywords like `Closes #N`, dependency/relation wording, plain
   bullets, Japanese idioms), lists the candidates back to the user for
   approval, and forwards the accepted numbers via `--include`.
+- **Issue creation skill** → `claude/skills/fanout-issues/SKILL.md` is
+  installed to `~/.claude/skills/fanout-issues/SKILL.md` and guides the
+  agent when turning a plan into a fanout-ready GitHub parent issue plus
+  linked child issues. It creates same-repo children, links them through
+  GitHub Sub-issues, mirrors them in the parent task list, and records
+  blocker waves in the `## Blocked by` / `(blocked by #N)` shapes that
+  `fanout --unblocked-only` understands.
 
 Recommended integration for Codex CLI — the skill is bundled under
 `codex/` and gets placed by `make install`:
@@ -225,6 +234,12 @@ Recommended integration for Codex CLI — the skill is bundled under
   same safety flow as the Claude command: dry-run first, confirm targets, then
   run the real `fanout` command unless the user asked to skip confirmation.
   It also performs the implicit-child scan and generates `--name` flags.
+- **Issue creation skill** → `codex/skills/fanout-issues/SKILL.md` is
+  installed to `~/.codex/skills/fanout-issues/SKILL.md`. Use it by asking
+  Codex to create a fanout-ready GitHub issue tree, decompose a plan into
+  parent/child issues, or prepare blocker waves for `fanout --unblocked-only`.
+  It mirrors the Claude issue-creation skill: same-repo children, GitHub
+  Sub-issues links, parent task-list rows, and `## Blocked by` annotations.
 
 The CLI prerequisites above still apply: the dmux session must be alive,
 the TUI must be on the pane-list view, and only one agent should be

--- a/claude/skills/fanout-issues/SKILL.md
+++ b/claude/skills/fanout-issues/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: fanout-issues
+description: "Create fanout-ready GitHub issue trees: a parent issue plus OPEN child issues linked with GitHub Sub-issues and mirrored in the parent task list. Use when the user asks to decompose work into parent/child GitHub issues, prepare issues for the fanout CLI or /fanout command, create sub-issues for parallel dmux panes, or encode blocker waves for fanout --unblocked-only."
+---
+
+# fanout-issues
+
+Build GitHub issue hierarchies that `fanout` can consume without extra cleanup.
+The output should work through both supported discovery paths: GitHub's
+Sub-issues relationship and same-repo task-list rows in the parent body.
+
+## Preconditions
+
+- Use the repository the user is working in unless they provide `--repo OWNER/REPO` or name another repo.
+- Verify `gh` is authenticated and `gh sub-issue --help` works. If the extension is missing, tell the user to install `gh extension install yahsan2/gh-sub-issue`.
+- Treat issue creation as a live GitHub mutation. Show the planned parent title, child list, dependency graph, labels/assignees, and target repo before creating issues. Proceed only after user confirmation unless the user explicitly asked to create them immediately.
+- Keep all child issues in the same repo as the parent. `fanout` skips cross-repo task-list references.
+
+## Decompose
+
+Create children that can run in parallel dmux panes:
+
+- Give every child a clear, bounded deliverable and an acceptance checklist.
+- Avoid children that all need to edit the same files unless the dependency is explicit.
+- Split dependencies into waves. If B needs A, mark B as blocked by A instead of asking the agent to infer ordering.
+- Do not create a catch-all "integration" child unless there is real integration work the parent cannot own.
+- Keep issue titles specific enough to become readable pane names.
+
+Use this child body shape:
+
+```markdown
+## Goal
+One or two sentences describing the outcome.
+
+## Scope
+- In scope item
+- In scope item
+
+## Acceptance criteria
+- [ ] Observable criterion
+- [ ] Tests/docs/verification expectation
+
+## Notes
+Important context, links, or constraints.
+
+## Blocked by
+None
+```
+
+For blocked children, replace `None` with same-repo issue references:
+
+```markdown
+## Blocked by
+- #123
+- #124
+```
+
+Use this parent body shape:
+
+```markdown
+## Goal
+Describe the full outcome.
+
+## Fanout children
+- [ ] #CHILD Child title
+- [ ] #BLOCKED Blocked child title (blocked by #CHILD)
+
+## Coordination notes
+- Base branch/ref:
+- Shared constraints:
+- Suggested command after creation: /fanout #PARENT --unblocked-only
+```
+
+The `## Fanout children` rows must be same-repo task-list rows in the form
+`- [ ] #N Title`. Append `(blocked by #A, #B)` to blocked rows so
+`fanout --unblocked-only` can defer them even before child bodies are hydrated.
+
+## Create Issues
+
+Prefer `gh issue create` plus `gh sub-issue add` over `gh sub-issue create`
+because `gh issue create --body-file` handles multiline bodies reliably.
+Write bodies to temporary Markdown files first instead of embedding large
+Markdown strings in shell commands.
+
+Recommended sequence:
+
+```bash
+repo="OWNER/REPO"
+
+parent_url=$(gh issue create -R "$repo" \
+  --title "Parent title" \
+  --body-file /tmp/fanout-parent.md)
+parent_num="${parent_url##*/}"
+
+child_url=$(gh issue create -R "$repo" \
+  --title "Child title" \
+  --body-file /tmp/fanout-child-1.md)
+child_num="${child_url##*/}"
+
+gh sub-issue add "$parent_num" "$child_num" -R "$repo"
+```
+
+For an existing parent, fetch and preserve its current body before appending or
+replacing only the fanout section:
+
+```bash
+gh issue view "$parent_num" -R "$repo" --json body -q .body > /tmp/fanout-parent-existing.md
+gh issue edit "$parent_num" -R "$repo" --body-file /tmp/fanout-parent-final.md
+```
+
+For an existing child, do not recreate it. Link it:
+
+```bash
+gh sub-issue add "$parent_num" "$child_num" -R "$repo"
+```
+
+Forward user-provided labels, assignees, milestones, and projects to both
+parent and children when appropriate. Verify labels exist before using them if
+the repository's label set is unknown.
+
+## Update Parent
+
+After every child number is known, edit the parent body so it mirrors the
+GitHub Sub-issues relationship:
+
+- List every OPEN child under `## Fanout children`.
+- Keep rows unchecked until the child issue is actually complete.
+- Add `(blocked by #N)` trailers for blocked children.
+- Include the suggested `/fanout #PARENT --unblocked-only` command when any blockers exist; otherwise `/fanout #PARENT` is enough.
+- Preserve unrelated existing parent text.
+
+## Validate
+
+Run:
+
+```bash
+gh sub-issue list "$parent_num" -R "$repo" --json number,title,state
+gh issue view "$parent_num" -R "$repo" --json body -q .body
+```
+
+Confirm:
+
+- Every intended child appears in `gh sub-issue list` with `state` open.
+- The parent body has a same-repo task-list row for every child.
+- Blocked children have both child-body `## Blocked by` references and parent-row `(blocked by #N)` trailers.
+- No cross-repo `owner/repo#N` row is required for fanout discovery.
+
+If a dmux session is already running and the user wants an end-to-end check,
+run `fanout <parent> --dry-run` from any cwd. Otherwise do not require dmux
+just to validate issue creation.

--- a/claude/skills/fanout-issues/agents/openai.yaml
+++ b/claude/skills/fanout-issues/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Fanout Issues"
+  short_description: "Create fanout-ready GitHub issue trees"
+  default_prompt: "Create a fanout-ready parent issue and linked child issues for this plan."

--- a/codex/skills/fanout-issues/SKILL.md
+++ b/codex/skills/fanout-issues/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: fanout-issues
+description: "Use from Codex CLI to create fanout-ready GitHub issue trees: a parent issue plus OPEN child issues linked with GitHub Sub-issues and mirrored in the parent task list. Use when the user asks Codex to decompose work into parent/child GitHub issues, prepare issues for the fanout CLI, create sub-issues for parallel dmux panes, or encode blocker waves for fanout --unblocked-only."
+metadata:
+  short-description: Create fanout-ready GitHub issue trees
+---
+
+# fanout-issues
+
+Build GitHub issue hierarchies that `fanout` can consume without extra cleanup.
+The output should work through both supported discovery paths: GitHub's
+Sub-issues relationship and same-repo task-list rows in the parent body.
+
+## When To Use
+
+Use this skill when the user asks Codex to create a parent issue with child
+issues, decompose a plan into GitHub issues, prepare work for `$fanout`, or
+model blocker waves for `fanout --unblocked-only`.
+
+Issue creation is a live GitHub mutation. Unless the user explicitly asked to
+create the issues immediately, show the planned parent title, child list,
+dependency graph, labels/assignees, and target repo before creating anything.
+
+## Preconditions
+
+- Use the repository the user is working in unless they provide `--repo OWNER/REPO` or name another repo.
+- Verify `gh` is authenticated and `gh sub-issue --help` works. If the extension is missing, tell the user to install `gh extension install yahsan2/gh-sub-issue`.
+- Keep all child issues in the same repo as the parent. `fanout` skips cross-repo task-list references.
+- Preserve user-provided labels, assignees, milestones, and projects when they are relevant to both parent and children.
+
+## Decompose
+
+Create children that can run in parallel dmux panes:
+
+- Give every child a clear, bounded deliverable and an acceptance checklist.
+- Avoid children that all need to edit the same files unless the dependency is explicit.
+- Split dependencies into waves. If B needs A, mark B as blocked by A instead of asking the agent to infer ordering.
+- Do not create a catch-all "integration" child unless there is real integration work the parent cannot own.
+- Keep issue titles specific enough to become readable pane names.
+
+Use this child body shape:
+
+```markdown
+## Goal
+One or two sentences describing the outcome.
+
+## Scope
+- In scope item
+- In scope item
+
+## Acceptance criteria
+- [ ] Observable criterion
+- [ ] Tests/docs/verification expectation
+
+## Notes
+Important context, links, or constraints.
+
+## Blocked by
+None
+```
+
+For blocked children, replace `None` with same-repo issue references:
+
+```markdown
+## Blocked by
+- #123
+- #124
+```
+
+Use this parent body shape:
+
+```markdown
+## Goal
+Describe the full outcome.
+
+## Fanout children
+- [ ] #CHILD Child title
+- [ ] #BLOCKED Blocked child title (blocked by #CHILD)
+
+## Coordination notes
+- Base branch/ref:
+- Shared constraints:
+- Suggested command after creation: $fanout #PARENT --unblocked-only
+```
+
+The `## Fanout children` rows must be same-repo task-list rows in the form
+`- [ ] #N Title`. Append `(blocked by #A, #B)` to blocked rows so
+`fanout --unblocked-only` can defer them even before child bodies are hydrated.
+
+## Create Issues
+
+Prefer `gh issue create` plus `gh sub-issue add` over `gh sub-issue create`
+because `gh issue create --body-file` handles multiline bodies reliably.
+Write bodies to temporary Markdown files first instead of embedding large
+Markdown strings in shell commands.
+
+Recommended sequence:
+
+```bash
+repo="OWNER/REPO"
+
+parent_url=$(gh issue create -R "$repo" \
+  --title "Parent title" \
+  --body-file /tmp/fanout-parent.md)
+parent_num="${parent_url##*/}"
+
+child_url=$(gh issue create -R "$repo" \
+  --title "Child title" \
+  --body-file /tmp/fanout-child-1.md)
+child_num="${child_url##*/}"
+
+gh sub-issue add "$parent_num" "$child_num" -R "$repo"
+```
+
+For an existing parent, fetch and preserve its current body before appending or
+replacing only the fanout section:
+
+```bash
+gh issue view "$parent_num" -R "$repo" --json body -q .body > /tmp/fanout-parent-existing.md
+gh issue edit "$parent_num" -R "$repo" --body-file /tmp/fanout-parent-final.md
+```
+
+For an existing child, do not recreate it. Link it:
+
+```bash
+gh sub-issue add "$parent_num" "$child_num" -R "$repo"
+```
+
+## Update Parent
+
+After every child number is known, edit the parent body so it mirrors the
+GitHub Sub-issues relationship:
+
+- List every OPEN child under `## Fanout children`.
+- Keep rows unchecked until the child issue is actually complete.
+- Add `(blocked by #N)` trailers for blocked children.
+- Include the suggested `$fanout #PARENT --unblocked-only` command when any blockers exist; otherwise `$fanout #PARENT` is enough.
+- Preserve unrelated existing parent text.
+
+## Validate
+
+Run:
+
+```bash
+gh sub-issue list "$parent_num" -R "$repo" --json number,title,state
+gh issue view "$parent_num" -R "$repo" --json body -q .body
+```
+
+Confirm:
+
+- Every intended child appears in `gh sub-issue list` with `state` open.
+- The parent body has a same-repo task-list row for every child.
+- Blocked children have both child-body `## Blocked by` references and parent-row `(blocked by #N)` trailers.
+- No cross-repo `owner/repo#N` row is required for fanout discovery.
+
+If a dmux session is already running and the user wants an end-to-end check,
+run `fanout <parent> --dry-run` from any cwd. Otherwise do not require dmux
+just to validate issue creation.

--- a/codex/skills/fanout-issues/agents/openai.yaml
+++ b/codex/skills/fanout-issues/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "fanout-issues"
+  short_description: "Create fanout-ready GitHub issue trees"
+  default_prompt: "Use $fanout-issues to create a fanout-ready parent issue and linked child issues."
+
+policy:
+  allow_implicit_invocation: true


### PR DESCRIPTION
## Summary

- add a `fanout-issues` skill for Claude Code and Codex CLI
- install/link/uninstall all bundled Claude and Codex skills dynamically from the repo
- document the new issue-creation workflow in English and Japanese READMEs

## Validation

- `make -n install`
- `make -n link`
- `make -n uninstall`
- YAML parse checks for bundled skills and `agents/openai.yaml`
- `make test`
- `make lint`
- `git diff --check --cached`

Note: `quick_validate.py` could not run in this environment because Python is missing the `yaml` module (`ModuleNotFoundError: No module named 'yaml'`).