### PR TITLE
feat(fanout): bash fanout 起動時に deprecation 警告を stderr に出す

### DIFF
--- a/fanout
+++ b/fanout
@@ -22,6 +22,10 @@ usage() {
   cat <<'EOF'
 Usage: fanout <parent-issue|project-url> [options]
 
+DEPRECATED: the Bash fanout is being phased out in favor of the Go port and
+will be removed in a future release. Install the Go build as the default
+`fanout` command with `make install-go-default` (or `make link-go-default`).
+
 Creates one dmux pane per OPEN sub-issue of the given parent issue, OR per
 OPEN item in the given Projects v2 URL (e.g. https://github.com/users/<u>/projects/<n>
 or https://github.com/orgs/<o>/projects/<n>). Each pane gets a dedicated git
@@ -211,6 +215,15 @@ log_debug() { (( ${debug:-0} )) || return 0; printf '%s[dbg ]%s %s\n' "$C_DIM" "
 die() {
   log_err "$*"
   exit 1
+}
+
+deprecation_notice() {
+  # Wave 1 of the bash->Go migration. Human-facing only: emit when stderr is a
+  # terminal, so pipelines, machine-readable callers, and the bats harness
+  # (which folds stderr into captured stdout via `2>&1`) stay clean and the
+  # Tier2 goldens don't shift. stdout / exit code are untouched.
+  [[ -t 2 ]] || return 0
+  log_warn 'bash fanout is deprecated and will be removed in a future release; install the Go port as the default with: make install-go-default'
 }
 
 parse_num_csv() {
@@ -1107,6 +1120,8 @@ cmd_status() {
     }
   }'
 }
+
+deprecation_notice
 
 if (( status_mode )); then
   cmd_status


### PR DESCRIPTION
## What

「bash 版 fanout の段階的廃止」ロードマップ Wave 1。Bash 版 `fanout` の実行時に、Go 実装への移行を促す 1 行の deprecation 警告を **stderr** に出す。deprecation window の利用者向けシグナル。

## Changes (`fanout` のみ / 3 箇所)

1. `deprecation_notice` 関数を追加（既存 `log_warn` を再利用）。
2. メインディスパッチ（`status_mode`）直前で 1 回呼ぶ — status / dry-run / 通常実行の共通チョークポイント。
3. `usage()` ヒアドキュメントに `DEPRECATED:` 注記（`make install-go-default` / `make link-go-default` を案内）。

## 抑制ゲート: `[[ -t 2 ]]`（stderr が端末か）

無条件に stderr へ出すとテストハーネス（`helpers.bash` の `run bash -c "$cmd 2>&1"`）が stderr を stdout にマージして golden 比較するため、Tier2 golden がずれてしまう。そこで **「stderr が端末のときだけ」** 警告を出す:

- 人間が対話実行（dmux ペイン等）→ 表示
- パイプ / 機械可読消費 / bats `run` 配下 → 自動抑制

これにより **stdout と exit code は不変**、golden / テストファイルは無変更。issue が例示する `NO_COLOR`/`TERM=dumb` ゲートより優れる（色の好みと廃止通知の有無を混同しない）。Go 側は後継のため警告を出さない。

`usage` の注記は `<<'EOF'` クォート付きヒアドキュメント内なのでバッククォートはリテラル（コマンド置換されない）。

## Acceptance criteria

- [x] `./fanout --help` に deprecation 注記が表示される
- [x] 通常（対話）実行時に stderr へ 1 行の移行案内が出る
- [x] `make test`（Tier1 + Tier2）green のまま（golden 差分なし）
- [x] `make test-go`（Go 実装）にも影響なし

## Verification

- `shellcheck fanout` clean
- `make test` / `make test-go` 共に green、`git status tests/golden tests/bats` 空（差分ゼロ）
- pty 経由（`script -q /dev/null ...`）で警告 1 行表示を確認 / stderr パイプ時は抑制を確認
- `./fanout --help` exit 0、usage に `DEPRECATED:` ブロック表示、ランタイム警告は help では非表示

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)