### PR TITLE
[codex] Codex review待機中のポーリングを抑制

### DIFF
--- a/codex/skills/fanout/SKILL.md
+++ b/codex/skills/fanout/SKILL.md
@@ -330,7 +330,10 @@ the likely next action:
 - When a created pane runs `codex`, the per-issue briefing requires the agent
   to run `codex review --uncommitted` after implementation/tests and repeat
   review -> fix -> retest -> review until no findings remain before it commits,
-  pushes, or opens the PR.
+  pushes, or opens the PR. The review command should be treated as one
+  blocking shell command: while it is running, do not open, resume, or inspect
+  any Review Session and do not run `/codex:status` or other polling commands;
+  wait for the command to exit, then read the final output once.
 - The CLI intentionally drives dmux through tmux popup result-file
   interception because dmux v5.8.1 still does not ship the documented HTTP
   API (an `apiActionHandler` skeleton exists in `dist/adapters/` but no

--- a/internal/briefing/briefing.go
+++ b/internal/briefing/briefing.go
@@ -78,6 +78,9 @@ const codexReviewWithPRSection = `
 Before committing your final changes or opening a PR, run
 ` + "`codex review --uncommitted`" + ` on your current diff. Treat it as a required gate:
 1. Run ` + "`codex review --uncommitted`" + `.
+   Use one blocking shell command. While it is running, do not open, resume,
+   or inspect any Review Session and do not run ` + "`/codex:status`" + ` or other polling
+   commands; wait for the command to exit, then read the final output once.
 2. If review reports any findings, fix them, rerun relevant lint/tests, then
    run review again.
 3. Repeat until review reports no findings / no issues / clean.
@@ -91,6 +94,9 @@ const codexReviewWithoutPRSection = `
 Before committing your final changes, run
 ` + "`codex review --uncommitted`" + ` on your current diff. Treat it as a required gate:
 1. Run ` + "`codex review --uncommitted`" + `.
+   Use one blocking shell command. While it is running, do not open, resume,
+   or inspect any Review Session and do not run ` + "`/codex:status`" + ` or other polling
+   commands; wait for the command to exit, then read the final output once.
 2. If review reports any findings, fix them, rerun relevant lint/tests, then
    run review again.
 3. Repeat until review reports no findings / no issues / clean.

--- a/tests/bats/tier1_briefing.bats
+++ b/tests/bats/tier1_briefing.bats
@@ -29,6 +29,9 @@ load helpers
   ! grep -q "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS" "$briefing"
   ! grep -q "/code-review" "$briefing"
   grep -q "codex review --uncommitted" "$briefing"
+  grep -q "do not open, resume," "$briefing"
+  grep -q "or inspect any Review Session" "$briefing"
+  grep -q "do not run \`/codex:status\` or other polling" "$briefing"
   grep -q "Repeat until review reports no findings / no issues / clean" "$briefing"
   grep -q "Only after the review loop is clean should you commit, push, and open the PR" "$briefing"
   grep -q "Make focused, minimal changes scoped to this single issue" "$briefing"
@@ -64,6 +67,7 @@ load helpers
   assert_success
   local briefing="/tmp/fanout-project_root-101.md"
   grep -q "codex review --uncommitted" "$briefing"
+  grep -q "do not run \`/codex:status\` or other polling" "$briefing"
   grep -q "Only after the review loop is clean should you commit and push the branch" "$briefing"
   ! grep -q "Open a pull request with \"Closes #101\"" "$briefing"
   ! grep -q "opening a PR" "$briefing"

--- a/tests/golden/scenario-sub-issue-only-codex.dry-run.txt
+++ b/tests/golden/scenario-sub-issue-only-codex.dry-run.txt
@@ -7,7 +7,7 @@
 [info] will create 2 pane(s); deferred (blocked): 0; deferred (--limit): 0
 [info] #101: First child
   briefing -> /tmp/fanout-project_root-101.md
-  briefing size: 1141 bytes
+  briefing size: 1375 bytes
   current panes[] length: 0
     $ tmux send-keys -t %1 Escape
     $ tmux send-keys -t %1 n
@@ -16,7 +16,7 @@
 [ ok ] #101: dry-run complete
 [info] #102: Second child
   briefing -> /tmp/fanout-project_root-102.md
-  briefing size: 1142 bytes
+  briefing size: 1376 bytes
   current panes[] length: 0
     $ tmux send-keys -t %1 Escape
     $ tmux send-keys -t %1 n


### PR DESCRIPTION
## 概要
- Codex ペイン向け briefing に、`codex review --uncommitted` を単一の blocking shell command として待つ指示を追加
- review 実行中に Review Session を open/resume/inspect したり、`/codex:status` 等で polling したりしないよう明記
- Codex skill の説明と briefing テスト/golden を更新

## 背景
`codex review --uncommitted` の完了待ち中にメインセッションが Review Session を何度も見に行き、不要なトークン消費が発生していたため、生成される Codex 向け指示で中間確認を抑制します。

## 検証
- `make go-test`
- `make test-tier1`
- `make test-tier2`
- `make lint`