### PR TITLE
docs: リリース手順を RELEASE.md に文書化する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ Build the binary with `make build-go` (output `./fanout-go`) and validate with `
 - Lint: `make lint` = `go vet` + `gofmt` on the Go sources plus a `shellcheck` of the bats test shims (`tests/bin/{gh,tmux,git}`, `tests/bats/helpers.bash`). Treat `SC2086`-style warnings on the shims as real.
 - Black-box tests: `make test` (requires `bats-core`) builds `./fanout-go` and runs the Go unit tests plus Tier 1 (flag/prerequisite) + Tier 2 (`--dry-run` golden output against fixture scenarios under `tests/fixtures/`) bats tests against it via `FANOUT_BIN`. Tier 1 locks in the CLI surface (error messages + exit codes) and Tier 2 locks in the dry-run planning output — the issue #20 invariants. Regenerate Tier 2 goldens with `FANOUT_GOLDEN_UPDATE=1 make test-tier2`. Tier 3 (live dmux E2E) is out of scope.
 - A live end-to-end test needs a running dmux session in tmux and a real GitHub parent issue with OPEN sub-issues; there is no mock layer.
+- Cutting a release: see `RELEASE.md`. It is CI-driven — push an annotated `vX.Y.Z` tag and `.github/workflows/release.yml` builds the four platform archives, generates `SHA256SUMS`, and publishes the GitHub Release. The version string is injected from the tag name via ldflags (`-X main.version`), so no source edit bumps the version, and a tag push is not subject to the `gh pr create` review gate.
 
 ## Architecture notes that span fanout
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh |
 
 # Custom destination or pinned release tag
 curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh | BIN_DIR=/usr/local/bin sh
-curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh | FANOUT_VERSION=v0.1.0 sh
+curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh | FANOUT_VERSION=v0.2.0 sh
 ```
 
 Installed paths:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,102 @@
+# Releasing fanout
+
+Cutting a release is **CI-driven**: the only manual step is pushing an annotated
+`vX.Y.Z` tag. Pushing the tag triggers `.github/workflows/release.yml`, which
+builds the four platform archives, generates `SHA256SUMS`, and publishes the
+GitHub Release with auto-generated notes. There is no `make release` target and
+no goreleaser config — the workflow is the whole pipeline.
+
+## What the tag push does for you
+
+`release.yml` fires on `push` of any `v*` tag and:
+
+1. Builds `darwin`/`linux` × `amd64`/`arm64` with
+   `CGO_ENABLED=0 go build -trimpath -ldflags "-s -w -X main.version=<tag> -X main.commit=<sha7>"`.
+   The version string is **injected from the tag name** (`GITHUB_REF_NAME`) — see
+   `cmd/fanout/main.go` (`version`/`commit` default to `dev`/`none` for local
+   builds). **No source edit is needed to bump the version.**
+2. Smoke-tests `./dist/fanout --version` on the native arch of each runner.
+3. Packages each binary together with `claude/`, `codex/`, and `LICENSE` into
+   `fanout_<os>_<arch>.tar.gz`.
+4. Generates `SHA256SUMS` and runs
+   `gh release create "<tag>" --title "<tag>" --generate-notes <archives> SHA256SUMS`.
+   The notes are built from the merged PRs since the previous tag.
+
+`install.sh` then serves these assets to users (latest Release, or a pinned
+`FANOUT_VERSION`).
+
+## Steps
+
+1. **Pick the version.** Look at the latest tag and the PRs merged since it:
+
+   ```bash
+   git fetch origin main --tags
+   git describe --tags --abbrev=0            # latest tag, e.g. v0.2.0
+   git log --oneline "$(git describe --tags --abbrev=0)"..origin/main
+   ```
+
+   Bump per semver (`v0.MINOR.PATCH` while pre-1.0: features bump MINOR, fixes
+   bump PATCH).
+
+2. **Preflight.** Release off the latest `origin/main` and make sure it is green:
+
+   ```bash
+   gh run list --branch main --workflow test.yml --limit 1 \
+     --json headSha,conclusion          # conclusion == "success" on main's tip
+   make test && make lint                # optional local re-check
+   git tag -l vX.Y.Z                     # must be empty — tag not yet used
+   ```
+
+3. **Tag and push.** Use an **annotated** tag pointing at `origin/main`, matching
+   how every prior tag was cut:
+
+   ```bash
+   git tag -a vX.Y.Z origin/main -m "vX.Y.Z"
+   git push origin vX.Y.Z                 # this starts the public release
+   ```
+
+   The tag does not have to be created from the `main` branch checkout —
+   `origin/main` is named explicitly, so any clean worktree works. Note the PR
+   review gate (`.claude/hooks/pre-pr-review-gate.sh`) only intercepts
+   `gh pr create`; **a tag push is not gated.**
+
+4. **Watch the build.**
+
+   ```bash
+   gh run watch "$(gh run list --workflow release.yml --limit 1 \
+     --json databaseId -q '.[0].databaseId')" --exit-status
+   ```
+
+5. **Verify the Release.**
+
+   ```bash
+   gh release view vX.Y.Z
+   ```
+
+   Confirm: the four `fanout_{darwin,linux}_{amd64,arm64}.tar.gz` archives plus
+   `SHA256SUMS` are attached, the notes list the expected PRs with a
+   `Full Changelog: <prev>...vX.Y.Z` link, and it is flagged `Latest`. As a final
+   end-to-end check, install the published artifact:
+
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh \
+     | FANOUT_VERSION=vX.Y.Z sh -s -- --no-skills
+   fanout --version            # -> fanout vX.Y.Z (<sha7>)
+   ```
+
+## If something goes wrong
+
+- **Workflow failed mid-build.** Fix the cause on `main`, then delete and re-cut
+  the tag (the Release is only created in the final job, so a failed build leaves
+  no partial Release):
+
+  ```bash
+  git push origin :refs/tags/vX.Y.Z      # delete remote tag
+  git tag -d vX.Y.Z                      # delete local tag
+  ```
+
+  Re-tag once `main` is fixed and green.
+
+- **Wrong commit tagged.** Same delete dance, then re-tag the intended commit.
+  Avoid moving a tag that has already published a Release; bump to the next patch
+  instead.


### PR DESCRIPTION
## 背景

v0.2.0 リリース（`git tag -a v0.2.0 origin/main` → push → `release.yml` が 4 プラットフォームをビルドし `SHA256SUMS` 生成 → `gh release create --generate-notes` で公開）を実施したが、リポジトリにリリース手順を残した文書が無かった（`RELEASE.md` も CLAUDE.md の節も無し）。今回踏んだ CI 駆動の手順を恒久化する。

## 変更

- **`RELEASE.md`（新規・メンテナ向け）**: バージョン選定 → プリフライト → annotated タグ push → CI 監視 → Release 検証、までをチェックリスト化。`version` はタグ名から ldflags で注入されソース変更不要であること、annotated タグ運用、タグ push は `gh pr create` レビューゲート対象外、失敗時のタグ削除手順といった非自明点も明記。
- **`CLAUDE.md`**: 「Working with fanout」に RELEASE.md へのポインタを 1 行追加（手順は重複させずポインタのみ）。
- **`README.md`**: インストール例の `FANOUT_VERSION` を最新タグ `v0.2.0` に更新。

ドキュメントのみの変更で Go コードへの影響なし。記載コマンドは v0.2.0 リリースで実際に実行・検証済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)