### PR TITLE
fanout(cli): accept Projects v2 URL; add --status and GraphQL item fetch

### DIFF
--- a/fanout
+++ b/fanout
@@ -87,11 +87,13 @@ Options:
                       Safe to rerun as blocker PRs merge.
   --session <name>    Target a specific tmux session (required when more than
                       one dmux session is alive on this machine).
-  --status <name>     [project mode only] Restrict to Project items whose
+  --project-status <name>
+                      [project mode only] Restrict to Project items whose
                       single-select "Status" field equals <name>. Default:
-                      "Todo". Pass `--status all` to disable the filter. If
-                      the Project has no Status field, fanout warns and falls
-                      back to all items. Ignored in issue mode.
+                      "Todo". Pass `--project-status all` to disable the
+                      filter. If the Project has no Status field, fanout
+                      warns and falls back to all items. Ignored in issue
+                      mode.
   --sleep <seconds>   Pause between pane-creation requests. Default 4. Raise
                       this if dmux reports "pane creation failed" under load.
   --popup-timeout <s> Seconds to wait for each dmux popup (new-pane, agent-
@@ -345,7 +347,7 @@ while (( $# > 0 )); do
     --include)    include_arg="${2:-}"; shift 2 || die "--include requires an argument" ;;
     --name)       parse_name_arg "${2:-}"; shift 2 || die "--name requires an argument" ;;
     --session)    session_arg="${2:-}"; shift 2 || die "--session requires an argument" ;;
-    --status)     status_filter="${2:-}"; shift 2 || die "--status requires an argument" ;;
+    --project-status) status_filter="${2:-}"; shift 2 || die "--project-status requires an argument" ;;
     --sleep)      sleep_between="${2:-}"; shift 2 || die "--sleep requires an argument" ;;
     --popup-timeout) popup_timeout="${2:-}"; shift 2 || die "--popup-timeout requires an argument" ;;
     --dry-run)    dry_run=1;          shift ;;
@@ -384,7 +386,7 @@ elif [[ "$parent" =~ ^https://github\.com/(users|orgs)/([^/]+)/projects/([0-9]+)
 else
   die "parent must be an integer issue number or Projects v2 URL, got: $parent"
 fi
-[[ -n "$status_filter" ]] || die "--status must not be empty"
+[[ -n "$status_filter" ]] || die "--project-status must not be empty"
 if [[ -n "$limit" ]] && ! [[ "$limit" =~ ^[1-9][0-9]*$ ]]; then
   die "--limit must be a positive integer, got: $limit"
 fi
@@ -535,7 +537,7 @@ EOF
       local has_status
       has_status=$(jq -r ".data.${entry_field}.projectV2.field // null | if . == null then 0 else 1 end" <<<"$page")
       if [[ "$has_status" == "0" ]]; then
-        log_warn "Project '$project_title' has no Status field; ignoring --status $status_filter and falling back to all items"
+        log_warn "Project '$project_title' has no Status field; ignoring --project-status $status_filter and falling back to all items"
         status_filter='all'
       fi
     fi

--- a/fanout
+++ b/fanout
@@ -107,7 +107,9 @@ Options:
   -h, --help          Show this message.
 
 Prerequisites:
-  * gh, gh-sub-issue extension, jq, tmux, pgrep installed.
+  * gh, jq, tmux, pgrep installed. gh-sub-issue extension is required for
+    issue mode only (project mode uses `gh api graphql`); for project mode
+    the gh token must additionally carry the `read:project` scope.
   * `cd <repo> && dmux` has been run; tmux session is alive.
   * dmux TUI is on the pane-list view (no modal open). fanout sends one Esc
     at startup as a best-effort.
@@ -416,7 +418,10 @@ need_cmd jq    || missing_deps+=('jq (brew install jq)')
 need_cmd tmux  || missing_deps+=('tmux (brew install tmux)')
 need_cmd pgrep || missing_deps+=('pgrep (procps-ng on Linux; preinstalled on macOS)')
 
-if ! gh extension list 2>/dev/null | cut -f1 | grep -qx 'gh sub-issue'; then
+# gh-sub-issue is only needed in issue mode (project mode goes through
+# `gh api graphql` instead).
+if [[ "$parent_mode" == issue ]] \
+  && ! gh extension list 2>/dev/null | cut -f1 | grep -qx 'gh sub-issue'; then
   missing_deps+=('gh-sub-issue extension (gh extension install yahsan2/gh-sub-issue)')
 fi
 
@@ -508,6 +513,14 @@ EOF
 
     if ! page=$(gh_in_root "${args[@]}" 2>&1); then
       die "gh api graphql (projectV2 items) failed: $page"
+    fi
+
+    # GraphQL returns projectV2: null for a syntactically valid URL when the
+    # project number is wrong or the token can't see it. Catch it here so the
+    # caller gets an actionable message instead of a jq null-arithmetic crash
+    # in the final flatten pass.
+    if [[ "$(jq -r ".data.${entry_field}.projectV2 // null | if . == null then 0 else 1 end" <<<"$page")" == "0" ]]; then
+      die "Project not found or not accessible: $parent (check the URL, token scopes, and project visibility)"
     fi
     pages+=("$page")
 

--- a/fanout
+++ b/fanout
@@ -376,7 +376,7 @@ if [[ -z "$parent" ]]; then
 fi
 if [[ "$parent" =~ ^[0-9]+$ ]]; then
   parent_mode=issue
-elif [[ "$parent" =~ ^https://github\.com/(users|orgs)/([^/]+)/projects/([0-9]+)/?$ ]]; then
+elif [[ "$parent" =~ ^https://github\.com/(users|orgs)/([^/]+)/projects/([0-9]+)([/?].*)?$ ]]; then
   parent_mode=project
   project_owner_type="${BASH_REMATCH[1]}"
   project_owner="${BASH_REMATCH[2]}"

--- a/fanout
+++ b/fanout
@@ -1406,16 +1406,26 @@ if (( ${#limit_deferred[@]} > 0 )); then
     limit_deferred_nums+=("#$(jq -r '.number' <<<"$row")")
   done
   printf '  %s\n' "${limit_deferred_nums[*]}"
+  # Every substituted value is run through `printf %q` so the printed
+  # command is safe to copy-paste: Project URLs can contain `&` query
+  # parameters, Status / session / agent names can contain spaces.
   agent_flag=''
-  [[ -n "$agent" ]] && agent_flag=" --agent $agent"
+  [[ -n "$agent" ]] && agent_flag=" --agent $(printf '%q' "$agent")"
   session_flag=''
-  [[ -n "$session_arg" ]] && session_flag=" --session $session_arg"
+  [[ -n "$session_arg" ]] && session_flag=" --session $(printf '%q' "$session_arg")"
   filter_flag=''
-  [[ -n "$only_arg" ]] && filter_flag=" --only $only_arg"
-  [[ -n "$skip_arg" ]] && filter_flag=" --skip $skip_arg"
+  [[ -n "$only_arg" ]] && filter_flag=" --only $(printf '%q' "$only_arg")"
+  [[ -n "$skip_arg" ]] && filter_flag=" --skip $(printf '%q' "$skip_arg")"
   unblocked_flag=''
   (( unblocked_only )) && unblocked_flag=' --unblocked-only'
-  printf '  fanout %s --limit %d%s%s%s%s\n' "$parent" "${#limit_deferred[@]}" "$filter_flag" "$unblocked_flag" "$agent_flag" "$session_flag"
+  # --project-status defaults to "Todo" when omitted, so only re-emit it
+  # when the user passed something non-default (otherwise we'd silently
+  # narrow the rerun).
+  status_flag=''
+  if [[ "$parent_mode" == project && "$status_filter" != "Todo" ]]; then
+    status_flag=" --project-status $(printf '%q' "$status_filter")"
+  fi
+  printf '  fanout %q --limit %d%s%s%s%s%s\n' "$parent" "${#limit_deferred[@]}" "$status_flag" "$filter_flag" "$unblocked_flag" "$agent_flag" "$session_flag"
 fi
 
 (( failed > 0 )) && exit 1

--- a/fanout
+++ b/fanout
@@ -331,8 +331,7 @@ parent_mode=''            # 'issue' | 'project' — set after positional validat
 project_owner_type=''     # 'users' | 'orgs' (project mode)
 project_owner=''
 project_number=''
-project_url=''
-project_repo=''           # resolved from gh_in_root once project_root is known
+project_repo=''           # resolved lazily from gh_in_root in project mode
 
 while (( $# > 0 )); do
   case "$1" in
@@ -380,7 +379,6 @@ elif [[ "$parent" =~ ^https://github\.com/(users|orgs)/([^/]+)/projects/([0-9]+)
   project_owner_type="${BASH_REMATCH[1]}"
   project_owner="${BASH_REMATCH[2]}"
   project_number="${BASH_REMATCH[3]}"
-  project_url="$parent"
 else
   die "parent must be an integer issue number or Projects v2 URL, got: $parent"
 fi
@@ -445,7 +443,7 @@ enumerate_project_items() {
   # Fetch all items from a Projects v2 board and emit children_json on stdout.
   #
   # Globals consumed (read-only): project_owner_type, project_owner,
-  #   project_number, project_url, project_repo
+  #   project_number, project_repo
   # Globals mutated: status_filter (only when the Project has no Status field
   #   AND the caller asked to filter; we warn once and fall back to 'all')
   #
@@ -496,7 +494,10 @@ query(\$owner: String!, \$number: Int!, \$first: Int!, \$after: String) {
 }
 EOF
 
-  local cursor='' all_nodes='[]' page status_field_seen=0 project_title=''
+  # Accumulate raw page responses into an array; a single jq -s pass after
+  # the loop flattens them. Reparsing $all_nodes on every page would be
+  # O(n²) — this stays O(n) regardless of project size.
+  local cursor='' page project_title='' pages=()
   while :; do
     local args=( api graphql
       -f "query=$gql"
@@ -508,25 +509,23 @@ EOF
     if ! page=$(gh_in_root "${args[@]}" 2>&1); then
       die "gh api graphql (projectV2 items) failed: $page"
     fi
+    pages+=("$page")
 
     if [[ -z "$project_title" ]]; then
       project_title=$(jq -r ".data.${entry_field}.projectV2.title // \"\"" <<<"$page")
     fi
 
-    # Status field detection only needs to run on the first page — its presence
-    # doesn't change mid-pagination. Falling back to 'all' is in-process only.
-    if (( ! status_field_seen )); then
+    # Status-field probe runs per page but only warns once: once status_filter
+    # is set to 'all' (either by the user or by this fallback), the inner
+    # condition stays false on subsequent pages.
+    if [[ "$status_filter" != "all" ]]; then
       local has_status
       has_status=$(jq -r ".data.${entry_field}.projectV2.field // null | if . == null then 0 else 1 end" <<<"$page")
-      if [[ "$has_status" == "0" && "$status_filter" != "all" ]]; then
+      if [[ "$has_status" == "0" ]]; then
         log_warn "Project '$project_title' has no Status field; ignoring --status $status_filter and falling back to all items"
         status_filter='all'
       fi
-      status_field_seen=1
     fi
-
-    all_nodes=$(jq --argjson acc "$all_nodes" \
-      ".data.${entry_field}.projectV2.items.nodes as \$n | \$acc + \$n" <<<"$page")
 
     local has_next end_cursor
     has_next=$(jq -r ".data.${entry_field}.projectV2.items.pageInfo.hasNextPage" <<<"$page")
@@ -534,6 +533,10 @@ EOF
     [[ "$has_next" != "true" ]] && break
     cursor="$end_cursor"
   done
+
+  local all_nodes
+  all_nodes=$(printf '%s\n' "${pages[@]}" | jq -s --arg ef "$entry_field" \
+    '[ .[] | .data[$ef].projectV2.items.nodes[] ]')
 
   # Cross-repo warn to stderr (children_json goes to stdout). Drafts and PR
   # items get silently dropped — only repo-matching Issues warrant a warn,
@@ -651,13 +654,6 @@ if ! (cd "$project_root" 2>/dev/null && git rev-parse --is-inside-work-tree >/de
   die "project root $project_root is not a git work tree; cannot resolve GitHub repo"
 fi
 
-# Resolve the repo slug once. Required in project mode (cross-repo filter
-# key inside enumerate_project_items); informational only in issue mode.
-project_repo=$(gh_in_root repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)
-if [[ "$parent_mode" == project && -z "$project_repo" ]]; then
-  die "could not resolve repo via 'gh repo view' in $project_root (required for project mode cross-repo filter)"
-fi
-
 # parent_body is only populated in issue mode; in project mode it stays empty,
 # and parse_blockers_from_parent_row's jq pipeline yields an empty result on
 # empty input so --unblocked-only still works without code branches.
@@ -665,8 +661,11 @@ parent_body=''
 body_nums=''
 
 if [[ "$parent_mode" == project ]]; then
+  # Cross-repo filter inside enumerate_project_items keys off project_repo.
+  project_repo=$(gh_in_root repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null) \
+    || die "could not resolve repo via 'gh repo view' in $project_root (required for project mode cross-repo filter)"
   log_info "mode: project (status=$status_filter, repo=$project_repo)"
-  log_info "fetching items from Project $project_url"
+  log_info "fetching items from Project $parent"
   children_json=$(enumerate_project_items)
 else
   log_info "fetching sub-issues of #$parent"
@@ -751,18 +750,11 @@ fi
 open_children_json=$(jq -c '[.[] | select(.state == "OPEN")]' <<<"$children_json")
 open_count=$(jq 'length' <<<"$open_children_json")
 
-if [[ "$parent_mode" == project ]]; then
-  log_info "project items: $total_children total, $open_count OPEN"
-else
-  log_info "sub-issues: $total_children total, $open_count OPEN"
-fi
+if [[ "$parent_mode" == project ]]; then child_noun="project items"; else child_noun="sub-issues"; fi
+log_info "$child_noun: $total_children total, $open_count OPEN"
 
 if (( open_count == 0 )); then
-  if [[ "$parent_mode" == project ]]; then
-    log_info "no OPEN project items. nothing to do."
-  else
-    log_info "no OPEN sub-issues. nothing to do."
-  fi
+  log_info "no OPEN $child_noun. nothing to do."
   exit 0
 fi
 

--- a/fanout
+++ b/fanout
@@ -17,11 +17,13 @@ default_popup_timeout=20
 
 usage() {
   cat <<'EOF'
-Usage: fanout <parent-issue> [options]
+Usage: fanout <parent-issue|project-url> [options]
 
-Creates one dmux pane per OPEN sub-issue of <parent-issue>. Each pane gets a
-dedicated git worktree (dmux handles that) and starts the configured agent
-with a briefing that points at /tmp/fanout-<repo>-<num>.md.
+Creates one dmux pane per OPEN sub-issue of the given parent issue, OR per
+OPEN item in the given Projects v2 URL (e.g. https://github.com/users/<u>/projects/<n>
+or https://github.com/orgs/<o>/projects/<n>). Each pane gets a dedicated git
+worktree (dmux handles that) and starts the configured agent with a briefing
+that points at /tmp/fanout-<repo>-<num>.md.
 
 Options:
   --agent <name>      Agent to launch (claude|codex|opencode|...). Required
@@ -85,6 +87,11 @@ Options:
                       Safe to rerun as blocker PRs merge.
   --session <name>    Target a specific tmux session (required when more than
                       one dmux session is alive on this machine).
+  --status <name>     [project mode only] Restrict to Project items whose
+                      single-select "Status" field equals <name>. Default:
+                      "Todo". Pass `--status all` to disable the filter. If
+                      the Project has no Status field, fanout warns and falls
+                      back to all items. Ignored in issue mode.
   --sleep <seconds>   Pause between pane-creation requests. Default 4. Raise
                       this if dmux reports "pane creation failed" under load.
   --popup-timeout <s> Seconds to wait for each dmux popup (new-pane, agent-
@@ -319,6 +326,13 @@ popup_timeout=$default_popup_timeout
 dry_run=0
 debug=0
 unblocked_only=0
+status_filter='Todo'      # project mode only; 'all' disables the filter
+parent_mode=''            # 'issue' | 'project' — set after positional validation
+project_owner_type=''     # 'users' | 'orgs' (project mode)
+project_owner=''
+project_number=''
+project_url=''
+project_repo=''           # resolved from gh_in_root once project_root is known
 
 while (( $# > 0 )); do
   case "$1" in
@@ -330,6 +344,7 @@ while (( $# > 0 )); do
     --include)    include_arg="${2:-}"; shift 2 || die "--include requires an argument" ;;
     --name)       parse_name_arg "${2:-}"; shift 2 || die "--name requires an argument" ;;
     --session)    session_arg="${2:-}"; shift 2 || die "--session requires an argument" ;;
+    --status)     status_filter="${2:-}"; shift 2 || die "--status requires an argument" ;;
     --sleep)      sleep_between="${2:-}"; shift 2 || die "--sleep requires an argument" ;;
     --popup-timeout) popup_timeout="${2:-}"; shift 2 || die "--popup-timeout requires an argument" ;;
     --dry-run)    dry_run=1;          shift ;;
@@ -358,9 +373,18 @@ if [[ -z "$parent" ]]; then
   usage >&2
   exit 2
 fi
-if ! [[ "$parent" =~ ^[0-9]+$ ]]; then
-  die "parent issue must be an integer, got: $parent"
+if [[ "$parent" =~ ^[0-9]+$ ]]; then
+  parent_mode=issue
+elif [[ "$parent" =~ ^https://github\.com/(users|orgs)/([^/]+)/projects/([0-9]+)/?$ ]]; then
+  parent_mode=project
+  project_owner_type="${BASH_REMATCH[1]}"
+  project_owner="${BASH_REMATCH[2]}"
+  project_number="${BASH_REMATCH[3]}"
+  project_url="$parent"
+else
+  die "parent must be an integer issue number or Projects v2 URL, got: $parent"
 fi
+[[ -n "$status_filter" ]] || die "--status must not be empty"
 if [[ -n "$limit" ]] && ! [[ "$limit" =~ ^[1-9][0-9]*$ ]]; then
   die "--limit must be a positive integer, got: $limit"
 fi
@@ -415,6 +439,127 @@ tmux_opt() {
 
 gh_in_root() {
   (cd "$project_root" && gh "$@")
+}
+
+enumerate_project_items() {
+  # Fetch all items from a Projects v2 board and emit children_json on stdout.
+  #
+  # Globals consumed (read-only): project_owner_type, project_owner,
+  #   project_number, project_url, project_repo
+  # Globals mutated: status_filter (only when the Project has no Status field
+  #   AND the caller asked to filter; we warn once and fall back to 'all')
+  #
+  # Output shape (stdout): [{number, title, state, body, labels:[{name}]}, ...]
+  # matching the contract the issue-mode path produces via gh-sub-issue +
+  # gh issue view hydration.
+  #
+  # `gh project item-list --format json` doesn't return Status field values,
+  # so we hit GraphQL directly with the right entry (`user` vs `organization`)
+  # based on the URL form.
+  local entry_field
+  case "$project_owner_type" in
+    users) entry_field='user' ;;
+    orgs)  entry_field='organization' ;;
+    *) die "internal: unknown project owner type: $project_owner_type" ;;
+  esac
+
+  # GraphQL variable refs use \$ so bash doesn't expand them.
+  local gql
+  read -r -d '' gql <<EOF || true
+query(\$owner: String!, \$number: Int!, \$first: Int!, \$after: String) {
+  ${entry_field}(login: \$owner) {
+    projectV2(number: \$number) {
+      title
+      url
+      field(name: "Status") { __typename }
+      items(first: \$first, after: \$after) {
+        nodes {
+          content {
+            __typename
+            ... on Issue {
+              number
+              title
+              state
+              body
+              repository { nameWithOwner }
+              labels(first: 20) { nodes { name } }
+            }
+          }
+          status: fieldValueByName(name: "Status") {
+            ... on ProjectV2ItemFieldSingleSelectValue { name }
+          }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}
+EOF
+
+  local cursor='' all_nodes='[]' page status_field_seen=0 project_title=''
+  while :; do
+    local args=( api graphql
+      -f "query=$gql"
+      -F "owner=$project_owner"
+      -F "number=$project_number"
+      -F first=100 )
+    [[ -n "$cursor" ]] && args+=( -F "after=$cursor" )
+
+    if ! page=$(gh_in_root "${args[@]}" 2>&1); then
+      die "gh api graphql (projectV2 items) failed: $page"
+    fi
+
+    if [[ -z "$project_title" ]]; then
+      project_title=$(jq -r ".data.${entry_field}.projectV2.title // \"\"" <<<"$page")
+    fi
+
+    # Status field detection only needs to run on the first page — its presence
+    # doesn't change mid-pagination. Falling back to 'all' is in-process only.
+    if (( ! status_field_seen )); then
+      local has_status
+      has_status=$(jq -r ".data.${entry_field}.projectV2.field // null | if . == null then 0 else 1 end" <<<"$page")
+      if [[ "$has_status" == "0" && "$status_filter" != "all" ]]; then
+        log_warn "Project '$project_title' has no Status field; ignoring --status $status_filter and falling back to all items"
+        status_filter='all'
+      fi
+      status_field_seen=1
+    fi
+
+    all_nodes=$(jq --argjson acc "$all_nodes" \
+      ".data.${entry_field}.projectV2.items.nodes as \$n | \$acc + \$n" <<<"$page")
+
+    local has_next end_cursor
+    has_next=$(jq -r ".data.${entry_field}.projectV2.items.pageInfo.hasNextPage" <<<"$page")
+    end_cursor=$(jq -r ".data.${entry_field}.projectV2.items.pageInfo.endCursor // empty" <<<"$page")
+    [[ "$has_next" != "true" ]] && break
+    cursor="$end_cursor"
+  done
+
+  # Cross-repo warn to stderr (children_json goes to stdout). Drafts and PR
+  # items get silently dropped — only repo-matching Issues warrant a warn,
+  # since cross-repo Issues are the user-surprise case.
+  while IFS= read -r cross; do
+    [[ -n "$cross" ]] && log_warn "skipping cross-repo project item: $cross (project root repo: $project_repo)"
+  done < <(jq -r --arg repo "$project_repo" '
+    .[] | select(.content.__typename == "Issue")
+        | select(.content.repository.nameWithOwner != $repo)
+        | "\(.content.repository.nameWithOwner)#\(.content.number)"
+  ' <<<"$all_nodes")
+
+  jq --arg repo "$project_repo" --arg status "$status_filter" '
+    [ .[]
+      | select(.content.__typename == "Issue")
+      | select(.content.repository.nameWithOwner == $repo)
+      | select($status == "all" or (.status.name // "") == $status)
+      | {
+          number: .content.number,
+          title:  .content.title,
+          state:  (.content.state | ascii_upcase),
+          body:   (.content.body  // ""),
+          labels: [ .content.labels.nodes[]? | {name} ]
+        }
+    ]
+  ' <<<"$all_nodes"
 }
 
 pid_alive() {
@@ -498,46 +643,67 @@ if [[ -z "$agent" ]] && [[ -n "${TMUX_PANE:-}" ]]; then
   fi
 fi
 
-# --- fetch sub-issues --------------------------------------------------------
+# --- fetch children (sub-issues or project items) ---------------------------
 
-# gh auto-detects the repo from cwd, so we'll chdir to project_root for the
-# sub-issue call. Sanity-check that cwd is actually a work tree.
+# gh auto-detects the repo from cwd, so we'll chdir to project_root for any
+# gh call. Sanity-check that cwd is actually a work tree.
 if ! (cd "$project_root" 2>/dev/null && git rev-parse --is-inside-work-tree >/dev/null 2>&1); then
   die "project root $project_root is not a git work tree; cannot resolve GitHub repo"
 fi
 
-log_info "fetching sub-issues of #$parent"
-sub_issues_raw=$(gh_in_root sub-issue list "$parent" --json number,title,state 2>&1) \
-  || die "gh sub-issue list failed: $sub_issues_raw"
+# Resolve the repo slug once. Required in project mode (cross-repo filter
+# key inside enumerate_project_items); informational only in issue mode.
+project_repo=$(gh_in_root repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null || true)
+if [[ "$parent_mode" == project && -z "$project_repo" ]]; then
+  die "could not resolve repo via 'gh repo view' in $project_root (required for project mode cross-repo filter)"
+fi
 
-# gh-sub-issue v0.5.x wraps as {"subIssues":[...]} with lowercase state and
-# no body field; flatten + upcase to match downstream filters.
-children_json=$(jq '[.subIssues // [] | .[] | {number, title, state: (.state | ascii_upcase), body: "", labels: []}]' <<<"$sub_issues_raw")
+# parent_body is only populated in issue mode; in project mode it stays empty,
+# and parse_blockers_from_parent_row's jq pipeline yields an empty result on
+# empty input so --unblocked-only still works without code branches.
+parent_body=''
+body_nums=''
 
-# Also union children declared as task-list items in the parent body; some
-# parents list them there without using the Sub-issues API.
-parent_body=$(gh_in_root issue view "$parent" --json body -q .body 2>/dev/null) || {
-  log_warn "could not read parent body (#$parent); skipping task-list scan"
-  parent_body=''
-}
+if [[ "$parent_mode" == project ]]; then
+  log_info "mode: project (status=$status_filter, repo=$project_repo)"
+  log_info "fetching items from Project $project_url"
+  children_json=$(enumerate_project_items)
+else
+  log_info "fetching sub-issues of #$parent"
+  sub_issues_raw=$(gh_in_root sub-issue list "$parent" --json number,title,state 2>&1) \
+    || die "gh sub-issue list failed: $sub_issues_raw"
 
-# Only take the first `#N` immediately after the checkbox — ignore trailing
-# refs like "(blocked by #X, #Y)". Prose-only rows (no leading `#N`) skip
-# naturally because `capture` yields empty on non-match.
-body_nums=$(printf '%s' "$parent_body" | jq -Rrs '
-  split("\n")
-  | map(select(test("^[[:space:]]*-[[:space:]]+\\[[ xX]\\]")))
-  | map([capture("^[[:space:]]*-[[:space:]]+\\[[ xX]\\][[:space:]]*#(?<n>[0-9]+)").n])
-  | flatten | map(tonumber) | unique | .[]
-')
+  # gh-sub-issue v0.5.x wraps as {"subIssues":[...]} with lowercase state and
+  # no body field; flatten + upcase to match downstream filters.
+  children_json=$(jq '[.subIssues // [] | .[] | {number, title, state: (.state | ascii_upcase), body: "", labels: []}]' <<<"$sub_issues_raw")
 
-# --include numbers join the same hydrate path as body-scanned numbers.
-# parse_num_csv already validated each token is a positive integer, so we
-# just splat include_set (space-sentinel-wrapped set " 123 456 ") into the
-# newline-separated body_nums list.
+  # Also union children declared as task-list items in the parent body; some
+  # parents list them there without using the Sub-issues API.
+  parent_body=$(gh_in_root issue view "$parent" --json body -q .body 2>/dev/null) || {
+    log_warn "could not read parent body (#$parent); skipping task-list scan"
+    parent_body=''
+  }
+
+  # Only take the first `#N` immediately after the checkbox — ignore trailing
+  # refs like "(blocked by #X, #Y)". Prose-only rows (no leading `#N`) skip
+  # naturally because `capture` yields empty on non-match.
+  body_nums=$(printf '%s' "$parent_body" | jq -Rrs '
+    split("\n")
+    | map(select(test("^[[:space:]]*-[[:space:]]+\\[[ xX]\\]")))
+    | map([capture("^[[:space:]]*-[[:space:]]+\\[[ xX]\\][[:space:]]*#(?<n>[0-9]+)").n])
+    | flatten | map(tonumber) | unique | .[]
+  ')
+fi
+
+# --include numbers join the same hydrate path as body-scanned numbers in
+# both modes (project mode contributes no body_nums of its own). parse_num_csv
+# already validated each token is a positive integer, so we just splat
+# include_set (space-sentinel-wrapped " 123 456 ") into a newline-separated
+# list of extras.
+extra_nums="$body_nums"
 if [[ -n "$include_arg" ]]; then
   for _tok in $include_set; do
-    body_nums+=$'\n'"$_tok"
+    extra_nums+=$'\n'"$_tok"
   done
 fi
 
@@ -549,8 +715,9 @@ while IFS= read -r _n; do
 done < <(jq -r '.[].number' <<<"$children_json")
 
 body_details=()
-for num in $body_nums; do
-  [[ "$num" == "$parent" ]] && continue
+for num in $extra_nums; do
+  [[ -z "$num" ]] && continue
+  [[ "$parent_mode" == issue && "$num" == "$parent" ]] && continue
   [[ "$existing_set" == *" $num "* ]] && continue
   detail=$(gh_in_root issue view "$num" --json number,title,state,body,labels 2>/dev/null) || {
     log_warn "parent body / --include references #$num but issue lookup failed; skipping"
@@ -563,23 +730,39 @@ done
 if (( ${#body_details[@]} > 0 )); then
   extra_json=$(printf '%s\n' "${body_details[@]}" | jq -s '.')
   children_json=$(jq --argjson extra "$extra_json" '. + $extra' <<<"$children_json")
-  log_info "parent body / --include added ${#body_details[@]} extra child reference(s) not in sub-issue API"
+  if [[ "$parent_mode" == project ]]; then
+    log_info "--include added ${#body_details[@]} extra child reference(s) not in project items"
+  else
+    log_info "parent body / --include added ${#body_details[@]} extra child reference(s) not in sub-issue API"
+  fi
 fi
 
 # Count & filter.
 total_children=$(jq 'length' <<<"$children_json")
 if (( total_children == 0 )); then
-  log_info "no sub-issues on #$parent. nothing to do."
+  if [[ "$parent_mode" == project ]]; then
+    log_info "no items in Project (after status/repo filter). nothing to do."
+  else
+    log_info "no sub-issues on #$parent. nothing to do."
+  fi
   exit 0
 fi
 
 open_children_json=$(jq -c '[.[] | select(.state == "OPEN")]' <<<"$children_json")
 open_count=$(jq 'length' <<<"$open_children_json")
 
-log_info "sub-issues: $total_children total, $open_count OPEN"
+if [[ "$parent_mode" == project ]]; then
+  log_info "project items: $total_children total, $open_count OPEN"
+else
+  log_info "sub-issues: $total_children total, $open_count OPEN"
+fi
 
 if (( open_count == 0 )); then
-  log_info "no OPEN sub-issues. nothing to do."
+  if [[ "$parent_mode" == project ]]; then
+    log_info "no OPEN project items. nothing to do."
+  else
+    log_info "no OPEN sub-issues. nothing to do."
+  fi
   exit 0
 fi
 

--- a/tests/bats/tier1_flags.bats
+++ b/tests/bats/tier1_flags.bats
@@ -55,10 +55,28 @@ load helpers
 
 # --- Positional / required-argument validation -----------------------------
 
-@test "parent must be an integer: exit 1" {
+@test "parent must be an integer or Projects v2 URL: exit 1" {
   run_fanout abc
   [ "$status" -eq 1 ]
-  [[ "$output" == *"parent issue must be an integer, got: abc"* ]]
+  [[ "$output" == *"parent must be an integer issue number or Projects v2 URL, got: abc"* ]]
+}
+
+@test "parent URL with wrong host rejected: exit 1" {
+  run_fanout https://example.com/users/foo/projects/3
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"parent must be an integer issue number or Projects v2 URL"* ]]
+}
+
+@test "parent URL missing project number rejected: exit 1" {
+  run_fanout https://github.com/users/foo/projects/
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"parent must be an integer issue number or Projects v2 URL"* ]]
+}
+
+@test "--status missing value: exit 1" {
+  run_fanout 20 --status
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"--status requires an argument"* ]]
 }
 
 @test "--agent missing value: exit 1" {

--- a/tests/bats/tier1_flags.bats
+++ b/tests/bats/tier1_flags.bats
@@ -73,10 +73,10 @@ load helpers
   [[ "$output" == *"parent must be an integer issue number or Projects v2 URL"* ]]
 }
 
-@test "--status missing value: exit 1" {
-  run_fanout 20 --status
+@test "--project-status missing value: exit 1" {
+  run_fanout 20 --project-status
   [ "$status" -eq 1 ]
-  [[ "$output" == *"--status requires an argument"* ]]
+  [[ "$output" == *"--project-status requires an argument"* ]]
 }
 
 # Project URL parser must accept the canonical links users copy from GitHub

--- a/tests/bats/tier1_flags.bats
+++ b/tests/bats/tier1_flags.bats
@@ -79,6 +79,26 @@ load helpers
   [[ "$output" == *"--status requires an argument"* ]]
 }
 
+# Project URL parser must accept the canonical links users copy from GitHub
+# Projects: the bare /projects/<n>, /projects/<n>/views/<id>, and either
+# form with a ?query suffix. We only assert the parser does not reject
+# them — downstream stages (tmux/gh) fail in the test env but that's not
+# the parser's concern.
+@test "Projects URL bare form is accepted by parser" {
+  run_fanout 'https://github.com/users/foo/projects/3'
+  [[ "$output" != *"parent must be"* ]]
+}
+
+@test "Projects URL with /views/<id> is accepted by parser" {
+  run_fanout 'https://github.com/orgs/bar/projects/7/views/1'
+  [[ "$output" != *"parent must be"* ]]
+}
+
+@test "Projects URL with query string is accepted by parser" {
+  run_fanout 'https://github.com/users/foo/projects/3?filterQuery=is%3Aopen'
+  [[ "$output" != *"parent must be"* ]]
+}
+
 @test "--agent missing value: exit 1" {
   run_fanout 20 --agent
   [ "$status" -eq 1 ]


### PR DESCRIPTION
## Summary

- 第 1 引数が integer (既存) または `https://github.com/(users|orgs)/<owner>/projects/<n>` のいずれかを受け付けるよう判別を追加。
- 新フラグ `--status <name>` (default `Todo`、`--status all` で無効化、任意の単一選択 Status 値で絞り込み可)。
- `enumerate_project_items` 関数を新設。`gh api graphql` で projectV2 items を pagination 付きで取得し、`__typename == Issue` のみ採用、`content.repository.nameWithOwner` が dmux project_root の repo と異なる item は warn+skip、Status field が存在しない project は warn+全件フォールバック。整形後の `children_json` を既存の OPEN フィルタ / `[fanout #N]` 冪等性 / `--include/--only/--skip/--unblocked-only` パスに合流。
- issue モードの挙動・出力は完全に保持 (Tier 2 golden 全 9 シナリオ pass、issue mode の新規ログ出力なし)。

## Acceptance criteria

- [x] `./fanout https://github.com/users/<u>/projects/<n> --dry-run` で mode/status/repo を表示 (project モードのみ log_info で出力)
- [x] `./fanout <num> --dry-run` の既存挙動が壊れていない (Tier 2 全 pass)
- [x] `--status all` で Status フィルタ無効化 (jq の `$status == "all"` ガード)
- [x] cross-repo item を warn+skip
- [x] 不正な URL や数字でも URL でもない引数で die (Tier 1 で 3 新規ケース追加)
- [x] Status field 不在 project で warn + 全件フォールバック
- [x] `shellcheck fanout` グリーン (`make lint` 確認済み)

## Out of scope (別 child issue で対応)

- `claude/commands/fanout.md` の URL routing
- `claude/skills/fanout/SKILL.md` / `codex/skills/fanout/SKILL.md` の project mode 説明
- `README.md` の Usage / Prerequisites 追記
- Tier 2 fixture (project mode) と GraphQL shim 拡張

## Test plan

- [x] `make lint` — shellcheck pass
- [x] `make test` — Tier 1 (28 tests) + Tier 2 (9 tests) all pass
- [ ] Live verification (要 `gh auth refresh -s read:project`): Project URL で dry-run / `--status all` / cross-repo skip / 冪等性

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)