### PR TITLE
docs: Go を主実装に位置づけ、Bash deprecation を告知 (#77)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,10 +28,18 @@ the README before changing CLI behavior.
 
 ## Working With The Script
 
-- Run it directly with `./fanout <parent-issue>`.
-- Validate logic without driving dmux with
-  `./fanout <parent-issue> --dry-run`.
-- Lint with `shellcheck fanout` when available. Treat quoting warnings as real.
+The default `fanout` is the Go binary (`make build-go` → `./fanout-go`); the
+Bash `./fanout` is the deprecated lane. Both are kept at parity by the bats
+suite, so validate the lane you change and keep the two in sync.
+
+- Run it directly with `./fanout-go <parent-issue>` (Go default) or
+  `./fanout <parent-issue>` (deprecated Bash).
+- Validate logic without driving dmux by appending `--dry-run` to either
+  binary, e.g. `./fanout-go <parent-issue> --dry-run`.
+- Lint with `make lint` (go vet + gofmt + shellcheck). Treat shellcheck
+  quoting warnings on the Bash script as real.
+- Run the parity suite with `make test` (Bash `./fanout`) and `make test-go`
+  (Go `./fanout-go`) before relying on a change.
 - A live end-to-end test requires tmux, a running dmux session, and a real
   GitHub parent issue with OPEN sub-issues. There is no mock layer.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,8 +5,13 @@ repository.
 
 ## Project Shape
 
-This is a single-file Bash CLI (`fanout`) plus docs and agent integration
-files. There is no build system, test suite, or lint config.
+The Go implementation (`cmd/fanout` + `internal/`) is the primary, default
+`fanout`; `make install` builds it and installs it at `$(BINDIR)/fanout`. The
+original single-file Bash `fanout` is **deprecated** and kept side-by-side as
+`$(BINDIR)/fanout-bash` during the migration window (Wave 1 of #80; removed in
+Wave 2). A Go build (`make build-go`), a bats parity suite that covers both
+implementations (`make test` / `make test-go`), and lint (`make lint` =
+go vet + gofmt + shellcheck) all exist.
 
 Source-of-truth integration files:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,9 @@ The default `fanout` is the Go binary (`make build-go` → `./fanout-go`); the
 Bash `./fanout` is the deprecated lane. Both are kept at parity by the bats
 suite, so validate the lane you change and keep the two in sync.
 
-- Run it directly with `./fanout-go <parent-issue>` (Go default) or
-  `./fanout <parent-issue>` (deprecated Bash).
+- Run it: build the Go binary with `make build-go`, then
+  `./fanout-go <parent-issue>` (Go default); the tracked, deprecated Bash
+  `./fanout <parent-issue>` runs directly with no build step.
 - Validate logic without driving dmux by appending `--dry-run` to either
   binary, e.g. `./fanout-go <parent-issue> --dry-run`.
 - Lint with `make lint` (go vet + gofmt + shellcheck). Treat shellcheck

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,10 +16,12 @@ The user-facing surface (CLI flags, prerequisites, troubleshooting) is in `READM
 
 ## Working with the script
 
-- Run it: `./fanout <parent-issue>` (it's executable; no install step).
-- Verify changes without driving dmux: `./fanout <parent-issue> --dry-run`. The dry-run path prints every `tmux send-keys` invocation with `%q` quoting and the would-be briefing size, so use it as the primary way to validate logic changes that don't need a live dmux.
-- Lint: `shellcheck fanout` (no config file; treat `SC2086`-style warnings as real — the script intentionally quotes everything because prompts and titles can contain spaces and shell metacharacters). `make lint` runs the same check plus the test shims.
-- Black-box tests: `make test` (requires `bats-core`) runs Tier 1 (flag/prerequisite) + Tier 2 (`--dry-run` golden output against fixture scenarios under `tests/fixtures/`) tests. Tier 1 locks in the CLI surface (error messages + exit codes) and Tier 2 locks in the dry-run planning output — both are issue #20 invariants the future Go rewrite must match. Regenerate Tier 2 goldens with `FANOUT_GOLDEN_UPDATE=1 make test-tier2`. Tier 3 (live dmux E2E) is out of scope.
+The default `fanout` is the Go binary (`make build-go` → `./fanout-go`); the Bash `./fanout` is the deprecated lane. Both are kept at parity by the bats suite, so validate the lane you change and run both `make test` (Bash) and `make test-go` (Go).
+
+- Run it: `./fanout-go <parent-issue>` (Go default) or `./fanout <parent-issue>` (deprecated Bash) — both are executable, no install step.
+- Verify changes without driving dmux: append `--dry-run` to either binary, e.g. `./fanout-go <parent-issue> --dry-run`. The dry-run path prints every `tmux send-keys` invocation with `%q` quoting and the would-be briefing size, so use it as the primary way to validate logic changes that don't need a live dmux.
+- Lint: `shellcheck fanout` (no config file; treat `SC2086`-style warnings as real — the script intentionally quotes everything because prompts and titles can contain spaces and shell metacharacters). `make lint` runs that shellcheck plus the test shims, alongside `go vet` and `gofmt` on the Go sources.
+- Black-box tests: `make test` (requires `bats-core`) runs Tier 1 (flag/prerequisite) + Tier 2 (`--dry-run` golden output against fixture scenarios under `tests/fixtures/`) tests. Tier 1 locks in the CLI surface (error messages + exit codes) and Tier 2 locks in the dry-run planning output — both are issue #20 parity invariants both implementations must match. Regenerate Tier 2 goldens with `FANOUT_GOLDEN_UPDATE=1 make test-tier2`. Tier 3 (live dmux E2E) is out of scope.
 - A live end-to-end test needs a running dmux session in tmux and a real GitHub parent issue with OPEN sub-issues; there is no mock layer.
 
 ## Architecture notes that span the script

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ The user-facing surface (CLI flags, prerequisites, troubleshooting) is in `READM
 
 The default `fanout` is the Go binary (`make build-go` → `./fanout-go`); the Bash `./fanout` is the deprecated lane. Both are kept at parity by the bats suite, so validate the lane you change and run both `make test` (Bash) and `make test-go` (Go).
 
-- Run it: `./fanout-go <parent-issue>` (Go default) or `./fanout <parent-issue>` (deprecated Bash) — both are executable, no install step.
+- Run it: build the Go binary first with `make build-go`, then `./fanout-go <parent-issue>` (Go default); the tracked, deprecated Bash `./fanout <parent-issue>` runs directly with no build step.
 - Verify changes without driving dmux: append `--dry-run` to either binary, e.g. `./fanout-go <parent-issue> --dry-run`. The dry-run path prints every `tmux send-keys` invocation with `%q` quoting and the would-be briefing size, so use it as the primary way to validate logic changes that don't need a live dmux.
 - Lint: `shellcheck fanout` (no config file; treat `SC2086`-style warnings as real — the script intentionally quotes everything because prompts and titles can contain spaces and shell metacharacters). `make lint` runs that shellcheck plus the test shims, alongside `go vet` and `gofmt` on the Go sources.
 - Black-box tests: `make test` (requires `bats-core`) runs Tier 1 (flag/prerequisite) + Tier 2 (`--dry-run` golden output against fixture scenarios under `tests/fixtures/`) tests. Tier 1 locks in the CLI surface (error messages + exit codes) and Tier 2 locks in the dry-run planning output — both are issue #20 parity invariants both implementations must match. Regenerate Tier 2 goldens with `FANOUT_GOLDEN_UPDATE=1 make test-tier2`. Tier 3 (live dmux E2E) is out of scope.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project shape
 
-Single-file Bash script (`fanout`) plus docs and agent integration files. No build system, no test suite, no lint config.
+The Go implementation (`cmd/fanout` + `internal/`) is the primary, default `fanout` — `make install` builds it and places it at `$(BINDIR)/fanout`. The original single-file Bash `fanout` script is **deprecated** and kept side-by-side as `$(BINDIR)/fanout-bash` during the migration window (Wave 1 of #80; removed in Wave 2). There is now a Go build (`make build-go`), a bats parity suite that runs against both implementations (`make test` exercises the Bash `./fanout`, `make test-go` the Go `./fanout-go` via `FANOUT_BIN`), and lint (`make lint` = go vet + gofmt + shellcheck). The popup-intercept and dmux-specific architecture notes below still describe the shared behavior both implementations must match.
 
 The Claude Code integration files (`claude/commands/fanout.md` slash command and `claude/skills/fanout/SKILL.md` skill) and Codex CLI integration file (`codex/skills/fanout/SKILL.md`) are bundled in the repo as the source-of-truth. `make install` places them under `~/.claude/` and `~/.codex/`. Don't edit installed copies directly — edit the repo versions and rerun `make install` (or use `make link` during development).
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -106,6 +106,13 @@ CLAUDE_DIR=/path/to/.claude make install # 既定以外の Claude データデ�
 CODEX_DIR=/path/to/.codex make install   # 既定以外の Codex データディレクトリを指定
 ```
 
+ソースからのビルドには **Go ツールチェイン**（Go 1.23+）が必要です。`make install`・
+`make link`・`make build-go` はいずれも `go build ./cmd/fanout` を実行するため、
+Go の無いマシンはビルド段階で失敗します。prebuilt バイナリ配布（#67）が出るまでは
+先に Go を導入してください（macOS は `brew install go`、Linux はディストリの
+`golang`/`go` パッケージ）。Go が必要なのは `fanout` バイナリだけで、エージェント
+連携ファイルの配置には不要です。
+
 配置パス:
 
 - `$(BINDIR)/fanout` — Go バイナリ（既定は `~/.local/bin/fanout`）

--- a/README.ja.md
+++ b/README.ja.md
@@ -82,12 +82,14 @@ resultFile パスを特定し、プロンプトポップアップ用には
 > **⚠️ Bash 版の廃止予定。** Go 実装（`cmd/fanout`）が既定です — 下記で
 > インストールされる Release バイナリがそれで、`make install` がビルドするのも
 > Go です。従来の単一ファイル Bash 版 `fanout` は **deprecated（廃止予定）** で、
-> 移行期間中は `fanout-bash`（およびチェックアウト内）として併存します。prebuilt
-> バイナリ配布は完了済み（下記 curl 経路、#67）なので、Bash スクリプト撤去までに
-> 残る条件は「Wave 1 の変更が出揃うこと」と「bash 起動時 deprecation 警告を載せた
-> リリースが最低 1 タグ出ること」です。ユーザー側の対応は不要 — curl でも
-> `make install` でも Go が入り、`fanout-bash` がフォールバックとして残ります。
-> 全体ロードマップは #80 を参照してください。
+> 移行期間中はチェックアウト内に残ります。ユーザー側の対応は不要 — curl でも
+> `make install` でも Go の `fanout` が入ります。チェックアウトからの
+> `make install` / `make link` は加えて Bash スクリプトを `fanout-bash` として
+> 残しますが、curl 経路は Go バイナリのみ（`fanout-bash` は入りません）なので、
+> 旧 Bash が必要な場合はチェックアウトから実行してください。撤去は「Wave 1 の
+> 変更が出揃うこと」と「bash 起動時 deprecation 警告を載せたリリースが出ること」
+> が条件です（prebuilt バイナリ配布は curl 経路で完了済み、#67）。全体ロード
+> マップは #80 を参照してください。
 
 推奨インストール経路は Release 済みの Go バイナリです。安定コマンド名
 `fanout` と、同梱の Claude/Codex 連携ファイルをまとめて配置します:

--- a/README.ja.md
+++ b/README.ja.md
@@ -79,15 +79,26 @@ resultFile パスを特定し、プロンプトポップアップ用には
 
 ## インストール
 
-fanout は Bash CLI と任意の Go 版に、エージェント連携ファイルを加えた構成で
+> **⚠️ Bash 版の廃止予定。** Go 実装（`cmd/fanout`）が既定実装になり、
+> `make install` が `$(BINDIR)/fanout` に配置するのも Go バイナリです。
+> 従来の単一ファイル Bash 版 `fanout` は **deprecated（廃止予定）** です:
+> 引き続き動作し、移行期間中は `$(BINDIR)/fanout-bash` として併存しますが、
+> (1) prebuilt バイナリ配布（#67）が完了してソースからビルドしない利用者も
+> Go バイナリを入手できるようになり、(2) Wave 1 の変更が出揃い、(3) Bash
+> 起動時の deprecation 警告を載せたリリースが最低 1 タグ出た時点で撤去されます。
+> それまでユーザー側の対応は不要です — `make install` で自動的に Go に
+> 切り替わり、`fanout-bash` がフォールバックとして残ります。全体ロードマップは
+> #80 を参照してください。
+
+fanout は Go バイナリ（既定実装）に、エージェント連携ファイルを加えた構成で
 配布されます。Claude Code にはスラッシュコマンド + スキル群、Codex CLI には
-スキル群を用意しています。すべて `Makefile` 経由で一括配置されます:
+スキル群を用意しています。`make install` は Go バイナリをビルドして
+`$(BINDIR)/fanout` に配置し、deprecated な Bash 実装を `$(BINDIR)/fanout-bash`
+として残します。すべて `Makefile` 経由で一括配置されます:
 
 ```bash
-make install        # CLI + Claude/Codex 連携を ~/.local, ~/.claude, ~/.codex にコピー
-make link           # チェックアウト先を指す symlink を作成（開発用）
-make install-go-default # Go 版をビルドし、既定の fanout コマンドとして配置
-make link-go-default    # Go 版を既定の fanout コマンドとして symlink
+make install        # Go バイナリを $(BINDIR)/fanout（+ deprecated な fanout-bash）に配置し Claude/Codex 連携をコピー
+make link           # Go ビルドを $(BINDIR)/fanout（+ fanout-bash）としてチェックアウト先に symlink（開発用）
 make uninstall      # インストール済みのパスを削除
 
 PREFIX=/usr/local sudo make install     # システム全体に CLI を配置; BINDIR を $PREFIX/bin に上書き
@@ -97,25 +108,27 @@ CODEX_DIR=/path/to/.codex make install   # 既定以外の Codex データディ
 
 配置パス:
 
-- `$(BINDIR)/fanout`（既定は `~/.local/bin/fanout`）
+- `$(BINDIR)/fanout` — Go バイナリ（既定は `~/.local/bin/fanout`）
+- `$(BINDIR)/fanout-bash` — deprecated な Bash 実装、移行期間中の残置
 - `$(CLAUDE_DIR)/commands/fanout.md`（既定は `~/.claude/commands/fanout.md`）
 - `$(CLAUDE_DIR)/skills/fanout/`（既定は `~/.claude/skills/fanout/`）
 - `$(CLAUDE_DIR)/skills/fanout-issues/`（既定は `~/.claude/skills/fanout-issues/`）
 - `$(CODEX_DIR)/skills/fanout/`（既定は `~/.codex/skills/fanout/`）
 - `$(CODEX_DIR)/skills/fanout-issues/`（既定は `~/.codex/skills/fanout-issues/`）
 
-エージェント連携は常に安定した `fanout` コマンド名を呼びます。エージェントに
-Go 実装を優先させたい場合は `make install-go-default` または
-`make link-go-default` を実行してください。これらのターゲットは Go バイナリを
-`$(BINDIR)/fanout` に置き、Bash 実装を `$(BINDIR)/fanout-bash` として残します。
-エージェントに `fanout-go` を直接呼ばせないでください。`fanout-go` は
-`make install-go` / `make link-go` で配置する比較用コマンドです。
+エージェント連携は常に安定した `fanout` コマンド名を呼びます。この名前は
+既定で Go バイナリに解決されます。deprecated な Bash 実装は移行期間中
+`$(BINDIR)/fanout-bash` として残ります。エージェントに `fanout-go` を直接
+呼ばせないでください。`fanout-go` は `make install-go` / `make link-go` で
+配置する並行比較用コマンドです。
 
 `make install` は安定しています — リポジトリを消しても、コピー済みのファイルで
-動作し続けます。`make link` はチェックアウトを指すので、編集がすぐ反映され、
-`git pull` だけで更新が終わります。どちらのターゲットも、親ディレクトリが
-存在しなければ作成します。インストールまたはリンク後、実行中の Codex CLI
-セッションがある場合は再起動すると新しいスキルを認識します。
+動作し続けます。`make link` はチェックアウトを symlink します。連携ファイルへの
+編集はすぐ反映され（`git pull` だけで更新が終わります）、一方 Go 製の `fanout`
+バイナリはビルド成果物なので、Go ソースを変更したら `make link` を再実行して
+ビルドし直してください。どちらのターゲットも、親ディレクトリが存在しなければ
+作成します。インストールまたはリンク後、実行中の Codex CLI セッションがある
+場合は再起動すると新しいスキルを認識します。
 
 `~/.local/bin` が `PATH` に入っていることを確認してください
 （`echo $PATH | tr ':' '\n' | grep -F "$HOME/.local/bin"`）。
@@ -127,23 +140,24 @@ Go 実装を優先させたい場合は `make install-go-default` または
 make test           # Tier 1 + Tier 2 黒箱テスト (bats-core 必須)
 make test-tier1     # フラグ / prereq テストのみ
 make test-tier2     # --dry-run ゴールデン出力テスト (fixture 駆動)
-make lint           # shellcheck fanout + テスト用 shim
-make build-go       # 実験中の Go 版を ./fanout-go としてビルド
+make lint           # go vet + gofmt チェック + shellcheck（Go・Bash 両方を lint）
+make build-go       # Go 実装を ./fanout-go としてビルド
 make test-go        # 同じ黒箱テストを ./fanout-go に対して実行
 make install-go     # Go 版を比較用の $(BINDIR)/fanout-go として配置
 ```
 
 bats: macOS は `brew install bats-core`、Debian/Ubuntu は `apt install bats`。
+Go 実装が既定になりました — `make install` はこれを `fanout` として配置します。
+両実装は廃止猶予期間中も併存し、単一の parity スイートで担保されます:
 Tier 1 は CLI サーフェス (エラーメッセージ + exit code)、Tier 2 は `--dry-run`
 の計画出力を `tests/fixtures/` 配下のシナリオ fixture に対して凍結します。
-いずれも Go 書き換え時の parity テスト資産です。`make install` /
-`make link` では Bash 製の `./fanout` が既定のままです。一方、
-`make install-go-default` / `make link-go-default` は、エージェントが既に
-呼んでいる安定コマンド名 `fanout` の中身を Go 版に差し替えます。
-`./fanout-go` は動作比較用として並行配置できます。`$(BINDIR)` に
-`fanout-go` コマンドを入れたい場合は `make install-go` または
-`make link-go` を使ってください。`--dry-run` 出力を意図的に変更した
-場合は `FANOUT_GOLDEN_UPDATE=1 make test-tier2` で golden を再生成してください。
+`make test` は両 Tier を Bash 製 `./fanout` に対して、`make test-go` は同一
+fixture を Go 製 `./fanout-go`（`FANOUT_BIN` で切替）に対して実行するので、
+二実装は挙動レベルで一致し続けます。Wave 2 で既定の `make test` を Go へ
+向け、Bash lane を畳みます。`$(BINDIR)` に動作比較用の `fanout-go` コマンドを
+入れたい場合は `make install-go` または `make link-go` を使ってください。
+`--dry-run` 出力を意図的に変更した場合は
+`FANOUT_GOLDEN_UPDATE=1 make test-tier2` で golden を再生成してください。
 Tier 3 (live dmux E2E) は手動運用のままです。
 
 ## 前提条件

--- a/README.md
+++ b/README.md
@@ -79,15 +79,26 @@ task-list union.
 
 ## Installation
 
-fanout ships as a Bash CLI with an optional Go port plus agent integration
-files: Claude Code gets a slash command + skills, and Codex CLI gets skills.
-All of them are placed in one shot via the `Makefile`:
+> **⚠️ Bash deprecation.** The Go implementation (`cmd/fanout`) is now the
+> default and what `make install` places at `$(BINDIR)/fanout`. The original
+> single-file Bash `fanout` is **deprecated**: it still works and stays
+> available side-by-side as `$(BINDIR)/fanout-bash` throughout the migration
+> window, but it will be removed once (1) prebuilt binaries are distributed
+> (#67) so users who don't build from source can still get the Go binary,
+> (2) the Wave 1 changes have landed, and (3) at least one release has shipped
+> carrying the Bash entrypoint's startup deprecation warning. Until then no
+> action is required — `make install` switches you to Go automatically and
+> `fanout-bash` remains as a fallback. See #80 for the full roadmap.
+
+fanout ships as a Go binary (the default implementation) plus agent
+integration files: Claude Code gets a slash command + skills, and Codex CLI
+gets skills. `make install` builds the Go binary, installs it as
+`$(BINDIR)/fanout`, and keeps the deprecated Bash implementation as
+`$(BINDIR)/fanout-bash`. All of them are placed in one shot via the `Makefile`:
 
 ```bash
-make install        # copies CLI + Claude/Codex integrations into ~/.local, ~/.claude, ~/.codex
-make link           # symlinks the same paths at the checkout (use while hacking)
-make install-go-default # builds the Go port and installs it as the default fanout command
-make link-go-default    # symlinks the Go port as the default fanout command
+make install        # builds the Go binary as $(BINDIR)/fanout (+ deprecated fanout-bash) and copies Claude/Codex integrations
+make link           # symlinks the Go build as $(BINDIR)/fanout (+ fanout-bash) at the checkout (use while hacking)
 make uninstall      # removes the installed paths
 
 PREFIX=/usr/local sudo make install     # system-wide CLI; overrides BINDIR to $PREFIX/bin
@@ -97,25 +108,27 @@ CODEX_DIR=/path/to/.codex make install   # non-default Codex data dir
 
 Installed paths:
 
-- `$(BINDIR)/fanout` (default `~/.local/bin/fanout`)
+- `$(BINDIR)/fanout` — the Go binary (default `~/.local/bin/fanout`)
+- `$(BINDIR)/fanout-bash` — the deprecated Bash implementation, kept during the migration window
 - `$(CLAUDE_DIR)/commands/fanout.md` (default `~/.claude/commands/fanout.md`)
 - `$(CLAUDE_DIR)/skills/fanout/` (default `~/.claude/skills/fanout/`)
 - `$(CLAUDE_DIR)/skills/fanout-issues/` (default `~/.claude/skills/fanout-issues/`)
 - `$(CODEX_DIR)/skills/fanout/` (default `~/.codex/skills/fanout/`)
 - `$(CODEX_DIR)/skills/fanout-issues/` (default `~/.codex/skills/fanout-issues/`)
 
-Agent integrations always invoke the stable `fanout` command name. If you want
-agents to prefer the Go implementation, run `make install-go-default` or
-`make link-go-default`; those targets place the Go binary at `$(BINDIR)/fanout`
-and keep the Bash implementation available as `$(BINDIR)/fanout-bash`.
+Agent integrations always invoke the stable `fanout` command name, which now
+resolves to the Go binary by default. The deprecated Bash implementation stays
+available as `$(BINDIR)/fanout-bash` for the duration of the migration window.
 Do not teach agents to call `fanout-go` directly — `fanout-go` is only a
 side-by-side comparison command installed by `make install-go` / `make link-go`.
 
 `make install` is stable — delete the repo and the copies still work.
-`make link` points at the checkout, so edits take effect immediately and
-`git pull` is enough to update. Either target creates the parent
-directories if they don't exist. Restart any running Codex CLI session after
-installing or linking so it picks up the new skill.
+`make link` symlinks the checkout instead: edits to the integration files take
+effect immediately (a `git pull` is enough to update them), while the Go
+`fanout` binary is a built artifact, so rerun `make link` after changing Go
+source to rebuild it. Either target creates the parent directories if they
+don't exist. Restart any running Codex CLI session after installing or linking
+so it picks up the new skill.
 
 Confirm `~/.local/bin` is on your `PATH` (`echo $PATH | tr ':' '\n' | grep -F "$HOME/.local/bin"`).
 If not, add `export PATH="$HOME/.local/bin:$PATH"` to your shell rc.
@@ -126,23 +139,25 @@ If not, add `export PATH="$HOME/.local/bin:$PATH"` to your shell rc.
 make test           # Tier 1 + Tier 2 black-box tests (bats-core required)
 make test-tier1     # flag/prereq tests only
 make test-tier2     # --dry-run golden tests against fixture scenarios
-make lint           # shellcheck fanout + test shims
-make build-go       # build the experimental Go port as ./fanout-go
+make lint           # go vet + gofmt check + shellcheck (Go and Bash both linted)
+make build-go       # build the Go implementation as ./fanout-go
 make test-go        # run the same black-box tests against ./fanout-go
 make install-go     # install the Go port side-by-side as $(BINDIR)/fanout-go
 ```
 
 bats: `brew install bats-core` on macOS, `apt install bats` on Debian/Ubuntu.
-Tier 1 locks the CLI surface (error messages + exit codes); Tier 2 locks the
-`--dry-run` planning output against fixture scenarios under `tests/fixtures/`.
-Both tiers are parity-test material for the Go rewrite. The Bash `./fanout`
-remains the default for `make install` / `make link`, while
-`make install-go-default` / `make link-go-default` promote the Go port under
-the stable `fanout` command name that agents already invoke. `./fanout-go`
-still exists in parallel for behavior comparison; use `make install-go` or
-`make link-go` if you want a `fanout-go` command in `$(BINDIR)`. Regenerate
-Tier 2 goldens with `FANOUT_GOLDEN_UPDATE=1 make test-tier2` when you
-intentionally change dry-run output. Tier 3 (live dmux E2E) stays manual.
+The Go implementation is now the default — `make install` ships it as
+`fanout`. Both implementations still exist during the deprecation window and
+are held to a single parity suite: Tier 1 locks the CLI surface (error
+messages + exit codes) and Tier 2 locks the `--dry-run` planning output
+against fixture scenarios under `tests/fixtures/`. `make test` runs both tiers
+against the Bash `./fanout`; `make test-go` runs the identical fixtures against
+the Go `./fanout-go` (via `FANOUT_BIN`), so the two implementations stay
+behavior-for-behavior equal. Wave 2 will retarget the default `make test` at Go
+and retire the Bash lane. Use `make install-go` / `make link-go` if you want a
+side-by-side `fanout-go` comparison command in `$(BINDIR)`. Regenerate Tier 2
+goldens with `FANOUT_GOLDEN_UPDATE=1 make test-tier2` when you intentionally
+change dry-run output. Tier 3 (live dmux E2E) stays manual.
 
 ## Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -106,6 +106,13 @@ CLAUDE_DIR=/path/to/.claude make install # non-default Claude data dir
 CODEX_DIR=/path/to/.codex make install   # non-default Codex data dir
 ```
 
+Building from source needs a **Go toolchain** (Go 1.23+): `make install`,
+`make link`, and `make build-go` all run `go build ./cmd/fanout`, so a machine
+without Go fails at the build step. Install Go first (`brew install go` on
+macOS, your distro's `golang`/`go` package on Linux) until prebuilt binaries
+land (#67). Only the `fanout` binary needs Go; the agent integration files do
+not.
+
 Installed paths:
 
 - `$(BINDIR)/fanout` — the Go binary (default `~/.local/bin/fanout`)

--- a/README.md
+++ b/README.md
@@ -80,14 +80,16 @@ task-list union.
 ## Installation
 
 > **⚠️ Bash deprecation.** The Go implementation (`cmd/fanout`) is the default —
-> it's the released binary installed below and what `make install` builds. The
-> original single-file Bash `fanout` is **deprecated**; it still works and stays
-> available as `fanout-bash` (and in the checkout) during the migration window.
-> Prebuilt binaries now ship (the curl path below, #67), so the remaining gates
-> before the Bash script is removed are the Wave 1 changes landing and at least
-> one release carrying the Bash entrypoint's startup deprecation warning. No
-> action is required — the curl install or `make install` gives you Go, with
-> `fanout-bash` as a fallback. See #80 for the full roadmap.
+> the released binary installed below and what `make install` builds. The
+> original single-file Bash `fanout` is **deprecated**; it still works and
+> remains in the checkout during the migration window. No action is required:
+> both the curl install and `make install` give you the Go `fanout`. From a
+> checkout, `make install` / `make link` also keep the Bash script as
+> `fanout-bash`; the curl path ships the Go binary only (no `fanout-bash`), so
+> curl users who still need the old Bash should run it from a checkout. The
+> script is removed once the Wave 1 changes land and a release carries the Bash
+> startup deprecation warning (prebuilt binaries already ship via the curl path,
+> #67). See #80 for the full roadmap.
 
 The recommended install path is the released Go binary. It installs the stable
 `fanout` command plus the bundled Claude/Codex integration files:


### PR DESCRIPTION
## What

親ロードマップ #80「bash 版 fanout を段階的に廃止し Go 実装へ一本化する」の **Wave 1（deprecation window を開く）** の docs 担当（#77）。README / README.ja / CLAUDE.md / AGENTS.md を「**Go 実装（`cmd/fanout` + `internal/`）が既定、Bash `fanout` は廃止予定**」という位置づけへ改訂し、bash 版の廃止予定・撤去条件・移行手順を明示する。

## Changes

- **README.md / README.ja.md（Installation 節）**
  - 冒頭文を「fanout ships as a Go binary (the default implementation)」へ書き換え。`make install` が Go バイナリを `$(BINDIR)/fanout` に置き、deprecated な Bash を `$(BINDIR)/fanout-bash` として残す旨を明記。
  - **deprecation 告知ブロック**（blockquote callout）を新設:
    - 撤去条件 = (1) prebuilt バイナリ配布 #67 完了 + (2) Wave 1 マージ済み + (3) bash 起動警告を載せたリリースが最低 1 タグ（親 #80 の window 定義に準拠）
    - 移行手順 = ユーザー対応不要・`make install` で自動 Go 切替・`fanout-bash` がフォールバック
  - 配置パス一覧に `$(BINDIR)/fanout-bash` を追加。冗長になった `install-go-default` / `link-go-default` 行を撤去（`make install`/`link` 自体が Go 既定になるため）。
  - **Development 節**: 「既定は Go」を明記しつつ、廃止猶予期間中は両実装が単一 bats parity スイートで担保される旨へ調整。`make test`=Bash `./fanout` / `make test-go`=Go `./fanout-go`（`FANOUT_BIN` 切替）と現状を正確に記述し、Wave 2 で `make test` も Go へ向ける方向を 1 文で示す。
- **CLAUDE.md / AGENTS.md "Project shape"**: 「Single-file Bash script」→「Go 主実装・既定、Bash は `fanout-bash` として残置の廃止予定」。古くなった「No build system / test / lint」表記も現状（`make build-go` / bats parity / `make lint`= go vet + gofmt + shellcheck）へ補正。
- **内部不整合の修正**: `make link` の説明を「Go ビルドを symlink」に変えたのに合わせ、未変更だった「編集がすぐ反映」文を連携ファイル向けに限定し、Go ソース変更時は `make link` 再実行（再ビルド）が要る旨へ修正。

## Scope notes

- **docs 専用 PR**。Makefile の実体フリップ（`make install`/`make link` の既定を Go へ、bash を `fanout-bash` へ降格）は **並列・独立な兄弟 issue #76** が担当する。親 #80 が「Wave 1 の 3 件（#76/#77/#78）は独立・並列実行可」と明言しているため、本 PR の install 記述は **#76 マージ後の到達状態**を記述している（Wave 1 設計上、各項目は独立マージ）。#76 がマージされるまで docs は Makefile より一時的に先行する。
- agent 連携ファイル（`claude/commands/fanout.md`・各 `SKILL.md`）と popup intercept 等 bash 固有アーキ詳細・AGENTS.md の `v5.6.3` 表記は対象外（親が「変更不要」と明言／Wave 2 範囲）。

## Verification

- `make lint`（go vet + gofmt + shellcheck）→ exit 0
- `make test`（Tier1 + Tier2 bats、82 ケース）→ exit 0 / 全 pass（docs のみの変更で挙動不変）
- 4 ファイルに旧 positioning（「single-file Bash」「Bash CLI」「optional Go port」）が残っていないこと、両 README に deprecation 告知と `fanout-bash` 記載があることを grep で確認

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)