### PR TITLE
Codex pane の PR 前 review gate を追加

### DIFF
--- a/codex/skills/fanout/SKILL.md
+++ b/codex/skills/fanout/SKILL.md
@@ -284,6 +284,10 @@ the likely next action:
   preferred over hand-built wave lists when blocker annotations exist.
 - Default project-mode filter is `--project-status Todo`. Use
   `--project-status all` for a full sweep of the board's OPEN items.
+- When a created pane runs `codex`, the per-issue briefing requires the agent
+  to run `codex review --uncommitted` after implementation/tests and repeat
+  review -> fix -> retest -> review until no findings remain before it commits,
+  pushes, or opens the PR.
 - The CLI intentionally drives dmux through tmux popup result-file
   interception because dmux v5.8.1 still does not ship the documented HTTP
   API (an `apiActionHandler` skeleton exists in `dist/adapters/` but no

--- a/fanout
+++ b/fanout
@@ -1564,6 +1564,21 @@ Requirements:
 - Open a pull request with "Closes #$num" in the body.
 - If the scope is ambiguous, stop and leave a comment on the issue instead of guessing.
 EOF
+  if [[ "${agent:-}" == "codex" ]]; then
+    cat >>"$path" <<'EOF'
+
+Before committing your final changes or opening a PR, run
+`codex review --uncommitted` on your current diff. Treat it as a required gate:
+1. Run `codex review --uncommitted`.
+2. If review reports any findings, fix them, rerun relevant lint/tests, then
+   run review again.
+3. Repeat until review reports no findings / no issues / clean.
+
+Only after the review loop is clean should you commit, push, and open the PR.
+If the review command is unavailable or fails for tooling/auth reasons, stop
+and report that instead of bypassing the gate.
+EOF
+  fi
   if [[ "${agent:-}" == "claude" ]]; then
     cat >>"$path" <<'EOF'
 

--- a/internal/briefing/briefing.go
+++ b/internal/briefing/briefing.go
@@ -35,6 +35,20 @@ Requirements:
 - Open a pull request with "Closes #%d" in the body.
 - If the scope is ambiguous, stop and leave a comment on the issue instead of guessing.
 `, num, title, body, num)
+	if agent == "codex" {
+		return base + `
+Before committing your final changes or opening a PR, run
+` + "`codex review --uncommitted`" + ` on your current diff. Treat it as a required gate:
+1. Run ` + "`codex review --uncommitted`" + `.
+2. If review reports any findings, fix them, rerun relevant lint/tests, then
+   run review again.
+3. Repeat until review reports no findings / no issues / clean.
+
+Only after the review loop is clean should you commit, push, and open the PR.
+If the review command is unavailable or fails for tooling/auth reasons, stop
+and report that instead of bypassing the gate.
+`
+	}
 	if agent != "claude" {
 		return base
 	}

--- a/tests/bats/tier1_briefing.bats
+++ b/tests/bats/tier1_briefing.bats
@@ -20,7 +20,7 @@ load helpers
   grep -q "Closes #101" "$briefing"
 }
 
-@test "briefing for --agent codex omits Agent Teams hint and /code-review directive but keeps Requirements" {
+@test "briefing for --agent codex contains review gate and omits Claude-only directives" {
   use_fixture scenario-sub-issue-only
   run_fanout_dry 100 --agent codex
   assert_success
@@ -28,6 +28,9 @@ load helpers
   ! grep -q "Agent Teams" "$briefing"
   ! grep -q "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS" "$briefing"
   ! grep -q "/code-review" "$briefing"
+  grep -q "codex review --uncommitted" "$briefing"
+  grep -q "Repeat until review reports no findings / no issues / clean" "$briefing"
+  grep -q "Only after the review loop is clean should you commit, push, and open the PR" "$briefing"
   grep -q "Make focused, minimal changes scoped to this single issue" "$briefing"
   grep -q "Closes #101" "$briefing"
 }

--- a/tests/bats/tier2_dry_run.bats
+++ b/tests/bats/tier2_dry_run.bats
@@ -127,11 +127,11 @@ load helpers
   assert_golden scenario-sub-issue-only-branch-override
 }
 
-@test "agent-codex variant of scenario-sub-issue-only: briefing omits Agent Teams hint" {
+@test "agent-codex variant of scenario-sub-issue-only: briefing has Codex review gate" {
   # Reuses the scenario-sub-issue-only fixture; the only thing under test is
   # that --agent codex (last-wins over the helper's default --agent claude)
-  # produces a briefing without the Agent Teams section, so the size lines
-  # diverge from scenario-sub-issue-only.dry-run.txt.
+  # produces a Codex-specific briefing without the Claude-only Agent Teams
+  # section, so the size lines diverge from scenario-sub-issue-only.dry-run.txt.
   use_fixture scenario-sub-issue-only
   run_fanout_dry 100 --agent codex
   assert_success

--- a/tests/golden/scenario-sub-issue-only-codex.dry-run.txt
+++ b/tests/golden/scenario-sub-issue-only-codex.dry-run.txt
@@ -7,7 +7,7 @@
 [info] will create 2 pane(s); deferred (blocked): 0; deferred (--limit): 0
 [info] #101: First child
   briefing -> /tmp/fanout-project_root-101.md
-  briefing size: 600 bytes
+  briefing size: 1141 bytes
   current panes[] length: 0
     $ tmux send-keys -t %1 Escape
     $ tmux send-keys -t %1 n
@@ -16,7 +16,7 @@
 [ ok ] #101: dry-run complete
 [info] #102: Second child
   briefing -> /tmp/fanout-project_root-102.md
-  briefing size: 601 bytes
+  briefing size: 1142 bytes
   current panes[] length: 0
     $ tmux send-keys -t %1 Escape
     $ tmux send-keys -t %1 n


### PR DESCRIPTION
## 概要
- Codex agent の per-issue briefing に `codex review --uncommitted` の review -> fix -> retest -> review ループを追加
- Go 実装と deprecated Bash lane の briefing 生成を同期
- Codex skill note、Bats test、Codex briefing golden を更新

## 検証
- `codex review --commit HEAD`（指摘なし）
- `make test`
- `make test-go`（Go module stat cache の sandbox 警告は出るが exit 0）
- `make lint`
- `git diff --check`
- `make install`