### PR TITLE
Document Project mode in README (docs-only slice of #43)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -44,6 +44,31 @@ resultFile パスを特定し、プロンプトポップアップ用には
 同じ経路でペイン作成を進めます。dmux が HTTP API を正式公開したら、この
 スクリプトは `POST /api/panes` 数行に戻せます。
 
+## Project モード
+
+第1引数には親 issue 番号だけでなく、Projects v2 の URL
+（`https://github.com/users/<owner>/projects/<n>` または
+`https://github.com/orgs/<org>/projects/<n>`）も渡せます。Project モードでは
+親 issue の Sub-issues + タスクリスト和集合の代わりに、Project items から
+子 issue を取り出します。
+
+- **既定フィルタは `Status == Todo`**。`--status "<name>"` で別の
+  single-select 値（例: `"In Progress"`）に切り替え、`--status all` で
+  Status フィルタを無効化して全 item（Done、Status 未設定なども含む）を
+  対象にします。
+- **親 body が無いので暗黙の子参照サルベージは無い**。同梱の Claude/Codex
+  スキルが通常拾う `Closes #N` / `Depends on #N` / 日本語の慣用句は
+  Project モードでは検出対象になりません — Project が source of truth。
+  Project が取りこぼしている子は `--include 4,7` で手動補完してください。
+- **同一リポジトリ前提は維持**。`content.repository` が dmux の
+  `@dmux_project_root` の repo と一致しない item は warn ログを出してスキップ
+  します（fanout は今でも 1 回 1 repo の前提）。
+- **Project に Status フィールドが無い場合** は warn を出して
+  `--status` を無視し、全 item を対象にフォールバックします。
+- **冪等性 (`[fanout #N]`) と `--unblocked-only` は issue モードと共通**。
+  Project モードでの blocker 情報源は child body の `## Blocked by` セクションと
+  `blocked` ラベルのみ（親 body の `(blocked by #X)` トレイラは存在しない）。
+
 ## インストール
 
 fanout は 1 つの Bash スクリプトに、エージェント連携ファイルを加えた構成で
@@ -102,6 +127,9 @@ Tier 1 は CLI サーフェス (エラーメッセージ + exit code)、Tier 2 �
   チェックし、失敗時にはインストールのヒントを表示します。子 issue は
   Sub-issues API 経由でも、親本文のタスクリスト（`- [ ] #NUM ...`）経由でも、
   あるいは両方で宣言されていても構いません。fanout は両ソースの和集合を取ります。
+- **Project モード時のみ**: Project items を取得する GraphQL クエリのため、
+  `gh` CLI に `read:project` スコープが必要です。`gh auth refresh -s read:project`
+  で付与してください。issue モード（`fanout <N>`）では不要です。
 - このマシン上で動作中の dmux セッション: `cd <repo> && dmux`。fanout は
   tmux セッションを走査して `@dmux_controller_pid` オプションを探し、PID が
   生きているかを確認することで dmux を検出します。
@@ -126,13 +154,17 @@ Tier 1 は CLI サーフェス (エラーメッセージ + exit code)、Tier 2 �
 ## 使い方
 
 ```
-fanout <parent-issue> [--agent <name>] [--limit <N>] [--only <list>] [--skip <list>]
-                     [--include <list>] [--unblocked-only]
-                     [--name <NUM>=<slug>[|<display>]]
-                     [--session <tmux-session>] [--sleep <seconds>]
-                     [--popup-timeout <seconds>] [--dry-run] [--debug]
+fanout <parent> [--agent <name>] [--limit <N>] [--only <list>] [--skip <list>]
+               [--include <list>] [--unblocked-only] [--status <name>]
+               [--name <NUM>=<slug>[|<display>]]
+               [--session <tmux-session>] [--sleep <seconds>]
+               [--popup-timeout <seconds>] [--dry-run] [--debug]
 fanout --help
 ```
+
+`<parent>` は GitHub issue 番号（Sub-issues + タスクリストモード）または
+Projects v2 URL（Project モード、上記参照）。`--status` は Project モード
+でのみ意味を持ち、issue モードでは無視されます。
 
 ### 例
 
@@ -184,6 +216,17 @@ fanout 123 --popup-timeout 45
 # 子ペインを立てたいときなど）。通常は不要 — fanout が dmux.config.json の
 # 呼び出し元ペイン `.panes[].agent` を自動で拾う。
 fanout 123 --agent codex
+
+# 親 issue ではなく Projects v2 ボードの OPEN issue をファンアウトする。
+# 既定は Status=Todo フィルタ、同一リポジトリのみ。`gh auth refresh -s
+# read:project` が必要。詳しいルールは上の「Project モード」節を参照。
+fanout https://github.com/users/<owner>/projects/<n>
+
+# 別の Status 列を指定（任意の single-select 値が使える）
+fanout https://github.com/orgs/<org>/projects/<n> --status "In Progress"
+
+# Status フィルタを無効化して全 item を対象に（Done / Status 未設定も含む）
+fanout https://github.com/users/<owner>/projects/<n> --status all
 ```
 
 ## エージェントセッション内から呼び出す

--- a/README.ja.md
+++ b/README.ja.md
@@ -46,16 +46,18 @@ resultFile パスを特定し、プロンプトポップアップ用には
 
 ## Project モード
 
-第1引数には親 issue 番号だけでなく、Projects v2 の URL
-（`https://github.com/users/<owner>/projects/<n>` または
-`https://github.com/orgs/<org>/projects/<n>`）も渡せます。Project モードでは
+第1引数には親 issue 番号だけでなく、Projects v2 の URL —
+`https://github.com/users/<owner>/projects/<n>` または
+`https://github.com/orgs/<org>/projects/<n>` — も渡せます。正規形の
+`/views/<id>` サフィックスやトレイリングのクエリ文字列付き URL も受け付ける
+ので、ブラウザのアドレスバーからそのままコピペできます。Project モードでは
 親 issue の Sub-issues + タスクリスト和集合の代わりに、Project items から
 子 issue を取り出します。
 
-- **既定フィルタは `Status == Todo`**。`--status "<name>"` で別の
-  single-select 値（例: `"In Progress"`）に切り替え、`--status all` で
-  Status フィルタを無効化して全 item（Done、Status 未設定なども含む）を
-  対象にします。
+- **既定フィルタは `Status == Todo`**。`--project-status "<name>"` で別の
+  single-select 値（例: `"In Progress"`）に切り替え、`--project-status all`
+  でフィルタを無効化して全 item（Done、Status 未設定なども含む）を対象に
+  します。
 - **親 body が無いので暗黙の子参照サルベージは無い**。同梱の Claude/Codex
   スキルが通常拾う `Closes #N` / `Depends on #N` / 日本語の慣用句は
   Project モードでは検出対象になりません — Project が source of truth。
@@ -64,7 +66,7 @@ resultFile パスを特定し、プロンプトポップアップ用には
   `@dmux_project_root` の repo と一致しない item は warn ログを出してスキップ
   します（fanout は今でも 1 回 1 repo の前提）。
 - **Project に Status フィールドが無い場合** は warn を出して
-  `--status` を無視し、全 item を対象にフォールバックします。
+  `--project-status` を無視し、全 item を対象にフォールバックします。
 - **冪等性 (`[fanout #N]`) と `--unblocked-only` は issue モードと共通**。
   Project モードでの blocker 情報源は child body の `## Blocked by` セクションと
   `blocked` ラベルのみ（親 body の `(blocked by #X)` トレイラは存在しない）。
@@ -154,17 +156,18 @@ Tier 1 は CLI サーフェス (エラーメッセージ + exit code)、Tier 2 �
 ## 使い方
 
 ```
-fanout <parent> [--agent <name>] [--limit <N>] [--only <list>] [--skip <list>]
-               [--include <list>] [--unblocked-only] [--status <name>]
-               [--name <NUM>=<slug>[|<display>]]
-               [--session <tmux-session>] [--sleep <seconds>]
-               [--popup-timeout <seconds>] [--dry-run] [--debug]
+fanout <parent-issue|project-url>
+       [--agent <name>] [--limit <N>] [--only <list>] [--skip <list>]
+       [--include <list>] [--unblocked-only] [--project-status <name>]
+       [--name <NUM>=<slug>[|<display>]]
+       [--session <tmux-session>] [--sleep <seconds>]
+       [--popup-timeout <seconds>] [--dry-run] [--debug]
 fanout --help
 ```
 
-`<parent>` は GitHub issue 番号（Sub-issues + タスクリストモード）または
-Projects v2 URL（Project モード、上記参照）。`--status` は Project モード
-でのみ意味を持ち、issue モードでは無視されます。
+第1引数は GitHub issue 番号（Sub-issues + タスクリストモード）または
+Projects v2 URL（Project モード、上記参照）のいずれか。`--project-status`
+は Project モードでのみ意味を持ち、issue モードでは無視されます。
 
 ### 例
 
@@ -223,10 +226,10 @@ fanout 123 --agent codex
 fanout https://github.com/users/<owner>/projects/<n>
 
 # 別の Status 列を指定（任意の single-select 値が使える）
-fanout https://github.com/orgs/<org>/projects/<n> --status "In Progress"
+fanout https://github.com/orgs/<org>/projects/<n> --project-status "In Progress"
 
 # Status フィルタを無効化して全 item を対象に（Done / Status 未設定も含む）
-fanout https://github.com/users/<owner>/projects/<n> --status all
+fanout https://github.com/users/<owner>/projects/<n> --project-status all
 ```
 
 ## エージェントセッション内から呼び出す

--- a/README.md
+++ b/README.md
@@ -42,6 +42,33 @@ exit, dmux reads the file we wrote, and pane creation proceeds as if a
 human had answered. When dmux eventually ships the HTTP API, this script
 can collapse back to `POST /api/panes` in a page.
 
+## Project mode
+
+In addition to a parent issue number, fanout's positional argument also
+accepts a Projects v2 URL (`https://github.com/users/<owner>/projects/<n>`
+or `https://github.com/orgs/<org>/projects/<n>`). In this mode children
+come from the Project's items instead of a parent issue's Sub-issues +
+task-list union.
+
+- **Default filter is `Status == Todo`.** Pass `--status "<name>"` to pick
+  a different single-select value (e.g. `"In Progress"`), or
+  `--status all` to disable the Status filter and include every item
+  (Done, no status, etc.).
+- **No parent body means no implicit-children salvage.** Phrases like
+  `Closes #N`, `Depends on #N`, or Japanese idioms that the bundled
+  Claude/Codex skills normally surface from a parent body don't exist
+  here — the Project is the source of truth. Use `--include 4,7` to
+  force-add anything the Project happens to omit.
+- **Single-repo only.** Items whose `content.repository` differs from the
+  dmux `@dmux_project_root` repo are warned and skipped; fanout still
+  assumes one repo per run.
+- **Status field missing on the Project?** fanout warns and falls back to
+  every item regardless of `--status`.
+- **Idempotency, `[fanout #N]` detection, and `--unblocked-only` work
+  identically.** Blockers in this mode come only from the child body's
+  `## Blocked by` section and the `blocked` label; the
+  `(blocked by #X)` task-list trailer doesn't exist without a parent body.
+
 ## Installation
 
 fanout ships as a single Bash script plus agent integration files:
@@ -99,6 +126,10 @@ intentionally change dry-run output. Tier 3 (live dmux E2E) stays manual.
   startup and prints install hints on failure. Children can be declared via
   the Sub-issues API, the parent body's task-list (`- [ ] #NUM ...`), or
   both — fanout unions them.
+- **Project mode only**: the `gh` CLI must have the `read:project` scope so
+  the GraphQL query that lists Project items can succeed. Add it with
+  `gh auth refresh -s read:project`. Issue-mode (`fanout <N>`) does not
+  need this scope.
 - A running dmux session on this machine: `cd <repo> && dmux`. fanout discovers
   it by scanning tmux sessions for the `@dmux_controller_pid` option and
   checking that the PID is alive.
@@ -123,13 +154,17 @@ intentionally change dry-run output. Tier 3 (live dmux E2E) stays manual.
 ## Usage
 
 ```
-fanout <parent-issue> [--agent <name>] [--limit <N>] [--only <list>] [--skip <list>]
-                     [--include <list>] [--unblocked-only]
-                     [--name <NUM>=<slug>[|<display>]]
-                     [--session <tmux-session>] [--sleep <seconds>]
-                     [--popup-timeout <seconds>] [--dry-run]
+fanout <parent> [--agent <name>] [--limit <N>] [--only <list>] [--skip <list>]
+               [--include <list>] [--unblocked-only] [--status <name>]
+               [--name <NUM>=<slug>[|<display>]]
+               [--session <tmux-session>] [--sleep <seconds>]
+               [--popup-timeout <seconds>] [--dry-run]
 fanout --help
 ```
+
+`<parent>` is either a GitHub issue number (Sub-issues + task-list mode)
+or a Projects v2 URL (Project mode; see above). `--status` only applies
+to Project mode and is ignored otherwise.
 
 ### Examples
 
@@ -195,6 +230,17 @@ fanout 123 --popup-timeout 45
 # agent than the parent pane). Normally you don't need this — fanout reads
 # the caller's .panes[].agent from dmux.config.json.
 fanout 123 --agent codex
+
+# Fan out OPEN issues from a Projects v2 board instead of a parent issue.
+# Default filter is Status=Todo; same-repo only. Requires `gh auth refresh
+# -s read:project`. See the "Project mode" section above for the full rules.
+fanout https://github.com/users/<owner>/projects/<n>
+
+# Pick a different Status column (any single-select value works)
+fanout https://github.com/orgs/<org>/projects/<n> --status "In Progress"
+
+# Disable the Status filter entirely (include Done / no-status items)
+fanout https://github.com/users/<owner>/projects/<n> --status all
 ```
 
 ## From inside an agent session

--- a/README.md
+++ b/README.md
@@ -45,14 +45,16 @@ can collapse back to `POST /api/panes` in a page.
 ## Project mode
 
 In addition to a parent issue number, fanout's positional argument also
-accepts a Projects v2 URL (`https://github.com/users/<owner>/projects/<n>`
-or `https://github.com/orgs/<org>/projects/<n>`). In this mode children
-come from the Project's items instead of a parent issue's Sub-issues +
+accepts a Projects v2 URL — `https://github.com/users/<owner>/projects/<n>`
+or `https://github.com/orgs/<org>/projects/<n>`. The canonical
+`/views/<id>` suffix and trailing query strings are also accepted, so
+copy/paste from the browser address bar works. In this mode children come
+from the Project's items instead of a parent issue's Sub-issues +
 task-list union.
 
-- **Default filter is `Status == Todo`.** Pass `--status "<name>"` to pick
-  a different single-select value (e.g. `"In Progress"`), or
-  `--status all` to disable the Status filter and include every item
+- **Default filter is `Status == Todo`.** Pass `--project-status "<name>"`
+  to pick a different single-select value (e.g. `"In Progress"`), or
+  `--project-status all` to disable the filter and include every item
   (Done, no status, etc.).
 - **No parent body means no implicit-children salvage.** Phrases like
   `Closes #N`, `Depends on #N`, or Japanese idioms that the bundled
@@ -63,7 +65,7 @@ task-list union.
   dmux `@dmux_project_root` repo are warned and skipped; fanout still
   assumes one repo per run.
 - **Status field missing on the Project?** fanout warns and falls back to
-  every item regardless of `--status`.
+  every item regardless of `--project-status`.
 - **Idempotency, `[fanout #N]` detection, and `--unblocked-only` work
   identically.** Blockers in this mode come only from the child body's
   `## Blocked by` section and the `blocked` label; the
@@ -154,17 +156,18 @@ intentionally change dry-run output. Tier 3 (live dmux E2E) stays manual.
 ## Usage
 
 ```
-fanout <parent> [--agent <name>] [--limit <N>] [--only <list>] [--skip <list>]
-               [--include <list>] [--unblocked-only] [--status <name>]
-               [--name <NUM>=<slug>[|<display>]]
-               [--session <tmux-session>] [--sleep <seconds>]
-               [--popup-timeout <seconds>] [--dry-run]
+fanout <parent-issue|project-url>
+       [--agent <name>] [--limit <N>] [--only <list>] [--skip <list>]
+       [--include <list>] [--unblocked-only] [--project-status <name>]
+       [--name <NUM>=<slug>[|<display>]]
+       [--session <tmux-session>] [--sleep <seconds>]
+       [--popup-timeout <seconds>] [--dry-run]
 fanout --help
 ```
 
-`<parent>` is either a GitHub issue number (Sub-issues + task-list mode)
-or a Projects v2 URL (Project mode; see above). `--status` only applies
-to Project mode and is ignored otherwise.
+The positional accepts either a GitHub issue number (Sub-issues +
+task-list mode) or a Projects v2 URL (Project mode; see above).
+`--project-status` only applies to Project mode and is ignored otherwise.
 
 ### Examples
 
@@ -237,10 +240,10 @@ fanout 123 --agent codex
 fanout https://github.com/users/<owner>/projects/<n>
 
 # Pick a different Status column (any single-select value works)
-fanout https://github.com/orgs/<org>/projects/<n> --status "In Progress"
+fanout https://github.com/orgs/<org>/projects/<n> --project-status "In Progress"
 
 # Disable the Status filter entirely (include Done / no-status items)
-fanout https://github.com/users/<owner>/projects/<n> --status all
+fanout https://github.com/users/<owner>/projects/<n> --project-status all
 ```
 
 ## From inside an agent session


### PR DESCRIPTION
## Summary

- Add a top-level `## Project mode` / `## Project モード` section to README.md and README.ja.md right after "Why this looks weird", covering the default `Status == Todo` filter, single-repo cross-repo skip, missing-Status fallback, and the absence of parent-body implicit-children salvage.
- Document the `gh auth refresh -s read:project` requirement in Prerequisites (Project mode only — issue mode is unaffected).
- Update the Usage synopsis to use `<parent-issue|project-url>` (matching `fanout --help`), advertise `[--project-status <name>]`, and add three Examples (`users/`, `orgs/`, `--project-status all`).
- Mention that canonical `/views/<id>` suffixes and trailing query strings on Projects URLs are accepted, so copy/paste from the browser address bar works.

## Status vs. #43

#41 (`fanout(cli): accept Projects v2 URL ...`) merged via #45 while this PR was open, so the CLI surface this README describes — `--project-status`, the `<parent-issue|project-url>` positional, URL parsing for `/views` and query strings — is now live on `main`. This branch was rebased onto the post-#45 main and the docs were updated to use `--project-status` (renamed from `--status` in the merged CLI) and the canonical positional name from `fanout --help`.

What's still **outstanding** under #43 (deferred to a follow-up PR):
- `tests/fixtures/project_basic/`, `project_status_all/`, `project_cross_repo/`
- `gh api graphql` mock shim for `tests/lib/` (or extension of `tests/bin/gh`)
- Tier 2 bats cases + `tests/golden/project_*.dry-run.txt`

That's why this PR is still `Refs #43`, not `Closes #43`. The Tier 1 URL/flag validation cases were already shipped with #45.

## Test plan

- [x] `make lint` — shellcheck clean
- [x] `make test` — Tier 1 (31 tests, including the URL/flag cases #45 added) + Tier 2 (9 tests) all green
- [x] Visually confirm `## Project mode` (en) and `## Project モード` (ja) sit between "Why this looks weird" and "Installation"
- [x] No stale `--status` references; positional uses `<parent-issue|project-url>` everywhere a user-facing form was needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)