### PR TITLE
Add parallel Go fanout port

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,21 +7,29 @@ on:
 
 jobs:
   test:
-    name: Tier 1 + Tier 2
+    name: Tier 1 + Tier 2 (shell + Go)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
 
       - name: Install bats / jq / shellcheck
         run: |
           sudo apt-get update
           sudo apt-get install -y bats jq shellcheck
 
-      - name: Tier 1 tests
+      - name: Tier 1 tests (shell)
         run: make test-tier1
 
-      - name: Tier 2 tests
+      - name: Tier 2 tests (shell)
         run: make test-tier2
+
+      - name: Go tests (unit + Tier 1 + Tier 2 against fanout-go)
+        run: make test-go
 
       - name: Lint
         run: make lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,36 @@ on:
   pull_request:
 
 jobs:
-  test:
-    name: Tier 1 + Tier 2 (shell + Go)
+  shell-tier1:
+    name: Shell Tier 1
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install bats / jq
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bats jq
+
+      - name: Run shell Tier 1 tests
+        run: make test-tier1
+
+  shell-tier2:
+    name: Shell Tier 2
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install bats / jq
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bats jq
+
+      - name: Run shell Tier 2 tests
+        run: make test-tier2
+
+  go-unit:
+    name: Go unit tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -17,19 +45,62 @@ jobs:
         with:
           go-version-file: go.mod
 
-      - name: Install bats / jq / shellcheck
+      - name: Run Go unit tests
+        run: make go-test
+
+  go-tier1:
+    name: Go Tier 1
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install bats / jq
         run: |
           sudo apt-get update
-          sudo apt-get install -y bats jq shellcheck
+          sudo apt-get install -y bats jq
 
-      - name: Tier 1 tests (shell)
-        run: make test-tier1
+      - name: Run Go Tier 1 tests
+        run: make test-go-tier1
 
-      - name: Tier 2 tests (shell)
-        run: make test-tier2
+  go-tier2:
+    name: Go Tier 2
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
 
-      - name: Go tests (unit + Tier 1 + Tier 2 against fanout-go)
-        run: make test-go
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
 
-      - name: Lint
+      - name: Install bats / jq
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bats jq
+
+      - name: Run Go Tier 2 tests
+        run: make test-go-tier2
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install shellcheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+
+      - name: Run lint
         run: make lint

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .claude/settings.local.json
 .dmux/
+.cache/
 tests/tmp/
+/fanout-go

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,17 @@ CLAUDE_SKILLS   := $(notdir $(wildcard claude/skills/*))
 CODEX_SKILLS    := $(notdir $(wildcard codex/skills/*))
 
 BATS       ?= bats
+GO         ?= go
+GO_BIN     ?= fanout-go
+GOCACHE    ?= $(CURDIR)/.cache/go-build
 
-.PHONY: install link uninstall test test-tier1 test-tier2 lint check-bats
+.PHONY: install link uninstall install-go link-go uninstall-go build-go clean-go go-test go-vet go-fmt-check test test-tier1 test-tier2 test-go test-go-tier1 test-go-tier2 lint check-bats
+
+build-go:
+	GOCACHE="$(GOCACHE)" $(GO) build -o "$(GO_BIN)" ./cmd/fanout
+
+clean-go:
+	rm -f "$(GO_BIN)"
 
 install:
 	@mkdir -p "$(BINDIR)" "$(CLAUDE_CMD_DIR)" "$(CLAUDE_SKILL_DIR)" "$(CODEX_SKILL_DIR)"
@@ -35,6 +44,12 @@ install:
 	@for skill in $(CLAUDE_SKILLS); do echo "  $(CLAUDE_SKILL_DIR)/$$skill"; done
 	@for skill in $(CODEX_SKILLS); do echo "  $(CODEX_SKILL_DIR)/$$skill"; done
 
+install-go: build-go
+	@mkdir -p "$(BINDIR)"
+	install -m 0755 "$(GO_BIN)" "$(BINDIR)/fanout-go"
+	@echo "Installed:"
+	@echo "  $(BINDIR)/fanout-go"
+
 link:
 	@mkdir -p "$(BINDIR)" "$(CLAUDE_CMD_DIR)" "$(CLAUDE_SKILL_DIR)" "$(CODEX_SKILL_DIR)"
 	ln -sf "$(CURDIR)/fanout" "$(BINDIR)/fanout"
@@ -55,6 +70,12 @@ link:
 	@for skill in $(CLAUDE_SKILLS); do echo "  $(CLAUDE_SKILL_DIR)/$$skill -> $(CURDIR)/claude/skills/$$skill"; done
 	@for skill in $(CODEX_SKILLS); do echo "  $(CODEX_SKILL_DIR)/$$skill -> $(CURDIR)/codex/skills/$$skill"; done
 
+link-go: build-go
+	@mkdir -p "$(BINDIR)"
+	ln -sf "$(CURDIR)/$(GO_BIN)" "$(BINDIR)/fanout-go"
+	@echo "Linked:"
+	@echo "  $(BINDIR)/fanout-go -> $(CURDIR)/$(GO_BIN)"
+
 uninstall:
 	rm -f "$(BINDIR)/fanout"
 	@for cmd in $(CLAUDE_COMMANDS); do rm -f "$(CLAUDE_CMD_DIR)/$$cmd"; done
@@ -66,11 +87,17 @@ uninstall:
 	@for skill in $(CLAUDE_SKILLS); do echo "  $(CLAUDE_SKILL_DIR)/$$skill"; done
 	@for skill in $(CODEX_SKILLS); do echo "  $(CODEX_SKILL_DIR)/$$skill"; done
 
+uninstall-go:
+	rm -f "$(BINDIR)/fanout-go"
+	@echo "Removed:"
+	@echo "  $(BINDIR)/fanout-go"
+
 # --- test / lint -------------------------------------------------------------
-# `make test`         — run Tier 1 + Tier 2 black-box tests.
+# `make test`         — run Tier 1 + Tier 2 black-box tests against ./fanout.
+# `make test-go`      — build ./fanout-go and run the same tests via FANOUT_BIN.
 # `make test-tier1`   — flag / prerequisite tests, no live dmux.
 # `make test-tier2`   — --dry-run golden tests against fixture scenarios.
-# `make lint`         — shellcheck the fanout script and all test shims.
+# `make lint`         — shellcheck Bash files plus Go vet/gofmt checks.
 #
 # bats-core is required: `brew install bats-core` (macOS) or `apt install bats`
 # (Debian/Ubuntu). check-bats prints the install hint before failing.
@@ -95,5 +122,23 @@ test-tier1: check-bats
 test-tier2: check-bats
 	$(BATS) tests/bats/tier2_dry_run.bats tests/bats/tier2_status.bats
 
-lint:
+test-go: go-test test-go-tier1 test-go-tier2
+
+test-go-tier1: build-go check-bats
+	FANOUT_BIN="$(CURDIR)/$(GO_BIN)" $(BATS) tests/bats/tier1_flags.bats tests/bats/tier1_briefing.bats
+
+test-go-tier2: build-go check-bats
+	FANOUT_BIN="$(CURDIR)/$(GO_BIN)" $(BATS) tests/bats/tier2_dry_run.bats tests/bats/tier2_status.bats
+
+go-test:
+	GOCACHE="$(GOCACHE)" $(GO) test ./...
+
+go-vet:
+	GOCACHE="$(GOCACHE)" $(GO) vet ./...
+
+go-fmt-check:
+	@out="$$(gofmt -l cmd internal 2>/dev/null)"; \
+	if [ -n "$$out" ]; then echo "gofmt diff in:"; echo "$$out"; exit 1; fi
+
+lint: go-vet go-fmt-check
 	shellcheck fanout tests/bin/gh tests/bin/tmux tests/bin/git tests/bats/helpers.bash

--- a/README.ja.md
+++ b/README.ja.md
@@ -119,14 +119,19 @@ make test           # Tier 1 + Tier 2 黒箱テスト (bats-core 必須)
 make test-tier1     # フラグ / prereq テストのみ
 make test-tier2     # --dry-run ゴールデン出力テスト (fixture 駆動)
 make lint           # shellcheck fanout + テスト用 shim
+make build-go       # 実験中の Go 版を ./fanout-go としてビルド
+make test-go        # 同じ黒箱テストを ./fanout-go に対して実行
 ```
 
 bats: macOS は `brew install bats-core`、Debian/Ubuntu は `apt install bats`。
 Tier 1 は CLI サーフェス (エラーメッセージ + exit code)、Tier 2 は `--dry-run`
 の計画出力を `tests/fixtures/` 配下のシナリオ fixture に対して凍結します。
-いずれも Go 書き換え時の parity テスト資産。`--dry-run` 出力を意図的に変更
-した場合は `FANOUT_GOLDEN_UPDATE=1 make test-tier2` で golden を再生成して
-ください。Tier 3 (live dmux E2E) は手動運用のままです。
+いずれも Go 書き換え時の parity テスト資産です。Bash 製の `./fanout` は
+既定の CLI として残し、Go 版は動作比較用に `./fanout-go` として並行配置
+します。`$(BINDIR)` に `fanout-go` コマンドを入れたい場合は `make install-go`
+または `make link-go` を使ってください。`--dry-run` 出力を意図的に変更した
+場合は `FANOUT_GOLDEN_UPDATE=1 make test-tier2` で golden を再生成してください。
+Tier 3 (live dmux E2E) は手動運用のままです。
 
 ## 前提条件
 

--- a/README.md
+++ b/README.md
@@ -118,12 +118,17 @@ make test           # Tier 1 + Tier 2 black-box tests (bats-core required)
 make test-tier1     # flag/prereq tests only
 make test-tier2     # --dry-run golden tests against fixture scenarios
 make lint           # shellcheck fanout + test shims
+make build-go       # build the experimental Go port as ./fanout-go
+make test-go        # run the same black-box tests against ./fanout-go
 ```
 
 bats: `brew install bats-core` on macOS, `apt install bats` on Debian/Ubuntu.
 Tier 1 locks the CLI surface (error messages + exit codes); Tier 2 locks the
 `--dry-run` planning output against fixture scenarios under `tests/fixtures/`.
-Both tiers are parity-test material for the upcoming Go rewrite. Regenerate
+Both tiers are parity-test material for the Go rewrite. The Bash `./fanout`
+remains the default installed CLI while `./fanout-go` exists in parallel for
+behavior comparison; use `make install-go` or `make link-go` if you want a
+`fanout-go` command in `$(BINDIR)`. Regenerate
 Tier 2 goldens with `FANOUT_GOLDEN_UPDATE=1 make test-tier2` when you
 intentionally change dry-run output. Tier 3 (live dmux E2E) stays manual.
 

--- a/cmd/fanout/main.go
+++ b/cmd/fanout/main.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"strconv"
 	"strings"
 	"time"
 
@@ -393,9 +392,4 @@ func ghSubIssueAvailable() bool {
 		}
 	}
 	return false
-}
-
-func atoiOrZero(s string) int {
-	n, _ := strconv.Atoi(s)
-	return n
 }

--- a/cmd/fanout/main.go
+++ b/cmd/fanout/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -22,6 +23,7 @@ var sleepBetweenIssues = time.Sleep
 
 func main() {
 	lg := log.New(false)
+	commandName := invokedCommandName(os.Args)
 
 	pr := cliflags.Parse(os.Args[1:], lg, os.Stdout)
 	if pr.Code != exitcode.OK || pr.Config == nil {
@@ -44,10 +46,21 @@ func main() {
 		os.Exit(int(cmdStatus(cfg, lg)))
 	}
 
-	os.Exit(int(run(cfg, lg)))
+	os.Exit(int(run(cfg, lg, commandName)))
 }
 
-func run(cfg *cliflags.Config, lg *log.Logger) exitcode.Code {
+func invokedCommandName(args []string) string {
+	if len(args) == 0 || args[0] == "" {
+		return "fanout"
+	}
+	name := filepath.Base(args[0])
+	if name == "." || name == string(os.PathSeparator) {
+		return "fanout"
+	}
+	return name
+}
+
+func run(cfg *cliflags.Config, lg *log.Logger, commandName string) exitcode.Code {
 	rt, code := resolveRuntime(cfg, lg)
 	if code != exitcode.OK {
 		return code
@@ -124,7 +137,7 @@ func run(cfg *cliflags.Config, lg *log.Logger) exitcode.Code {
 
 	result := executePlan(cfg, lg, rt.info, rt.gh, plan.Targets, c)
 	applyDisplayNameOverrides(cfg, rt.info.ConfigPath, result.CreatedNums, lg, c)
-	printSummary(plan, result, cfg, lg, c)
+	printSummary(plan, result, cfg, lg, c, commandName)
 
 	if result.Failed > 0 {
 		return exitcode.Env

--- a/cmd/fanout/main.go
+++ b/cmd/fanout/main.go
@@ -1,0 +1,401 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/butaosuinu/fanout/internal/cliflags"
+	"github.com/butaosuinu/fanout/internal/displayname"
+	"github.com/butaosuinu/fanout/internal/dmuxconfig"
+	"github.com/butaosuinu/fanout/internal/dmuxsession"
+	"github.com/butaosuinu/fanout/internal/exitcode"
+	"github.com/butaosuinu/fanout/internal/ghissue"
+	"github.com/butaosuinu/fanout/internal/log"
+)
+
+const fanoutTagPrefix = "[fanout #"
+
+var sleepBetweenIssues = time.Sleep
+
+func main() {
+	lg := log.New(false)
+
+	pr := cliflags.Parse(os.Args[1:], lg, os.Stdout)
+	if pr.Code != exitcode.OK || pr.Config == nil {
+		os.Exit(int(pr.Code))
+	}
+	cfg := pr.Config
+	if cfg.Debug {
+		lg = log.New(true)
+	}
+
+	if missing := checkDeps(cfg); len(missing) > 0 {
+		lg.Err("missing dependencies:")
+		for _, d := range missing {
+			fmt.Fprintf(lg.Stderr(), "  - %s\n", d)
+		}
+		os.Exit(int(exitcode.Env))
+	}
+
+	if cfg.StatusMode {
+		os.Exit(int(cmdStatus(cfg, lg)))
+	}
+
+	os.Exit(int(run(cfg, lg)))
+}
+
+func run(cfg *cliflags.Config, lg *log.Logger) exitcode.Code {
+	rt, code := resolveRuntime(cfg, lg)
+	if code != exitcode.OK {
+		return code
+	}
+
+	loaded, code := loadChildren(cfg, rt.gh, lg)
+	if code != exitcode.OK {
+		return code
+	}
+
+	totalChildren := len(loaded.Children)
+	if totalChildren == 0 {
+		if cfg.ParentMode == cliflags.ModeProject {
+			lg.Info("no items in Project (after status/repo filter). nothing to do.")
+		} else {
+			lg.Info("no sub-issues on #%d. nothing to do.", cfg.Parent)
+		}
+		return exitcode.OK
+	}
+
+	openCount := len(openIssues(loaded.Children))
+	lg.Info("%s: %d total, %d OPEN", loaded.ChildNoun, totalChildren, openCount)
+	if openCount == 0 {
+		lg.Info("no OPEN %s. nothing to do.", loaded.ChildNoun)
+		return exitcode.OK
+	}
+
+	claim := loaded.StrongChildren
+	if migrated, ok := migrateLegacyPaneTags(cfg, rt.info.ConfigPath, loaded.StrongChildren, rt.config, lg); ok {
+		if migrated > 0 && !cfg.DryRun {
+			reloaded, err := dmuxconfig.Load(rt.info.ConfigPath)
+			if err == nil {
+				rt.config = reloaded
+			}
+		}
+	} else {
+		claim = nil
+	}
+
+	plan := buildPlan(
+		cfg,
+		loaded.Children,
+		rt.config.FannedNumbersForParent(cfg.ParentRef, claim),
+		loaded.ParentBody,
+		func(issue *ghissue.Issue) {
+			if err := rt.gh.HydrateBodyLabels(issue); err != nil {
+				lg.Warn("#%d: could not fetch body/labels for blocker check; treating as unblocked", issue.Number)
+			}
+		},
+		func(num int) string {
+			state, _ := rt.gh.IssueState(num)
+			return state
+		},
+	)
+	logPlanDetails(plan, lg)
+
+	if plan.OpenAfterFilter == 0 {
+		lg.Info("all OPEN sub-issues filtered out by --only/--skip. nothing to do.")
+		return exitcode.OK
+	}
+	if plan.UnfannedCount == 0 {
+		lg.Ok("all %d OPEN sub-issue(s) already have a fanout pane. nothing to do.", len(plan.AlreadyFanned))
+		return exitcode.OK
+	}
+
+	logAlreadyFanned(plan.AlreadyFanned, lg)
+	lg.Info("will create %d pane(s); deferred (blocked): %d; deferred (--limit): %d",
+		len(plan.Targets), len(plan.BlockedRows), len(plan.LimitDeferred))
+
+	c := lg.Colors()
+	if cfg.DryRun {
+		printDryRunPlan(plan, lg, c)
+	}
+
+	result := executePlan(cfg, lg, rt.info, rt.gh, plan.Targets, c)
+	applyDisplayNameOverrides(cfg, rt.info.ConfigPath, result.CreatedNums, lg, c)
+	printSummary(plan, result, cfg, lg, c)
+
+	if result.Failed > 0 {
+		return exitcode.Env
+	}
+	return exitcode.OK
+}
+
+type runtimeInfo struct {
+	info   *dmuxsession.Info
+	config *dmuxconfig.Config
+	gh     ghissue.Runner
+}
+
+func resolveRuntime(cfg *cliflags.Config, lg *log.Logger) (*runtimeInfo, exitcode.Code) {
+	info, err := dmuxsession.Resolve(cfg.Session)
+	if err != nil {
+		lg.Err("%s", err.Error())
+		return nil, exitcode.Env
+	}
+
+	if _, err := os.Stat(info.ConfigPath); err != nil {
+		lg.Err("dmux config not found at %s (session reports it but file is missing)", info.ConfigPath)
+		return nil, exitcode.Env
+	}
+
+	lg.Info("dmux session: %s", info.Session)
+	lg.Info("control pane: %s", info.ControlPane)
+	lg.Info("project root: %s", info.ProjectRoot)
+	lg.Info("config:       %s", info.ConfigPath)
+
+	dcfg, err := dmuxconfig.Load(info.ConfigPath)
+	if err != nil {
+		lg.Err("%s", err.Error())
+		return nil, exitcode.Env
+	}
+
+	if cfg.Agent == "" {
+		if pid := os.Getenv("TMUX_PANE"); pid != "" {
+			if a := dcfg.AgentForPane(pid); a != "" {
+				cfg.Agent = a
+				lg.Info("auto-detected agent: %s (from calling pane %s)", cfg.Agent, pid)
+			}
+		}
+	}
+
+	if !isGitWorkTree(info.ProjectRoot) {
+		lg.Err("project root %s is not a git work tree; cannot resolve GitHub repo", info.ProjectRoot)
+		return nil, exitcode.Env
+	}
+
+	return &runtimeInfo{
+		info:   info,
+		config: dcfg,
+		gh:     ghissue.Runner{Cwd: info.ProjectRoot},
+	}, exitcode.OK
+}
+
+type childLoadResult struct {
+	Children       []ghissue.Issue
+	ParentBody     string
+	StrongChildren map[int]bool
+	ChildNoun      string
+}
+
+func loadChildren(cfg *cliflags.Config, gh ghissue.Runner, lg *log.Logger) (childLoadResult, exitcode.Code) {
+	if cfg.ParentMode == cliflags.ModeProject {
+		return loadProjectChildren(cfg, gh, lg)
+	}
+	return loadIssueChildren(cfg, gh, lg)
+}
+
+func loadIssueChildren(cfg *cliflags.Config, gh ghissue.Runner, lg *log.Logger) (childLoadResult, exitcode.Code) {
+	lg.Info("fetching sub-issues of #%d", cfg.Parent)
+	subIssues, err := gh.SubIssueList(cfg.Parent)
+	if err != nil {
+		lg.Err("gh sub-issue list failed: %v", err)
+		return childLoadResult{}, exitcode.Env
+	}
+
+	parentBody, err := gh.ParentBody(cfg.Parent)
+	if err != nil {
+		lg.Warn("could not read parent body (#%d); skipping task-list scan", cfg.Parent)
+		parentBody = ""
+	}
+
+	bodyNums := ghissue.TaskListNumbers(parentBody)
+	loaded, added := mergeExtraChildren(cfg, gh, subIssues, bodyNums, true, lg)
+	if added > 0 {
+		lg.Info("parent body / --include added %d extra child reference(s) not in sub-issue API", added)
+	}
+
+	return childLoadResult{
+		Children:       loaded,
+		ParentBody:     parentBody,
+		StrongChildren: issueSet(subIssues),
+		ChildNoun:      "sub-issues",
+	}, exitcode.OK
+}
+
+func loadProjectChildren(cfg *cliflags.Config, gh ghissue.Runner, lg *log.Logger) (childLoadResult, exitcode.Code) {
+	repo, err := gh.RepoNameWithOwner()
+	if err != nil {
+		lg.Err("could not resolve repo via 'gh repo view' in project root (required for project mode cross-repo filter)")
+		return childLoadResult{}, exitcode.Env
+	}
+	lg.Info("mode: project (status=%s, repo=%s)", cfg.ProjectStatus, repo)
+	lg.Info("fetching items from Project %s", cfg.ParentRef)
+
+	res, err := gh.ProjectItems(cfg.ProjectOwnerType, cfg.ProjectOwner, cfg.ProjectNumber, repo, cfg.ProjectStatus)
+	if err != nil {
+		lg.Err("%v", err)
+		return childLoadResult{}, exitcode.Env
+	}
+	if res.MissingStatus && cfg.ProjectStatus != "all" {
+		lg.Warn("Project '%s' has no Status field; ignoring --project-status %s and falling back to all items", res.ProjectTitle, cfg.ProjectStatus)
+		cfg.ProjectStatus = "all"
+	}
+	for _, cross := range res.CrossRepoWarnings {
+		lg.Warn("skipping cross-repo project item: %s (project root repo: %s)", cross, repo)
+	}
+
+	loaded, added := mergeExtraChildren(cfg, gh, res.Issues, nil, false, lg)
+	if added > 0 {
+		lg.Info("--include added %d extra child reference(s) not in project items", added)
+	}
+
+	return childLoadResult{
+		Children:       loaded,
+		StrongChildren: issueSet(res.Issues),
+		ChildNoun:      "project items",
+	}, exitcode.OK
+}
+
+func mergeExtraChildren(cfg *cliflags.Config, gh ghissue.Runner, base []ghissue.Issue, bodyNums []int, skipParent bool, lg *log.Logger) ([]ghissue.Issue, int) {
+	existing := map[int]bool{}
+	if skipParent {
+		existing[cfg.Parent] = true
+	}
+	for _, s := range base {
+		existing[s.Number] = true
+	}
+
+	extraNums := append([]int{}, bodyNums...)
+	extraNums = append(extraNums, cfg.Include...)
+	var extra []ghissue.Issue
+	for _, num := range extraNums {
+		if existing[num] {
+			continue
+		}
+		detail, err := gh.IssueDetail(num)
+		if err != nil {
+			lg.Warn("parent body / --include references #%d but issue lookup failed; skipping", num)
+			continue
+		}
+		extra = append(extra, detail)
+		existing[num] = true
+	}
+	return ghissue.MergeExtra(base, extra), len(extra)
+}
+
+func issueSet(issues []ghissue.Issue) map[int]bool {
+	out := map[int]bool{}
+	for _, issue := range issues {
+		out[issue.Number] = true
+	}
+	return out
+}
+
+func migrateLegacyPaneTags(cfg *cliflags.Config, configPath string, strong map[int]bool, loaded *dmuxconfig.Config, lg *log.Logger) (int, bool) {
+	count := loaded.LegacyMigrationCount(strong)
+	if count == 0 {
+		return 0, true
+	}
+	if cfg.DryRun {
+		lg.Info("would migrate %d legacy [fanout #N] pane tag(s) to include parent #%s", count, cfg.ParentRef)
+		return count, true
+	}
+	migrated, err := dmuxconfig.MigrateLegacyPaneTags(configPath, cfg.ParentRef, strong)
+	if err == nil {
+		lg.Info("migrated %d legacy [fanout #N] pane tag(s) to include parent #%s", migrated, cfg.ParentRef)
+		return migrated, true
+	}
+	lg.Warn("could not migrate legacy pane tags in %s; falling back to strict idempotency so legacy panes don't mask new --status entries", configPath)
+	return 0, false
+}
+
+func executePlan(cfg *cliflags.Config, lg *log.Logger, info *dmuxsession.Info, gh ghissue.Runner, targets []ghissue.Issue, c log.Palette) executionResult {
+	var result executionResult
+	for i, issue := range targets {
+		// Hydrate body lazily for issues that came from the Sub-issues API
+		// path (body=""), unless --unblocked-only already did it upfront.
+		if issue.Body == "" {
+			if detail, err := gh.IssueDetail(issue.Number); err == nil {
+				issue.Body = detail.Body
+			}
+		}
+		if createPaneForIssue(cfg, lg, info, issue, c) {
+			result.Created++
+			result.CreatedNums = append(result.CreatedNums, issue.Number)
+		} else {
+			result.Failed++
+			break
+		}
+		if i < len(targets)-1 {
+			if cfg.SleepBetween > 0 {
+				sleepBetweenIssues(time.Duration(cfg.SleepBetween * float64(time.Second)))
+			}
+		}
+	}
+	return result
+}
+
+func applyDisplayNameOverrides(cfg *cliflags.Config, configPath string, createdNums []int, lg *log.Logger, c log.Palette) {
+	if len(createdNums) == 0 || !cfg.HasAnyDisplayName() {
+		return
+	}
+	var overrides []displayname.Override
+	for _, num := range createdNums {
+		if name := cfg.FindName(num); name != nil && name.DisplayName != "" {
+			overrides = append(overrides, displayname.Override{Num: name.Num, ParentRef: cfg.ParentRef, DisplayName: name.DisplayName})
+		}
+	}
+	displayname.ApplyAll(configPath, overrides, cfg.DryRun, lg.Stdout(), c, displayname.LogFns{
+		Info: lg.Info, Warn: lg.Warn, Dim: lg.Dim, Err: lg.Err,
+	})
+}
+
+func isGitWorkTree(path string) bool {
+	cmd := exec.Command("git", "rev-parse", "--is-inside-work-tree")
+	cmd.Dir = path
+	return cmd.Run() == nil
+}
+
+func checkDeps(cfg *cliflags.Config) []string {
+	var missing []string
+	check := func(cmd, hint string) {
+		if _, err := exec.LookPath(cmd); err != nil {
+			missing = append(missing, hint)
+		}
+	}
+	check("gh", "gh (brew install gh)")
+	check("jq", "jq (brew install jq)")
+
+	if !cfg.StatusMode || os.Getenv("DMUX_CONFIG_PATH") == "" {
+		check("tmux", "tmux (brew install tmux)")
+	}
+
+	if !cfg.StatusMode {
+		check("pgrep", "pgrep (procps-ng on Linux; preinstalled on macOS)")
+		if cfg.ParentMode == cliflags.ModeIssue && !ghSubIssueAvailable() {
+			missing = append(missing, "gh-sub-issue extension (gh extension install yahsan2/gh-sub-issue)")
+		}
+	}
+	return missing
+}
+
+func ghSubIssueAvailable() bool {
+	out, err := exec.Command("gh", "extension", "list").Output()
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		if first, _, ok := strings.Cut(line, "\t"); ok && first == "gh sub-issue" {
+			return true
+		}
+	}
+	return false
+}
+
+func atoiOrZero(s string) int {
+	n, _ := strconv.Atoi(s)
+	return n
+}

--- a/cmd/fanout/main_test.go
+++ b/cmd/fanout/main_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/butaosuinu/fanout/internal/cliflags"
+	"github.com/butaosuinu/fanout/internal/dmuxsession"
+	"github.com/butaosuinu/fanout/internal/ghissue"
+	"github.com/butaosuinu/fanout/internal/log"
+)
+
+func TestExecutePlanSleepsBetweenDryRunIssues(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "dmux.config.json")
+	if err := os.WriteFile(configPath, []byte(`{"panes":[]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	oldSleep := sleepBetweenIssues
+	var sleeps []time.Duration
+	sleepBetweenIssues = func(d time.Duration) {
+		sleeps = append(sleeps, d)
+	}
+	t.Cleanup(func() { sleepBetweenIssues = oldSleep })
+
+	cfg := &cliflags.Config{
+		Agent:        "claude",
+		DryRun:       true,
+		SleepBetween: 0.25,
+	}
+	lg := log.NewWith(io.Discard, io.Discard, false)
+	info := &dmuxsession.Info{
+		ControlPane: "%1",
+		ConfigPath:  configPath,
+		ProjectRoot: dir,
+	}
+	targets := []ghissue.Issue{
+		{Number: 1, Title: "one", State: "OPEN", Body: "body"},
+		{Number: 2, Title: "two", State: "OPEN", Body: "body"},
+	}
+
+	result := executePlan(cfg, lg, info, ghissue.Runner{}, targets, log.Palette{})
+
+	if result.Created != 2 || result.Failed != 0 {
+		t.Fatalf("executePlan result = %+v, want 2 created and 0 failed", result)
+	}
+	if len(sleeps) != 1 {
+		t.Fatalf("sleep calls = %d, want 1", len(sleeps))
+	}
+	if want := 250 * time.Millisecond; sleeps[0] != want {
+		t.Fatalf("sleep duration = %s, want %s", sleeps[0], want)
+	}
+}

--- a/cmd/fanout/main_test.go
+++ b/cmd/fanout/main_test.go
@@ -55,3 +55,22 @@ func TestExecutePlanSleepsBetweenDryRunIssues(t *testing.T) {
 		t.Fatalf("sleep duration = %s, want %s", sleeps[0], want)
 	}
 }
+
+func TestInvokedCommandNameUsesBinaryName(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "path binary", args: []string{"/tmp/build/fanout-go"}, want: "fanout-go"},
+		{name: "relative binary", args: []string{"./fanout-go"}, want: "fanout-go"},
+		{name: "empty args", args: nil, want: "fanout"},
+		{name: "empty argv0", args: []string{""}, want: "fanout"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := invokedCommandName(tc.args); got != tc.want {
+				t.Fatalf("invokedCommandName(%#v) = %q, want %q", tc.args, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/fanout/pane.go
+++ b/cmd/fanout/pane.go
@@ -1,0 +1,205 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/butaosuinu/fanout/internal/briefing"
+	"github.com/butaosuinu/fanout/internal/cliflags"
+	"github.com/butaosuinu/fanout/internal/dmuxconfig"
+	"github.com/butaosuinu/fanout/internal/dmuxsession"
+	"github.com/butaosuinu/fanout/internal/ghissue"
+	"github.com/butaosuinu/fanout/internal/log"
+	"github.com/butaosuinu/fanout/internal/popup"
+	"github.com/butaosuinu/fanout/internal/tmuxctl"
+)
+
+type paneRequest struct {
+	Issue               ghissue.Issue
+	BriefingPath        string
+	BriefingBody        string
+	ShortTitle          string
+	SlugHint            string
+	DisplayNameOverride string
+	BranchName          string
+	OneLinePrompt       string
+}
+
+func createPaneForIssue(cfg *cliflags.Config, lg *log.Logger, info *dmuxsession.Info, issue ghissue.Issue, c log.Palette) bool {
+	req := newPaneRequest(cfg, info.ProjectRoot, issue)
+	if err := os.WriteFile(req.BriefingPath, []byte(req.BriefingBody), 0o644); err != nil {
+		lg.Err("#%d: write briefing: %v", req.Issue.Number, err)
+		return false
+	}
+
+	logPaneRequest(req, lg)
+
+	baseline, err := currentPanesLen(info.ConfigPath)
+	if err != nil {
+		lg.Err("#%d: reload dmux config: %v", req.Issue.Number, err)
+		return false
+	}
+
+	newpanePayload, agentPayload, err := panePayloads(cfg, req.OneLinePrompt, req.BranchName)
+	if err != nil {
+		lg.Err("#%d: %v", req.Issue.Number, err)
+		return false
+	}
+
+	if cfg.DryRun {
+		printPaneDryRun(req, baseline, newpanePayload, agentPayload, info.ControlPane, lg, c)
+		return true
+	}
+
+	if len(agentPayload) == 0 {
+		lg.Err("#%d: no agent resolved. dmux v5.6.3 always shows the agent-choice popup after the prompt popup, so fanout needs an agent name. Pass --agent <name> or invoke fanout from a dmux-managed pane.", req.Issue.Number)
+		return false
+	}
+
+	return drivePaneCreation(cfg, lg, info, req.Issue.Number, baseline, newpanePayload, agentPayload)
+}
+
+func newPaneRequest(cfg *cliflags.Config, projectRoot string, issue ghissue.Issue) paneRequest {
+	req := paneRequest{
+		Issue:        issue,
+		BriefingPath: briefing.Path(projectRoot, issue.Number),
+		BriefingBody: briefing.Render(issue.Number, issue.Title, issue.Body, cfg.Agent),
+		ShortTitle:   shortIssueTitle(issue.Title),
+	}
+	if name := cfg.FindName(issue.Number); name != nil {
+		req.SlugHint = name.SlugHint
+		req.DisplayNameOverride = name.DisplayName
+		req.BranchName = name.BranchName
+	}
+	req.OneLinePrompt = oneLinePrompt(cfg.ParentRef, req)
+	return req
+}
+
+func shortIssueTitle(title string) string {
+	const maxRunes = 60
+	count := 0
+	for i := range title {
+		if count == maxRunes {
+			return title[:i]
+		}
+		count++
+	}
+	return title
+}
+
+func oneLinePrompt(parentRef string, req paneRequest) string {
+	if req.SlugHint != "" {
+		return fmt.Sprintf("%s%d of #%s] %s: %s. read %s and begin.", fanoutTagPrefix, req.Issue.Number, parentRef, req.SlugHint, req.ShortTitle, req.BriefingPath)
+	}
+	return fmt.Sprintf("%s%d of #%s] %s: read %s and begin.", fanoutTagPrefix, req.Issue.Number, parentRef, req.ShortTitle, req.BriefingPath)
+}
+
+func logPaneRequest(req paneRequest, lg *log.Logger) {
+	lg.Info("#%d: %s", req.Issue.Number, req.ShortTitle)
+	lg.Dim("  briefing -> %s", req.BriefingPath)
+	if req.SlugHint != "" {
+		lg.Dim("  slug-hint -> %s", req.SlugHint)
+	}
+	if req.DisplayNameOverride != "" {
+		lg.Dim("  display-name -> %s", req.DisplayNameOverride)
+	}
+	if req.BranchName != "" {
+		lg.Dim("  branch-name -> %s", req.BranchName)
+	}
+}
+
+func currentPanesLen(configPath string) (int, error) {
+	// Re-read dmux.config.json each iteration: a previous iteration in this
+	// run may have already grown panes[], so a cached baseline would let
+	// waitForNewPane() return immediately for subsequent issues even if the
+	// current pane creation actually failed.
+	cfg, err := dmuxconfig.Load(configPath)
+	if err != nil {
+		return 0, err
+	}
+	return cfg.PanesLen(), nil
+}
+
+func panePayloads(cfg *cliflags.Config, prompt, branchName string) (newpanePayload, agentPayload []byte, err error) {
+	newpanePayload, err = popup.MakeNewPanePayload(prompt, branchName)
+	if err != nil {
+		return nil, nil, fmt.Errorf("build newPane payload: %w", err)
+	}
+	if cfg.Agent == "" {
+		return newpanePayload, nil, nil
+	}
+	agentPayload, err = popup.MakeAgentPayload(cfg.Agent)
+	if err != nil {
+		return nil, nil, fmt.Errorf("build agent payload: %w", err)
+	}
+	return newpanePayload, agentPayload, nil
+}
+
+func printPaneDryRun(req paneRequest, baseline int, newpanePayload, agentPayload []byte, controlPane string, lg *log.Logger, c log.Palette) {
+	fmt.Fprintf(lg.Stdout(), "  %sbriefing size%s: %d bytes\n", c.Dim, c.Reset, len(req.BriefingBody))
+	fmt.Fprintf(lg.Stdout(), "  %scurrent panes[] length%s: %d\n", c.Dim, c.Reset, baseline)
+	tmuxctl.PrintSendKeys(lg.Stdout(), c.Dim, c.Reset, controlPane, "Escape")
+	tmuxctl.PrintSendKeys(lg.Stdout(), c.Dim, c.Reset, controlPane, "n")
+	fmt.Fprintf(lg.Stdout(), "    %s# would intercept newPanePopup and write: %s%s\n", c.Dim, string(newpanePayload), c.Reset)
+	if len(agentPayload) > 0 {
+		fmt.Fprintf(lg.Stdout(), "    %s# would intercept agentChoicePopup and write: %s%s\n", c.Dim, string(agentPayload), c.Reset)
+	} else {
+		fmt.Fprintf(lg.Stdout(), "    %s# WOULD FAIL: agent is empty (pass --agent or run from a dmux pane)%s\n", c.Warn, c.Reset)
+	}
+	lg.Ok("#%d: dry-run complete", req.Issue.Number)
+}
+
+func drivePaneCreation(cfg *cliflags.Config, lg *log.Logger, info *dmuxsession.Info, issueNum, baseline int, newpanePayload, agentPayload []byte) bool {
+	pidBaseline, err := popup.BaselinePIDs()
+	if err != nil {
+		lg.Err("#%d: pgrep baseline: %v", issueNum, err)
+		return false
+	}
+
+	if err := tmuxctl.SendKeys(info.ControlPane, "Escape"); err != nil {
+		lg.Err("#%d: tmux send-keys Escape: %v", issueNum, err)
+		return false
+	}
+	time.Sleep(200 * time.Millisecond)
+	if err := tmuxctl.SendKeys(info.ControlPane, "n"); err != nil {
+		lg.Err("#%d: tmux send-keys n: %v", issueNum, err)
+		return false
+	}
+
+	popupTimeout := time.Duration(cfg.PopupTimeoutSec) * time.Second
+	if err := popup.InterceptWithDebug(popup.NewPanePattern, pidBaseline, newpanePayload, "  newPanePopup", popupTimeout, lg.Debug); err != nil {
+		lg.Err("#%d: %v", issueNum, err)
+		return false
+	}
+
+	pidBaseline, _ = popup.BaselinePIDs()
+	if err := popup.InterceptWithDebug(popup.AgentChoicePattern, pidBaseline, agentPayload, "  agentChoicePopup", popupTimeout, lg.Debug); err != nil {
+		lg.Err("#%d: %v", issueNum, err)
+		return false
+	}
+
+	if !waitForNewPane(info.ConfigPath, baseline, 60*time.Second) {
+		lg.Err("#%d: timed out after 60s waiting for config.json to grow", issueNum)
+		return false
+	}
+	current, _ := dmuxconfig.Load(info.ConfigPath)
+	cur := 0
+	if current != nil {
+		cur = current.PanesLen()
+	}
+	lg.Ok("#%d: pane created (panes[] now %d)", issueNum, cur)
+	return true
+}
+
+func waitForNewPane(configPath string, baseline int, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		cfg, err := dmuxconfig.Load(configPath)
+		if err == nil && cfg.PanesLen() > baseline {
+			return true
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	return false
+}

--- a/cmd/fanout/pane.go
+++ b/cmd/fanout/pane.go
@@ -53,7 +53,7 @@ func createPaneForIssue(cfg *cliflags.Config, lg *log.Logger, info *dmuxsession.
 	}
 
 	if len(agentPayload) == 0 {
-		lg.Err("#%d: no agent resolved. dmux v5.6.3 always shows the agent-choice popup after the prompt popup, so fanout needs an agent name. Pass --agent <name> or invoke fanout from a dmux-managed pane.", req.Issue.Number)
+		lg.Err("#%d: no agent resolved. dmux v5.8.1 always shows the agent-choice popup after the prompt popup, so fanout needs an agent name. Pass --agent <name> or invoke fanout from a dmux-managed pane.", req.Issue.Number)
 		return false
 	}
 

--- a/cmd/fanout/pane_test.go
+++ b/cmd/fanout/pane_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestShortIssueTitleTruncatesOnRuneBoundary(t *testing.T) {
+	title := strings.Repeat("あ", 61)
+
+	got := shortIssueTitle(title)
+
+	if !utf8.ValidString(got) {
+		t.Fatalf("short title is invalid UTF-8: %q", got)
+	}
+	if gotRunes := utf8.RuneCountInString(got); gotRunes != 60 {
+		t.Fatalf("short title rune count = %d, want 60", gotRunes)
+	}
+	if got != strings.Repeat("あ", 60) {
+		t.Fatalf("unexpected short title: %q", got)
+	}
+}
+
+func TestShortIssueTitleKeepsSixtyRunes(t *testing.T) {
+	title := strings.Repeat("界", 60)
+
+	if got := shortIssueTitle(title); got != title {
+		t.Fatalf("shortIssueTitle changed 60-rune title:\nwant %q\ngot  %q", title, got)
+	}
+}

--- a/cmd/fanout/plan.go
+++ b/cmd/fanout/plan.go
@@ -1,0 +1,207 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/butaosuinu/fanout/internal/blockers"
+	"github.com/butaosuinu/fanout/internal/cliflags"
+	"github.com/butaosuinu/fanout/internal/ghissue"
+)
+
+type blockedRow struct {
+	Issue ghissue.Issue
+	Refs  string
+}
+
+type Plan struct {
+	TotalChildren           int
+	OpenCount               int
+	OpenAfterFilter         int
+	UnfannedCount           int
+	Targets                 []ghissue.Issue
+	AlreadyFanned           []int
+	FilteredOnly            []ghissue.Issue
+	FilteredSkip            []ghissue.Issue
+	MissingOnly             []int
+	BlockedRows             []blockedRow
+	BlockedLabelWithoutRefs []int
+	LimitDeferred           []ghissue.Issue
+}
+
+func buildPlan(
+	cfg *cliflags.Config,
+	children []ghissue.Issue,
+	fanned map[int]bool,
+	parentBody string,
+	hydrateIssue func(*ghissue.Issue),
+	issueState func(int) string,
+) Plan {
+	openChildren := openIssues(children)
+	plan := Plan{
+		TotalChildren: len(children),
+		OpenCount:     len(openChildren),
+	}
+	if plan.OpenCount == 0 {
+		return plan
+	}
+
+	openChildren, plan.FilteredOnly, plan.FilteredSkip, plan.MissingOnly = filterOnlySkip(openChildren, cfg.Only, cfg.Skip)
+	plan.OpenAfterFilter = len(openChildren)
+	if plan.OpenAfterFilter == 0 {
+		return plan
+	}
+
+	if cfg.UnblockedOnly {
+		hydrateIssues(openChildren, hydrateIssue)
+	}
+
+	targets, skipped := splitAlreadyFanned(openChildren, fanned)
+	plan.Targets = targets
+	plan.AlreadyFanned = skipped
+	plan.UnfannedCount = len(targets)
+	if plan.UnfannedCount == 0 {
+		return plan
+	}
+
+	if cfg.UnblockedOnly {
+		plan.Targets, plan.BlockedRows, plan.BlockedLabelWithoutRefs = splitBlocked(plan.Targets, parentBody, issueState)
+	}
+
+	plan.Targets, plan.LimitDeferred = applyLimit(plan.Targets, cfg.Limit)
+	return plan
+}
+
+func openIssues(issues []ghissue.Issue) []ghissue.Issue {
+	open := make([]ghissue.Issue, 0, len(issues))
+	for _, issue := range issues {
+		if issue.State == "OPEN" {
+			open = append(open, issue)
+		}
+	}
+	return open
+}
+
+func filterOnlySkip(issues []ghissue.Issue, only, skip []int) (kept, filteredOnly, filteredSkip []ghissue.Issue, missingOnly []int) {
+	if len(only) == 0 && len(skip) == 0 {
+		return issues, nil, nil, nil
+	}
+
+	openSet := map[int]bool{}
+	for _, issue := range issues {
+		openSet[issue.Number] = true
+	}
+	for _, num := range only {
+		if !openSet[num] {
+			missingOnly = append(missingOnly, num)
+		}
+	}
+
+	onlySet := intSet(only)
+	skipSet := intSet(skip)
+	for _, issue := range issues {
+		switch {
+		case len(only) > 0 && !onlySet[issue.Number]:
+			filteredOnly = append(filteredOnly, issue)
+		case len(skip) > 0 && skipSet[issue.Number]:
+			filteredSkip = append(filteredSkip, issue)
+		default:
+			kept = append(kept, issue)
+		}
+	}
+	return kept, filteredOnly, filteredSkip, missingOnly
+}
+
+func hydrateIssues(issues []ghissue.Issue, hydrateIssue func(*ghissue.Issue)) {
+	if hydrateIssue == nil {
+		return
+	}
+	for i := range issues {
+		if issues[i].Body != "" {
+			continue
+		}
+		hydrateIssue(&issues[i])
+	}
+}
+
+func splitAlreadyFanned(issues []ghissue.Issue, fanned map[int]bool) (targets []ghissue.Issue, skipped []int) {
+	for _, issue := range issues {
+		if fanned[issue.Number] {
+			skipped = append(skipped, issue.Number)
+			continue
+		}
+		targets = append(targets, issue)
+	}
+	return targets, skipped
+}
+
+func splitBlocked(issues []ghissue.Issue, parentBody string, issueState func(int) string) (kept []ghissue.Issue, blocked []blockedRow, blockedLabelWithoutRefs []int) {
+	if issueState == nil {
+		issueState = func(int) string { return "UNKNOWN" }
+	}
+
+	stateCache := map[int]string{}
+	for _, issue := range issues {
+		childBlockers := blockers.FromChildBody(issue.Body)
+		parentBlockers := blockers.FromParentRow(parentBody, issue.Number)
+		allBlockers := blockers.Dedupe(childBlockers, parentBlockers)
+		openBlockers := openBlockerRefs(allBlockers, stateCache, issueState)
+
+		if hasLabel(issue, "blocked") && len(allBlockers) == 0 {
+			blockedLabelWithoutRefs = append(blockedLabelWithoutRefs, issue.Number)
+		}
+		if len(openBlockers) > 0 {
+			blocked = append(blocked, blockedRow{Issue: issue, Refs: formatOpenBlockers(openBlockers)})
+			continue
+		}
+		kept = append(kept, issue)
+	}
+	return kept, blocked, blockedLabelWithoutRefs
+}
+
+func openBlockerRefs(blockerNums []int, cache map[int]string, issueState func(int) string) []int {
+	var open []int
+	for _, num := range blockerNums {
+		state, ok := cache[num]
+		if !ok {
+			state = issueState(num)
+			cache[num] = state
+		}
+		if state == "OPEN" {
+			open = append(open, num)
+		}
+	}
+	return open
+}
+
+func hasLabel(issue ghissue.Issue, name string) bool {
+	for _, label := range issue.Labels {
+		if label.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func formatOpenBlockers(blockers []int) string {
+	parts := make([]string, len(blockers))
+	for i, num := range blockers {
+		parts[i] = fmt.Sprintf("OPEN #%d", num)
+	}
+	return strings.Join(parts, ", ")
+}
+
+func applyLimit(issues []ghissue.Issue, limit int) (targets, deferred []ghissue.Issue) {
+	if limit > 0 && len(issues) > limit {
+		return issues[:limit], issues[limit:]
+	}
+	return issues, nil
+}
+
+func intSet(nums []int) map[int]bool {
+	set := make(map[int]bool, len(nums))
+	for _, num := range nums {
+		set[num] = true
+	}
+	return set
+}

--- a/cmd/fanout/plan_test.go
+++ b/cmd/fanout/plan_test.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/butaosuinu/fanout/internal/cliflags"
+	"github.com/butaosuinu/fanout/internal/ghissue"
+)
+
+func TestBuildPlanOnlyIdempotencyAndLimit(t *testing.T) {
+	children := []ghissue.Issue{
+		{Number: 101, Title: "first", State: "OPEN"},
+		{Number: 102, Title: "second", State: "OPEN"},
+		{Number: 103, Title: "closed", State: "CLOSED"},
+		{Number: 104, Title: "already", State: "OPEN"},
+	}
+	cfg := &cliflags.Config{
+		Only:  []int{101, 102, 104, 999},
+		Limit: 1,
+	}
+
+	plan := buildPlan(cfg, children, map[int]bool{104: true}, "", nil, nil)
+
+	assertEqual(t, "total", plan.TotalChildren, 4)
+	assertEqual(t, "open", plan.OpenCount, 3)
+	assertEqual(t, "open after filter", plan.OpenAfterFilter, 3)
+	assertEqual(t, "unfanned", plan.UnfannedCount, 2)
+	assertInts(t, "missing only", plan.MissingOnly, []int{999})
+	assertInts(t, "targets", issueNums(plan.Targets), []int{101})
+	assertInts(t, "limit deferred", issueNums(plan.LimitDeferred), []int{102})
+	assertInts(t, "already fanned", plan.AlreadyFanned, []int{104})
+}
+
+func TestBuildPlanSkipFilter(t *testing.T) {
+	children := []ghissue.Issue{
+		{Number: 201, Title: "keep one", State: "OPEN"},
+		{Number: 202, Title: "skip me", State: "OPEN"},
+		{Number: 203, Title: "keep two", State: "OPEN"},
+	}
+	cfg := &cliflags.Config{Skip: []int{202}}
+
+	plan := buildPlan(cfg, children, nil, "", nil, nil)
+
+	assertInts(t, "targets", issueNums(plan.Targets), []int{201, 203})
+	assertInts(t, "filtered skip", issueNums(plan.FilteredSkip), []int{202})
+	if len(plan.FilteredOnly) != 0 {
+		t.Fatalf("filtered only = %#v, want empty", plan.FilteredOnly)
+	}
+}
+
+func TestBuildPlanUnblockedOnly(t *testing.T) {
+	children := []ghissue.Issue{
+		{Number: 301, Title: "blocked by child body", State: "OPEN", Body: "## Blocked by\n- #401\n"},
+		{Number: 302, Title: "blocked label only", State: "OPEN", Labels: []ghissue.Label{{Name: "blocked"}}},
+		{Number: 303, Title: "blocked by parent row", State: "OPEN", Body: "## Blocked by\n- #402\n"},
+	}
+	parentBody := "## Fanout children\n- [ ] #303 blocked by parent (blocked by #403)\n"
+	states := map[int]string{
+		401: "OPEN",
+		402: "CLOSED",
+		403: "OPEN",
+	}
+	cfg := &cliflags.Config{UnblockedOnly: true}
+
+	plan := buildPlan(cfg, children, nil, parentBody, nil, func(num int) string {
+		return states[num]
+	})
+
+	assertInts(t, "targets", issueNums(plan.Targets), []int{302})
+	assertInts(t, "blocked label without refs", plan.BlockedLabelWithoutRefs, []int{302})
+	if len(plan.BlockedRows) != 2 {
+		t.Fatalf("blocked rows len = %d, want 2", len(plan.BlockedRows))
+	}
+	assertEqual(t, "first blocked issue", plan.BlockedRows[0].Issue.Number, 301)
+	assertEqual(t, "first blocked refs", plan.BlockedRows[0].Refs, "OPEN #401")
+	assertEqual(t, "second blocked issue", plan.BlockedRows[1].Issue.Number, 303)
+	assertEqual(t, "second blocked refs", plan.BlockedRows[1].Refs, "OPEN #403")
+}
+
+func TestBuildPlanHydratesBeforeBlockerCheck(t *testing.T) {
+	children := []ghissue.Issue{
+		{Number: 501, Title: "needs hydration", State: "OPEN"},
+	}
+	cfg := &cliflags.Config{UnblockedOnly: true}
+	hydrated := false
+
+	plan := buildPlan(cfg, children, nil, "", func(issue *ghissue.Issue) {
+		hydrated = true
+		issue.Body = "## Blocked by\n- #601\n"
+	}, func(num int) string {
+		if num == 601 {
+			return "OPEN"
+		}
+		return "UNKNOWN"
+	})
+
+	if !hydrated {
+		t.Fatal("hydrateIssue was not called")
+	}
+	if len(plan.Targets) != 0 {
+		t.Fatalf("targets = %#v, want empty", plan.Targets)
+	}
+	if len(plan.BlockedRows) != 1 {
+		t.Fatalf("blocked rows len = %d, want 1", len(plan.BlockedRows))
+	}
+	assertEqual(t, "blocked issue", plan.BlockedRows[0].Issue.Number, 501)
+	assertEqual(t, "blocked refs", plan.BlockedRows[0].Refs, "OPEN #601")
+}
+
+func issueNums(issues []ghissue.Issue) []int {
+	nums := make([]int, len(issues))
+	for i, issue := range issues {
+		nums[i] = issue.Number
+	}
+	return nums
+}
+
+func assertInts(t *testing.T, name string, got, want []int) {
+	t.Helper()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("%s = %#v, want %#v", name, got, want)
+	}
+}
+
+func assertEqual[T comparable](t *testing.T, name string, got, want T) {
+	t.Helper()
+	if got != want {
+		t.Fatalf("%s = %#v, want %#v", name, got, want)
+	}
+}

--- a/cmd/fanout/report.go
+++ b/cmd/fanout/report.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/butaosuinu/fanout/internal/cliflags"
+	"github.com/butaosuinu/fanout/internal/log"
+)
+
+type executionResult struct {
+	Created     int
+	Failed      int
+	CreatedNums []int
+}
+
+func logPlanDetails(plan Plan, lg *log.Logger) {
+	for _, num := range plan.MissingOnly {
+		lg.Warn("--only: #%d not in OPEN child set (ignored)", num)
+	}
+	for _, num := range plan.BlockedLabelWithoutRefs {
+		lg.Warn("#%d: has 'blocked' label but no parseable blocker numbers — treating as unblocked", num)
+	}
+	for _, row := range plan.BlockedRows {
+		lg.Info("deferred: #%d (blocked by %s)", row.Issue.Number, row.Refs)
+	}
+}
+
+func logAlreadyFanned(skipped []int, lg *log.Logger) {
+	if len(skipped) == 0 {
+		return
+	}
+	sort.Ints(skipped)
+	parts := make([]string, len(skipped))
+	for i, num := range skipped {
+		parts[i] = fmt.Sprintf("#%d", num)
+	}
+	lg.Info("already fanned-out (skipping): %s", strings.Join(parts, " "))
+}
+
+func printDryRunPlan(plan Plan, lg *log.Logger, c log.Palette) {
+	if len(plan.FilteredOnly) > 0 || len(plan.FilteredSkip) > 0 {
+		fmt.Fprintf(lg.Stdout(), "\n%sfiltered out:%s\n", c.Info, c.Reset)
+		for _, row := range plan.FilteredOnly {
+			fmt.Fprintf(lg.Stdout(), "  #%d %s — not in --only\n", row.Number, row.Title)
+		}
+		for _, row := range plan.FilteredSkip {
+			fmt.Fprintf(lg.Stdout(), "  #%d %s — in --skip\n", row.Number, row.Title)
+		}
+		fmt.Fprintln(lg.Stdout())
+	}
+
+	if len(plan.BlockedRows) > 0 {
+		fmt.Fprintf(lg.Stdout(), "\n%sdeferred (blocked):%s\n", c.Info, c.Reset)
+		for _, row := range plan.BlockedRows {
+			fmt.Fprintf(lg.Stdout(), "  #%d %s — blocked by %s\n", row.Issue.Number, row.Issue.Title, row.Refs)
+		}
+		fmt.Fprintln(lg.Stdout())
+	}
+}
+
+func printSummary(plan Plan, result executionResult, cfg *cliflags.Config, lg *log.Logger, c log.Palette) {
+	fmt.Fprintln(lg.Stdout())
+	if result.Created > 0 {
+		lg.Ok("created: %d", result.Created)
+	}
+	if result.Failed > 0 {
+		lg.Err("failed:  %d", result.Failed)
+	}
+	if len(plan.AlreadyFanned) > 0 {
+		lg.Info("skipped (already fanned-out): %d", len(plan.AlreadyFanned))
+	}
+	if total := len(plan.FilteredOnly) + len(plan.FilteredSkip); total > 0 {
+		lg.Info("skipped (filtered): %d", total)
+	}
+	if len(plan.BlockedRows) > 0 {
+		lg.Info("deferred (blocked): %d", len(plan.BlockedRows))
+	}
+
+	if len(plan.LimitDeferred) > 0 {
+		fmt.Fprintf(lg.Stdout(), "\n%sDeferred %d issue(s) due to --limit. Rerun with:%s\n", c.Info, len(plan.LimitDeferred), c.Reset)
+		nums := make([]string, len(plan.LimitDeferred))
+		for i, row := range plan.LimitDeferred {
+			nums[i] = fmt.Sprintf("#%d", row.Number)
+		}
+		fmt.Fprintf(lg.Stdout(), "  %s\n", strings.Join(nums, " "))
+		statusFlag := ""
+		if cfg.ParentMode == cliflags.ModeProject && cfg.ProjectStatus != cliflags.DefaultProjectStatus {
+			statusFlag = optFlag("--project-status", cfg.ProjectStatus)
+		}
+		fmt.Fprintf(lg.Stdout(), "  fanout %s --limit %d%s%s%s%s%s\n",
+			shellQuote(cfg.ParentRef), len(plan.LimitDeferred),
+			statusFlag,
+			optFlag("--only", cfg.OnlyArg)+optFlag("--skip", cfg.SkipArg),
+			boolFlag(" --unblocked-only", cfg.UnblockedOnly),
+			optFlag("--agent", cfg.Agent),
+			optFlag("--session", cfg.Session))
+	}
+}
+
+func optFlag(flag, value string) string {
+	if value == "" {
+		return ""
+	}
+	return " " + flag + " " + shellQuote(value)
+}
+
+func boolFlag(flagWithLeadSpace string, on bool) string {
+	if on {
+		return flagWithLeadSpace
+	}
+	return ""
+}
+
+func shellQuote(s string) string {
+	if s == "" {
+		return "''"
+	}
+	if strings.IndexFunc(s, func(r rune) bool {
+		return !(r == '/' || r == ':' || r == '.' || r == '-' || r == '_' || (r >= '0' && r <= '9') || (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z'))
+	}) < 0 {
+		return s
+	}
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}

--- a/cmd/fanout/report.go
+++ b/cmd/fanout/report.go
@@ -60,7 +60,7 @@ func printDryRunPlan(plan Plan, lg *log.Logger, c log.Palette) {
 	}
 }
 
-func printSummary(plan Plan, result executionResult, cfg *cliflags.Config, lg *log.Logger, c log.Palette) {
+func printSummary(plan Plan, result executionResult, cfg *cliflags.Config, lg *log.Logger, c log.Palette, commandName string) {
 	fmt.Fprintln(lg.Stdout())
 	if result.Created > 0 {
 		lg.Ok("created: %d", result.Created)
@@ -89,8 +89,8 @@ func printSummary(plan Plan, result executionResult, cfg *cliflags.Config, lg *l
 		if cfg.ParentMode == cliflags.ModeProject && cfg.ProjectStatus != cliflags.DefaultProjectStatus {
 			statusFlag = optFlag("--project-status", cfg.ProjectStatus)
 		}
-		fmt.Fprintf(lg.Stdout(), "  fanout %s --limit %d%s%s%s%s%s\n",
-			shellQuote(cfg.ParentRef), len(plan.LimitDeferred),
+		fmt.Fprintf(lg.Stdout(), "  %s %s --limit %d%s%s%s%s%s\n",
+			shellQuote(commandName), shellQuote(cfg.ParentRef), len(plan.LimitDeferred),
 			statusFlag,
 			optFlag("--only", cfg.OnlyArg)+optFlag("--skip", cfg.SkipArg),
 			boolFlag(" --unblocked-only", cfg.UnblockedOnly),

--- a/cmd/fanout/report_test.go
+++ b/cmd/fanout/report_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"os/exec"
 	"strings"
 	"testing"
 
@@ -29,5 +30,59 @@ func TestPrintSummaryUsesInvokedCommandNameInLimitRerunHint(t *testing.T) {
 	}
 	if strings.Contains(got, "  fanout 700 --limit") {
 		t.Fatalf("summary output fell back to fanout:\n%s", got)
+	}
+}
+
+// TestShellQuoteIsCopyPasteSafe pins shellQuote and, more importantly, proves
+// the property that actually matters for the --limit rerun hint: the quoted
+// token must evaluate back to the original argument under a POSIX shell, so the
+// printed command is copy-paste-safe. This is the path reached by metacharacter
+// flag values such as `--only 1,2,3` (comma) and `--project-status "In Progress"`
+// (space), which previously had no test.
+//
+// We deliberately do NOT assert byte-equality with bash's `printf %q`: that
+// output is bash-version-dependent (bash 3.2 vs 5.x disagree on leading `=`/`~`,
+// `!`, and control-char wrapping), so there is no single correct target. POSIX
+// single-quoting is portable and round-trips identically everywhere, which is
+// the real requirement here.
+func TestShellQuoteIsCopyPasteSafe(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", "''"},
+		{"plain", "claude", "claude"},
+		{"command", "fanout-go", "fanout-go"},
+		{"issue-number", "700", "700"},
+		{"project-url-is-bare", "https://github.com/orgs/acme/projects/3", "https://github.com/orgs/acme/projects/3"},
+		{"only-csv-comma", "1,2,3", "'1,2,3'"},
+		{"project-status-space", "In Progress", "'In Progress'"},
+		{"ampersand", "a&b", "'a&b'"},
+		{"embedded-single-quote", "it's", `'it'\''s'`},
+		{"dollar-no-expand", "$HOME", "'$HOME'"},
+	}
+
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available; skipping round-trip check")
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := shellQuote(c.in)
+			if got != c.want {
+				t.Errorf("shellQuote(%q) = %q, want %q", c.in, got, c.want)
+			}
+			// Round-trip: a POSIX shell must parse the quoted token back into the
+			// exact original string (a single argument). If shellQuote under-quoted,
+			// `sh` would split or expand it and the output would not match.
+			out, err := exec.Command("sh", "-c", "printf %s "+got).Output()
+			if err != nil {
+				t.Fatalf("sh failed on shellQuote(%q)=%q: %v", c.in, got, err)
+			}
+			if string(out) != c.in {
+				t.Errorf("round-trip: sh parsed shellQuote(%q)=%q as %q, want %q", c.in, got, string(out), c.in)
+			}
+		})
 	}
 }

--- a/cmd/fanout/report_test.go
+++ b/cmd/fanout/report_test.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/butaosuinu/fanout/internal/cliflags"
+	"github.com/butaosuinu/fanout/internal/ghissue"
+	"github.com/butaosuinu/fanout/internal/log"
+)
+
+func TestPrintSummaryUsesInvokedCommandNameInLimitRerunHint(t *testing.T) {
+	var out, err bytes.Buffer
+	lg := log.NewWith(&out, &err, false)
+	plan := Plan{
+		LimitDeferred: []ghissue.Issue{{Number: 702}},
+	}
+	cfg := &cliflags.Config{
+		ParentRef: "700",
+		Agent:     "claude",
+	}
+
+	printSummary(plan, executionResult{}, cfg, lg, log.Palette{}, "fanout-go")
+
+	got := out.String()
+	if !strings.Contains(got, "  fanout-go 700 --limit 1 --agent claude\n") {
+		t.Fatalf("summary output did not include fanout-go rerun hint:\n%s", got)
+	}
+	if strings.Contains(got, "  fanout 700 --limit") {
+		t.Fatalf("summary output fell back to fanout:\n%s", got)
+	}
+}

--- a/cmd/fanout/status.go
+++ b/cmd/fanout/status.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/butaosuinu/fanout/internal/cliflags"
@@ -217,11 +218,7 @@ func sortedKeys(set map[int]bool) []int {
 	for n := range set {
 		nums = append(nums, n)
 	}
-	for i := 1; i < len(nums); i++ {
-		for j := i; j > 0 && nums[j-1] > nums[j]; j-- {
-			nums[j-1], nums[j] = nums[j], nums[j-1]
-		}
-	}
+	sort.Ints(nums)
 	return nums
 }
 

--- a/cmd/fanout/status.go
+++ b/cmd/fanout/status.go
@@ -1,0 +1,250 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/butaosuinu/fanout/internal/cliflags"
+	"github.com/butaosuinu/fanout/internal/dmuxconfig"
+	"github.com/butaosuinu/fanout/internal/dmuxsession"
+	"github.com/butaosuinu/fanout/internal/exitcode"
+	"github.com/butaosuinu/fanout/internal/ghissue"
+	"github.com/butaosuinu/fanout/internal/log"
+)
+
+type statusRuntime struct {
+	configPath  string
+	projectRoot string
+	config      *dmuxconfig.Config
+}
+
+type statusReport struct {
+	Parent   int           `json:"parent"`
+	Children []statusChild `json:"children"`
+	Summary  statusSummary `json:"summary"`
+}
+
+type statusChild struct {
+	Num         int             `json:"num"`
+	State       string          `json:"state"`
+	PRs         []ghissue.PRRef `json:"prs"`
+	HasMergedPR bool            `json:"has_merged_pr"`
+}
+
+type statusSummary struct {
+	Total     int  `json:"total"`
+	Merged    int  `json:"merged"`
+	Pending   int  `json:"pending"`
+	AllMerged bool `json:"all_merged"`
+}
+
+func cmdStatus(cfg *cliflags.Config, lg *log.Logger) exitcode.Code {
+	rt, code := resolveStatusRuntime(cfg, lg)
+	if code != exitcode.OK {
+		return code
+	}
+	if rt.projectRoot == "" || !dirExists(rt.projectRoot) {
+		lg.Err("--status: project_root is not a directory: %s (config=%s)", emptyLabel(rt.projectRoot), rt.configPath)
+		return exitcode.Invocation
+	}
+
+	fanned := rt.config.FannedNumbersForParent(cfg.ParentRef, nil)
+	nums := sortedKeys(fanned)
+	if len(nums) == 0 {
+		return writeStatusReport(statusReport{
+			Parent:   cfg.Parent,
+			Children: []statusChild{},
+			Summary:  statusSummary{AllMerged: false},
+		}, lg)
+	}
+
+	gh := ghissue.Runner{Cwd: rt.projectRoot}
+	nwo, err := gh.RepoNameWithOwner()
+	if err != nil {
+		lg.Err("--status: failed to resolve repo (gh repo view) in %s", rt.projectRoot)
+		return exitcode.GitHub
+	}
+	owner, repo, ok := strings.Cut(nwo, "/")
+	if !ok || owner == "" || repo == "" {
+		lg.Err("--status: unexpected nameWithOwner from gh: %s", nwo)
+		return exitcode.GitHub
+	}
+
+	children := make([]statusChild, 0, len(nums))
+	for _, num := range nums {
+		state, prs, err := gh.IssueWithPRs(owner, repo, num)
+		if err != nil {
+			lg.Err("--status: gh api graphql for #%d failed or returned no issue (auth / network / not found)", num)
+			return exitcode.GitHub
+		}
+		child := statusChild{Num: num, State: state, PRs: prs}
+		for _, pr := range prs {
+			if pr.State == "MERGED" {
+				child.HasMergedPR = true
+				break
+			}
+		}
+		children = append(children, child)
+	}
+
+	merged := 0
+	for _, child := range children {
+		if child.HasMergedPR {
+			merged++
+		}
+	}
+	report := statusReport{
+		Parent:   cfg.Parent,
+		Children: children,
+		Summary: statusSummary{
+			Total:     len(children),
+			Merged:    merged,
+			Pending:   len(children) - merged,
+			AllMerged: len(children) > 0 && merged == len(children),
+		},
+	}
+	return writeStatusReport(report, lg)
+}
+
+func resolveStatusRuntime(cfg *cliflags.Config, lg *log.Logger) (statusRuntime, exitcode.Code) {
+	if p := os.Getenv("DMUX_CONFIG_PATH"); p != "" {
+		cfg, err := loadStatusConfig(p, lg)
+		if err != nil {
+			return statusRuntime{}, exitcode.Invocation
+		}
+		root := cfg.ProjectRoot()
+		if root == "" {
+			root = filepath.Dir(filepath.Dir(p))
+		}
+		return statusRuntime{configPath: p, projectRoot: root, config: cfg}, exitcode.OK
+	}
+
+	sessions, err := listTmuxSessions()
+	if err != nil {
+		lg.Err("--status: no tmux server is running (set DMUX_CONFIG_PATH to bypass live-session discovery)")
+		return statusRuntime{}, exitcode.Invocation
+	}
+	var dmuxSessions []string
+	for _, s := range sessions {
+		if dmuxsession.IsDmux(s) {
+			dmuxSessions = append(dmuxSessions, s)
+		}
+	}
+	if len(dmuxSessions) == 0 {
+		lg.Err("--status: no active dmux session found (set DMUX_CONFIG_PATH to bypass)")
+		return statusRuntime{}, exitcode.Invocation
+	}
+
+	session := ""
+	if cfg.Session != "" {
+		for _, s := range dmuxSessions {
+			if s == cfg.Session {
+				session = s
+				break
+			}
+		}
+		if session == "" {
+			lg.Err("--status: tmux session '%s' is not running dmux. Active dmux sessions: %s", cfg.Session, strings.Join(dmuxSessions, " "))
+			return statusRuntime{}, exitcode.Invocation
+		}
+	} else if len(dmuxSessions) > 1 {
+		lg.Err("--status: multiple dmux sessions active (%s); pass --session <name> to pick one", strings.Join(dmuxSessions, " "))
+		return statusRuntime{}, exitcode.Invocation
+	} else {
+		session = dmuxSessions[0]
+	}
+
+	configPath := dmuxsession.TmuxOption(session, "@dmux_config_path")
+	projectRoot := dmuxsession.TmuxOption(session, "@dmux_project_root")
+	if configPath == "" || !fileExists(configPath) {
+		lg.Err("--status: dmux config not found at %s", emptyUnset(configPath))
+		return statusRuntime{}, exitcode.Invocation
+	}
+	cfgFile, err := loadStatusConfig(configPath, lg)
+	if err != nil {
+		return statusRuntime{}, exitcode.Invocation
+	}
+	if projectRoot == "" {
+		lg.Err("--status: session '%s' has no @dmux_project_root option", session)
+		return statusRuntime{}, exitcode.Invocation
+	}
+	return statusRuntime{configPath: configPath, projectRoot: projectRoot, config: cfgFile}, exitcode.OK
+}
+
+func loadStatusConfig(path string, lg *log.Logger) (*dmuxconfig.Config, error) {
+	if !fileExists(path) {
+		lg.Err("--status: $DMUX_CONFIG_PATH points to non-existent file: %s", path)
+		return nil, fmt.Errorf("missing config")
+	}
+	cfg, err := dmuxconfig.Load(path)
+	if err != nil {
+		lg.Err("--status: dmux config at %s is not valid JSON or .panes is not an array", path)
+		return nil, err
+	}
+	return cfg, nil
+}
+
+func writeStatusReport(report statusReport, lg *log.Logger) exitcode.Code {
+	out, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		lg.Err("--status: failed to encode report: %v", err)
+		return exitcode.GitHub
+	}
+	fmt.Fprintln(lg.Stdout(), string(out))
+	return exitcode.OK
+}
+
+func listTmuxSessions() ([]string, error) {
+	out, err := exec.Command("tmux", "list-sessions", "-F", "#{session_name}").Output()
+	if err != nil {
+		return nil, err
+	}
+	var sessions []string
+	for _, line := range strings.Split(strings.TrimRight(string(out), "\n"), "\n") {
+		if line != "" {
+			sessions = append(sessions, line)
+		}
+	}
+	return sessions, nil
+}
+
+func sortedKeys(set map[int]bool) []int {
+	nums := make([]int, 0, len(set))
+	for n := range set {
+		nums = append(nums, n)
+	}
+	for i := 1; i < len(nums); i++ {
+		for j := i; j > 0 && nums[j-1] > nums[j]; j-- {
+			nums[j-1], nums[j] = nums[j], nums[j-1]
+		}
+	}
+	return nums
+}
+
+func fileExists(path string) bool {
+	st, err := os.Stat(path)
+	return err == nil && !st.IsDir()
+}
+
+func dirExists(path string) bool {
+	st, err := os.Stat(path)
+	return err == nil && st.IsDir()
+}
+
+func emptyUnset(s string) string {
+	if s == "" {
+		return "<unset>"
+	}
+	return s
+}
+
+func emptyLabel(s string) string {
+	if s == "" {
+		return "<empty>"
+	}
+	return s
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/butaosuinu/fanout
+
+go 1.23

--- a/internal/atomicfs/atomicfs.go
+++ b/internal/atomicfs/atomicfs.go
@@ -1,0 +1,40 @@
+// Package atomicfs writes a file atomically: tempfile in the destination
+// directory, then rename. Multiple packages need this exact dance for
+// dmux.config.json and worktree-metadata.json updates, so it lives here once.
+package atomicfs
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// WriteFile creates a sibling tempfile in filepath.Dir(path), writes data,
+// closes, then renames over path. perm is applied to the final file via the
+// rename target (the tempfile inherits CreateTemp's 0600 until the rename
+// resolves the path). On any error the tempfile is removed.
+func WriteFile(path string, data []byte, perm os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmp, err := os.CreateTemp(dir, ".fanout-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	if _, err := tmp.Write(data); err != nil {
+		tmp.Close()
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := os.Chmod(tmpPath, perm); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	if err := os.Rename(tmpPath, path); err != nil {
+		os.Remove(tmpPath)
+		return err
+	}
+	return nil
+}

--- a/internal/blockers/blockers.go
+++ b/internal/blockers/blockers.go
@@ -1,0 +1,90 @@
+// Package blockers parses the two textual blocker sources that --unblocked-only
+// consults: a child issue's `## Blocked by` section, and a (blocked by #X, #Y)
+// trailer on the parent's task-list row. Mirrors fanout:270-306.
+package blockers
+
+import (
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+var (
+	blockedBySectionStartRE = regexp.MustCompile(`^##\s+blocked by`)
+	headingRE               = regexp.MustCompile(`^##`)
+	hashNumRE               = regexp.MustCompile(`#([0-9]+)`)
+)
+
+// FromChildBody extracts blocker numbers from the first "## Blocked by"
+// section in body. The section ends at a blank line or the next heading.
+// Heading detection is case-insensitive (matches the awk tolower() in
+// fanout:277).
+func FromChildBody(body string) []int {
+	out := []int{}
+	inSection := false
+	for _, line := range strings.Split(body, "\n") {
+		lower := strings.ToLower(line)
+		if blockedBySectionStartRE.MatchString(lower) {
+			inSection = true
+			continue
+		}
+		if !inSection {
+			continue
+		}
+		if strings.TrimSpace(line) == "" {
+			inSection = false
+			continue
+		}
+		if headingRE.MatchString(line) {
+			inSection = false
+			continue
+		}
+		for _, m := range hashNumRE.FindAllStringSubmatch(line, -1) {
+			n, err := strconv.Atoi(m[1])
+			if err == nil {
+				out = append(out, n)
+			}
+		}
+	}
+	return out
+}
+
+// FromParentRow extracts blocker numbers from the task-list row in parentBody
+// that begins with `#child`. Looks for a `(blocked by ...)` trailer (case-
+// insensitive) on that row and returns every `#N` inside.
+func FromParentRow(parentBody string, child int) []int {
+	rowPrefix := regexp.MustCompile(`^\s*-\s+\[[ xX]\]\s*#` + strconv.Itoa(child) + `(?:[^0-9]|$)`)
+	blockedByRE := regexp.MustCompile(`(?i)\(blocked by\s+([^)]+)\)`)
+	out := []int{}
+	for _, line := range strings.Split(parentBody, "\n") {
+		if !rowPrefix.MatchString(line) {
+			continue
+		}
+		bm := blockedByRE.FindStringSubmatch(line)
+		if len(bm) != 2 {
+			continue
+		}
+		for _, m := range hashNumRE.FindAllStringSubmatch(bm[1], -1) {
+			n, err := strconv.Atoi(m[1])
+			if err == nil {
+				out = append(out, n)
+			}
+		}
+	}
+	return out
+}
+
+// Dedupe combines two slices into a sorted, unique list.
+func Dedupe(a, b []int) []int {
+	seen := map[int]bool{}
+	for _, n := range append(a, b...) {
+		seen[n] = true
+	}
+	out := make([]int, 0, len(seen))
+	for n := range seen {
+		out = append(out, n)
+	}
+	sort.Ints(out)
+	return out
+}

--- a/internal/briefing/briefing.go
+++ b/internal/briefing/briefing.go
@@ -1,0 +1,74 @@
+// Package briefing builds the per-issue task brief that fanout drops at
+// /tmp/fanout-<repo>-<N>.md and points the agent at via the one-line prompt.
+//
+// The body is locked in by Tier 2 goldens (briefing size: NNN bytes) — both
+// the heredoc text and the trailing newline must match fanout:799-814 byte
+// for byte.
+package briefing
+
+import (
+	"fmt"
+	"path/filepath"
+)
+
+// Path returns /tmp/fanout-<repo_slug>-<num>.md.
+func Path(projectRoot string, num int) string {
+	repo := filepath.Base(projectRoot)
+	return fmt.Sprintf("/tmp/fanout-%s-%d.md", repo, num)
+}
+
+// Render produces the brief body. Live mode writes it to Path(); dry-run uses
+// len(Render()) to compute the goldened "briefing size" without touching disk.
+func Render(num int, title, body, agent string) string {
+	base := fmt.Sprintf(`You are assigned GitHub issue #%d in this repository.
+
+Title: %s
+
+Body:
+%s
+
+Requirements:
+- You are working inside a git worktree that was prepared for this task. Do not create additional worktrees.
+- Make focused, minimal changes scoped to this single issue.
+- Run the project's lint/test commands if they exist (inspect package.json / Makefile / pyproject.toml first).
+- When implementation passes tests, commit and push the branch.
+- Open a pull request with "Closes #%d" in the body.
+- If the scope is ambiguous, stop and leave a comment on the issue instead of guessing.
+`, num, title, body, num)
+	if agent != "claude" {
+		return base
+	}
+	return base + `
+Before committing your final changes, run the ` + "`/simplify`" + ` slash command on the
+files you've changed. /simplify is a Claude Code skill that reviews changed code
+for reuse, quality, and efficiency and fixes issues it finds. Apply its fixes,
+re-run lint/test, then commit and push as described above.
+
+Optional: Agent Teams (Claude Code v2.1.32+, requires CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1)
+
+Before starting, decide whether this issue benefits from spawning an Agent Team.
+This is a hint, not a rule — if Agent Teams aren't enabled in your environment,
+or the issue doesn't fit the criteria below, just proceed as a single session.
+
+Consider Agent Teams when the issue involves:
+- Open-ended research or investigation that benefits from multiple angles
+  (RFC drafting, library evaluation, root-cause hunts with competing hypotheses).
+- New feature work that splits cleanly across independent layers
+  (e.g. backend handler + frontend integration + tests, each ownable separately).
+- Refactors where files partition naturally so teammates won't collide.
+- Reviewing a large diff where security / performance / coverage are distinct lenses.
+
+Skip Agent Teams (single session is better) when:
+- The change is sequential or mostly in one file.
+- Subtasks share state and would race on the same files.
+- The fix is small and focused (typo, single bug, config bump).
+
+If you decide to use Agent Teams:
+1. Sketch 3-5 self-contained subtasks with clear deliverables before spawning.
+2. Spawn teammates with task-specific prompts that include the issue scope they own.
+3. Coordinate via the shared task list; let teammates self-claim where possible.
+4. Synthesize findings yourself before opening the PR.
+5. Ask the lead to "Clean up the team" before closing the issue.
+   Token cost scales linearly with teammate count — favor 3 focused teammates over 5 scattered ones.
+`
+}

--- a/internal/briefing/briefing.go
+++ b/internal/briefing/briefing.go
@@ -39,8 +39,8 @@ Requirements:
 		return base
 	}
 	return base + `
-Before committing your final changes, run the ` + "`/simplify`" + ` slash command on the
-files you've changed. /simplify is a Claude Code skill that reviews changed code
+Before committing your final changes, run the ` + "`/code-review`" + ` slash command on the
+files you've changed. /code-review is a Claude Code skill that reviews changed code
 for reuse, quality, and efficiency and fixes issues it finds. Apply its fixes,
 re-run lint/test, then commit and push as described above.
 

--- a/internal/cliflags/cliflags.go
+++ b/internal/cliflags/cliflags.go
@@ -368,6 +368,7 @@ var (
 )
 
 func parseNumCSV(flag, csv string) ([]int, error) {
+	csv = strings.TrimSuffix(csv, ",")
 	parts := strings.Split(csv, ",")
 	out := make([]int, 0, len(parts))
 	for _, tok := range parts {

--- a/internal/cliflags/cliflags.go
+++ b/internal/cliflags/cliflags.go
@@ -1,0 +1,436 @@
+// Package cliflags is a hand-rolled clone of the Bash arg parser. The standard
+// flag package cannot reproduce the exact error wording, exit-code split, or
+// repeatable --name shape that the black-box tests pin.
+package cliflags
+
+import (
+	"fmt"
+	"io"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/butaosuinu/fanout/internal/exitcode"
+	"github.com/butaosuinu/fanout/internal/log"
+)
+
+const (
+	DefaultSleepBetween  = 4.0
+	DefaultPopupTimeout  = 20
+	DefaultProjectStatus = "Todo"
+
+	ModeIssue   = "issue"
+	ModeProject = "project"
+)
+
+// Config holds the parsed CLI invocation. Validation has already run when a
+// non-nil Config is returned.
+type Config struct {
+	Parent           int
+	ParentRef        string
+	ParentMode       string
+	ProjectOwnerType string
+	ProjectOwner     string
+	ProjectNumber    int
+	ProjectStatus    string
+	Agent            string
+	Limit            int // 0 = unset
+	OnlyArg          string
+	SkipArg          string
+	IncludeArg       string
+	Only             []int
+	Skip             []int
+	Include          []int
+	Names            []NameOverride
+	Session          string
+	SleepBetween     float64
+	PopupTimeoutSec  int
+	DryRun           bool
+	Debug            bool
+	UnblockedOnly    bool
+	StatusMode       bool
+}
+
+// NameOverride represents a parsed `--name NUM=slug-hint|display-name|branch`
+// entry. Empty segments are allowed as long as at least one segment is present.
+type NameOverride struct {
+	Num         int
+	SlugHint    string
+	DisplayName string
+	BranchName  string
+}
+
+// FindName returns a pointer to the override for issue num, or nil.
+func (c *Config) FindName(num int) *NameOverride {
+	for i := range c.Names {
+		if c.Names[i].Num == num {
+			return &c.Names[i]
+		}
+	}
+	return nil
+}
+
+func (c *Config) HasAnyDisplayName() bool {
+	for _, n := range c.Names {
+		if n.DisplayName != "" {
+			return true
+		}
+	}
+	return false
+}
+
+// ParseResult communicates parse outcome to main without duplicating the exit
+// machinery. When Code is non-OK, output has already been written.
+type ParseResult struct {
+	Config *Config
+	Code   exitcode.Code
+}
+
+// Parse processes args (typically os.Args[1:]) and writes any usage / error
+// output to stdout / stderr via lg.
+func Parse(args []string, lg *log.Logger, stdout io.Writer) ParseResult {
+	cfg := &Config{
+		SleepBetween:    DefaultSleepBetween,
+		PopupTimeoutSec: DefaultPopupTimeout,
+		ProjectStatus:   DefaultProjectStatus,
+	}
+
+	state := parseState{}
+	valueOptions := map[string]valueOption{
+		"--agent": func(cfg *Config, _ *parseState, v string) error {
+			cfg.Agent = v
+			return nil
+		},
+		"--limit": func(_ *Config, state *parseState, v string) error {
+			state.limit = v
+			return nil
+		},
+		"--only": func(cfg *Config, _ *parseState, v string) error {
+			cfg.OnlyArg = v
+			return nil
+		},
+		"--skip": func(cfg *Config, _ *parseState, v string) error {
+			cfg.SkipArg = v
+			return nil
+		},
+		"--include": func(cfg *Config, _ *parseState, v string) error {
+			cfg.IncludeArg = v
+			return nil
+		},
+		"--name": func(_ *Config, state *parseState, v string) error {
+			state.rawNames = append(state.rawNames, v)
+			return nil
+		},
+		"--session": func(cfg *Config, _ *parseState, v string) error {
+			cfg.Session = v
+			return nil
+		},
+		"--project-status": func(cfg *Config, _ *parseState, v string) error {
+			cfg.ProjectStatus = v
+			return nil
+		},
+		"--sleep": func(_ *Config, state *parseState, v string) error {
+			state.sleepRaw = v
+			state.sleepExplicit = true
+			return nil
+		},
+		"--popup-timeout": func(_ *Config, state *parseState, v string) error {
+			state.popupRaw = v
+			state.popupExplicit = true
+			return nil
+		},
+	}
+	boolOptions := map[string]boolOption{
+		"--dry-run":        func(cfg *Config) { cfg.DryRun = true },
+		"--debug":          func(cfg *Config) { cfg.Debug = true },
+		"--unblocked-only": func(cfg *Config) { cfg.UnblockedOnly = true },
+		"--status":         func(cfg *Config) { cfg.StatusMode = true },
+	}
+
+	requireValue := func(flag string, i int) (string, bool) {
+		if i+1 >= len(args) {
+			lg.Err("%s requires an argument", flag)
+			return "", false
+		}
+		return args[i+1], true
+	}
+
+	for i := 0; i < len(args); {
+		a := args[i]
+		if a == "-h" || a == "--help" {
+			Usage(stdout)
+			return ParseResult{Code: exitcode.OK}
+		}
+
+		if a == "--" {
+			i++
+			for ; i < len(args); i++ {
+				if !setParent(&state.parent, args[i], lg) {
+					Usage(lg.Stderr())
+					return ParseResult{Code: exitcode.Invocation}
+				}
+			}
+			break
+		}
+
+		if handle, ok := valueOptions[a]; ok {
+			v, ok := requireValue(a, i)
+			if !ok {
+				return ParseResult{Code: exitcode.Env}
+			}
+			if err := handle(cfg, &state, v); err != nil {
+				lg.Err("%s", err.Error())
+				return ParseResult{Code: exitcode.Env}
+			}
+			i += 2
+			continue
+		}
+
+		if handle, ok := boolOptions[a]; ok {
+			handle(cfg)
+			i++
+			continue
+		}
+
+		switch {
+		case strings.HasPrefix(a, "-"):
+			lg.Err("unknown option: %s", a)
+			Usage(lg.Stderr())
+			return ParseResult{Code: exitcode.Invocation}
+		default:
+			if !setParent(&state.parent, a, lg) {
+				Usage(lg.Stderr())
+				return ParseResult{Code: exitcode.Invocation}
+			}
+			i++
+		}
+	}
+
+	return validateParsed(cfg, state, lg)
+}
+
+type parseState struct {
+	parent        string
+	limit         string
+	sleepRaw      string
+	popupRaw      string
+	rawNames      []string
+	sleepExplicit bool
+	popupExplicit bool
+}
+
+type valueOption func(*Config, *parseState, string) error
+type boolOption func(*Config)
+
+func setParent(parent *string, arg string, lg *log.Logger) bool {
+	if *parent == "" {
+		*parent = arg
+		return true
+	}
+	lg.Err("unexpected positional argument: %s", arg)
+	return false
+}
+
+func validateParsed(cfg *Config, state parseState, lg *log.Logger) ParseResult {
+	if state.parent == "" {
+		Usage(lg.Stderr())
+		return ParseResult{Code: exitcode.Invocation}
+	}
+
+	if reAllDigits.MatchString(state.parent) {
+		cfg.ParentMode = ModeIssue
+		cfg.Parent, _ = strconv.Atoi(state.parent)
+		cfg.ParentRef = strconv.Itoa(cfg.Parent)
+	} else if m := reProjectURL.FindStringSubmatch(state.parent); len(m) == 5 {
+		cfg.ParentMode = ModeProject
+		cfg.ProjectOwnerType = m[1]
+		cfg.ProjectOwner = m[2]
+		cfg.ProjectNumber, _ = strconv.Atoi(m[3])
+		cfg.ParentRef = fmt.Sprintf("https://github.com/%s/%s/projects/%d", cfg.ProjectOwnerType, cfg.ProjectOwner, cfg.ProjectNumber)
+	} else {
+		if cfg.StatusMode {
+			lg.Err("--status: parent must be an integer issue number or Projects v2 URL, got: %s", state.parent)
+			return ParseResult{Code: exitcode.Invocation}
+		}
+		lg.Err("parent must be an integer issue number or Projects v2 URL, got: %s", state.parent)
+		return ParseResult{Code: exitcode.Env}
+	}
+
+	if cfg.ProjectStatus == "" {
+		lg.Err("--project-status must not be empty")
+		return ParseResult{Code: exitcode.Env}
+	}
+
+	if cfg.StatusMode {
+		if cfg.ParentMode == ModeProject {
+			lg.Err("--status cannot be combined with Projects v2 URLs as parent")
+			return ParseResult{Code: exitcode.Invocation}
+		}
+		switch {
+		case cfg.Agent != "":
+			return statusConflict(lg, "--agent")
+		case state.limit != "":
+			return statusConflict(lg, "--limit")
+		case cfg.OnlyArg != "":
+			return statusConflict(lg, "--only")
+		case cfg.SkipArg != "":
+			return statusConflict(lg, "--skip")
+		case cfg.IncludeArg != "":
+			return statusConflict(lg, "--include")
+		case len(state.rawNames) > 0:
+			return statusConflict(lg, "--name")
+		case cfg.DryRun:
+			return statusConflict(lg, "--dry-run")
+		case cfg.UnblockedOnly:
+			return statusConflict(lg, "--unblocked-only")
+		case state.sleepExplicit:
+			return statusConflict(lg, "--sleep")
+		case state.popupExplicit:
+			return statusConflict(lg, "--popup-timeout")
+		}
+	}
+
+	for _, raw := range state.rawNames {
+		if err := parseNameArg(cfg, raw); err != nil {
+			lg.Err("%s", err.Error())
+			return ParseResult{Code: exitcode.Env}
+		}
+	}
+
+	if state.limit != "" {
+		if !rePositiveInt.MatchString(state.limit) {
+			lg.Err("--limit must be a positive integer, got: %s", state.limit)
+			return ParseResult{Code: exitcode.Env}
+		}
+		cfg.Limit, _ = strconv.Atoi(state.limit)
+	}
+
+	if state.sleepRaw != "" {
+		if !reNumber.MatchString(state.sleepRaw) {
+			lg.Err("--sleep must be a number, got: %s", state.sleepRaw)
+			return ParseResult{Code: exitcode.Env}
+		}
+		cfg.SleepBetween, _ = strconv.ParseFloat(state.sleepRaw, 64)
+	}
+
+	if state.popupRaw != "" {
+		if !rePositiveInt.MatchString(state.popupRaw) {
+			lg.Err("--popup-timeout must be a positive integer (seconds), got: %s", state.popupRaw)
+			return ParseResult{Code: exitcode.Env}
+		}
+		cfg.PopupTimeoutSec, _ = strconv.Atoi(state.popupRaw)
+	}
+
+	if cfg.OnlyArg != "" && cfg.SkipArg != "" {
+		lg.Err("--only and --skip are mutually exclusive")
+		return ParseResult{Code: exitcode.Env}
+	}
+
+	if cfg.OnlyArg != "" {
+		nums, err := parseNumCSV("--only", cfg.OnlyArg)
+		if err != nil {
+			lg.Err("%s", err.Error())
+			return ParseResult{Code: exitcode.Env}
+		}
+		cfg.Only = nums
+	}
+	if cfg.SkipArg != "" {
+		nums, err := parseNumCSV("--skip", cfg.SkipArg)
+		if err != nil {
+			lg.Err("%s", err.Error())
+			return ParseResult{Code: exitcode.Env}
+		}
+		cfg.Skip = nums
+	}
+	if cfg.IncludeArg != "" {
+		nums, err := parseNumCSV("--include", cfg.IncludeArg)
+		if err != nil {
+			lg.Err("%s", err.Error())
+			return ParseResult{Code: exitcode.Env}
+		}
+		cfg.Include = nums
+	}
+
+	return ParseResult{Config: cfg, Code: exitcode.OK}
+}
+
+func statusConflict(lg *log.Logger, flag string) ParseResult {
+	lg.Err("--status cannot be combined with %s", flag)
+	return ParseResult{Code: exitcode.Invocation}
+}
+
+var (
+	reAllDigits   = regexp.MustCompile(`^[0-9]+$`)
+	rePositiveInt = regexp.MustCompile(`^[1-9][0-9]*$`)
+	reNumber      = regexp.MustCompile(`^[0-9]+(\.[0-9]+)?$`)
+	reKebab       = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*$`)
+	reProjectURL  = regexp.MustCompile(`^https://github\.com/(users|orgs)/([^/]+)/projects/([0-9]+)([/?].*)?$`)
+)
+
+func parseNumCSV(flag, csv string) ([]int, error) {
+	parts := strings.Split(csv, ",")
+	out := make([]int, 0, len(parts))
+	for _, tok := range parts {
+		if !reAllDigits.MatchString(tok) {
+			return nil, fmt.Errorf("%s: invalid entry '%s' (must be a positive integer)", flag, tok)
+		}
+		n, _ := strconv.Atoi(tok)
+		out = append(out, n)
+	}
+	return out, nil
+}
+
+func parseNameArg(cfg *Config, raw string) error {
+	if !strings.Contains(raw, "=") {
+		return fmt.Errorf("--name requires <NUM>=<slug-hint>[|<display-name>[|<branch-name>]], got: '%s'", raw)
+	}
+	eq := strings.IndexByte(raw, '=')
+	num := raw[:eq]
+	val := raw[eq+1:]
+
+	if !reAllDigits.MatchString(num) {
+		return fmt.Errorf("--name: <NUM> must be a positive integer, got: '%s'", num)
+	}
+	n, _ := strconv.Atoi(num)
+
+	segs := strings.Split(val, "|")
+	if len(segs) > 3 {
+		return fmt.Errorf("--name #%d: too many '|'-separated segments (max 3: slug|display|branch), got: '%s'", n, val)
+	}
+	slug := segs[0]
+	disp := ""
+	branch := ""
+	if len(segs) > 1 {
+		disp = segs[1]
+	}
+	if len(segs) > 2 {
+		branch = segs[2]
+	}
+
+	if slug == "" && disp == "" && branch == "" {
+		return fmt.Errorf("--name #%d: slug-hint, display-name, and branch-name are all empty", n)
+	}
+	if slug != "" && !reKebab.MatchString(slug) {
+		return fmt.Errorf("--name #%d: slug-hint must be lowercase kebab-case (alnum+hyphens, starting with alnum), got: '%s'", n, slug)
+	}
+	if branch != "" && strings.ContainsAny(branch, " \t\r\n") {
+		return fmt.Errorf("--name #%d: branch-name must not contain whitespace, got: '%s'", n, branch)
+	}
+
+	for i := range cfg.Names {
+		if cfg.Names[i].Num == n {
+			if slug != "" {
+				cfg.Names[i].SlugHint = slug
+			}
+			if disp != "" {
+				cfg.Names[i].DisplayName = disp
+			}
+			if branch != "" {
+				cfg.Names[i].BranchName = branch
+			}
+			return nil
+		}
+	}
+	cfg.Names = append(cfg.Names, NameOverride{Num: n, SlugHint: slug, DisplayName: disp, BranchName: branch})
+	return nil
+}

--- a/internal/cliflags/cliflags_test.go
+++ b/internal/cliflags/cliflags_test.go
@@ -1,0 +1,24 @@
+package cliflags
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseNumCSVAllowsSingleTrailingComma(t *testing.T) {
+	got, err := parseNumCSV("--only", "501,")
+	if err != nil {
+		t.Fatalf("parseNumCSV returned error: %v", err)
+	}
+	if want := []int{501}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseNumCSV = %#v, want %#v", got, want)
+	}
+}
+
+func TestParseNumCSVRejectsInternalAndRepeatedTrailingEmptyEntries(t *testing.T) {
+	for _, raw := range []string{"501,,502", "501,,", ","} {
+		if _, err := parseNumCSV("--only", raw); err == nil {
+			t.Fatalf("parseNumCSV(%q) returned nil error", raw)
+		}
+	}
+}

--- a/internal/cliflags/usage.go
+++ b/internal/cliflags/usage.go
@@ -1,0 +1,122 @@
+package cliflags
+
+import (
+	"fmt"
+	"io"
+)
+
+const usageText = `Usage: fanout <parent-issue|project-url> [options]
+
+Creates one dmux pane per OPEN sub-issue of a parent issue, OR per OPEN item in
+a GitHub Projects v2 URL. Each pane gets a dedicated git worktree (dmux handles
+that) and starts the configured agent with a briefing that points at
+/tmp/fanout-<repo>-<num>.md.
+
+Options:
+  --agent <name>      Agent to launch (claude|codex|opencode|...). Required
+                      unless the caller's tmux pane is itself a dmux-managed
+                      pane — in that case fanout auto-detects the agent from
+                      dmux.config.json. dmux v5.6.3 always opens an agent-
+                      choice popup after the prompt popup, so fanout must
+                      know the agent name to inject into it.
+  --limit <N>         Cap how many children to enqueue this run. Remainder is
+                      printed with a rerun command.
+  --only <list>       Comma-separated list of issue numbers to fan out,
+                      e.g. --only 4,7,8,10. Numbers not present in the OPEN
+                      child set (Sub-issues API + parent body task-list
+                      union) are warned and ignored; fanout never widens the
+                      search to arbitrary issues. Cannot be combined with
+                      --skip. Applied before --limit.
+  --skip <list>       Comma-separated list of issue numbers to exclude,
+                      e.g. --skip 6,9. Everything else in the OPEN child
+                      set is fanned out. Cannot be combined with --only.
+                      Applied before --limit.
+  --include <list>    Comma-separated list of issue numbers to force-add to
+                      the children set even if they aren't returned by the
+                      Sub-issues API or picked up from the parent body's
+                      task-list scan, e.g. --include 123,456. Intended for
+                      the bundled Claude/Codex agent integrations, which
+                      read the parent body for implicit child references
+                      (close keywords, prose, Japanese idioms) and forward
+                      the accepted numbers here. Combines with --only/--skip
+                      (included first, then filtered). Numbers that end up
+                      CLOSED or don't exist are warned and skipped.
+  --name <NUM>=<slug-hint>[|<display-name>[|<branch-name>]]
+                      Override the default naming for issue <NUM>. Repeatable
+                      (once per issue). <slug-hint> is 2-4 kebab-case words
+                      (lowercase alnum + hyphens) front-loaded into the one-
+                      line prompt so dmux's slug generator is very likely to
+                      echo it as the worktree directory name.
+                      <display-name> (optional; ≤80 chars after sanitization)
+                      is written post-creation into panes[].displayName in
+                      dmux.config.json and merged into the worktree's
+                      .dmux/worktree-metadata.json, so dmux's enforcePaneTitles
+                      loop (every 5-30s) surfaces it as the tmux pane border
+                      title and reopenWorktree restores it across restarts.
+                      <branch-name> (optional; dmux v5.8.1+) is passed through
+                      the newPanePopup payload as branchName.
+                      Examples:
+                        --name 17=fix-login-timeout|Fix login
+                        --name 18=update-docs
+                        --name 19=|Bug triage   (display-name only)
+                        --name 20=feat-x|Feature X|feat/issue-20-x
+                        --name 21=||release/v2.0   (branch override only)
+  --unblocked-only    Only fan out children whose blockers are all CLOSED.
+                      Blockers are read from (1) the child body's
+                      "## Blocked by" section, (2) a "(blocked by #X, #Y)"
+                      trailer on the parent's task-list row, and (3) the
+                      child's "blocked" label (weak signal — logged but
+                      not deduced from). Children with any OPEN blocker
+                      are reported as deferred in the final summary.
+                      Safe to rerun as blocker PRs merge.
+  --session <name>    Target a specific tmux session (required when more than
+                      one dmux session is alive on this machine).
+  --project-status <name>
+                      [project mode only] Restrict to Project items whose
+                      single-select "Status" field equals <name>. Default:
+                      "Todo". Pass "all" to disable the filter.
+  --sleep <seconds>   Pause between pane-creation requests. Default 4. Raise
+                      this if dmux reports "pane creation failed" under load.
+  --popup-timeout <s> Seconds to wait for each dmux popup (new-pane, agent-
+                      choice) to appear after the triggering keystroke.
+                      Default 20. Raise on slow machines or large worktrees
+                      where dmux takes longer than that between closing the
+                      prompt popup and opening the agent-choice popup.
+  --dry-run           Print the send-keys commands, the popup JSON payloads
+                      that would be injected, and the briefings, without
+                      driving dmux.
+  --debug             Log intercept steps (popup PID, result file path, JSON
+                      payload) to stderr as each pane is created.
+  --status            Read-only mode. Print JSON describing each fanned-out
+                      child issue's state and closed-by PR merge status, then
+                      exit. Exclusive with action-bearing flags.
+  -h, --help          Show this message.
+
+Prerequisites:
+  * gh, jq, tmux, pgrep installed. gh-sub-issue extension is required for
+    issue mode only; project mode uses gh api graphql.
+  * ` + "`" + `cd <repo> && dmux` + "`" + ` has been run; tmux session is alive.
+  * dmux TUI is on the pane-list view (no modal open). fanout sends one Esc
+    at startup as a best-effort.
+  * --agent given, OR the caller's pane is a dmux-managed pane so fanout
+    can auto-detect it. dmux v5.6.3 routes new-pane prompts through
+    tmux display-popup (a separate tmux client that send-keys cannot
+    reach), so fanout drives the flow by intercepting the popup's result
+    file. The agent name is required to satisfy the picker popup that
+    dmux always shows next.
+
+Exit codes (default flow):
+  0 success (including "no children, nothing to do")
+  1 prerequisite / environment problem
+  2 bad invocation
+
+Exit codes (--status):
+  0 success (JSON emitted; check summary.all_merged for state)
+  2 cannot enumerate children
+  3 gh API call failed
+`
+
+// Usage writes the help text to w.
+func Usage(w io.Writer) {
+	fmt.Fprint(w, usageText)
+}

--- a/internal/cliflags/usage.go
+++ b/internal/cliflags/usage.go
@@ -16,7 +16,7 @@ Options:
   --agent <name>      Agent to launch (claude|codex|opencode|...). Required
                       unless the caller's tmux pane is itself a dmux-managed
                       pane — in that case fanout auto-detects the agent from
-                      dmux.config.json. dmux v5.6.3 always opens an agent-
+                      dmux.config.json. dmux v5.8.1 always opens an agent-
                       choice popup after the prompt popup, so fanout must
                       know the agent name to inject into it.
   --limit <N>         Cap how many children to enqueue this run. Remainder is
@@ -99,7 +99,7 @@ Prerequisites:
   * dmux TUI is on the pane-list view (no modal open). fanout sends one Esc
     at startup as a best-effort.
   * --agent given, OR the caller's pane is a dmux-managed pane so fanout
-    can auto-detect it. dmux v5.6.3 routes new-pane prompts through
+    can auto-detect it. dmux v5.8.1 routes new-pane prompts through
     tmux display-popup (a separate tmux client that send-keys cannot
     reach), so fanout drives the flow by intercepting the popup's result
     file. The agent name is required to satisfy the picker popup that

--- a/internal/displayname/displayname.go
+++ b/internal/displayname/displayname.go
@@ -1,0 +1,143 @@
+// Package displayname applies --name <NUM>=|<display-name> overrides post-
+// pane-creation. Mirrors fanout:1039-1130.
+//
+// Two writes per issue:
+//
+//  1. dmux.config.json — panes[i].displayName for the [fanout #N]-tagged pane
+//  2. <worktreePath>/.dmux/worktree-metadata.json — merge {"displayName":...}
+//
+// (1) takes effect within dmux's enforcePaneTitles loop (5-30s); (2) ensures
+// reopenWorktree restores the displayName across dmux restarts. Either alone
+// is volatile / delayed; doing both is required.
+package displayname
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/butaosuinu/fanout/internal/atomicfs"
+	"github.com/butaosuinu/fanout/internal/dmuxconfig"
+	"github.com/butaosuinu/fanout/internal/log"
+)
+
+// LogFns is the indirection between this package and internal/log; we route
+// status / warning / error messages through callbacks so the dry-run printer
+// can keep its own writer.
+type LogFns struct {
+	Info func(format string, a ...any)
+	Warn func(format string, a ...any)
+	Dim  func(format string, a ...any)
+	Err  func(format string, a ...any)
+}
+
+type Override struct {
+	Num         int
+	ParentRef   string
+	DisplayName string
+}
+
+// ApplyAll updates panes[].displayName and worktree-metadata.json for every
+// override whose DisplayName is non-empty. Already-tracked panes that have
+// not been (re)created in this run can still be updated, matching the bash
+// behavior — apply_display_names looks panes up by [fanout #N] prompt.
+//
+// In dry-run mode the plan is printed unconditionally — no pane lookup is
+// done, because for fresh runs the panes don't exist yet and the dry-run
+// printer must reflect intent regardless.
+func ApplyAll(configPath string, overrides []Override, dryRun bool, dryOut io.Writer, palette log.Palette, fns LogFns) {
+	if len(overrides) == 0 {
+		return
+	}
+
+	if dryRun {
+		for _, o := range overrides {
+			if o.DisplayName == "" {
+				continue
+			}
+			fmt.Fprintf(dryOut, "    %s# would set panes[].displayName for #%d = %s%s\n", palette.Dim, o.Num, shellQuoteForDryRun(o.DisplayName), palette.Reset)
+			fmt.Fprintf(dryOut, "    %s# would merge displayName into <worktree>/.dmux/worktree-metadata.json%s\n", palette.Dim, palette.Reset)
+		}
+		return
+	}
+
+	cfg, err := dmuxconfig.Load(configPath)
+	if err != nil {
+		fns.Warn("could not read dmux config for displayName: %v", err)
+		return
+	}
+
+	applied := 0
+	for _, o := range overrides {
+		if o.DisplayName == "" {
+			continue
+		}
+		slug, worktreePath := cfg.FindPaneByFanoutTag(o.Num, o.ParentRef)
+		if slug == "" {
+			fns.Warn("#%d: could not locate pane in dmux.config.json by [fanout #%d of #%s] prefix; displayName skipped", o.Num, o.Num, o.ParentRef)
+			continue
+		}
+
+		if err := dmuxconfig.SetDisplayNameBySlug(configPath, slug, o.DisplayName); err != nil {
+			fns.Warn("displayName for #%d: %v", o.Num, err)
+			continue
+		}
+		// Worktree metadata is the persistence half (a) panes[].displayName is
+		// the volatile half. We've already written (a); skip (b) only when the
+		// worktreePath is missing, mirroring the bash `-n $path && -d $path`
+		// guard. Without this check, an empty/stale path causes a metadata
+		// file to be created somewhere unintended (cwd if path is "").
+		if worktreePath == "" {
+			fns.Warn("worktree-metadata.json for #%d: pane has no worktreePath; skipping persistence write", o.Num)
+		} else if st, err := os.Stat(worktreePath); err != nil || !st.IsDir() {
+			fns.Warn("worktree-metadata.json for #%d: worktreePath %s missing; skipping persistence write", o.Num, worktreePath)
+		} else if err := mergeWorktreeMetadata(worktreePath, o.DisplayName); err != nil {
+			fns.Warn("worktree-metadata.json for #%d: %v", o.Num, err)
+			continue
+		}
+		applied++
+	}
+	if applied > 0 {
+		fns.Info("applied displayName for %d pane(s)", applied)
+	}
+}
+
+func shellQuoteForDryRun(s string) string {
+	var out []rune
+	for _, r := range s {
+		switch r {
+		case ' ', '\t', '\n', '\\', '"', '\'', '$', '&', ';', '|', '<', '>', '(', ')', '[', ']', '{', '}', '*', '?':
+			out = append(out, '\\', r)
+		default:
+			out = append(out, r)
+		}
+	}
+	return string(out)
+}
+
+func mergeWorktreeMetadata(worktreePath, displayName string) error {
+	dir := filepath.Join(worktreePath, ".dmux")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return err
+	}
+	path := filepath.Join(dir, "worktree-metadata.json")
+	m := map[string]any{}
+	if data, err := os.ReadFile(path); err == nil {
+		if err := json.Unmarshal(data, &m); err != nil {
+			return fmt.Errorf("parse existing metadata %s: %w", path, err)
+		}
+		if m == nil {
+			m = map[string]any{}
+		}
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+	m["displayName"] = displayName
+	out, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return err
+	}
+	return atomicfs.WriteFile(path, append(out, '\n'), 0o644)
+}

--- a/internal/displayname/displayname_test.go
+++ b/internal/displayname/displayname_test.go
@@ -1,0 +1,64 @@
+package displayname
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestMergeWorktreeMetadataPreservesExistingFields(t *testing.T) {
+	worktree := t.TempDir()
+	dmuxDir := filepath.Join(worktree, ".dmux")
+	if err := os.MkdirAll(dmuxDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dmuxDir, "worktree-metadata.json")
+	if err := os.WriteFile(path, []byte("{\"branch\":\"feature\",\"agent\":\"codex\"}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := mergeWorktreeMetadata(worktree, "Review Pane"); err != nil {
+		t.Fatalf("mergeWorktreeMetadata returned error: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(got)
+	for _, want := range []string{`"branch": "feature"`, `"agent": "codex"`, `"displayName": "Review Pane"`} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("metadata missing %s:\n%s", want, text)
+		}
+	}
+}
+
+func TestMergeWorktreeMetadataLeavesInvalidJSONUntouched(t *testing.T) {
+	worktree := t.TempDir()
+	dmuxDir := filepath.Join(worktree, ".dmux")
+	if err := os.MkdirAll(dmuxDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dmuxDir, "worktree-metadata.json")
+	original := []byte("{bad json\n")
+	if err := os.WriteFile(path, original, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := mergeWorktreeMetadata(worktree, "Should Not Write")
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+	if !strings.Contains(err.Error(), "parse existing metadata") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(original) {
+		t.Fatalf("metadata changed after parse failure:\nwant %q\ngot  %q", original, got)
+	}
+}

--- a/internal/dmuxconfig/dmuxconfig.go
+++ b/internal/dmuxconfig/dmuxconfig.go
@@ -1,0 +1,328 @@
+// Package dmuxconfig handles dmux.config.json: read panes, look up the agent
+// for the caller's tmux pane, find existing fanout-tagged panes, and write
+// updates to a single pane's displayName without losing unknown fields.
+//
+// The "preserve unknown fields" property is non-negotiable. dmux's pane object
+// has many fields fanout doesn't know about; round-tripping through a typed
+// struct would silently drop them. So each pane is held as json.RawMessage and
+// re-decoded on demand for the few fields fanout actually needs.
+package dmuxconfig
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/butaosuinu/fanout/internal/atomicfs"
+)
+
+type Config struct {
+	path  string
+	root  rawRoot
+	panes []json.RawMessage
+}
+
+type rawRoot map[string]json.RawMessage
+
+// Load reads the dmux.config.json file. Missing or malformed input returns an
+// error that should be surfaced via die().
+func Load(path string) (*Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read dmux config %s: %w", path, err)
+	}
+	root := rawRoot{}
+	if err := json.Unmarshal(data, &root); err != nil {
+		return nil, fmt.Errorf("parse dmux config %s: %w", path, err)
+	}
+	cfg := &Config{path: path, root: root}
+	if pr, ok := root["panes"]; ok {
+		var panes []json.RawMessage
+		if err := json.Unmarshal(pr, &panes); err != nil {
+			return nil, fmt.Errorf("parse dmux panes: %w", err)
+		}
+		cfg.panes = panes
+	}
+	return cfg, nil
+}
+
+// PanesLen returns the number of pane objects currently in the config.
+func (c *Config) PanesLen() int { return len(c.panes) }
+
+// PaneField extracts a single string field from pane index i, or "" if absent.
+func (c *Config) PaneField(i int, field string) string {
+	if i < 0 || i >= len(c.panes) {
+		return ""
+	}
+	var m map[string]any
+	if err := json.Unmarshal(c.panes[i], &m); err != nil {
+		return ""
+	}
+	if v, ok := m[field].(string); ok {
+		return v
+	}
+	return ""
+}
+
+// AgentForPane returns the .agent of the pane whose paneId == tmuxPaneID, or
+// "" if no such pane.
+func (c *Config) AgentForPane(tmuxPaneID string) string {
+	for i := range c.panes {
+		var m map[string]any
+		if err := json.Unmarshal(c.panes[i], &m); err != nil {
+			continue
+		}
+		if id, _ := m["paneId"].(string); id == tmuxPaneID {
+			if a, ok := m["agent"].(string); ok {
+				return a
+			}
+		}
+	}
+	return ""
+}
+
+var fanoutPrefixRE = regexp.MustCompile(`^\[fanout #([0-9]+)( of #([^\]]+))?\]`)
+
+// FannedNumbers returns the set of issue numbers prefixed `[fanout #N]` in
+// any pane's prompt.
+func (c *Config) FannedNumbers() map[int]bool {
+	return c.FannedNumbersForParent("", nil)
+}
+
+// ProjectRoot returns dmux's project root when present. dmux versions have
+// used both projectRoot and project_root.
+func (c *Config) ProjectRoot() string {
+	for _, key := range []string{"projectRoot", "project_root"} {
+		raw, ok := c.root[key]
+		if !ok {
+			continue
+		}
+		var s string
+		if json.Unmarshal(raw, &s) == nil {
+			return s
+		}
+	}
+	return ""
+}
+
+// FannedNumbersForParent returns issue numbers from fanout-tagged prompts,
+// optionally filtering to one parent. Legacy prompts without "of #parent" are
+// counted only when the caller's claim set contains the child number.
+func (c *Config) FannedNumbersForParent(parent string, legacyClaim map[int]bool) map[int]bool {
+	out := map[int]bool{}
+	for i := range c.panes {
+		var m map[string]any
+		if err := json.Unmarshal(c.panes[i], &m); err != nil {
+			continue
+		}
+		prompt, _ := m["prompt"].(string)
+		matches := fanoutPrefixRE.FindStringSubmatch(prompt)
+		if len(matches) == 0 {
+			continue
+		}
+		n, err := strconv.Atoi(matches[1])
+		if err != nil {
+			continue
+		}
+		paneParent := matches[3]
+		if parent != "" && !parentMatches(paneParent, parent, n, legacyClaim) {
+			continue
+		}
+		out[n] = true
+	}
+	return out
+}
+
+// FindPaneByFanoutTag returns slug + worktreePath for the pane whose prompt
+// starts with `[fanout #<num> of #<parent>]`, or "", "" if no match.
+func (c *Config) FindPaneByFanoutTag(num int, parent string) (slug, worktreePath string) {
+	prefix := fmt.Sprintf("[fanout #%d of #%s]", num, parent)
+	for i := range c.panes {
+		var m map[string]any
+		if err := json.Unmarshal(c.panes[i], &m); err != nil {
+			continue
+		}
+		p, _ := m["prompt"].(string)
+		if !strings.HasPrefix(p, prefix) {
+			continue
+		}
+		slug, _ = m["slug"].(string)
+		worktreePath, _ = m["worktreePath"].(string)
+		return
+	}
+	return
+}
+
+func parentMatches(paneParent, filterParent string, num int, legacyClaim map[int]bool) bool {
+	if paneParent == "" {
+		return legacyClaim != nil && legacyClaim[num]
+	}
+	pn, perr := strconv.Atoi(paneParent)
+	fn, ferr := strconv.Atoi(filterParent)
+	if perr == nil && ferr == nil {
+		return pn == fn
+	}
+	return paneParent == filterParent
+}
+
+// LegacyMigrationCount counts legacy [fanout #N] prompts that are strongly
+// owned by this parent and should be retagged with "of #parent".
+func (c *Config) LegacyMigrationCount(strong map[int]bool) int {
+	count := 0
+	for i := range c.panes {
+		var m map[string]any
+		if err := json.Unmarshal(c.panes[i], &m); err != nil {
+			continue
+		}
+		prompt, _ := m["prompt"].(string)
+		matches := fanoutPrefixRE.FindStringSubmatch(prompt)
+		if len(matches) == 0 || matches[3] != "" {
+			continue
+		}
+		n, err := strconv.Atoi(matches[1])
+		if err == nil && strong[n] {
+			count++
+		}
+	}
+	return count
+}
+
+// MigrateLegacyPaneTags rewrites legacy [fanout #N] prompt prefixes for the
+// strong-ownership set to include this run's parent annotation.
+func MigrateLegacyPaneTags(path, parent string, strong map[int]bool) (int, error) {
+	cfg, err := Load(path)
+	if err != nil {
+		return 0, err
+	}
+	count := cfg.LegacyMigrationCount(strong)
+	if count == 0 {
+		return 0, nil
+	}
+	for i := range cfg.panes {
+		var m map[string]json.RawMessage
+		if err := json.Unmarshal(cfg.panes[i], &m); err != nil {
+			continue
+		}
+		var prompt string
+		if raw, ok := m["prompt"]; ok {
+			_ = json.Unmarshal(raw, &prompt)
+		}
+		matches := fanoutPrefixRE.FindStringSubmatch(prompt)
+		if len(matches) == 0 || matches[3] != "" {
+			continue
+		}
+		n, err := strconv.Atoi(matches[1])
+		if err != nil || !strong[n] {
+			continue
+		}
+		rest := strings.TrimPrefix(prompt, matches[0])
+		repl := fmt.Sprintf("[fanout #%d of #%s]%s", n, parent, rest)
+		raw, _ := json.Marshal(repl)
+		m["prompt"] = raw
+		out, err := marshalSortedRaw(m)
+		if err != nil {
+			return 0, err
+		}
+		cfg.panes[i] = out
+	}
+	pj, err := json.Marshal(cfg.panes)
+	if err != nil {
+		return 0, err
+	}
+	cfg.root["panes"] = pj
+	return count, atomicWriteJSON(path, cfg.root)
+}
+
+// SetDisplayNameBySlug rereads the file (so we don't trample dmux's concurrent
+// saves), updates panes[].displayName for the pane whose `slug` matches, and
+// atomically writes it back.
+//
+// Targeting by slug (not by `[fanout #N]` prompt) matches the bash predecessor
+// and stays correct when an external editor or dmux itself rewrites the prompt
+// after pane creation; the slug is immutable once dmux generates it.
+func SetDisplayNameBySlug(path, slug, displayName string) error {
+	cfg, err := Load(path)
+	if err != nil {
+		return err
+	}
+	updated := false
+	for i := range cfg.panes {
+		var m map[string]json.RawMessage
+		if err := json.Unmarshal(cfg.panes[i], &m); err != nil {
+			continue
+		}
+		var paneSlug string
+		if s, ok := m["slug"]; ok {
+			_ = json.Unmarshal(s, &paneSlug)
+		}
+		if paneSlug != slug {
+			continue
+		}
+		dn, _ := json.Marshal(displayName)
+		m["displayName"] = dn
+		// Re-marshal preserving deterministic field ordering.
+		out, err := marshalSortedRaw(m)
+		if err != nil {
+			return err
+		}
+		cfg.panes[i] = out
+		updated = true
+	}
+	if !updated {
+		return fmt.Errorf("no pane found with slug %q", slug)
+	}
+
+	// Re-pack panes, then root.
+	pj, err := json.Marshal(cfg.panes)
+	if err != nil {
+		return err
+	}
+	cfg.root["panes"] = pj
+	return atomicWriteJSON(path, cfg.root)
+}
+
+// marshalSortedRaw re-encodes a map keeping keys in alphabetical order so
+// downstream bytes are deterministic between runs.
+func marshalSortedRaw(m map[string]json.RawMessage) ([]byte, error) {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var buf bytes.Buffer
+	buf.WriteByte('{')
+	for i, k := range keys {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		kb, err := json.Marshal(k)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(kb)
+		buf.WriteByte(':')
+		buf.Write(m[k])
+	}
+	buf.WriteByte('}')
+	return buf.Bytes(), nil
+}
+
+// atomicWriteJSON writes root to path atomically, indented to two spaces
+// (dmux itself round-trips with two-space indentation).
+func atomicWriteJSON(path string, root rawRoot) error {
+	raw, err := marshalSortedRaw(root)
+	if err != nil {
+		return err
+	}
+	var pretty bytes.Buffer
+	if err := json.Indent(&pretty, raw, "", "  "); err != nil {
+		return err
+	}
+	pretty.WriteByte('\n')
+	return atomicfs.WriteFile(path, pretty.Bytes(), 0o644)
+}

--- a/internal/dmuxconfig/dmuxconfig.go
+++ b/internal/dmuxconfig/dmuxconfig.go
@@ -22,7 +22,6 @@ import (
 )
 
 type Config struct {
-	path  string
 	root  rawRoot
 	panes []json.RawMessage
 }
@@ -40,7 +39,7 @@ func Load(path string) (*Config, error) {
 	if err := json.Unmarshal(data, &root); err != nil {
 		return nil, fmt.Errorf("parse dmux config %s: %w", path, err)
 	}
-	cfg := &Config{path: path, root: root}
+	cfg := &Config{root: root}
 	if pr, ok := root["panes"]; ok {
 		var panes []json.RawMessage
 		if err := json.Unmarshal(pr, &panes); err != nil {
@@ -53,21 +52,6 @@ func Load(path string) (*Config, error) {
 
 // PanesLen returns the number of pane objects currently in the config.
 func (c *Config) PanesLen() int { return len(c.panes) }
-
-// PaneField extracts a single string field from pane index i, or "" if absent.
-func (c *Config) PaneField(i int, field string) string {
-	if i < 0 || i >= len(c.panes) {
-		return ""
-	}
-	var m map[string]any
-	if err := json.Unmarshal(c.panes[i], &m); err != nil {
-		return ""
-	}
-	if v, ok := m[field].(string); ok {
-		return v
-	}
-	return ""
-}
 
 // AgentForPane returns the .agent of the pane whose paneId == tmuxPaneID, or
 // "" if no such pane.
@@ -87,12 +71,6 @@ func (c *Config) AgentForPane(tmuxPaneID string) string {
 }
 
 var fanoutPrefixRE = regexp.MustCompile(`^\[fanout #([0-9]+)( of #([^\]]+))?\]`)
-
-// FannedNumbers returns the set of issue numbers prefixed `[fanout #N]` in
-// any pane's prompt.
-func (c *Config) FannedNumbers() map[int]bool {
-	return c.FannedNumbersForParent("", nil)
-}
 
 // ProjectRoot returns dmux's project root when present. dmux versions have
 // used both projectRoot and project_root.

--- a/internal/dmuxconfig/dmuxconfig_test.go
+++ b/internal/dmuxconfig/dmuxconfig_test.go
@@ -1,0 +1,70 @@
+package dmuxconfig
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestSetDisplayNameBySlugMatchesEvenWhenPromptIsRewritten(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "dmux.config.json")
+	// Pane has a slug "alpha-slug" but its prompt no longer carries the
+	// `[fanout #N]` tag — e.g. dmux or a user edited it. Slug-based targeting
+	// must still find and update it.
+	in := `{
+  "panes": [
+    {"slug": "alpha-slug", "prompt": "renamed by hand", "agent": "claude"},
+    {"slug": "beta-slug", "prompt": "[fanout #2] beta", "agent": "claude"}
+  ]
+}`
+	if err := os.WriteFile(path, []byte(in), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := SetDisplayNameBySlug(path, "alpha-slug", "Alpha Pane"); err != nil {
+		t.Fatalf("SetDisplayNameBySlug failed: %v", err)
+	}
+
+	out, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var parsed struct {
+		Panes []map[string]any `json:"panes"`
+	}
+	if err := json.Unmarshal(out, &parsed); err != nil {
+		t.Fatalf("config no longer parses after write: %v\n%s", err, out)
+	}
+	if len(parsed.Panes) != 2 {
+		t.Fatalf("pane count changed: got %d, want 2", len(parsed.Panes))
+	}
+	if got := parsed.Panes[0]["displayName"]; got != "Alpha Pane" {
+		t.Errorf("alpha pane displayName: got %v, want Alpha Pane", got)
+	}
+	if got := parsed.Panes[0]["agent"]; got != "claude" {
+		t.Errorf("alpha pane lost agent field: got %v", got)
+	}
+	if _, has := parsed.Panes[1]["displayName"]; has {
+		t.Errorf("beta pane should not have been touched: %v", parsed.Panes[1])
+	}
+}
+
+func TestSetDisplayNameBySlugReturnsErrorWhenSlugMissing(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "dmux.config.json")
+	in := `{"panes":[{"slug":"only-slug","prompt":"x"}]}`
+	if err := os.WriteFile(path, []byte(in), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := SetDisplayNameBySlug(path, "missing-slug", "x")
+	if err == nil {
+		t.Fatal("expected error for missing slug, got nil")
+	}
+	if !strings.Contains(err.Error(), "missing-slug") {
+		t.Errorf("error should mention slug name: %v", err)
+	}
+}

--- a/internal/dmuxsession/dmuxsession.go
+++ b/internal/dmuxsession/dmuxsession.go
@@ -1,0 +1,117 @@
+// Package dmuxsession resolves which tmux session is running dmux. Mirrors
+// fanout:411-482.
+package dmuxsession
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+type Info struct {
+	Session     string
+	ControlPane string
+	ConfigPath  string
+	ProjectRoot string
+}
+
+// TmuxOption returns the value of `tmux show-options -v -t <session> <key>`
+// or "" when unset.
+func TmuxOption(session, key string) string {
+	out, err := exec.Command("tmux", "show-options", "-v", "-t", session, key).Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimRight(string(out), "\n")
+}
+
+// ListSessions returns the names of every tmux session, or an error if no
+// tmux server is running.
+func ListSessions() ([]string, error) {
+	out, err := exec.Command("tmux", "list-sessions", "-F", "#{session_name}").Output()
+	if err != nil {
+		return nil, fmt.Errorf("no tmux server is running. Start dmux in your repo first: cd <repo> && dmux")
+	}
+	lines := strings.Split(strings.TrimRight(string(out), "\n"), "\n")
+	if len(lines) == 1 && lines[0] == "" {
+		return nil, nil
+	}
+	return lines, nil
+}
+
+func pidAlive(pidStr string) bool {
+	if pidStr == "" {
+		return false
+	}
+	pid, err := strconv.Atoi(pidStr)
+	if err != nil || pid <= 0 {
+		return false
+	}
+	return syscall.Kill(pid, 0) == nil
+}
+
+// IsDmux reports whether session has @dmux_controller_pid pointing at a live
+// process.
+func IsDmux(session string) bool {
+	return pidAlive(TmuxOption(session, "@dmux_controller_pid"))
+}
+
+// Resolve picks the dmux session given an optional --session preference.
+// Returns an error matching the bash die() messages when 0 or many sessions
+// are dmux-managed and no preference disambiguates.
+func Resolve(sessionArg string) (*Info, error) {
+	sessions, err := ListSessions()
+	if err != nil {
+		return nil, err
+	}
+
+	var dmuxSessions []string
+	for _, s := range sessions {
+		if IsDmux(s) {
+			dmuxSessions = append(dmuxSessions, s)
+		}
+	}
+
+	if len(dmuxSessions) == 0 {
+		return nil, fmt.Errorf("no active dmux session found. Start one with: cd <repo> && dmux")
+	}
+
+	var session string
+	switch {
+	case sessionArg != "":
+		found := false
+		for _, s := range dmuxSessions {
+			if s == sessionArg {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil, fmt.Errorf("tmux session '%s' is not running dmux. Active dmux sessions: %s", sessionArg, strings.Join(dmuxSessions, " "))
+		}
+		session = sessionArg
+	case len(dmuxSessions) > 1:
+		return nil, fmt.Errorf("multiple dmux sessions active (%s); pass --session <name> to pick one", strings.Join(dmuxSessions, " "))
+	default:
+		session = dmuxSessions[0]
+	}
+
+	info := &Info{
+		Session:     session,
+		ControlPane: TmuxOption(session, "@dmux_control_pane"),
+		ConfigPath:  TmuxOption(session, "@dmux_config_path"),
+		ProjectRoot: TmuxOption(session, "@dmux_project_root"),
+	}
+	if info.ControlPane == "" {
+		return nil, fmt.Errorf("session '%s' has no @dmux_control_pane option; dmux may be in a broken state", session)
+	}
+	if info.ConfigPath == "" {
+		return nil, fmt.Errorf("session '%s' has no @dmux_config_path option", session)
+	}
+	if info.ProjectRoot == "" {
+		return nil, fmt.Errorf("session '%s' has no @dmux_project_root option", session)
+	}
+	return info, nil
+}

--- a/internal/exitcode/exitcode.go
+++ b/internal/exitcode/exitcode.go
@@ -1,0 +1,12 @@
+// Package exitcode centralizes the three CLI exit codes fanout uses.
+// Behavior locked in by tests/bats/tier1_flags.bats; see fanout:113-117.
+package exitcode
+
+type Code int
+
+const (
+	OK         Code = 0
+	Env        Code = 1
+	Invocation Code = 2
+	GitHub     Code = 3
+)

--- a/internal/ghissue/ghissue.go
+++ b/internal/ghissue/ghissue.go
@@ -5,6 +5,7 @@ package ghissue
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os/exec"
 	"regexp"
@@ -285,6 +286,12 @@ query($owner: String!, $number: Int!, $first: Int!, $after: String) {
 		}
 		page, err := parseProjectPage(out, entryField)
 		if err != nil {
+			if errors.Is(err, errProjectNotFound) {
+				// Mirror the shell's actionable message, including the
+				// canonical project URL so the user can check it.
+				projectURL := fmt.Sprintf("https://github.com/%s/%s/projects/%d", ownerType, owner, number)
+				return result, fmt.Errorf("%s: %s (check the URL, token scopes, and project visibility)", err, projectURL)
+			}
 			return result, err
 		}
 		if result.ProjectTitle == "" {
@@ -362,6 +369,12 @@ type projectItem struct {
 	} `json:"status"`
 }
 
+// errProjectNotFound is returned when GraphQL yields projectV2: null for a
+// syntactically valid URL whose project number is wrong or whose token can't
+// see it. ProjectItems wraps it with the project URL + actionable guidance to
+// match the shell's `die "Project not found or not accessible: $parent (...)"`.
+var errProjectNotFound = errors.New("Project not found or not accessible")
+
 func parseProjectPage(raw []byte, entryField string) (projectPage, error) {
 	var root struct {
 		Data map[string]struct {
@@ -380,7 +393,7 @@ func parseProjectPage(raw []byte, entryField string) (projectPage, error) {
 	}
 	entry, ok := root.Data[entryField]
 	if !ok || entry.ProjectV2 == nil {
-		return projectPage{}, fmt.Errorf("Project not found or not accessible")
+		return projectPage{}, errProjectNotFound
 	}
 	return projectPage{
 		Title:          entry.ProjectV2.Title,

--- a/internal/ghissue/ghissue.go
+++ b/internal/ghissue/ghissue.go
@@ -1,0 +1,433 @@
+// Package ghissue wraps the `gh` CLI calls fanout makes — sub-issue list,
+// issue view (full and field-projected). It also assembles the children union
+// (Sub-issues API + parent body task-list scan + --include).
+package ghissue
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Label is the slim shape fanout cares about (just the name; we treat the
+// presence of "blocked" as a weak signal).
+type Label struct {
+	Name string `json:"name"`
+}
+
+// Issue is the unified row used downstream. The Sub-issues API path leaves
+// Body and Labels at zero-value; lazy hydration fills them in.
+type Issue struct {
+	Number int     `json:"number"`
+	Title  string  `json:"title"`
+	State  string  `json:"state"`
+	Body   string  `json:"body"`
+	Labels []Label `json:"labels"`
+}
+
+type PRRef struct {
+	Number   int     `json:"number"`
+	State    string  `json:"state"`
+	MergedAt *string `json:"mergedAt"`
+}
+
+// Runner abstracts `gh` invocation so tests can swap in a fake. The Tier 2
+// shim runs the real `gh` binary path through PATH, so the default execRunner
+// is sufficient and tests don't actually need to swap.
+type Runner struct {
+	Cwd string
+}
+
+func (r Runner) gh(args ...string) ([]byte, error) {
+	cmd := exec.Command("gh", args...)
+	if r.Cwd != "" {
+		cmd.Dir = r.Cwd
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			return out, fmt.Errorf("gh %s: %s", strings.Join(args, " "), strings.TrimSpace(string(ee.Stderr)))
+		}
+		return out, err
+	}
+	return out, nil
+}
+
+// RepoNameWithOwner runs `gh repo view --json nameWithOwner -q .nameWithOwner`.
+func (r Runner) RepoNameWithOwner() (string, error) {
+	out, err := r.gh("repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// SubIssueList runs `gh sub-issue list <parent> --json number,title,state` and
+// returns the flattened, state-uppercased issue rows.
+func (r Runner) SubIssueList(parent int) ([]Issue, error) {
+	out, err := r.gh("sub-issue", "list", strconv.Itoa(parent), "--json", "number,title,state")
+	if err != nil {
+		return nil, err
+	}
+	var wrap struct {
+		SubIssues []struct {
+			Number int    `json:"number"`
+			Title  string `json:"title"`
+			State  string `json:"state"`
+		} `json:"subIssues"`
+	}
+	if err := json.Unmarshal(out, &wrap); err != nil {
+		return nil, fmt.Errorf("parse gh sub-issue list output: %w", err)
+	}
+	issues := make([]Issue, 0, len(wrap.SubIssues))
+	for _, s := range wrap.SubIssues {
+		issues = append(issues, Issue{
+			Number: s.Number,
+			Title:  s.Title,
+			State:  strings.ToUpper(s.State),
+			Labels: []Label{},
+		})
+	}
+	return issues, nil
+}
+
+// ParentBody fetches `gh issue view <parent> --json body -q .body`. Empty
+// string + non-error means "couldn't read".
+func (r Runner) ParentBody(parent int) (string, error) {
+	out, err := r.gh("issue", "view", strconv.Itoa(parent), "--json", "body", "-q", ".body")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimRight(string(out), "\n"), nil
+}
+
+// IssueDetail fetches the full issue JSON used to hydrate body/labels.
+func (r Runner) IssueDetail(num int) (Issue, error) {
+	out, err := r.gh("issue", "view", strconv.Itoa(num), "--json", "number,title,state,body,labels")
+	if err != nil {
+		return Issue{}, err
+	}
+	var d Issue
+	if err := json.Unmarshal(out, &d); err != nil {
+		return Issue{}, fmt.Errorf("parse gh issue view %d: %w", num, err)
+	}
+	d.State = strings.ToUpper(d.State)
+	if d.Labels == nil {
+		d.Labels = []Label{}
+	}
+	return d, nil
+}
+
+// IssueState fetches just `.state` for blocker resolution.
+func (r Runner) IssueState(num int) (string, error) {
+	out, err := r.gh("issue", "view", strconv.Itoa(num), "--json", "state", "-q", ".state")
+	if err != nil {
+		return "UNKNOWN", err
+	}
+	s := strings.ToUpper(strings.TrimSpace(string(out)))
+	if s == "" {
+		return "UNKNOWN", nil
+	}
+	return s, nil
+}
+
+// IssueWithPRs returns an issue's state plus all closed-by PR refs, following
+// closedByPullRequestsReferences pagination.
+func (r Runner) IssueWithPRs(owner, repo string, num int) (state string, prs []PRRef, err error) {
+	const query = `
+    query($owner: String!, $repo: String!, $num: Int!, $after: String) {
+      repository(owner: $owner, name: $repo) {
+        issue(number: $num) {
+          state
+          closedByPullRequestsReferences(first: 100, after: $after) {
+            pageInfo { hasNextPage endCursor }
+            nodes { number state mergedAt }
+          }
+        }
+      }
+    }
+  `
+	prs = []PRRef{}
+	cursor := ""
+	for {
+		args := []string{
+			"api", "graphql",
+			"-F", "owner=" + owner,
+			"-F", "repo=" + repo,
+			"-F", "num=" + strconv.Itoa(num),
+			"-f", "query=" + query,
+			"--jq", ".data.repository.issue // empty",
+		}
+		if cursor != "" {
+			args = append(args, "-F", "after="+cursor)
+		}
+		out, err := r.gh(args...)
+		if err != nil {
+			return "", nil, err
+		}
+		if len(strings.TrimSpace(string(out))) == 0 {
+			return "", nil, fmt.Errorf("empty issue response")
+		}
+		var page struct {
+			State string `json:"state"`
+			Refs  struct {
+				PageInfo struct {
+					HasNextPage bool   `json:"hasNextPage"`
+					EndCursor   string `json:"endCursor"`
+				} `json:"pageInfo"`
+				Nodes []PRRef `json:"nodes"`
+			} `json:"closedByPullRequestsReferences"`
+		}
+		if err := json.Unmarshal(out, &page); err != nil {
+			return "", nil, fmt.Errorf("parse gh api graphql issue %d: %w", num, err)
+		}
+		state = page.State
+		prs = append(prs, page.Refs.Nodes...)
+		if !page.Refs.PageInfo.HasNextPage {
+			break
+		}
+		next := page.Refs.PageInfo.EndCursor
+		if next == "" || next == cursor {
+			break
+		}
+		cursor = next
+	}
+	return state, prs, nil
+}
+
+// HydrateBodyLabels fetches body and labels for an issue and merges them into
+// the existing struct (used by --unblocked-only's eager hydration pass).
+func (r Runner) HydrateBodyLabels(iss *Issue) error {
+	out, err := r.gh("issue", "view", strconv.Itoa(iss.Number), "--json", "body,labels")
+	if err != nil {
+		return err
+	}
+	var d struct {
+		Body   string  `json:"body"`
+		Labels []Label `json:"labels"`
+	}
+	if err := json.Unmarshal(out, &d); err != nil {
+		return fmt.Errorf("parse gh issue view %d body/labels: %w", iss.Number, err)
+	}
+	iss.Body = d.Body
+	if d.Labels != nil {
+		iss.Labels = d.Labels
+	}
+	return nil
+}
+
+type ProjectItemsResult struct {
+	Issues            []Issue
+	CrossRepoWarnings []string
+	ProjectTitle      string
+	MissingStatus     bool
+}
+
+// ProjectItems lists issue items from a GitHub Projects v2 board, filters to
+// the current repo, and applies the single-select Status filter unless status
+// is "all".
+func (r Runner) ProjectItems(ownerType, owner string, number int, repo, status string) (ProjectItemsResult, error) {
+	entryField := "user"
+	if ownerType == "orgs" {
+		entryField = "organization"
+	}
+	const query = `
+query($owner: String!, $number: Int!, $first: Int!, $after: String) {
+  ENTRY(login: $owner) {
+    projectV2(number: $number) {
+      title
+      url
+      field(name: "Status") { __typename }
+      items(first: $first, after: $after) {
+        nodes {
+          content {
+            __typename
+            ... on Issue {
+              number
+              title
+              state
+              body
+              repository { nameWithOwner }
+              labels(first: 20) { nodes { name } }
+            }
+          }
+          status: fieldValueByName(name: "Status") {
+            ... on ProjectV2ItemFieldSingleSelectValue { name }
+          }
+        }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}
+`
+	gql := strings.ReplaceAll(query, "ENTRY", entryField)
+	var result ProjectItemsResult
+	cursor := ""
+	for {
+		args := []string{
+			"api", "graphql",
+			"-f", "query=" + gql,
+			"-F", "owner=" + owner,
+			"-F", "number=" + strconv.Itoa(number),
+			"-F", "first=100",
+		}
+		if cursor != "" {
+			args = append(args, "-F", "after="+cursor)
+		}
+		out, err := r.gh(args...)
+		if err != nil {
+			return result, fmt.Errorf("gh api graphql (projectV2 items) failed: %w", err)
+		}
+		page, err := parseProjectPage(out, entryField)
+		if err != nil {
+			return result, err
+		}
+		if result.ProjectTitle == "" {
+			result.ProjectTitle = page.Title
+		}
+		effectiveStatus := status
+		if !page.HasStatusField {
+			result.MissingStatus = true
+			effectiveStatus = "all"
+		}
+		for _, item := range page.Items {
+			if item.Content.TypeName != "Issue" {
+				continue
+			}
+			itemRepo := item.Content.Repository.NameWithOwner
+			if itemRepo != repo {
+				result.CrossRepoWarnings = append(result.CrossRepoWarnings, fmt.Sprintf("%s#%d", itemRepo, item.Content.Number))
+				continue
+			}
+			if effectiveStatus != "all" && item.Status.Name != effectiveStatus {
+				continue
+			}
+			labels := make([]Label, 0, len(item.Content.Labels.Nodes))
+			for _, l := range item.Content.Labels.Nodes {
+				labels = append(labels, Label{Name: l.Name})
+			}
+			result.Issues = append(result.Issues, Issue{
+				Number: item.Content.Number,
+				Title:  item.Content.Title,
+				State:  strings.ToUpper(item.Content.State),
+				Body:   item.Content.Body,
+				Labels: labels,
+			})
+		}
+		if !page.PageInfo.HasNextPage {
+			break
+		}
+		next := page.PageInfo.EndCursor
+		if next == "" || next == cursor {
+			break
+		}
+		cursor = next
+	}
+	return result, nil
+}
+
+type projectPage struct {
+	Title          string
+	HasStatusField bool
+	Items          []projectItem
+	PageInfo       pageInfo
+}
+
+type pageInfo struct {
+	HasNextPage bool   `json:"hasNextPage"`
+	EndCursor   string `json:"endCursor"`
+}
+
+type projectItem struct {
+	Content struct {
+		TypeName   string `json:"__typename"`
+		Number     int    `json:"number"`
+		Title      string `json:"title"`
+		State      string `json:"state"`
+		Body       string `json:"body"`
+		Repository struct {
+			NameWithOwner string `json:"nameWithOwner"`
+		} `json:"repository"`
+		Labels struct {
+			Nodes []Label `json:"nodes"`
+		} `json:"labels"`
+	} `json:"content"`
+	Status struct {
+		Name string `json:"name"`
+	} `json:"status"`
+}
+
+func parseProjectPage(raw []byte, entryField string) (projectPage, error) {
+	var root struct {
+		Data map[string]struct {
+			ProjectV2 *struct {
+				Title string           `json:"title"`
+				Field *json.RawMessage `json:"field"`
+				Items struct {
+					Nodes    []projectItem `json:"nodes"`
+					PageInfo pageInfo      `json:"pageInfo"`
+				} `json:"items"`
+			} `json:"projectV2"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &root); err != nil {
+		return projectPage{}, fmt.Errorf("parse gh api graphql project items: %w", err)
+	}
+	entry, ok := root.Data[entryField]
+	if !ok || entry.ProjectV2 == nil {
+		return projectPage{}, fmt.Errorf("Project not found or not accessible")
+	}
+	return projectPage{
+		Title:          entry.ProjectV2.Title,
+		HasStatusField: entry.ProjectV2.Field != nil,
+		Items:          entry.ProjectV2.Items.Nodes,
+		PageInfo:       entry.ProjectV2.Items.PageInfo,
+	}, nil
+}
+
+var taskListRE = regexp.MustCompile(`^\s*-\s+\[[ xX]\]\s*#([0-9]+)`)
+
+// TaskListNumbers extracts issue numbers from each `- [ ] #N ...` row in the
+// parent body. Cross-repo refs (`owner/repo#N`) are silently ignored: the
+// regex only matches `#N` immediately after the checkbox.
+//
+// Order is preserved (first appearance wins) and duplicates collapsed, to
+// match the bash jq pipeline that runs `unique` before iterating.
+func TaskListNumbers(parentBody string) []int {
+	seen := map[int]bool{}
+	var out []int
+	for _, line := range strings.Split(parentBody, "\n") {
+		m := taskListRE.FindStringSubmatch(line)
+		if len(m) != 2 {
+			continue
+		}
+		n, err := strconv.Atoi(m[1])
+		if err != nil || seen[n] {
+			continue
+		}
+		seen[n] = true
+		out = append(out, n)
+	}
+	sort.Ints(out)
+	return out
+}
+
+// MergeExtra adds rows from extra to base, deduplicating by .number.
+func MergeExtra(base, extra []Issue) []Issue {
+	seen := map[int]bool{}
+	for _, b := range base {
+		seen[b.Number] = true
+	}
+	for _, e := range extra {
+		if !seen[e.Number] {
+			base = append(base, e)
+			seen[e.Number] = true
+		}
+	}
+	return base
+}

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -1,0 +1,90 @@
+// Package log mirrors the fanout:121-144 helpers. Exact prefixes and
+// stdout/stderr routing are locked in by Tier 1/2 tests.
+package log
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/butaosuinu/fanout/internal/tty"
+)
+
+type Logger struct {
+	out     io.Writer
+	err     io.Writer
+	color   bool
+	debug   bool
+	palette Palette
+}
+
+// Palette holds the active ANSI escape codes (or empty strings when color is
+// off). Returned by Logger.Colors so callers can render compound output (the
+// dry-run printer needs raw escapes around adjacent unstyled text).
+type Palette struct {
+	Info, Ok, Warn, Err, Dim, Reset string
+}
+
+// New constructs a Logger that writes to stdout/stderr and detects color.
+func New(debug bool) *Logger {
+	return NewWith(os.Stdout, os.Stderr, debug)
+}
+
+// NewWith constructs a Logger with explicit destinations (for tests).
+func NewWith(out, err io.Writer, debug bool) *Logger {
+	l := &Logger{out: out, err: err, color: tty.IsColorCapable(out), debug: debug}
+	if l.color {
+		// Match bash tput colors: blue, green, yellow, red, dim.
+		l.palette = Palette{
+			Info:  "\x1b[34m",
+			Ok:    "\x1b[32m",
+			Warn:  "\x1b[33m",
+			Err:   "\x1b[31m",
+			Dim:   "\x1b[2m",
+			Reset: "\x1b[0m",
+		}
+	}
+	return l
+}
+
+func (l *Logger) Info(format string, a ...any) {
+	fmt.Fprintf(l.out, "%s[info]%s %s\n", l.palette.Info, l.palette.Reset, fmt.Sprintf(format, a...))
+}
+
+func (l *Logger) Ok(format string, a ...any) {
+	fmt.Fprintf(l.out, "%s[ ok ]%s %s\n", l.palette.Ok, l.palette.Reset, fmt.Sprintf(format, a...))
+}
+
+func (l *Logger) Warn(format string, a ...any) {
+	fmt.Fprintf(l.err, "%s[warn]%s %s\n", l.palette.Warn, l.palette.Reset, fmt.Sprintf(format, a...))
+}
+
+func (l *Logger) Err(format string, a ...any) {
+	fmt.Fprintf(l.err, "%s[err ]%s %s\n", l.palette.Err, l.palette.Reset, fmt.Sprintf(format, a...))
+}
+
+// Dim writes a dim-styled line to stdout (no level prefix).
+func (l *Logger) Dim(format string, a ...any) {
+	fmt.Fprintf(l.out, "%s%s%s\n", l.palette.Dim, fmt.Sprintf(format, a...), l.palette.Reset)
+}
+
+func (l *Logger) Debug(format string, a ...any) {
+	if !l.debug {
+		return
+	}
+	fmt.Fprintf(l.err, "%s[dbg ]%s %s\n", l.palette.Dim, l.palette.Reset, fmt.Sprintf(format, a...))
+}
+
+// Die writes the message via Err and exits 1.
+func (l *Logger) Die(format string, a ...any) {
+	l.Err(format, a...)
+	os.Exit(1)
+}
+
+// Stdout / Stderr expose the writers for ad-hoc fmt.Fprintf calls (used by
+// dry-run printer to render escape-sequence-aware indented blocks).
+func (l *Logger) Stdout() io.Writer { return l.out }
+func (l *Logger) Stderr() io.Writer { return l.err }
+
+// Colors returns the active palette. Empty strings when color is off.
+func (l *Logger) Colors() Palette { return l.palette }

--- a/internal/popup/popup.go
+++ b/internal/popup/popup.go
@@ -1,0 +1,225 @@
+// Package popup intercepts dmux's `tmux display-popup` driven prompts.
+// See fanout:851-956 and the README "Why this looks weird" section.
+//
+// The flow:
+//
+//  1. Snapshot the set of dmux popup PIDs as a baseline.
+//  2. Send Esc + n at the dmux control pane.
+//  3. Watch for a NEW popup PID matching `<pattern>` (e.g. newPanePopup\.js).
+//  4. Read its argv via `ps -o args=`, extract the resultFile path.
+//  5. Atomically write {"success":true,"data":...} to that file.
+//  6. Kill the popup process. dmux's parent reads the file we wrote.
+//
+// dmux always launches an agent-choice popup after the new-pane popup closes
+// with a non-empty prompt, even when only one agent is enabled. fanout drives
+// both popups in sequence.
+package popup
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// Patterns matched against `pgrep -f` argv. These are dmux-internal popup
+// script names, not public API — when bumping dmux, re-verify against
+// dist/components/popups/.
+const (
+	AnyPopupPattern    = `/popups/.*Popup\.js`
+	NewPanePattern     = `newPanePopup\.js`
+	AgentChoicePattern = `agentChoicePopup\.js`
+)
+
+// Field order matches dmux's PopupWrapper.writeSuccessAndExit (success first,
+// data second). encoding/json marshals struct fields in declaration order, so
+// don't reorder these without regenerating Tier 2 goldens.
+
+type stringPayload struct {
+	Success bool   `json:"success"`
+	Data    string `json:"data"`
+}
+
+type newPaneInput struct {
+	Prompt     string `json:"prompt"`
+	BranchName string `json:"branchName"`
+}
+
+type objectPayload struct {
+	Success bool         `json:"success"`
+	Data    newPaneInput `json:"data"`
+}
+
+type stringsPayload struct {
+	Success bool     `json:"success"`
+	Data    []string `json:"data"`
+}
+
+// MakeNewPanePayload returns the bytes fanout writes to the newPanePopup
+// resultFile.
+func MakeNewPanePayload(prompt, branchName string) ([]byte, error) {
+	if branchName != "" {
+		return json.Marshal(objectPayload{Success: true, Data: newPaneInput{Prompt: prompt, BranchName: branchName}})
+	}
+	return json.Marshal(stringPayload{Success: true, Data: prompt})
+}
+
+// MakeAgentPayload returns the bytes fanout writes to the agentChoicePopup
+// resultFile (a single-element list).
+func MakeAgentPayload(agent string) ([]byte, error) {
+	return json.Marshal(stringsPayload{Success: true, Data: []string{agent}})
+}
+
+// BaselinePIDs captures the PIDs of any dmux popup currently running so
+// FindNew() can tell new popups from leftovers.
+func BaselinePIDs() (map[int]bool, error) {
+	pids, err := pgrepF(AnyPopupPattern)
+	if err != nil {
+		// pgrep returns 1 with empty output when nothing matches — treat
+		// that as "no baseline" rather than an error. exec.ExitError is the
+		// only way to detect this short of inspecting the exit code.
+		if _, ok := err.(*exec.ExitError); ok {
+			return map[int]bool{}, nil
+		}
+		return nil, err
+	}
+	out := make(map[int]bool, len(pids))
+	for _, p := range pids {
+		out[p] = true
+	}
+	return out, nil
+}
+
+// FindNew polls every 100ms for a new popup matching pattern. Returns the
+// popup's PID and resultFile path, or an error after maxWait.
+func FindNew(pattern string, baseline map[int]bool, maxWait time.Duration) (int, string, error) {
+	deadline := time.Now().Add(maxWait)
+	for time.Now().Before(deadline) {
+		pids, err := pgrepF(pattern)
+		if err != nil {
+			if _, ok := err.(*exec.ExitError); !ok {
+				return 0, "", err
+			}
+			pids = nil
+		}
+		for _, pid := range pids {
+			if baseline[pid] {
+				continue
+			}
+			comm, err := psField(pid, "comm")
+			if err != nil {
+				continue
+			}
+			// macOS BSD ps returns the full path; procps-ng returns the
+			// basename. Normalize so all of /usr/local/bin/node, node,
+			// node24 match.
+			base := filepath.Base(strings.TrimSpace(comm))
+			if !strings.HasPrefix(base, "node") {
+				continue
+			}
+			args, err := psField(pid, "args")
+			if err != nil {
+				continue
+			}
+			rf := resultFileRE.FindString(args)
+			if rf != "" {
+				return pid, rf, nil
+			}
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return 0, "", fmt.Errorf("popup did not appear within %s", maxWait)
+}
+
+// WriteResult atomically writes payload to path. dmux reads the file only
+// after its child process exits, so as long as the rename happens before the
+// kill, the read sees the complete payload.
+func WriteResult(path string, payload []byte) error {
+	tmp := path + ".fanout.tmp"
+	if err := os.WriteFile(tmp, payload, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// Intercept performs the full sequence for one popup.
+func Intercept(pattern string, baseline map[int]bool, payload []byte, label string, maxWait time.Duration) error {
+	return InterceptWithDebug(pattern, baseline, payload, label, maxWait, nil)
+}
+
+// InterceptWithDebug performs the full sequence for one popup and emits
+// detailed progress when debugf is non-nil.
+func InterceptWithDebug(pattern string, baseline map[int]bool, payload []byte, label string, maxWait time.Duration, debugf func(format string, a ...any)) error {
+	debugLabel := strings.TrimSpace(label)
+	if debugf != nil {
+		debugf("%s: waiting pattern=%s timeout=%s baseline_pids=%d payload=%s", debugLabel, pattern, maxWait, len(baseline), string(payload))
+	}
+	pid, rf, err := FindNew(pattern, baseline, maxWait)
+	if err != nil {
+		if debugf != nil {
+			debugf("%s: popup lookup failed: %v", debugLabel, err)
+		}
+		return fmt.Errorf("%s %w", label, err)
+	}
+	if debugf != nil {
+		debugf("%s: found pid=%d resultFile=%s", debugLabel, pid, rf)
+	}
+	// Give dmux's PopupWrapper time to mount and write its readyFile so the
+	// parent's readyPromise resolves via the ready-file path rather than via
+	// child.close after we kill. 150ms covers the React Ink useEffect tick.
+	time.Sleep(150 * time.Millisecond)
+	if err := WriteResult(rf, payload); err != nil {
+		if debugf != nil {
+			debugf("%s: write result failed: %v", debugLabel, err)
+		}
+		return fmt.Errorf("%s write result: %w", label, err)
+	}
+	if debugf != nil {
+		debugf("%s: wrote resultFile=%s payload=%s", debugLabel, rf, string(payload))
+	}
+	if err := syscall.Kill(pid, syscall.SIGTERM); err != nil {
+		// Process may have already exited; not fatal.
+		if debugf != nil {
+			debugf("%s: SIGTERM pid=%d failed: %v", debugLabel, pid, err)
+		}
+		_ = err
+	} else if debugf != nil {
+		debugf("%s: sent SIGTERM pid=%d", debugLabel, pid)
+	}
+	return nil
+}
+
+var resultFileRE = regexp.MustCompile(`[[:alnum:]/_.\-]+/dmux-popup-[0-9]+\.json`)
+
+func pgrepF(pattern string) ([]int, error) {
+	out, err := exec.Command("pgrep", "-f", pattern).Output()
+	if err != nil {
+		return nil, err
+	}
+	var pids []int
+	for _, line := range strings.Split(strings.TrimRight(string(out), "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		p, err := strconv.Atoi(line)
+		if err != nil {
+			continue
+		}
+		pids = append(pids, p)
+	}
+	return pids, nil
+}
+
+func psField(pid int, field string) (string, error) {
+	out, err := exec.Command("ps", "-o", field+"=", "-p", strconv.Itoa(pid)).Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}

--- a/internal/popup/popup.go
+++ b/internal/popup/popup.go
@@ -174,27 +174,50 @@ func InterceptWithDebug(pattern string, baseline map[int]bool, payload []byte, l
 	// parent's readyPromise resolves via the ready-file path rather than via
 	// child.close after we kill. 150ms covers the React Ink useEffect tick.
 	time.Sleep(150 * time.Millisecond)
-	if err := WriteResult(rf, payload); err != nil {
-		if debugf != nil {
-			debugf("%s: write result failed: %v", debugLabel, err)
-		}
-		return fmt.Errorf("%s write result: %w", label, err)
-	}
+	writeErr := WriteResult(rf, payload)
 	if debugf != nil {
-		debugf("%s: wrote resultFile=%s payload=%s", debugLabel, rf, string(payload))
+		if writeErr != nil {
+			debugf("%s: write result failed: %v", debugLabel, writeErr)
+		} else {
+			debugf("%s: wrote resultFile=%s payload=%s", debugLabel, rf, string(payload))
+		}
 	}
+	// Kill the popup even when the write failed: a doomed attempt must not
+	// orphan the Node popup inside `tmux display-popup`, or the stale popup
+	// blocks the next display-popup and freezes the dmux TUI. The shell's
+	// intercept_popup is invoked as `intercept_popup ... || return 1`, which
+	// suspends `set -euo pipefail` inside it, so it likewise always reaches
+	// `kill "$pid"` (fanout:1754) after the write, regardless of write success.
+	//
+	// Kill right after the write so the pid is still this popup. There is an
+	// inherent pgrep/ps/kill race (the pid could be reused between FindNew's ps
+	// check and this Kill), but the window is microseconds: dmux's
+	// PopupWrapper.writeSuccessAndExit exits promptly once it detects the result
+	// file, so the pid is almost always still that short-lived Node popup. A
+	// missed/reused pid is treated as non-fatal.
 	if err := syscall.Kill(pid, syscall.SIGTERM); err != nil {
 		// Process may have already exited; not fatal.
 		if debugf != nil {
 			debugf("%s: SIGTERM pid=%d failed: %v", debugLabel, pid, err)
 		}
-		_ = err
 	} else if debugf != nil {
 		debugf("%s: sent SIGTERM pid=%d", debugLabel, pid)
+	}
+	if writeErr != nil {
+		return fmt.Errorf("%s write result: %w", label, writeErr)
 	}
 	return nil
 }
 
+// resultFileRE extracts the popup's resultFile path from its argv. The
+// character class permits '.' and '-', so a path containing ".." (e.g.
+// /tmp/../etc/dmux-popup-1.json) would match and be written unvalidated. This
+// is intentionally byte-identical to the shell's grep -oE pattern
+// (fanout:1688): the path originates from dmux's own popup process argv, not
+// from user input, and dmux builds it with path.join under its tmpdir, so no
+// traversal sequence is ever produced. Tightening the regex (rejecting "..")
+// only in Go would diverge from the shell source-of-truth without closing a
+// real attack surface; keep the patterns in lockstep.
 var resultFileRE = regexp.MustCompile(`[[:alnum:]/_.\-]+/dmux-popup-[0-9]+\.json`)
 
 func pgrepF(pattern string) ([]int, error) {

--- a/internal/tmuxctl/tmuxctl.go
+++ b/internal/tmuxctl/tmuxctl.go
@@ -1,0 +1,21 @@
+// Package tmuxctl wraps the few `tmux` subcommands fanout invokes during
+// pane creation. dmuxsession owns show-options / list-sessions; this package
+// owns send-keys.
+package tmuxctl
+
+import (
+	"fmt"
+	"io"
+	"os/exec"
+)
+
+// SendKeys fires a single named key at controlPane.
+func SendKeys(controlPane, key string) error {
+	return exec.Command("tmux", "send-keys", "-t", controlPane, key).Run()
+}
+
+// PrintSendKeys writes the dry-run-equivalent shell invocation to w. The exact
+// format is locked in by the Tier 2 goldens (`    $ tmux send-keys -t %P key`).
+func PrintSendKeys(w io.Writer, dim, reset, controlPane, key string) {
+	fmt.Fprintf(w, "    %s$ tmux send-keys -t %s %s%s\n", dim, controlPane, key, reset)
+}

--- a/internal/tty/tty.go
+++ b/internal/tty/tty.go
@@ -1,0 +1,27 @@
+// Package tty mirrors fanout:123 — only emit ANSI color when the destination
+// is a real terminal, TERM is not "dumb", and NO_COLOR is unset.
+package tty
+
+import (
+	"io"
+	"os"
+)
+
+// IsColorCapable reports whether colored output is appropriate for w.
+func IsColorCapable(w io.Writer) bool {
+	if os.Getenv("NO_COLOR") != "" {
+		return false
+	}
+	if t := os.Getenv("TERM"); t == "" || t == "dumb" {
+		return false
+	}
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	fi, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	return fi.Mode()&os.ModeCharDevice != 0
+}

--- a/tests/bats/helpers.bash
+++ b/tests/bats/helpers.bash
@@ -12,7 +12,7 @@
 # Repo root (one level above tests/bats/).
 TESTS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 REPO_ROOT="$(cd "$TESTS_DIR/.." && pwd)"
-FANOUT_BIN="$REPO_ROOT/fanout"
+FANOUT_BIN="${FANOUT_BIN:-$REPO_ROOT/fanout}"
 TEST_BIN_DIR="$TESTS_DIR/bin"
 
 setup() {

--- a/tests/bats/helpers.bash
+++ b/tests/bats/helpers.bash
@@ -186,6 +186,12 @@ assert_golden() {
   local name="$1"
   local suffix="${2:-dry-run}"
   local golden="$TESTS_DIR/golden/$name.$suffix.txt"
+  local bin_name variant
+  bin_name="$(basename "$FANOUT_BIN")"
+  variant="$TESTS_DIR/golden/$name.$suffix.$bin_name.txt"
+  if [[ "$bin_name" != fanout && ( -f "$variant" || "${FANOUT_GOLDEN_UPDATE:-0}" == "1" ) ]]; then
+    golden="$variant"
+  fi
   local scrubbed
   # $output is populated by bats' `run` (via run_fanout_*) before this helper
   # is called, so the "unassigned" warning from shellcheck is a false positive.

--- a/tests/golden/scenario-limit.dry-run.fanout-go.txt
+++ b/tests/golden/scenario-limit.dry-run.fanout-go.txt
@@ -7,7 +7,7 @@
 [info] will create 2 pane(s); deferred (blocked): 0; deferred (--limit): 1
 [info] #701: Alpha
   briefing -> /tmp/fanout-project_root-701.md
-  briefing size: 2460 bytes
+  briefing size: 2466 bytes
   current panes[] length: 0
     $ tmux send-keys -t %1 Escape
     $ tmux send-keys -t %1 n
@@ -16,7 +16,7 @@
 [ ok ] #701: dry-run complete
 [info] #702: Bravo
   briefing -> /tmp/fanout-project_root-702.md
-  briefing size: 2460 bytes
+  briefing size: 2466 bytes
   current panes[] length: 0
     $ tmux send-keys -t %1 Escape
     $ tmux send-keys -t %1 n

--- a/tests/golden/scenario-limit.dry-run.fanout-go.txt
+++ b/tests/golden/scenario-limit.dry-run.fanout-go.txt
@@ -1,0 +1,31 @@
+[info] dmux session: dmux
+[info] control pane: %1
+[info] project root: <REPO>/tests/fixtures/scenario-limit/project_root
+[info] config:       <REPO>/tests/fixtures/scenario-limit/dmux.config.json
+[info] fetching sub-issues of #700
+[info] sub-issues: 3 total, 3 OPEN
+[info] will create 2 pane(s); deferred (blocked): 0; deferred (--limit): 1
+[info] #701: Alpha
+  briefing -> /tmp/fanout-project_root-701.md
+  briefing size: 2460 bytes
+  current panes[] length: 0
+    $ tmux send-keys -t %1 Escape
+    $ tmux send-keys -t %1 n
+    # would intercept newPanePopup and write: {"success":true,"data":"[fanout #701 of #700] Alpha: read /tmp/fanout-project_root-701.md and begin."}
+    # would intercept agentChoicePopup and write: {"success":true,"data":["claude"]}
+[ ok ] #701: dry-run complete
+[info] #702: Bravo
+  briefing -> /tmp/fanout-project_root-702.md
+  briefing size: 2460 bytes
+  current panes[] length: 0
+    $ tmux send-keys -t %1 Escape
+    $ tmux send-keys -t %1 n
+    # would intercept newPanePopup and write: {"success":true,"data":"[fanout #702 of #700] Bravo: read /tmp/fanout-project_root-702.md and begin."}
+    # would intercept agentChoicePopup and write: {"success":true,"data":["claude"]}
+[ ok ] #702: dry-run complete
+
+[ ok ] created: 2
+
+Deferred 1 issue(s) due to --limit. Rerun with:
+  #703
+  fanout-go 700 --limit 1 --agent claude


### PR DESCRIPTION
## Summary

Continues the Go rewrite work from #27 on top of the current `main`, but keeps the Bash `./fanout` as the default CLI for side-by-side behavior comparison.

- Adds an experimental Go implementation under `cmd/fanout` and `internal/*`, built as `./fanout-go` instead of replacing `./fanout`.
- Ports the current mainline behavior into the Go path, including Projects v2 mode, `--status`, parent-scoped idempotency, legacy tag migration, branch-name popup payloads, and the updated Claude briefing text.
- Adds Makefile targets for `build-go`, `test-go`, `install-go`, and `link-go`; existing `make test` continues to exercise the Bash CLI.
- Allows Bats tests to point at either implementation with `FANOUT_BIN`.

## Validation

- `make test-go`
- `make test`
- `make lint`

## Notes

The Bash `fanout` file remains in place and is still what `make install` / `make link` install as `fanout`. The Go binary is intentionally separate as `fanout-go`; removal or replacement of the Bash entrypoint should happen in a later PR.