### PR TITLE
docs: add MIT LICENSE and README badge

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 butaosuinu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.ja.md
+++ b/README.ja.md
@@ -2,6 +2,8 @@
 
 [English](README.md) | [日本語](README.ja.md)
 
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
 GitHub の親 issue に紐づく OPEN のサブ issue を、子ごとに 1 つの dmux ペインへ
 ファンアウトします。各ペインは独立した git worktree を持ち、issue ごとの
 ブリーフィングファイルを参照するプロンプトでエージェント CLI が起動します。
@@ -403,3 +405,7 @@ JSON を事前に確認するには `--dry-run` を使います。
   上限付きの並列キューを使いますが、TUI 側からは「新規ペイン」ダイアログは
   同時に 1 つしか開けません。sleep は、次の `n` を送る前に dmux が worktree
   作成フェーズを終えるための時間的余裕を与えます。
+
+## ライセンス
+
+本プロジェクトは MIT License で配布されています。詳細は [LICENSE](LICENSE) を参照してください。

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [English](README.md) | [日本語](README.ja.md)
 
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
 Fans a GitHub parent issue's OPEN sub-issues out into one dmux pane per child.
 Each pane gets its own git worktree and an agent CLI launched with a prompt
 that points at a per-issue briefing file.
@@ -515,3 +517,7 @@ a repo directory). Not a fanout bug.
   parallel queue internally, but from the TUI side you can only open one
   "new pane" dialog at a time. The sleep gives dmux time to finish the
   worktree-creation phase before the next `n` is sent.
+
+## License
+
+This project is licensed under the MIT License — see [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary
- Add `LICENSE` at the repo root with the standard MIT text (Copyright 2026 butaosuinu) so GitHub auto-detects the license.
- Add a shields.io MIT badge directly under the language switcher in both `README.md` and `README.ja.md`.
- Append a `## License` / `## ライセンス` section to each README pointing at `LICENSE`.

## Test plan
- [x] `make lint` (shellcheck) passes
- [x] `make test` (Tier 1 + Tier 2 goldens) passes
- [ ] After merge, confirm GitHub's repo sidebar shows "MIT license" auto-detected
- [ ] Rendered README on GitHub shows the badge and links to `https://opensource.org/licenses/MIT`

🤖 Generated with [Claude Code](https://claude.com/claude-code)