### PR TITLE
[codex] fix fanout status PR hydration

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -162,6 +162,7 @@ fanout <parent-issue|project-url>
        [--name <NUM>=<slug>[|<display>]]
        [--session <tmux-session>] [--sleep <seconds>]
        [--popup-timeout <seconds>] [--dry-run] [--debug]
+fanout <parent-issue> --status      # ファンアウト済み子 issue の JSON 状態を読む
 fanout --help
 ```
 
@@ -219,6 +220,11 @@ fanout 123 --popup-timeout 45
 # 子ペインを立てたいときなど）。通常は不要 — fanout が dmux.config.json の
 # 呼び出し元ペイン `.panes[].agent` を自動で拾う。
 fanout 123 --agent codex
+
+# ファンアウト済み子 issue と closed-by PR の merge 状態を JSON で読む。
+# 副作用は無いので jq と組み合わせて待機ループに使える。
+fanout 123 --status
+fanout 123 --status | jq '.summary.all_merged'
 
 # 親 issue ではなく Projects v2 ボードの OPEN issue をファンアウトする。
 # 既定は Status=Todo フィルタ、同一リポジトリのみ。`gh auth refresh -s

--- a/README.md
+++ b/README.md
@@ -176,7 +176,9 @@ task-list mode) or a Projects v2 URL (Project mode; see above).
 enumerate children already fanned out under that specific parent (panes
 whose prompt starts with `[fanout #N of #<parent>]`), calls
 `gh issue view <N> --json state,closedByPullRequestsReferences` for each,
-and prints one JSON document on stdout. Issue-mode parents only —
+then hydrates any returned PR refs with
+`gh pr view <PR> --json number,state,mergedAt`, and prints one JSON
+document on stdout. Issue-mode parents only —
 Projects v2 URLs as parent are rejected up-front (panes for project items
 carry the URL in their prefix, which `--status`'s strict filter doesn't
 address). In a session that has fanned multiple parents, children of

--- a/fanout
+++ b/fanout
@@ -322,13 +322,19 @@ get_issue_state() {
 
 get_issue_with_prs() {
   # $1 issue number. Echoes raw JSON
-  #   {state, closedByPullRequestsReferences:{nodes:[{number,state,mergedAt}]}, …}
+  #   {state, closedByPullRequestsReferences:[{number,url,repository}, …]}
   # exactly as gh returns it. No cache: the JSON-array shape doesn't fit
   # get_issue_state's string cache, and the single use site is one-shot.
   # Returns gh's exit status so callers can distinguish API failures from
   # empty results.
   local num="$1"
   gh_in_root issue view "$num" --json state,closedByPullRequestsReferences 2>/dev/null
+}
+
+get_pr_with_status() {
+  # $1 PR selector (URL or number). Echoes raw JSON with merge status fields.
+  local pr="$1"
+  gh_in_root pr view "$pr" --json number,state,mergedAt 2>/dev/null
 }
 
 parse_blockers_from_child_body() {
@@ -978,20 +984,72 @@ cmd_status() {
   fi
 
   local -a children_arr=()
-  local n raw projected
+  local n raw projected issue_state refs_json prs_json
   for n in "${nums_arr[@]}"; do
     raw=$(get_issue_with_prs "$n") || raw=''
     if [[ -z "$raw" ]]; then
       log_err "--status: gh issue view #$n failed (auth / network / not found)"
       exit 3
     fi
-    projected=$(jq --argjson n "$n" '{
+    issue_state=$(jq -r '.state // "UNKNOWN"' <<<"$raw") || {
+      log_err "--status: failed to parse gh response for #$n"
+      exit 3
+    }
+    refs_json=$(jq -c '
+      (.closedByPullRequestsReferences // [])
+      | if type == "array" then .
+        elif type == "object" then (.nodes // [])
+        else [] end
+    ' <<<"$raw") || {
+      log_err "--status: failed to parse gh response for #$n"
+      exit 3
+    }
+
+    local -a prs_arr=()
+    local ref selector pr_raw pr_projected
+    while IFS= read -r ref; do
+      [[ -z "$ref" ]] && continue
+      if jq -e 'has("state") and (.state != null)' >/dev/null <<<"$ref"; then
+        # Backward-compatible path for older fixtures / GraphQL-shaped refs
+        # that already carry the hydrated PR state.
+        pr_projected=$(jq -c '{ number, state, mergedAt: (.mergedAt // null) }' <<<"$ref") || {
+          log_err "--status: failed to parse gh response for #$n"
+          exit 3
+        }
+      else
+        selector=$(jq -r '.url // .number // empty' <<<"$ref") || {
+          log_err "--status: failed to parse gh response for #$n"
+          exit 3
+        }
+        if [[ -z "$selector" ]]; then
+          log_err "--status: gh response for #$n contains a PR ref without url or number"
+          exit 3
+        fi
+        pr_raw=$(get_pr_with_status "$selector") || pr_raw=''
+        if [[ -z "$pr_raw" ]]; then
+          log_err "--status: gh pr view $selector failed for issue #$n"
+          exit 3
+        fi
+        pr_projected=$(jq -c '{ number, state, mergedAt: (.mergedAt // null) }' <<<"$pr_raw") || {
+          log_err "--status: failed to parse gh pr response for $selector"
+          exit 3
+        }
+      fi
+      prs_arr+=("$pr_projected")
+    done < <(jq -c '.[]' <<<"$refs_json")
+
+    if (( ${#prs_arr[@]} )); then
+      prs_json=$(printf '%s\n' "${prs_arr[@]}" | jq -s '.')
+    else
+      prs_json='[]'
+    fi
+
+    projected=$(jq -n --argjson n "$n" --arg state "$issue_state" --argjson prs "$prs_json" '{
       num: $n,
-      state: .state,
-      prs: [(.closedByPullRequestsReferences.nodes // [])[]
-            | { number, state, mergedAt }],
-      has_merged_pr: (any((.closedByPullRequestsReferences.nodes // [])[]; .state == "MERGED"))
-    }' <<<"$raw") || {
+      state: $state,
+      prs: $prs,
+      has_merged_pr: (any($prs[]; .state == "MERGED"))
+    }') || {
       log_err "--status: failed to parse gh response for #$n"
       exit 3
     }

--- a/tests/bats/tier2_status.bats
+++ b/tests/bats/tier2_status.bats
@@ -9,7 +9,9 @@
 # The fixture contract for --status is the same dmux.config.json /
 # tmux-sessions.txt / tmux-show-options.tsv / project_root layout used by
 # the dry-run tests, plus per-issue gh-issue-view-<N>.json files that include
-# the `closedByPullRequestsReferences` field at the top level.
+# the `closedByPullRequestsReferences` field at the top level. Fixtures that
+# use real gh's PR-ref array shape also provide gh-pr-view-<N>.json files for
+# merge-state hydration.
 #
 # Regenerate goldens after an intentional schema change with:
 #   FANOUT_GOLDEN_UPDATE=1 bats tests/bats/tier2_status.bats

--- a/tests/bin/gh
+++ b/tests/bin/gh
@@ -18,6 +18,10 @@
 #         fanout uses -q .state and -q .body against the same endpoint,
 #         so fixtures are full issue objects (number/title/state/body/labels).
 #
+#   gh pr view <PR-or-URL> --json number,state,mergedAt [-q <filter>]
+#       — echoes $FIXTURE_DIR/gh-pr-view-<N>.json verbatim. URL selectors are
+#         reduced to their trailing PR number.
+#
 #   gh repo view --json <fields> [-q <filter>]
 #       — echoes $FIXTURE_DIR/gh-repo-view.json (with optional jq filter).
 #         Project mode calls this to resolve the cross-repo filter target
@@ -92,6 +96,16 @@ case "${1:-}" in
       shift 3 2>/dev/null || true
       jq_filter="$(extract_jq_filter "$@")"
       emit_fixture "$fixture/gh-issue-view-$num.json" "$jq_filter" "gh issue view $num"
+      exit 0
+    fi
+    ;;
+  pr)
+    if [[ "${2:-}" == "view" ]]; then
+      pr="${3:-}"
+      pr="${pr##*/}"
+      shift 3 2>/dev/null || true
+      jq_filter="$(extract_jq_filter "$@")"
+      emit_fixture "$fixture/gh-pr-view-$pr.json" "$jq_filter" "gh pr view $pr"
       exit 0
     fi
     ;;

--- a/tests/fixtures/scenario-status-mixed/gh-issue-view-201.json
+++ b/tests/fixtures/scenario-status-mixed/gh-issue-view-201.json
@@ -1,1 +1,1 @@
-{"state":"CLOSED","closedByPullRequestsReferences":{"nodes":[{"number":601,"state":"MERGED","mergedAt":"2026-05-03T12:00:00Z"}]}}
+{"state":"CLOSED","closedByPullRequestsReferences":[{"number":601,"url":"https://github.com/butaosuinu/fanout/pull/601","repository":{"nameWithOwner":"butaosuinu/fanout"}}]}

--- a/tests/fixtures/scenario-status-mixed/gh-issue-view-202.json
+++ b/tests/fixtures/scenario-status-mixed/gh-issue-view-202.json
@@ -1,1 +1,1 @@
-{"state":"OPEN","closedByPullRequestsReferences":{"nodes":[{"number":602,"state":"OPEN","mergedAt":null}]}}
+{"state":"OPEN","closedByPullRequestsReferences":[{"number":602,"url":"https://github.com/butaosuinu/fanout/pull/602","repository":{"nameWithOwner":"butaosuinu/fanout"}}]}

--- a/tests/fixtures/scenario-status-mixed/gh-issue-view-203.json
+++ b/tests/fixtures/scenario-status-mixed/gh-issue-view-203.json
@@ -1,1 +1,1 @@
-{"state":"OPEN","closedByPullRequestsReferences":{"nodes":[]}}
+{"state":"OPEN","closedByPullRequestsReferences":[]}

--- a/tests/fixtures/scenario-status-mixed/gh-pr-view-601.json
+++ b/tests/fixtures/scenario-status-mixed/gh-pr-view-601.json
@@ -1,0 +1,1 @@
+{"number":601,"state":"MERGED","mergedAt":"2026-05-03T12:00:00Z"}

--- a/tests/fixtures/scenario-status-mixed/gh-pr-view-602.json
+++ b/tests/fixtures/scenario-status-mixed/gh-pr-view-602.json
@@ -1,0 +1,1 @@
+{"number":602,"state":"OPEN","mergedAt":null}


### PR DESCRIPTION
## Summary
- Normalize closedByPullRequestsReferences whether gh returns a top-level array or legacy nodes object
- Hydrate PR refs with gh pr view before computing --status merged state
- Update status fixtures, gh shim coverage, and docs for the real gh response shape

## Root cause
fanout --status assumed closedByPullRequestsReferences.nodes existed, but gh issue view returns closedByPullRequestsReferences as an array. Empty PR refs caused jq to fail before status JSON could be emitted.

## Validation
- bash -n fanout
- bash -n tests/bin/gh
- bats tests/bats/tier2_status.bats
- make test
- make lint
- git diff --check
- /Users/butaosuinu/.local/bin/fanout --status 2 with DMUX_CONFIG_PATH against ai-limit-quota-hud