### PR TITLE
feat(fanout): direct Claude panes to run /simplify before commit

### DIFF
--- a/fanout
+++ b/fanout
@@ -1524,6 +1524,11 @@ EOF
   if [[ "${agent:-}" == "claude" ]]; then
     cat >>"$path" <<'EOF'
 
+Before committing your final changes, run the `/simplify` slash command on the
+files you've changed. /simplify is a Claude Code skill that reviews changed code
+for reuse, quality, and efficiency and fixes issues it finds. Apply its fixes,
+re-run lint/test, then commit and push as described above.
+
 Optional: Agent Teams (Claude Code v2.1.32+, requires CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1)
 
 Before starting, decide whether this issue benefits from spawning an Agent Team.

--- a/tests/bats/tier1_briefing.bats
+++ b/tests/bats/tier1_briefing.bats
@@ -8,24 +8,26 @@
 
 load helpers
 
-@test "briefing for --agent claude contains Agent Teams hint and existing Requirements" {
+@test "briefing for --agent claude contains Agent Teams hint, /simplify directive, and existing Requirements" {
   use_fixture scenario-sub-issue-only
   run_fanout_dry 100
   assert_success
   local briefing="/tmp/fanout-project_root-101.md"
   grep -q "Optional: Agent Teams" "$briefing"
   grep -q "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1" "$briefing"
+  grep -q "run the \`/simplify\` slash command" "$briefing"
   grep -q "Make focused, minimal changes scoped to this single issue" "$briefing"
   grep -q "Closes #101" "$briefing"
 }
 
-@test "briefing for --agent codex omits Agent Teams hint but keeps Requirements" {
+@test "briefing for --agent codex omits Agent Teams hint and /simplify directive but keeps Requirements" {
   use_fixture scenario-sub-issue-only
   run_fanout_dry 100 --agent codex
   assert_success
   local briefing="/tmp/fanout-project_root-101.md"
   ! grep -q "Agent Teams" "$briefing"
   ! grep -q "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS" "$briefing"
+  ! grep -q "/simplify" "$briefing"
   grep -q "Make focused, minimal changes scoped to this single issue" "$briefing"
   grep -q "Closes #101" "$briefing"
 }

--- a/tests/golden/scenario-body-task-list.dry-run.txt
+++ b/tests/golden/scenario-body-task-list.dry-run.txt
@@ -8,7 +8,7 @@
 [info] will create 2 pane(s); deferred (blocked): 0; deferred (--limit): 0
 [info] #201: First task
   briefing -> /tmp/fanout-project_root-201.md
-  briefing size: 2167 bytes
+  briefing size: 2466 bytes
   current panes[] length: 0
     $ tmux send-keys -t %1 Escape
     $ tmux send-keys -t %1 n
@@ -17,7 +17,7 @@
 [ ok ] #201: dry-run complete
 [info] #202: Second task
   briefing -> /tmp/fanout-project_root-202.md
-  briefing size: 2168 bytes
+  briefing size: 2467 bytes
   current panes[] length: 0
     $ tmux send-keys -t %1 Escape
     $ tmux send-keys -t %1 n

--- a/tests/golden/scenario-cross-parent-shared.dry-run.txt
+++ b/tests/golden/scenario-cross-parent-shared.dry-run.txt
@@ -7,7 +7,7 @@
 [info] will create 2 pane(s); deferred (blocked): 0; deferred (--limit): 0
 [info] #501: Shared child
   briefing -> /tmp/fanout-project_root-501.md
-  briefing size: 2175 bytes
+  briefing size: 2474 bytes
   current panes[] length: 1
     $ tmux send-keys -t %1 Escape
     $ tmux send-keys -t %1 n
@@ -16,7 +16,7 @@
 [ ok ] #501: dry-run complete
 [info] #502: B-only child
   briefing -> /tmp/fanout-project_root-502.md
-  briefing size: 2169 bytes
+  briefing size: 2468 bytes
   current panes[] length: 1
     $ tmux send-keys -t %1 Escape
     $ tmux send-keys -t %1 n

--- a/tests/golden/scenario-idempotency.dry-run.txt
+++ b/tests/golden/scenario-idempotency.dry-run.txt
@@ -9,7 +9,7 @@
 [info] will create 1 pane(s); deferred (blocked): 0; deferred (--limit): 0
 [info] #802: New target
   briefing -> /tmp/fanout-project_root-802.md
-  briefing size: 2167 bytes
+  briefing size: 2466 bytes
   current panes[] length: 1
     $ tmux send-keys -t %1 Escape
     $ tmux send-keys -t %1 n

--- a/tests/golden/scenario-include.dry-run.txt
+++ b/tests/golden/scenario-include.dry-run.txt
@@ -8,7 +8,7 @@
 [info] will create 2 pane(s); deferred (blocked): 0; deferred (--limit): 0
 [info] #401: Included child A
   briefing -> /tmp/fanout-project_root-401.md
-  briefing size: 2173 bytes
+  briefing size: 2472 bytes
   current panes[] length: 0
     $ tmux send-keys -t %1 Escape
     $ tmux send-keys -t %1 n
@@ -17,7 +17,7 @@
 [ ok ] #401: dry-run complete
 [info] #402: Included child B
   briefing -> /tmp/fanout-project_root-402.md
-  briefing size: 2173 bytes
+  briefing size: 2472 bytes
   current panes[] length: 0
     $ tmux send-keys -t %1 Escape
     $ tmux send-keys -t %1 n

--- a/tests/golden/scenario-legacy-weak-signal.dry-run.txt
+++ b/tests/golden/scenario-legacy-weak-signal.dry-run.txt
@@ -8,7 +8,7 @@
 [info] will create 2 pane(s); deferred (blocked): 0; deferred (--limit): 0
 [info] #601: First task
   briefing -> /tmp/fanout-project_root-601.md
-  briefing size: 2161 bytes
+  briefing size: 2460 bytes
   current panes[] length: 1
     $ tmux send-keys -t %1 Escape
     $ tmux send-keys -t %1 n
@@ -17,7 +17,7 @@
 [ ok ] #601: dry-run complete
 [info] #602: Second task
   briefing -> /tmp/fanout-project_root-602.md
-  briefing size: 2163 bytes
+  briefing size: 2462 bytes
   current panes[] length: 1
     $ tmux send-keys -t %1 Escape
     $ tmux send-keys -t %1 n

--- a/tests/golden/scenario-limit.dry-run.txt
+++ b/tests/golden/scenario-limit.dry-run.txt
@@ -7,7 +7,7 @@
 [info] will create 2 pane(s); deferred (blocked): 0; deferred (--limit): 1
 [info] #701: Alpha
   briefing -> /tmp/fanout-project_root-701.md
-  briefing size: 2161 bytes
+  briefing size: 2460 bytes
   current panes[] length: 0
     $ tmux send-keys -t %1 Escape
     $ tmux send-keys -t %1 n
@@ -16,7 +16,7 @@
 [ ok ] #701: dry-run complete
 [info] #702: Bravo
   briefing -> /tmp/fanout-project_root-702.md
-  briefing size: 2161 bytes
+  briefing size: 2460 bytes
   current panes[] length: 0
     $ tmux send-keys -t %1 Escape
     $ tmux send-keys -t %1 n

--- a/tests/golden/scenario-only.dry-run.txt
+++ b/tests/golden/scenario-only.dry-run.txt
@@ -11,7 +11,7 @@ filtered out:
 
 [info] #501: Alpha
   briefing -> /tmp/fanout-project_root-501.md
-  briefing size: 2161 bytes
+  briefing size: 2460 bytes
   current panes[] length: 0
     $ tmux send-keys -t %1 Escape
     $ tmux send-keys -t %1 n
@@ -20,7 +20,7 @@ filtered out:
 [ ok ] #501: dry-run complete
 [info] #503: Charlie
   briefing -> /tmp/fanout-project_root-503.md
-  briefing size: 2165 bytes
+  briefing size: 2464 bytes
   current panes[] length: 0
     $ tmux send-keys -t %1 Escape
     $ tmux send-keys -t %1 n

--- a/tests/golden/scenario-project-basic.dry-run.txt
+++ b/tests/golden/scenario-project-basic.dry-run.txt
@@ -8,7 +8,7 @@
 [info] will create 2 pane(s); deferred (blocked): 0; deferred (--limit): 0
 [info] #901: First todo item
   briefing -> /tmp/fanout-project_root-901.md
-  briefing size: 2178 bytes
+  briefing size: 2477 bytes
   current panes[] length: 0
     $ tmux send-keys -t %1 Escape
     $ tmux send-keys -t %1 n
@@ -17,7 +17,7 @@
 [ ok ] #901: dry-run complete
 [info] #902: Second todo item
   briefing -> /tmp/fanout-project_root-902.md
-  briefing size: 2179 bytes
+  briefing size: 2478 bytes
   current panes[] length: 0
     $ tmux send-keys -t %1 Escape
     $ tmux send-keys -t %1 n

--- a/tests/golden/scenario-project-cross-repo.dry-run.txt
+++ b/tests/golden/scenario-project-cross-repo.dry-run.txt
@@ -9,7 +9,7 @@
 [info] will create 1 pane(s); deferred (blocked): 0; deferred (--limit): 0
 [info] #921: Self-repo todo
   briefing -> /tmp/fanout-project_root-921.md
-  briefing size: 2177 bytes
+  briefing size: 2476 bytes
   current panes[] length: 0
     $ tmux send-keys -t %1 Escape
     $ tmux send-keys -t %1 n

--- a/tests/golden/scenario-project-status-all.dry-run.txt
+++ b/tests/golden/scenario-project-status-all.dry-run.txt
@@ -8,7 +8,7 @@
 [info] will create 3 pane(s); deferred (blocked): 0; deferred (--limit): 0
 [info] #911: Todo one
   briefing -> /tmp/fanout-project_root-911.md
-  briefing size: 2171 bytes
+  briefing size: 2470 bytes
   current panes[] length: 0
     $ tmux send-keys -t %1 Escape
     $ tmux send-keys -t %1 n
@@ -17,7 +17,7 @@
 [ ok ] #911: dry-run complete
 [info] #912: Todo two
   briefing -> /tmp/fanout-project_root-912.md
-  briefing size: 2171 bytes
+  briefing size: 2470 bytes
   current panes[] length: 0
     $ tmux send-keys -t %1 Escape
     $ tmux send-keys -t %1 n
@@ -26,7 +26,7 @@
 [ ok ] #912: dry-run complete
 [info] #913: Done item
   briefing -> /tmp/fanout-project_root-913.md
-  briefing size: 2172 bytes
+  briefing size: 2471 bytes
   current panes[] length: 0
     $ tmux send-keys -t %1 Escape
     $ tmux send-keys -t %1 n

--- a/tests/golden/scenario-skip.dry-run.txt
+++ b/tests/golden/scenario-skip.dry-run.txt
@@ -11,7 +11,7 @@ filtered out:
 
 [info] #601: Alpha
   briefing -> /tmp/fanout-project_root-601.md
-  briefing size: 2161 bytes
+  briefing size: 2460 bytes
   current panes[] length: 0
     $ tmux send-keys -t %1 Escape
     $ tmux send-keys -t %1 n
@@ -20,7 +20,7 @@ filtered out:
 [ ok ] #601: dry-run complete
 [info] #603: Charlie
   briefing -> /tmp/fanout-project_root-603.md
-  briefing size: 2165 bytes
+  briefing size: 2464 bytes
   current panes[] length: 0
     $ tmux send-keys -t %1 Escape
     $ tmux send-keys -t %1 n

--- a/tests/golden/scenario-sub-issue-only.dry-run.txt
+++ b/tests/golden/scenario-sub-issue-only.dry-run.txt
@@ -7,7 +7,7 @@
 [info] will create 2 pane(s); deferred (blocked): 0; deferred (--limit): 0
 [info] #101: First child
   briefing -> /tmp/fanout-project_root-101.md
-  briefing size: 2171 bytes
+  briefing size: 2470 bytes
   current panes[] length: 0
     $ tmux send-keys -t %1 Escape
     $ tmux send-keys -t %1 n
@@ -16,7 +16,7 @@
 [ ok ] #101: dry-run complete
 [info] #102: Second child
   briefing -> /tmp/fanout-project_root-102.md
-  briefing size: 2172 bytes
+  briefing size: 2471 bytes
   current panes[] length: 0
     $ tmux send-keys -t %1 Escape
     $ tmux send-keys -t %1 n

--- a/tests/golden/scenario-union.dry-run.txt
+++ b/tests/golden/scenario-union.dry-run.txt
@@ -8,7 +8,7 @@
 [info] will create 2 pane(s); deferred (blocked): 0; deferred (--limit): 0
 [info] #301: API child
   briefing -> /tmp/fanout-project_root-301.md
-  briefing size: 2166 bytes
+  briefing size: 2465 bytes
   current panes[] length: 0
     $ tmux send-keys -t %1 Escape
     $ tmux send-keys -t %1 n
@@ -17,7 +17,7 @@
 [ ok ] #301: dry-run complete
 [info] #302: Body-only
   briefing -> /tmp/fanout-project_root-302.md
-  briefing size: 2166 bytes
+  briefing size: 2465 bytes
   current panes[] length: 0
     $ tmux send-keys -t %1 Escape
     $ tmux send-keys -t %1 n


### PR DESCRIPTION
## Summary
- `write_briefing()` の Claude 専用ブロック先頭に「commit/push の前に `/simplify` を実行せよ」という指示を追記。子 Claude pane は briefing をそのまま指示として読むため、決定論的に効く (Claude Code hooks ではスラッシュコマンドを発火できないため briefing 経由が最も確実)。
- `agent==claude` の条件分岐内に閉じているので、codex 等の他エージェントには影響なし。
- `tier1_briefing.bats` に positive/negative アサーションを追加し、将来 `/simplify` 行が消えた場合のリグレッションをロック。
- briefing サイズが +299 bytes 変わるため `tests/golden/*.dry-run.txt` (13 件) を `FANOUT_GOLDEN_UPDATE=1 make test-tier2` で再生成。

## Test plan
- [x] `make lint` (shellcheck clean)
- [x] `make test` 78/78 pass (Tier 1: 56、Tier 2: 22)
- [x] `tier1_briefing.bats` の "claude contains ... /simplify directive" / "codex omits ... /simplify directive" 両方 pass
- [x] `agent-codex variant of scenario-sub-issue-only` (Tier 2 #11) — codex 側 briefing サイズが変化していないことを確認 (claude 限定の意図通り)
- [ ] 実 parent issue で `./fanout <parent>` を実行し、生成された Claude pane が `/simplify` を実行する流れに入ることを目視確認 (ライブ E2E、リリース前)

🤖 Generated with [Claude Code](https://claude.com/claude-code)