### PR TITLE
chore(install): make Go binary the default for make install / link

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,11 +57,13 @@ uninstall-integrations:
 	@for skill in $(CLAUDE_SKILLS); do rm -rf "$(CLAUDE_SKILL_DIR)/$$skill"; done
 	@for skill in $(CODEX_SKILLS); do rm -rf "$(CODEX_SKILL_DIR)/$$skill"; done
 
-install: install-integrations
+install: build-go install-integrations
 	@mkdir -p "$(BINDIR)"
-	install -m 0755 fanout "$(BINDIR)/fanout"
+	install -m 0755 "$(GO_BIN)" "$(BINDIR)/fanout"
+	install -m 0755 fanout "$(BINDIR)/fanout-bash"
 	@echo "Installed:"
-	@echo "  $(BINDIR)/fanout"
+	@echo "  $(BINDIR)/fanout (Go)"
+	@echo "  $(BINDIR)/fanout-bash (Bash)"
 	@for cmd in $(CLAUDE_COMMANDS); do echo "  $(CLAUDE_CMD_DIR)/$$cmd"; done
 	@for skill in $(CLAUDE_SKILLS); do echo "  $(CLAUDE_SKILL_DIR)/$$skill"; done
 	@for skill in $(CODEX_SKILLS); do echo "  $(CODEX_SKILL_DIR)/$$skill"; done
@@ -72,22 +74,18 @@ install-go: build-go
 	@echo "Installed:"
 	@echo "  $(BINDIR)/fanout-go"
 
-install-go-default: build-go install-integrations
-	@mkdir -p "$(BINDIR)"
-	install -m 0755 "$(GO_BIN)" "$(BINDIR)/fanout"
-	install -m 0755 fanout "$(BINDIR)/fanout-bash"
-	@echo "Installed Go implementation as default:"
-	@echo "  $(BINDIR)/fanout"
-	@echo "  $(BINDIR)/fanout-bash"
-	@for cmd in $(CLAUDE_COMMANDS); do echo "  $(CLAUDE_CMD_DIR)/$$cmd"; done
-	@for skill in $(CLAUDE_SKILLS); do echo "  $(CLAUDE_SKILL_DIR)/$$skill"; done
-	@for skill in $(CODEX_SKILLS); do echo "  $(CODEX_SKILL_DIR)/$$skill"; done
+# install-go-default / link-go-default are now aliases: the default install / link
+# targets already place the Go binary at $(BINDIR)/fanout and demote Bash to
+# $(BINDIR)/fanout-bash. Kept for call-site compatibility (CI, docs, agent skills).
+install-go-default: install
 
-link: link-integrations
+link: build-go link-integrations
 	@mkdir -p "$(BINDIR)"
-	ln -sf "$(CURDIR)/fanout" "$(BINDIR)/fanout"
+	ln -sf "$(CURDIR)/$(GO_BIN)" "$(BINDIR)/fanout"
+	ln -sf "$(CURDIR)/fanout" "$(BINDIR)/fanout-bash"
 	@echo "Linked:"
-	@echo "  $(BINDIR)/fanout -> $(CURDIR)/fanout"
+	@echo "  $(BINDIR)/fanout -> $(CURDIR)/$(GO_BIN)"
+	@echo "  $(BINDIR)/fanout-bash -> $(CURDIR)/fanout"
 	@for cmd in $(CLAUDE_COMMANDS); do echo "  $(CLAUDE_CMD_DIR)/$$cmd -> $(CURDIR)/claude/commands/$$cmd"; done
 	@for skill in $(CLAUDE_SKILLS); do echo "  $(CLAUDE_SKILL_DIR)/$$skill -> $(CURDIR)/claude/skills/$$skill"; done
 	@for skill in $(CODEX_SKILLS); do echo "  $(CODEX_SKILL_DIR)/$$skill -> $(CURDIR)/codex/skills/$$skill"; done
@@ -98,16 +96,7 @@ link-go: build-go
 	@echo "Linked:"
 	@echo "  $(BINDIR)/fanout-go -> $(CURDIR)/$(GO_BIN)"
 
-link-go-default: build-go link-integrations
-	@mkdir -p "$(BINDIR)"
-	ln -sf "$(CURDIR)/$(GO_BIN)" "$(BINDIR)/fanout"
-	ln -sf "$(CURDIR)/fanout" "$(BINDIR)/fanout-bash"
-	@echo "Linked Go implementation as default:"
-	@echo "  $(BINDIR)/fanout -> $(CURDIR)/$(GO_BIN)"
-	@echo "  $(BINDIR)/fanout-bash -> $(CURDIR)/fanout"
-	@for cmd in $(CLAUDE_COMMANDS); do echo "  $(CLAUDE_CMD_DIR)/$$cmd -> $(CURDIR)/claude/commands/$$cmd"; done
-	@for skill in $(CLAUDE_SKILLS); do echo "  $(CLAUDE_SKILL_DIR)/$$skill -> $(CURDIR)/claude/skills/$$skill"; done
-	@for skill in $(CODEX_SKILLS); do echo "  $(CODEX_SKILL_DIR)/$$skill -> $(CURDIR)/codex/skills/$$skill"; done
+link-go-default: link
 
 uninstall: uninstall-integrations
 	rm -f "$(BINDIR)/fanout" "$(BINDIR)/fanout-bash"


### PR DESCRIPTION
## Summary

Bash 版 fanout 段階的廃止ロードマップの **Wave 1（deprecation window を開く）**。#74 で追加した `install-go-default` / `link-go-default` のロジックを、デフォルトの `install` / `link` 側へ昇格させる。

- `make install`: Go バイナリを `$(BINDIR)/fanout`、Bash を `$(BINDIR)/fanout-bash` に配置（`build-go` を prereq に追加）
- `make link`: 同様に symlink（`fanout -> $(CURDIR)/fanout-go`、`fanout-bash -> $(CURDIR)/fanout`）
- 旧 `install-go-default` / `link-go-default` は recipe なしの **alias** 化（`install-go-default: install` / `link-go-default: link`）— CI・docs・agent skill 等の既存呼び出し互換を維持
- `uninstall` は現状維持（`fanout` + `fanout-bash` を両方削除済み）
- side-by-side 比較用の `install-go` / `link-go`（`fanout-go`）は不変更（Wave2 で整理）

agent 連携ファイル（`claude/commands/fanout.md`・各 `SKILL.md`）は安定名 `fanout` を呼ぶだけなので、本ターゲット切替だけで agent が Go 実装を叩くようになる。README / README.ja のインストール記述更新は別 issue（docs 改訂）で吸収。

## Verification

実 `~/.local/bin` を汚さないよう `PREFIX` / `CLAUDE_DIR` / `CODEX_DIR` を一時パスへ上書きして確認：

- ✅ `make link` 後 `readlink bin/fanout` → `<worktree>/fanout-go`（AC#1）、`fanout-bash --help` が Bash 実装を起動（AC#2）
- ✅ `make install` で `file bin/fanout` = Mach-O 実行ファイル（Go）、`head -1 bin/fanout-bash` = `#!/usr/bin/env bash`（AC#3）
- ✅ `make uninstall` で両方削除（AC#4）
- ✅ `make install-go-default` / `make link-go-default` の alias が壊れず Go をデフォルト配置（AC#5）
- ✅ `make lint` / `make test` / `make test-go` すべて green
- ✅ `/code-review`（xhigh）実行 — 修正すべき指摘なし

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)