### PR TITLE
docs(skills): suppress fanout --help / which fanout probing

### DIFF
--- a/claude/skills/fanout/SKILL.md
+++ b/claude/skills/fanout/SKILL.md
@@ -5,6 +5,20 @@ description: Spawn one dmux pane per OPEN sub-issue of a GitHub parent issue, or
 
 # fanout
 
+## Synopsis
+
+```
+fanout <parent-issue|project-url>
+       [--agent <name>] [--limit <N>] [--only <list>] [--skip <list>]
+       [--include <list>] [--unblocked-only] [--project-status <name>]
+       [--name <NUM>=<slug>[|<display>[|<branch>]]]
+       [--session <tmux-session>] [--sleep <seconds>]
+       [--popup-timeout <seconds>] [--dry-run] [--debug]
+fanout <parent-issue> --status      # JSON status of fanned children, no side effects
+```
+
+**Do not run `fanout --help`, `fanout -h`, or `which fanout`.** This SKILL.md is the source-of-truth for the CLI surface — every flag above is documented under "Running" below, and the binary path is `/Users/butaosuinu/.local/bin/fanout` (also stated in the next paragraph). Probing the CLI directly wastes a tool call and adds nothing.
+
 `fanout <parent-issue-or-project-url>` enumerates either a GitHub parent issue's OPEN sub-issues *or* a GitHub Projects v2 board's OPEN items, and for each child asks dmux to create a new pane with its own git worktree and an agent CLI started with a briefing that points at `/tmp/fanout-<repo>-<N>.md`. The caller's pane is not modified, so this is safe to invoke from inside an agent session that is itself running in a dmux pane.
 
 The positional argument selects the mode: an integer (or `#N`) means **issue mode**; a URL of the form `https://github.com/(users|orgs)/<owner>/projects/<num>` means **project mode**. The two modes share everything downstream of child enumeration — briefing generation, `[fanout #N]` idempotency, `--include` / `--only` / `--skip` / `--unblocked-only` / `--name` / `--limit`, dmux popup interception — only the children come from a different source.

--- a/codex/skills/fanout/SKILL.md
+++ b/codex/skills/fanout/SKILL.md
@@ -7,6 +7,24 @@ metadata:
 
 # fanout
 
+## Synopsis
+
+```
+fanout <parent-issue|project-url>
+       [--agent <name>] [--limit <N>] [--only <list>] [--skip <list>]
+       [--include <list>] [--unblocked-only] [--project-status <name>]
+       [--name <NUM>=<slug>[|<display>[|<branch>]]]
+       [--session <tmux-session>] [--sleep <seconds>]
+       [--popup-timeout <seconds>] [--dry-run] [--debug]
+fanout <parent-issue> --status      # JSON status of fanned children, no side effects
+```
+
+**Do not probe the CLI** with `fanout --help`, `fanout -h`, or
+`which fanout`. This SKILL.md is the source-of-truth for the CLI surface —
+every flag above is documented in the sections below, and the binary path
+is normally `~/.local/bin/fanout` (see the next paragraph). Calling `--help`
+or `which` just to "verify" the surface wastes a tool call and adds nothing.
+
 `fanout <parent-issue-or-project-url>` enumerates either a GitHub parent
 issue's OPEN sub-issues *or* a GitHub Projects v2 board's OPEN items, and
 asks dmux to create one new pane per child. Each pane gets its own git


### PR DESCRIPTION
## Summary

- `claude/skills/fanout/SKILL.md` と `codex/skills/fanout/SKILL.md` の `# fanout` 見出し直後に Synopsis ブロックを追加し、全フラグを一目で読める形にした
- 同じ位置に「`fanout --help` / `fanout -h` / `which fanout` を実行しない」旨の明示禁止文を入れた
- 既存セクション (Running, Pre-flight, Non-goals など) には手を入れていない

## Why

Claude Code / Codex CLI が fanout skill を使う際、skill が用意されているにもかかわらず `which fanout && fanout --help 2>&1 | head -50` で CLI surface を直接確認しに行く挙動が出ていた。SKILL.md には全フラグの説明があるが、冒頭にシグネチャがなく、明示的な禁止指示もなかったため、モデルが「念のため確認しておこう」と判断する余地が残っていた。

## Test plan

- [ ] `make install` 後、新しい Claude Code セッションで `/fanout <issue>` を起動し、Bash の `which fanout` / `fanout --help` が呼ばれないことを確認
- [ ] `diff claude/skills/fanout/SKILL.md ~/.claude/skills/fanout/SKILL.md` と Codex 側の同等比較が空であること
- [ ] `make lint` / `make test` が緑のままであること (SKILL.md は CLI の dry-run 出力に出てこないため golden には影響しない想定)

🤖 Generated with [Claude Code](https://claude.com/claude-code)