### PR TITLE
tests(tier2): refresh project-mode goldens for [fanout #N of #P] prefix

### DIFF
--- a/tests/golden/scenario-project-basic.dry-run.txt
+++ b/tests/golden/scenario-project-basic.dry-run.txt
@@ -12,7 +12,7 @@
   current panes[] length: 0
     $ tmux send-keys -t %1 Escape
     $ tmux send-keys -t %1 n
-    # would intercept newPanePopup and write: {"success":true,"data":"[fanout #901] First todo item: read /tmp/fanout-project_root-901.md and begin."}
+    # would intercept newPanePopup and write: {"success":true,"data":"[fanout #901 of #https://github.com/users/butaosuinu/projects/3] First todo item: read /tmp/fanout-project_root-901.md and begin."}
     # would intercept agentChoicePopup and write: {"success":true,"data":["claude"]}
 [ ok ] #901: dry-run complete
 [info] #902: Second todo item
@@ -21,7 +21,7 @@
   current panes[] length: 0
     $ tmux send-keys -t %1 Escape
     $ tmux send-keys -t %1 n
-    # would intercept newPanePopup and write: {"success":true,"data":"[fanout #902] Second todo item: read /tmp/fanout-project_root-902.md and begin."}
+    # would intercept newPanePopup and write: {"success":true,"data":"[fanout #902 of #https://github.com/users/butaosuinu/projects/3] Second todo item: read /tmp/fanout-project_root-902.md and begin."}
     # would intercept agentChoicePopup and write: {"success":true,"data":["claude"]}
 [ ok ] #902: dry-run complete
 

--- a/tests/golden/scenario-project-cross-repo.dry-run.txt
+++ b/tests/golden/scenario-project-cross-repo.dry-run.txt
@@ -13,7 +13,7 @@
   current panes[] length: 0
     $ tmux send-keys -t %1 Escape
     $ tmux send-keys -t %1 n
-    # would intercept newPanePopup and write: {"success":true,"data":"[fanout #921] Self-repo todo: read /tmp/fanout-project_root-921.md and begin."}
+    # would intercept newPanePopup and write: {"success":true,"data":"[fanout #921 of #https://github.com/users/butaosuinu/projects/3] Self-repo todo: read /tmp/fanout-project_root-921.md and begin."}
     # would intercept agentChoicePopup and write: {"success":true,"data":["claude"]}
 [ ok ] #921: dry-run complete
 

--- a/tests/golden/scenario-project-status-all.dry-run.txt
+++ b/tests/golden/scenario-project-status-all.dry-run.txt
@@ -12,7 +12,7 @@
   current panes[] length: 0
     $ tmux send-keys -t %1 Escape
     $ tmux send-keys -t %1 n
-    # would intercept newPanePopup and write: {"success":true,"data":"[fanout #911] Todo one: read /tmp/fanout-project_root-911.md and begin."}
+    # would intercept newPanePopup and write: {"success":true,"data":"[fanout #911 of #https://github.com/users/butaosuinu/projects/3] Todo one: read /tmp/fanout-project_root-911.md and begin."}
     # would intercept agentChoicePopup and write: {"success":true,"data":["claude"]}
 [ ok ] #911: dry-run complete
 [info] #912: Todo two
@@ -21,7 +21,7 @@
   current panes[] length: 0
     $ tmux send-keys -t %1 Escape
     $ tmux send-keys -t %1 n
-    # would intercept newPanePopup and write: {"success":true,"data":"[fanout #912] Todo two: read /tmp/fanout-project_root-912.md and begin."}
+    # would intercept newPanePopup and write: {"success":true,"data":"[fanout #912 of #https://github.com/users/butaosuinu/projects/3] Todo two: read /tmp/fanout-project_root-912.md and begin."}
     # would intercept agentChoicePopup and write: {"success":true,"data":["claude"]}
 [ ok ] #912: dry-run complete
 [info] #913: Done item
@@ -30,7 +30,7 @@
   current panes[] length: 0
     $ tmux send-keys -t %1 Escape
     $ tmux send-keys -t %1 n
-    # would intercept newPanePopup and write: {"success":true,"data":"[fanout #913] Done item: read /tmp/fanout-project_root-913.md and begin."}
+    # would intercept newPanePopup and write: {"success":true,"data":"[fanout #913 of #https://github.com/users/butaosuinu/projects/3] Done item: read /tmp/fanout-project_root-913.md and begin."}
     # would intercept agentChoicePopup and write: {"success":true,"data":["claude"]}
 [ ok ] #913: dry-run complete
 


### PR DESCRIPTION
## Summary
- PR #39 widened the pane prompt prefix from `[fanout #N]` to `[fanout #N of #<parent>]` so that `fanout --status <parent>` can filter children by their owning parent. The three Project-mode Tier 2 golden fixtures missed that update and have been red on `main` since #39 merged — this PR regenerates them.
- Diff is limited to `tests/golden/scenario-project-{basic,status-all,cross-repo}.dry-run.txt`; only the prefix string changes.
- Pre-req for cutting v0.0.3 off a green `main`.

## Test plan
- [x] `FANOUT_GOLDEN_UPDATE=1 make test-tier2` then `make test` — Tier 1 + Tier 2 both green (20/20 locally on darwin)
- [ ] CI green on `release-prep/v0.0.3-goldens`

🤖 Generated with [Claude Code](https://claude.com/claude-code)