### PR TITLE
[codex] add Go release distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,106 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build ${{ matrix.goos }}/${{ matrix.goarch }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goos: darwin
+            goarch: amd64
+            runner: macos-latest
+          - goos: darwin
+            goarch: arm64
+            runner: macos-latest
+          - goos: linux
+            goarch: amd64
+            runner: ubuntu-latest
+          - goos: linux
+            goarch: arm64
+            runner: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build archive
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF_NAME}"
+          commit="${GITHUB_SHA::7}"
+          asset="fanout_${GOOS}_${GOARCH}.tar.gz"
+
+          rm -rf dist artifacts
+          mkdir -p dist artifacts
+
+          CGO_ENABLED=0 GOOS="$GOOS" GOARCH="$GOARCH" \
+            go build -trimpath \
+              -ldflags "-s -w -X main.version=${version} -X main.commit=${commit}" \
+              -o dist/fanout ./cmd/fanout
+
+          host_goos="$(go env GOHOSTOS)"
+          host_goarch="$(go env GOHOSTARCH)"
+          if [ "$host_goos" = "$GOOS" ] && [ "$host_goarch" = "$GOARCH" ]; then
+            ./dist/fanout --version
+          else
+            echo "Skipping smoke test for ${GOOS}/${GOARCH} on ${host_goos}/${host_goarch}"
+          fi
+
+          cp -R claude codex LICENSE dist/
+          tar -C dist -czf "artifacts/${asset}" fanout claude codex LICENSE
+
+      - name: Upload archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: fanout-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: artifacts/fanout_${{ matrix.goos }}_${{ matrix.goarch }}.tar.gz
+          if-no-files-found: error
+
+  release:
+    name: Publish GitHub Release
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Download archives
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Create checksums
+        run: |
+          set -euo pipefail
+          cd artifacts
+          sha256sum fanout_*.tar.gz > SHA256SUMS
+
+      - name: Publish release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          cd artifacts
+          gh release create "${GITHUB_REF_NAME}" \
+            --title "${GITHUB_REF_NAME}" \
+            --generate-notes \
+            fanout_*.tar.gz SHA256SUMS

--- a/README.ja.md
+++ b/README.ja.md
@@ -79,47 +79,91 @@ resultFile パスを特定し、プロンプトポップアップ用には
 
 ## インストール
 
-fanout は Bash CLI と任意の Go 版に、エージェント連携ファイルを加えた構成で
-配布されます。Claude Code にはスラッシュコマンド + スキル群、Codex CLI には
-スキル群を用意しています。すべて `Makefile` 経由で一括配置されます:
+推奨インストール経路は Release 済みの Go バイナリです。安定コマンド名
+`fanout` と、同梱の Claude/Codex 連携ファイルをまとめて配置します:
 
 ```bash
-make install        # CLI + Claude/Codex 連携を ~/.local, ~/.claude, ~/.codex にコピー
-make link           # チェックアウト先を指す symlink を作成（開発用）
-make install-go-default # Go 版をビルドし、既定の fanout コマンドとして配置
-make link-go-default    # Go 版を既定の fanout コマンドとして symlink
-make uninstall      # インストール済みのパスを削除
+# fanout + Claude/Codex 連携を ~/.local, ~/.claude, ~/.codex に配置
+curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh | sh
 
-PREFIX=/usr/local sudo make install     # システム全体に CLI を配置; BINDIR を $PREFIX/bin に上書き
-CLAUDE_DIR=/path/to/.claude make install # 既定以外の Claude データディレクトリを指定
-CODEX_DIR=/path/to/.codex make install   # 既定以外の Codex データディレクトリを指定
+# バイナリのみ
+curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh | sh -s -- --no-skills
+
+# 配置先や Release tag を指定
+curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh | BIN_DIR=/usr/local/bin sh
+curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh | FANOUT_VERSION=v0.1.0 sh
 ```
 
 配置パス:
 
-- `$(BINDIR)/fanout`（既定は `~/.local/bin/fanout`）
-- `$(CLAUDE_DIR)/commands/fanout.md`（既定は `~/.claude/commands/fanout.md`）
-- `$(CLAUDE_DIR)/skills/fanout/`（既定は `~/.claude/skills/fanout/`）
-- `$(CLAUDE_DIR)/skills/fanout-issues/`（既定は `~/.claude/skills/fanout-issues/`）
-- `$(CODEX_DIR)/skills/fanout/`（既定は `~/.codex/skills/fanout/`）
-- `$(CODEX_DIR)/skills/fanout-issues/`（既定は `~/.codex/skills/fanout-issues/`）
+- `$BIN_DIR/fanout`（既定は `~/.local/bin/fanout`）
+- `$CLAUDE_DIR/commands/fanout.md`（既定は `~/.claude/commands/fanout.md`）
+- `$CLAUDE_DIR/skills/fanout/`（既定は `~/.claude/skills/fanout/`）
+- `$CLAUDE_DIR/skills/fanout-issues/`（既定は `~/.claude/skills/fanout-issues/`）
+- `$CODEX_DIR/skills/fanout/`（既定は `~/.codex/skills/fanout/`）
+- `$CODEX_DIR/skills/fanout-issues/`（既定は `~/.codex/skills/fanout-issues/`）
 
-エージェント連携は常に安定した `fanout` コマンド名を呼びます。エージェントに
-Go 実装を優先させたい場合は `make install-go-default` または
-`make link-go-default` を実行してください。これらのターゲットは Go バイナリを
-`$(BINDIR)/fanout` に置き、Bash 実装を `$(BINDIR)/fanout-bash` として残します。
-エージェントに `fanout-go` を直接呼ばせないでください。`fanout-go` は
-`make install-go` / `make link-go` で配置する比較用コマンドです。
+`install.sh` は macOS/Linux と amd64/arm64 を自動判定し、最新 GitHub Release
+（または `FANOUT_VERSION` で指定した tag）から
+`fanout_<os>_<arch>.tar.gz` を取得します。`sha256sum` または `shasum` が
+あれば `SHA256SUMS` で検証し、再実行時は同じパスへ上書きします。シェル rc は
+自動編集しません。削除は次で行えます:
 
-`make install` は安定しています — リポジトリを消しても、コピー済みのファイルで
-動作し続けます。`make link` はチェックアウトを指すので、編集がすぐ反映され、
-`git pull` だけで更新が終わります。どちらのターゲットも、親ディレクトリが
-存在しなければ作成します。インストールまたはリンク後、実行中の Codex CLI
-セッションがある場合は再起動すると新しいスキルを認識します。
+```bash
+curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh | sh -s -- --uninstall
+```
 
 `~/.local/bin` が `PATH` に入っていることを確認してください
 （`echo $PATH | tr ':' '\n' | grep -F "$HOME/.local/bin"`）。
 入っていない場合は、シェルの rc に `export PATH="$HOME/.local/bin:$PATH"` を追記してください。
+スキルをインストールまたは更新した後、実行中の Codex CLI セッションがある場合は
+再起動すると新しいファイルを認識します。
+
+### macOS セキュリティメモ
+
+curl/wget 経由のインストールでは通常 `com.apple.quarantine` 拡張属性が付かない
+ため、Gatekeeper の「開発元を検証できません」GUI ブロックは基本的に発生しません。
+ブラウザ経由でアーカイブを取得して quarantine が付いた場合は、展開後に次で
+属性を削除してください:
+
+```bash
+xattr -d com.apple.quarantine /path/to/fanout
+```
+
+Apple Silicon では、すべての実行ファイルに最低限 ad-hoc 署名が必要です。Release
+workflow は macOS 上で Go 1.23 の darwin バイナリをビルドするため、Go linker
+がビルド時に署名します。Release package 作成後に外部 `strip` をかけると署名が
+壊れることがあるので避けてください。ローカルコピーが壊れた場合は次で
+ad-hoc 再署名できます:
+
+```bash
+codesign -s - /path/to/fanout
+```
+
+Apple Developer ID 署名や notarization は curl 配布経路では当面スコープ外です。
+ブラウザ、dmg/pkg、管理対象 Mac 向け配布が必要になった段階で追加できます。
+
+### チェックアウトから使う場合
+
+Go port が Release artifact になったため、リポジトリ root の Bash 実装は
+deprecated です。移行期間と parity testing のために、チェックアウト内には
+残しています。開発中は従来の Makefile ターゲットも使えます:
+
+```bash
+make install        # Bash CLI + Claude/Codex 連携をコピー
+make link           # Bash CLI + 連携をこのチェックアウトへ symlink
+make install-go-default # Go 版をビルドし、$(BINDIR)/fanout として配置
+make link-go-default    # Go 版を $(BINDIR)/fanout として symlink
+make uninstall      # インストール済みのパスを削除
+
+PREFIX=/usr/local sudo make install     # システム全体に Bash CLI を配置
+CLAUDE_DIR=/path/to/.claude make install # 既定以外の Claude データディレクトリを指定
+CODEX_DIR=/path/to/.codex make install   # 既定以外の Codex データディレクトリを指定
+```
+
+エージェント連携は常に安定した `fanout` コマンド名を呼びます。エージェントに
+`fanout-go` を直接呼ばせないでください。`fanout-go` は `make install-go` /
+`make link-go` で配置する比較用コマンドです。
 
 ## 開発
 
@@ -128,7 +172,7 @@ make test           # Tier 1 + Tier 2 黒箱テスト (bats-core 必須)
 make test-tier1     # フラグ / prereq テストのみ
 make test-tier2     # --dry-run ゴールデン出力テスト (fixture 駆動)
 make lint           # shellcheck fanout + テスト用 shim
-make build-go       # 実験中の Go 版を ./fanout-go としてビルド
+make build-go       # ローカル比較用に Go CLI を ./fanout-go としてビルド
 make test-go        # 同じ黒箱テストを ./fanout-go に対して実行
 make install-go     # Go 版を比較用の $(BINDIR)/fanout-go として配置
 ```
@@ -136,14 +180,13 @@ make install-go     # Go 版を比較用の $(BINDIR)/fanout-go として配置
 bats: macOS は `brew install bats-core`、Debian/Ubuntu は `apt install bats`。
 Tier 1 は CLI サーフェス (エラーメッセージ + exit code)、Tier 2 は `--dry-run`
 の計画出力を `tests/fixtures/` 配下のシナリオ fixture に対して凍結します。
-いずれも Go 書き換え時の parity テスト資産です。`make install` /
-`make link` では Bash 製の `./fanout` が既定のままです。一方、
-`make install-go-default` / `make link-go-default` は、エージェントが既に
-呼んでいる安定コマンド名 `fanout` の中身を Go 版に差し替えます。
+Bash 実装がチェックアウトに残っている間は、これらを parity テスト資産として
+使います。`make install-go-default` / `make link-go-default` は、エージェントが
+既に呼んでいる安定コマンド名 `fanout` の中身を Go 版に差し替えます。
 `./fanout-go` は動作比較用として並行配置できます。`$(BINDIR)` に
-`fanout-go` コマンドを入れたい場合は `make install-go` または
-`make link-go` を使ってください。`--dry-run` 出力を意図的に変更した
-場合は `FANOUT_GOLDEN_UPDATE=1 make test-tier2` で golden を再生成してください。
+`fanout-go` コマンドを入れたい場合は `make install-go` または `make link-go`
+を使ってください。`--dry-run` 出力を意図的に変更した場合は
+`FANOUT_GOLDEN_UPDATE=1 make test-tier2` で golden を再生成してください。
 Tier 3 (live dmux E2E) は手動運用のままです。
 
 ## 前提条件

--- a/README.ja.md
+++ b/README.ja.md
@@ -150,20 +150,21 @@ deprecated です。移行期間と parity testing のために、チェック�
 残しています。開発中は従来の Makefile ターゲットも使えます:
 
 ```bash
-make install        # Bash CLI + Claude/Codex 連携をコピー
-make link           # Bash CLI + 連携をこのチェックアウトへ symlink
-make install-go-default # Go 版をビルドし、$(BINDIR)/fanout として配置
-make link-go-default    # Go 版を $(BINDIR)/fanout として symlink
+make install        # Go 版を $(BINDIR)/fanout としてビルド + 連携をコピー
+make link           # Go 版を $(BINDIR)/fanout として symlink + 連携を symlink
+make install-go-default # make install の互換 alias
+make link-go-default    # make link の互換 alias
 make uninstall      # インストール済みのパスを削除
 
-PREFIX=/usr/local sudo make install     # システム全体に Bash CLI を配置
+PREFIX=/usr/local sudo make install     # システム全体に Go CLI を配置
 CLAUDE_DIR=/path/to/.claude make install # 既定以外の Claude データディレクトリを指定
 CODEX_DIR=/path/to/.codex make install   # 既定以外の Codex データディレクトリを指定
 ```
 
-エージェント連携は常に安定した `fanout` コマンド名を呼びます。エージェントに
-`fanout-go` を直接呼ばせないでください。`fanout-go` は `make install-go` /
-`make link-go` で配置する比較用コマンドです。
+`make install` / `make link` は、移行期間用に Bash 実装も `fanout-bash` として
+残します。エージェント連携は常に安定した `fanout` コマンド名を呼びます。
+エージェントに `fanout-go` を直接呼ばせないでください。`fanout-go` は
+`make install-go` / `make link-go` で配置する比較用コマンドです。
 
 ## 開発
 

--- a/README.md
+++ b/README.md
@@ -150,20 +150,22 @@ the release artifact. It remains in the checkout for the deprecation period and
 for parity testing. Local Makefile targets are still available while hacking:
 
 ```bash
-make install            # copies Bash CLI + Claude/Codex integrations
-make link               # symlinks Bash CLI + integrations at this checkout
-make install-go-default # builds Go and installs it as $(BINDIR)/fanout
-make link-go-default    # symlinks Go as $(BINDIR)/fanout
+make install            # builds Go as $(BINDIR)/fanout + installs integrations
+make link               # symlinks Go as $(BINDIR)/fanout + links integrations
+make install-go-default # alias for make install
+make link-go-default    # alias for make link
 make uninstall          # removes installed paths
 
-PREFIX=/usr/local sudo make install     # system-wide Bash CLI; overrides BINDIR
+PREFIX=/usr/local sudo make install     # system-wide Go CLI; overrides BINDIR
 CLAUDE_DIR=/path/to/.claude make install # non-default Claude data dir
 CODEX_DIR=/path/to/.codex make install   # non-default Codex data dir
 ```
 
-Agent integrations always invoke the stable `fanout` command name. Do not teach
-agents to call `fanout-go` directly — `fanout-go` is only a side-by-side
-comparison command installed by `make install-go` / `make link-go`.
+`make install` / `make link` also keep the Bash implementation available as
+`fanout-bash` for the deprecation period. Agent integrations always invoke the
+stable `fanout` command name. Do not teach agents to call `fanout-go` directly
+— `fanout-go` is only a side-by-side comparison command installed by
+`make install-go` / `make link-go`.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -79,46 +79,91 @@ task-list union.
 
 ## Installation
 
-fanout ships as a Bash CLI with an optional Go port plus agent integration
-files: Claude Code gets a slash command + skills, and Codex CLI gets skills.
-All of them are placed in one shot via the `Makefile`:
+The recommended install path is the released Go binary. It installs the stable
+`fanout` command plus the bundled Claude/Codex integration files:
 
 ```bash
-make install        # copies CLI + Claude/Codex integrations into ~/.local, ~/.claude, ~/.codex
-make link           # symlinks the same paths at the checkout (use while hacking)
-make install-go-default # builds the Go port and installs it as the default fanout command
-make link-go-default    # symlinks the Go port as the default fanout command
-make uninstall      # removes the installed paths
+# fanout + Claude/Codex integrations into ~/.local, ~/.claude, ~/.codex
+curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh | sh
 
-PREFIX=/usr/local sudo make install     # system-wide CLI; overrides BINDIR to $PREFIX/bin
-CLAUDE_DIR=/path/to/.claude make install # non-default Claude data dir
-CODEX_DIR=/path/to/.codex make install   # non-default Codex data dir
+# Binary only
+curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh | sh -s -- --no-skills
+
+# Custom destination or pinned release tag
+curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh | BIN_DIR=/usr/local/bin sh
+curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh | FANOUT_VERSION=v0.1.0 sh
 ```
 
 Installed paths:
 
-- `$(BINDIR)/fanout` (default `~/.local/bin/fanout`)
-- `$(CLAUDE_DIR)/commands/fanout.md` (default `~/.claude/commands/fanout.md`)
-- `$(CLAUDE_DIR)/skills/fanout/` (default `~/.claude/skills/fanout/`)
-- `$(CLAUDE_DIR)/skills/fanout-issues/` (default `~/.claude/skills/fanout-issues/`)
-- `$(CODEX_DIR)/skills/fanout/` (default `~/.codex/skills/fanout/`)
-- `$(CODEX_DIR)/skills/fanout-issues/` (default `~/.codex/skills/fanout-issues/`)
+- `$BIN_DIR/fanout` (default `~/.local/bin/fanout`)
+- `$CLAUDE_DIR/commands/fanout.md` (default `~/.claude/commands/fanout.md`)
+- `$CLAUDE_DIR/skills/fanout/` (default `~/.claude/skills/fanout/`)
+- `$CLAUDE_DIR/skills/fanout-issues/` (default `~/.claude/skills/fanout-issues/`)
+- `$CODEX_DIR/skills/fanout/` (default `~/.codex/skills/fanout/`)
+- `$CODEX_DIR/skills/fanout-issues/` (default `~/.codex/skills/fanout-issues/`)
 
-Agent integrations always invoke the stable `fanout` command name. If you want
-agents to prefer the Go implementation, run `make install-go-default` or
-`make link-go-default`; those targets place the Go binary at `$(BINDIR)/fanout`
-and keep the Bash implementation available as `$(BINDIR)/fanout-bash`.
-Do not teach agents to call `fanout-go` directly — `fanout-go` is only a
-side-by-side comparison command installed by `make install-go` / `make link-go`.
+`install.sh` detects macOS/Linux and amd64/arm64, downloads
+`fanout_<os>_<arch>.tar.gz` from the latest GitHub Release (or
+`FANOUT_VERSION`), verifies `SHA256SUMS` when `sha256sum` or `shasum` exists,
+and overwrites the same paths on rerun. It never edits shell rc files. Remove
+the installed files with:
 
-`make install` is stable — delete the repo and the copies still work.
-`make link` points at the checkout, so edits take effect immediately and
-`git pull` is enough to update. Either target creates the parent
-directories if they don't exist. Restart any running Codex CLI session after
-installing or linking so it picks up the new skill.
+```bash
+curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh | sh -s -- --uninstall
+```
 
 Confirm `~/.local/bin` is on your `PATH` (`echo $PATH | tr ':' '\n' | grep -F "$HOME/.local/bin"`).
 If not, add `export PATH="$HOME/.local/bin:$PATH"` to your shell rc.
+Restart any running Codex CLI session after installing or updating skills so it
+picks up the new skill files.
+
+### macOS security notes
+
+The curl/wget install path normally does not attach the `com.apple.quarantine`
+extended attribute, so the Gatekeeper "cannot verify developer" GUI block
+should not appear for the installed binary. If you download the archive through
+a browser and macOS quarantines it, remove the attribute after extracting:
+
+```bash
+xattr -d com.apple.quarantine /path/to/fanout
+```
+
+Apple Silicon requires every executable to carry at least an ad-hoc signature.
+The release workflow builds darwin binaries on macOS with Go 1.23, so the Go
+linker signs the binary as part of the build. Do not run an external `strip`
+after release packaging; it can invalidate the signature. If a local copy is
+damaged, ad-hoc re-sign it with:
+
+```bash
+codesign -s - /path/to/fanout
+```
+
+Developer ID signing and notarization are intentionally out of scope for the
+curl distribution path; they can be added later if browser, dmg/pkg, or
+managed-Mac distribution becomes a requirement.
+
+### From a checkout
+
+The repository-root Bash implementation is deprecated now that the Go port is
+the release artifact. It remains in the checkout for the deprecation period and
+for parity testing. Local Makefile targets are still available while hacking:
+
+```bash
+make install            # copies Bash CLI + Claude/Codex integrations
+make link               # symlinks Bash CLI + integrations at this checkout
+make install-go-default # builds Go and installs it as $(BINDIR)/fanout
+make link-go-default    # symlinks Go as $(BINDIR)/fanout
+make uninstall          # removes installed paths
+
+PREFIX=/usr/local sudo make install     # system-wide Bash CLI; overrides BINDIR
+CLAUDE_DIR=/path/to/.claude make install # non-default Claude data dir
+CODEX_DIR=/path/to/.codex make install   # non-default Codex data dir
+```
+
+Agent integrations always invoke the stable `fanout` command name. Do not teach
+agents to call `fanout-go` directly — `fanout-go` is only a side-by-side
+comparison command installed by `make install-go` / `make link-go`.
 
 ## Development
 
@@ -127,22 +172,22 @@ make test           # Tier 1 + Tier 2 black-box tests (bats-core required)
 make test-tier1     # flag/prereq tests only
 make test-tier2     # --dry-run golden tests against fixture scenarios
 make lint           # shellcheck fanout + test shims
-make build-go       # build the experimental Go port as ./fanout-go
+make build-go       # build the Go CLI as ./fanout-go for local comparison
 make test-go        # run the same black-box tests against ./fanout-go
-make install-go     # install the Go port side-by-side as $(BINDIR)/fanout-go
+make install-go     # install Go side-by-side as $(BINDIR)/fanout-go
 ```
 
 bats: `brew install bats-core` on macOS, `apt install bats` on Debian/Ubuntu.
 Tier 1 locks the CLI surface (error messages + exit codes); Tier 2 locks the
 `--dry-run` planning output against fixture scenarios under `tests/fixtures/`.
-Both tiers are parity-test material for the Go rewrite. The Bash `./fanout`
-remains the default for `make install` / `make link`, while
-`make install-go-default` / `make link-go-default` promote the Go port under
-the stable `fanout` command name that agents already invoke. `./fanout-go`
-still exists in parallel for behavior comparison; use `make install-go` or
-`make link-go` if you want a `fanout-go` command in `$(BINDIR)`. Regenerate
-Tier 2 goldens with `FANOUT_GOLDEN_UPDATE=1 make test-tier2` when you
-intentionally change dry-run output. Tier 3 (live dmux E2E) stays manual.
+Both tiers are parity-test material while the Bash implementation remains in
+the checkout. `make install-go-default` / `make link-go-default` promote the Go
+port under the stable `fanout` command name that agents already invoke.
+`./fanout-go` still exists in parallel for behavior comparison; use
+`make install-go` or `make link-go` if you want a `fanout-go` command in
+`$(BINDIR)`. Regenerate Tier 2 goldens with
+`FANOUT_GOLDEN_UPDATE=1 make test-tier2` when you intentionally change dry-run
+output. Tier 3 (live dmux E2E) stays manual.
 
 ## Prerequisites
 

--- a/cmd/fanout/main.go
+++ b/cmd/fanout/main.go
@@ -19,11 +19,20 @@ import (
 
 const fanoutTagPrefix = "[fanout #"
 
-var sleepBetweenIssues = time.Sleep
+var (
+	version            = "dev"
+	commit             = "none"
+	sleepBetweenIssues = time.Sleep
+)
 
 func main() {
 	lg := log.New(false)
 	commandName := invokedCommandName(os.Args)
+
+	if isVersionRequest(os.Args[1:]) {
+		fmt.Fprintln(os.Stdout, versionLine())
+		os.Exit(int(exitcode.OK))
+	}
 
 	pr := cliflags.Parse(os.Args[1:], lg, os.Stdout)
 	if pr.Code != exitcode.OK || pr.Config == nil {
@@ -47,6 +56,14 @@ func main() {
 	}
 
 	os.Exit(int(run(cfg, lg, commandName)))
+}
+
+func isVersionRequest(args []string) bool {
+	return len(args) == 1 && (args[0] == "--version" || args[0] == "-V")
+}
+
+func versionLine() string {
+	return fmt.Sprintf("fanout %s (%s)", version, commit)
 }
 
 func invokedCommandName(args []string) string {

--- a/cmd/fanout/main_test.go
+++ b/cmd/fanout/main_test.go
@@ -74,3 +74,38 @@ func TestInvokedCommandNameUsesBinaryName(t *testing.T) {
 		})
 	}
 }
+
+func TestIsVersionRequest(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "long", args: []string{"--version"}, want: true},
+		{name: "short", args: []string{"-V"}, want: true},
+		{name: "mixed with parent", args: []string{"123", "--version"}, want: false},
+		{name: "unknown capital", args: []string{"-v"}, want: false},
+		{name: "empty", args: nil, want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isVersionRequest(tc.args); got != tc.want {
+				t.Fatalf("isVersionRequest(%#v) = %v, want %v", tc.args, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestVersionLineUsesInjectedValues(t *testing.T) {
+	oldVersion := version
+	oldCommit := commit
+	version = "v1.2.3"
+	commit = "abc1234"
+	t.Cleanup(func() {
+		version = oldVersion
+		commit = oldCommit
+	})
+
+	if got, want := versionLine(), "fanout v1.2.3 (abc1234)"; got != want {
+		t.Fatalf("versionLine() = %q, want %q", got, want)
+	}
+}

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,251 @@
+#!/bin/sh
+set -eu
+
+repo="butaosuinu/fanout"
+install_skills=1
+uninstall=0
+tmp=""
+
+usage() {
+  cat <<'EOF'
+Usage: install.sh [--no-skills] [--uninstall] [-h|--help]
+
+Installs the latest fanout Go binary and bundled Claude/Codex integrations.
+
+Environment:
+  BIN_DIR         Binary destination (default: $HOME/.local/bin)
+  FANOUT_VERSION Git tag to install, e.g. v0.1.0 (default: latest)
+  CLAUDE_DIR      Claude data directory (default: $HOME/.claude)
+  CODEX_DIR       Codex data directory (default: $HOME/.codex)
+
+Options:
+  --no-skills   Install or uninstall only the fanout binary.
+  --uninstall   Remove fanout and bundled integrations.
+  -h, --help    Show this help.
+EOF
+}
+
+info() {
+  printf '[info] %s\n' "$*"
+}
+
+warn() {
+  printf '[warn] %s\n' "$*" >&2
+}
+
+die() {
+  printf '[err ] %s\n' "$*" >&2
+  exit 1
+}
+
+cleanup() {
+  if [ -n "$tmp" ]; then
+    rm -rf "$tmp"
+  fi
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --no-skills)
+      install_skills=0
+      ;;
+    --uninstall)
+      uninstall=1
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      die "unknown option: $1"
+      ;;
+  esac
+  shift
+done
+
+: "${HOME:?HOME must be set}"
+bin_dir="${BIN_DIR:-$HOME/.local/bin}"
+claude_dir="${CLAUDE_DIR:-$HOME/.claude}"
+codex_dir="${CODEX_DIR:-$HOME/.codex}"
+version="${FANOUT_VERSION:-latest}"
+
+download() {
+  url="$1"
+  out="$2"
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$url" -o "$out"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -qO "$out" "$url"
+  else
+    die "curl or wget is required to download fanout"
+  fi
+}
+
+install_exec() {
+  src="$1"
+  dest="$2"
+  if command -v install >/dev/null 2>&1; then
+    install -m 0755 "$src" "$dest"
+  else
+    cp "$src" "$dest"
+    chmod 0755 "$dest"
+  fi
+}
+
+install_data() {
+  src="$1"
+  dest="$2"
+  if command -v install >/dev/null 2>&1; then
+    install -m 0644 "$src" "$dest"
+  else
+    cp "$src" "$dest"
+    chmod 0644 "$dest"
+  fi
+}
+
+remove_integrations() {
+  rm -f "$claude_dir/commands/fanout.md"
+  rm -rf "$claude_dir/skills/fanout" "$claude_dir/skills/fanout-issues"
+  rm -rf "$codex_dir/skills/fanout" "$codex_dir/skills/fanout-issues"
+}
+
+copy_skill_dirs() {
+  src_root="$1"
+  dest_root="$2"
+  [ -d "$src_root" ] || return 0
+  mkdir -p "$dest_root"
+  for src in "$src_root"/*; do
+    [ -d "$src" ] || continue
+    name=$(basename "$src")
+    dest="$dest_root/$name"
+    rm -rf "$dest"
+    mkdir -p "$dest"
+    cp -R "$src/." "$dest/"
+  done
+}
+
+install_integrations() {
+  [ "$install_skills" -eq 1 ] || return 0
+
+  if [ -d "$tmp/extract/claude/commands" ]; then
+    mkdir -p "$claude_dir/commands"
+    for src in "$tmp"/extract/claude/commands/*.md; do
+      [ -f "$src" ] || continue
+      install_data "$src" "$claude_dir/commands/$(basename "$src")"
+    done
+  fi
+
+  copy_skill_dirs "$tmp/extract/claude/skills" "$claude_dir/skills"
+  copy_skill_dirs "$tmp/extract/codex/skills" "$codex_dir/skills"
+}
+
+normalize_os() {
+  case "$(uname -s)" in
+    Darwin) printf 'darwin' ;;
+    Linux) printf 'linux' ;;
+    *) die "unsupported OS: $(uname -s)" ;;
+  esac
+}
+
+normalize_arch() {
+  case "$(uname -m)" in
+    x86_64|amd64) printf 'amd64' ;;
+    arm64|aarch64) printf 'arm64' ;;
+    *) die "unsupported architecture: $(uname -m)" ;;
+  esac
+}
+
+checksum_tool() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    printf 'sha256sum'
+  elif command -v shasum >/dev/null 2>&1; then
+    printf 'shasum'
+  else
+    return 1
+  fi
+}
+
+file_sha256() {
+  tool="$1"
+  file="$2"
+  if [ "$tool" = "sha256sum" ]; then
+    sha256sum "$file" | awk '{print $1}'
+  else
+    shasum -a 256 "$file" | awk '{print $1}'
+  fi
+}
+
+verify_checksum() {
+  archive="$1"
+  sums="$2"
+  asset="$3"
+
+  if ! tool=$(checksum_tool); then
+    warn "sha256sum/shasum not found; skipping checksum verification"
+    return 0
+  fi
+
+  expected=$(awk -v file="$asset" '$2 == file || $2 == "./" file { print $1; found = 1 } END { if (!found) exit 1 }' "$sums") \
+    || die "SHA256SUMS does not contain $asset"
+  actual=$(file_sha256 "$tool" "$archive")
+
+  if [ "$expected" != "$actual" ]; then
+    die "checksum mismatch for $asset"
+  fi
+  info "checksum verified: $asset"
+}
+
+warn_path() {
+  case ":${PATH:-}:" in
+    *":$bin_dir:"*) ;;
+    *)
+      warn "$bin_dir is not on PATH"
+      warn "add this to your shell rc: export PATH=\"$bin_dir:\$PATH\""
+      ;;
+  esac
+}
+
+if [ "$uninstall" -eq 1 ]; then
+  rm -f "$bin_dir/fanout"
+  if [ "$install_skills" -eq 1 ]; then
+    remove_integrations
+  fi
+  info "removed $bin_dir/fanout"
+  exit 0
+fi
+
+os=$(normalize_os)
+arch=$(normalize_arch)
+asset="fanout_${os}_${arch}.tar.gz"
+
+if [ "$version" = "latest" ]; then
+  base_url="https://github.com/$repo/releases/latest/download"
+else
+  base_url="https://github.com/$repo/releases/download/$version"
+fi
+
+tmp=$(mktemp -d)
+trap cleanup EXIT HUP INT TERM
+
+archive="$tmp/$asset"
+sums="$tmp/SHA256SUMS"
+mkdir -p "$tmp/extract"
+
+info "downloading $asset from $version"
+download "$base_url/$asset" "$archive"
+download "$base_url/SHA256SUMS" "$sums"
+verify_checksum "$archive" "$sums" "$asset"
+
+tar -xzf "$archive" -C "$tmp/extract"
+[ -f "$tmp/extract/fanout" ] || die "archive does not contain fanout"
+
+mkdir -p "$bin_dir"
+install_exec "$tmp/extract/fanout" "$bin_dir/fanout"
+install_integrations
+
+info "installed $bin_dir/fanout"
+if [ "$install_skills" -eq 1 ]; then
+  info "installed Claude/Codex integrations"
+fi
+warn_path
+"$bin_dir/fanout" --version

--- a/internal/cliflags/usage.go
+++ b/internal/cliflags/usage.go
@@ -90,6 +90,7 @@ Options:
   --status            Read-only mode. Print JSON describing each fanned-out
                       child issue's state and closed-by PR merge status, then
                       exit. Exclusive with action-bearing flags.
+  -V, --version       Print version and commit, then exit.
   -h, --help          Show this message.
 
 Prerequisites:


### PR DESCRIPTION
## Summary
- add `--version` / `-V` support for the Go CLI with release-time version and commit injection
- add a tag-triggered release workflow that builds darwin/linux amd64/arm64 archives and publishes checksums
- add `install.sh` for curl-based installs and update English/Japanese installation docs, including macOS security notes
- merge current `main` and align checkout install docs with the Go-default Makefile behavior

## Validation
- `git diff --check`
- `shellcheck install.sh`
- `env GOMODCACHE=/Users/butaosuinu/fanout/.dmux/worktrees/dmux-1780410290446/.cache/go-mod make go-test`
- `env GOMODCACHE=/Users/butaosuinu/fanout/.dmux/worktrees/dmux-1780410290446/.cache/go-mod make lint`
- release ldflags build smoke test: `fanout v1.2.3 (def5678)`
- `./fanout-go --version` and `./fanout-go -V` both print `fanout dev (none)`