### PR TITLE
fix: launch Codex agents through tmux pane shell

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,9 +51,10 @@ The package map: `cmd/fanout` is the command flow (`main.go` dispatch and
   `git rev-parse --show-toplevel`, requires the caller to be inside tmux, and
   targets the invoking pane (`$TMUX_PANE`) unless `--session` is supplied.
 - Pane creation is direct: `worktree.Prepare` creates
-  `.fanout/worktrees/<slug>/`, `tmuxrun.SplitPane` runs
-  `tmux split-window -d -h -P -F '#{pane_id}'`, and `tmuxrun.SendShellCommand`
-  launches the selected agent in the child worktree.
+  `.fanout/worktrees/<slug>/`, `tmuxrun.SplitPaneWithAgentCommand` runs
+  `tmux split-window -d -h -P -F '#{pane_id}'`, and
+  `tmuxrun.BuildPaneLaunchCommand` launches the selected agent through the
+  user's shell startup path while leaving an interactive shell after exit.
 - `--agent` or `FANOUT_AGENT` is required. `internal/agent` validates supported
   agent names and, in live mode, verifies the corresponding CLI is installed.
 - Idempotency is stored in `.fanout/state.json` under `(parent, issueNum)`.

--- a/README.ja.md
+++ b/README.ja.md
@@ -438,11 +438,11 @@ worktree から実行すること、agent 名を明示すること。詳しく�
      base branch を fresh 化する。
    - `git worktree add -b <branch> <path> <base>` で `.fanout/worktrees/<slug>/`
      を作成する。
-   - `tmux split-window -t <invoking-pane> -d -h -P -F '#{pane_id}' -c <worktree>`
+   - `tmux split-window -t <invoking-pane> -d -h -P -F '#{pane_id}' -c <worktree> <launch-command>`
      で子ペインを選択せずに作る（`--session` 指定時は指定 session 名を target
-     にする）。
-   - ペインタイトルを設定し、`tmux select-layout tiled` を適用し、agent 起動
-     コマンドを `send-keys` する。
+     にする）。起動コマンドはユーザーの shell startup path 経由で実行し、agent
+     終了後は interactive shell に戻る。
+   - ペインタイトルを設定し、`tmux select-layout tiled` を適用する。
    - 次の処理に入る前に `--sleep` 秒（既定 4）だけスリープする。
 7. 作成済み / スキップ / 保留 / 失敗の件数サマリを表示する。
 

--- a/README.md
+++ b/README.md
@@ -507,10 +507,11 @@ should branch from the selected base.
    - Creates `.fanout/worktrees/<slug>/` with
      `git worktree add -b <branch> <path> <base>`.
    - Creates a tmux child pane without selecting it with
-     `tmux split-window -t <invoking-pane> -d -h -P -F '#{pane_id}' -c <worktree>`
-     (`--session` uses the supplied session name as the target).
-   - Sets the pane title, applies `tmux select-layout tiled`, and sends the
-     selected agent launch command plus Enter.
+     `tmux split-window -t <invoking-pane> -d -h -P -F '#{pane_id}' -c <worktree> <launch-command>`
+     (`--session` uses the supplied session name as the target). The launch
+     command runs through the user's shell startup path and returns to an
+     interactive shell after the agent exits.
+   - Sets the pane title and applies `tmux select-layout tiled`.
    - Sleeps `--sleep` seconds (default 4) before the next one.
 7. Prints a summary of created / skipped / deferred / failed counts.
 

--- a/cmd/fanout/pane.go
+++ b/cmd/fanout/pane.go
@@ -85,7 +85,7 @@ func createPaneForIssue(cfg *cliflags.Config, lg *log.Logger, info *fanoutruntim
 		return false
 	}
 
-	paneID, err := tmuxrun.SplitPane(info.Target, prepared.WorktreePath)
+	paneID, err := tmuxrun.SplitPaneWithAgentCommand(info.Target, prepared.WorktreePath, req.AgentCommand)
 	if err != nil {
 		lg.Err("#%d: %v", req.Issue.Number, err)
 		cleanupFailedLaunch(req.Issue.Number, "", prepared.Plan, lg)
@@ -113,12 +113,6 @@ func createPaneForIssue(cfg *cliflags.Config, lg *log.Logger, info *fanoutruntim
 		WorktreePath: prepared.WorktreePath,
 	}); err != nil {
 		lg.Err("#%d: write worktree metadata: %v", req.Issue.Number, err)
-		rollbackState(recorder, cfg.ParentRef, req.Issue.Number, lg)
-		cleanupFailedLaunch(req.Issue.Number, paneID, prepared.Plan, lg)
-		return false
-	}
-	if err := tmuxrun.SendShellCommand(paneID, req.AgentCommand); err != nil {
-		lg.Err("#%d: %v", req.Issue.Number, err)
 		rollbackState(recorder, cfg.ParentRef, req.Issue.Number, lg)
 		cleanupFailedLaunch(req.Issue.Number, paneID, prepared.Plan, lg)
 		return false
@@ -223,9 +217,9 @@ func printPaneDryRun(req paneRequest, target string, lg *log.Logger, c log.Palet
 		shellQuote(req.Worktree.BaseBranch),
 		c.Reset)
 	if target != "" {
-		fmt.Fprintf(lg.Stdout(), "    %s$ tmux split-window -t %s -d -h -P -F '#{pane_id}' -c %s%s\n", c.Dim, shellQuote(target), shellQuote(req.Worktree.WorktreePath), c.Reset)
+		fmt.Fprintf(lg.Stdout(), "    %s$ tmux split-window -t %s -d -h -P -F '#{pane_id}' -c %s %s%s\n", c.Dim, shellQuote(target), shellQuote(req.Worktree.WorktreePath), shellQuote(tmuxrun.BuildPaneLaunchCommand(req.AgentCommand)), c.Reset)
 	} else {
-		fmt.Fprintf(lg.Stdout(), "    %s$ tmux split-window -d -h -P -F '#{pane_id}' -c %s%s\n", c.Dim, shellQuote(req.Worktree.WorktreePath), c.Reset)
+		fmt.Fprintf(lg.Stdout(), "    %s$ tmux split-window -d -h -P -F '#{pane_id}' -c %s %s%s\n", c.Dim, shellQuote(req.Worktree.WorktreePath), shellQuote(tmuxrun.BuildPaneLaunchCommand(req.AgentCommand)), c.Reset)
 	}
 	if title := paneTitle(req); title != "" {
 		fmt.Fprintf(lg.Stdout(), "    %s$ tmux select-pane -t <pane_id> -T %s%s\n", c.Dim, shellQuote(title), c.Reset)
@@ -237,7 +231,6 @@ func printPaneDryRun(req paneRequest, target string, lg *log.Logger, c log.Palet
 	}
 	fmt.Fprintf(lg.Stdout(), "    %s# would write .fanout/state.json with paneId <pane_id>%s\n", c.Dim, c.Reset)
 	fmt.Fprintf(lg.Stdout(), "    %s# would write .fanout/worktree-metadata.json in the child worktree%s\n", c.Dim, c.Reset)
-	fmt.Fprintf(lg.Stdout(), "    %s$ tmux send-keys -t <pane_id> %s Enter%s\n", c.Dim, shellQuote(req.AgentCommand), c.Reset)
 	lg.Ok("#%d: dry-run complete", req.Issue.Number)
 }
 

--- a/codex/skills/fanout/SKILL.md
+++ b/codex/skills/fanout/SKILL.md
@@ -345,6 +345,8 @@ the likely next action:
   review -> fix -> retest -> review until no findings remain before it commits,
   pushes, or opens the PR.
 - The action path creates git worktrees itself, then uses detached
-  `tmux split-window -t <invoking-pane> -d` and `tmux send-keys` to launch the
-  selected agent CLI without moving focus away from the caller pane. `--session`
-  is the explicit escape hatch for targeting a different session.
+  `tmux split-window -t <invoking-pane> -d` with a shell launch command to start
+  the selected agent CLI without moving focus away from the caller pane. The
+  command runs through the user's shell startup path and returns to an
+  interactive shell after the agent exits. `--session` is the explicit escape
+  hatch for targeting a different session.

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -23,7 +23,7 @@ func TestBuildCommandRejectsUnknownAgent(t *testing.T) {
 	}
 }
 
-func TestBuildResolvedCommandUsesAbsoluteExecutablePath(t *testing.T) {
+func TestBuildResolvedCommandUsesAbsoluteExecutablePathAndPathPrefix(t *testing.T) {
 	tmp := t.TempDir()
 	binDir := filepath.Join(tmp, "bin with space")
 	if err := os.Mkdir(binDir, 0o755); err != nil {

--- a/internal/cliflags/usage.go
+++ b/internal/cliflags/usage.go
@@ -93,7 +93,7 @@ Options:
   --popup-timeout <s> Deprecated compatibility flag; accepted but ignored by
                       the direct tmux path.
   --dry-run           Print the git worktree, tmux split-window, and agent
-                      send-keys commands without executing them.
+                      launch commands without executing them.
   --debug             Enable extra diagnostic logging.
   --status            Read-only mode. Print JSON describing each fanned-out
                       child issue recorded in .fanout/state.json, including

--- a/internal/tmuxrun/tmuxrun.go
+++ b/internal/tmuxrun/tmuxrun.go
@@ -7,13 +7,28 @@ import (
 	"strings"
 )
 
+const userShellExpr = `"${SHELL:-/bin/sh}"`
+
 // SplitPane splits the target pane/session rooted at worktreePath and returns its pane id.
 func SplitPane(target, worktreePath string) (string, error) {
+	return splitPane(target, worktreePath, "")
+}
+
+// SplitPaneWithAgentCommand splits the target pane/session and starts the agent
+// command through a shell wrapper that keeps the pane alive after the agent exits.
+func SplitPaneWithAgentCommand(target, worktreePath, agentCommand string) (string, error) {
+	return splitPane(target, worktreePath, BuildPaneLaunchCommand(agentCommand))
+}
+
+func splitPane(target, worktreePath, launchCommand string) (string, error) {
 	args := []string{"split-window"}
 	if target != "" {
 		args = append(args, "-t", target)
 	}
 	args = append(args, "-d", "-h", "-P", "-F", "#{pane_id}", "-c", worktreePath)
+	if strings.TrimSpace(launchCommand) != "" {
+		args = append(args, launchCommand)
+	}
 	out, err := exec.Command("tmux", args...).Output()
 	if err != nil {
 		return "", fmt.Errorf("tmux split-window: %w", err)
@@ -23,6 +38,18 @@ func SplitPane(target, worktreePath string) (string, error) {
 		return "", fmt.Errorf("tmux split-window returned an empty pane id")
 	}
 	return paneID, nil
+}
+
+// BuildPaneLaunchCommand returns a tmux shell-command that starts the agent via
+// the user's shell startup path and leaves an interactive shell behind after the
+// agent exits.
+func BuildPaneLaunchCommand(agentCommand string) string {
+	agentCommand = strings.TrimSpace(agentCommand)
+	if agentCommand == "" {
+		return ""
+	}
+	body := agentCommand + `; __fanout_status=$?; printf '\n[fanout] agent exited with status %d; returning to shell.\n' "$__fanout_status"; exec ` + userShellExpr + ` -l`
+	return "exec " + userShellExpr + " -lic " + shellQuote(body)
 }
 
 // SelectTiled applies tmux's tiled layout to the target pane/session.
@@ -38,6 +65,18 @@ func SelectTiled(session string) error {
 	return nil
 }
 
+func shellQuote(s string) string {
+	if s == "" {
+		return "''"
+	}
+	if strings.IndexFunc(s, func(r rune) bool {
+		return !(r == '/' || r == ':' || r == '.' || r == '-' || r == '_' || (r >= '0' && r <= '9') || (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z'))
+	}) < 0 {
+		return s
+	}
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}
+
 // SetPaneTitle sets the tmux pane title when a display name is supplied.
 func SetPaneTitle(paneID, title string) error {
 	if strings.TrimSpace(title) == "" {
@@ -45,14 +84,6 @@ func SetPaneTitle(paneID, title string) error {
 	}
 	if err := exec.Command("tmux", "select-pane", "-t", paneID, "-T", title).Run(); err != nil {
 		return fmt.Errorf("tmux select-pane -T: %w", err)
-	}
-	return nil
-}
-
-// SendShellCommand sends command plus Enter to the target pane.
-func SendShellCommand(paneID, command string) error {
-	if err := exec.Command("tmux", "send-keys", "-t", paneID, command, "Enter").Run(); err != nil {
-		return fmt.Errorf("tmux send-keys: %w", err)
 	}
 	return nil
 }

--- a/internal/tmuxrun/tmuxrun_test.go
+++ b/internal/tmuxrun/tmuxrun_test.go
@@ -39,3 +39,54 @@ printf '%%42\n'
 		t.Fatalf("tmux args = %#v, want %#v", got, want)
 	}
 }
+
+func TestSplitPaneWithAgentCommandPassesWrappedLaunchCommandToTmux(t *testing.T) {
+	dir := t.TempDir()
+	argsPath := filepath.Join(dir, "args.txt")
+	tmuxPath := filepath.Join(dir, "tmux")
+	script := `#!/bin/sh
+printf '%s\n' "$@" > "$TMUXRUN_ARGS"
+printf '%%43\n'
+`
+	if err := os.WriteFile(tmuxPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TMUXRUN_ARGS", argsPath)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	command := "PATH='/very/long/path:/usr/bin' /tmp/bin/codex '[fanout #1] prompt'"
+	launchCommand := BuildPaneLaunchCommand(command)
+	paneID, err := SplitPaneWithAgentCommand("%1", "/tmp/work tree", command)
+	if err != nil {
+		t.Fatalf("SplitPaneWithAgentCommand() failed: %v", err)
+	}
+	if paneID != "%43" {
+		t.Fatalf("SplitPaneWithAgentCommand() paneID = %q, want %%43", paneID)
+	}
+
+	body, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := strings.Split(strings.TrimRight(string(body), "\n"), "\n")
+	want := []string{"split-window", "-t", "%1", "-d", "-h", "-P", "-F", "#{pane_id}", "-c", "/tmp/work tree", launchCommand}
+	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("tmux args = %#v, want %#v", got, want)
+	}
+}
+
+func TestBuildPaneLaunchCommandUsesUserShellAndKeepsPaneOpen(t *testing.T) {
+	got := BuildPaneLaunchCommand("PATH='/very/long/path:/usr/bin' /tmp/bin/codex '[fanout #1] prompt'")
+	for _, want := range []string{
+		`exec "${SHELL:-/bin/sh}" -lic `,
+		`/tmp/bin/codex`,
+		`[fanout #1] prompt`,
+		`__fanout_status=$?`,
+		`returning to shell`,
+		`exec "${SHELL:-/bin/sh}" -l`,
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("BuildPaneLaunchCommand() = %q, want substring %q", got, want)
+		}
+	}
+}

--- a/tests/golden/scenario-body-task-list.dry-run.txt
+++ b/tests/golden/scenario-body-task-list.dry-run.txt
@@ -17,12 +17,11 @@
     $ git -C <REPO>/tests/fixtures/scenario-body-task-list/project_root branch -f main refs/remotes/origin/main
     # if the base is checked out elsewhere, fanout uses merge --ff-only in that worktree
     $ git -C <REPO>/tests/fixtures/scenario-body-task-list/project_root worktree add -b fanout/first-task-201 <REPO>/tests/fixtures/scenario-body-task-list/project_root/.fanout/worktrees/first-task-201 main
-    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-body-task-list/project_root/.fanout/worktrees/first-task-201
+    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-body-task-list/project_root/.fanout/worktrees/first-task-201 'exec "${SHELL:-/bin/sh}" -lic '\''claude '\''\'\'''\''[fanout #201 of #200] first-task-201: First task. read /tmp/fanout-project_root-201.md and begin.'\''\'\'''\''; __fanout_status=$?; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T first-task-201
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
-    $ tmux send-keys -t <pane_id> 'claude '\''[fanout #201 of #200] first-task-201: First task. read /tmp/fanout-project_root-201.md and begin.'\''' Enter
 [ ok ] #201: dry-run complete
 [info] #202: Second task
   briefing -> /tmp/fanout-project_root-202.md
@@ -36,12 +35,11 @@
     $ git -C <REPO>/tests/fixtures/scenario-body-task-list/project_root branch -f main refs/remotes/origin/main
     # if the base is checked out elsewhere, fanout uses merge --ff-only in that worktree
     $ git -C <REPO>/tests/fixtures/scenario-body-task-list/project_root worktree add -b fanout/second-task-202 <REPO>/tests/fixtures/scenario-body-task-list/project_root/.fanout/worktrees/second-task-202 main
-    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-body-task-list/project_root/.fanout/worktrees/second-task-202
+    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-body-task-list/project_root/.fanout/worktrees/second-task-202 'exec "${SHELL:-/bin/sh}" -lic '\''claude '\''\'\'''\''[fanout #202 of #200] second-task-202: Second task. read /tmp/fanout-project_root-202.md and begin.'\''\'\'''\''; __fanout_status=$?; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T second-task-202
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
-    $ tmux send-keys -t <pane_id> 'claude '\''[fanout #202 of #200] second-task-202: Second task. read /tmp/fanout-project_root-202.md and begin.'\''' Enter
 [ ok ] #202: dry-run complete
 
 [ ok ] created: 2

--- a/tests/golden/scenario-cross-parent-shared.dry-run.txt
+++ b/tests/golden/scenario-cross-parent-shared.dry-run.txt
@@ -16,12 +16,11 @@
     $ git -C <REPO>/tests/fixtures/scenario-cross-parent-shared/project_root branch -f main refs/remotes/origin/main
     # if the base is checked out elsewhere, fanout uses merge --ff-only in that worktree
     $ git -C <REPO>/tests/fixtures/scenario-cross-parent-shared/project_root worktree add -b fanout/shared-child-parent-200-501 <REPO>/tests/fixtures/scenario-cross-parent-shared/project_root/.fanout/worktrees/shared-child-parent-200-501 main
-    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-cross-parent-shared/project_root/.fanout/worktrees/shared-child-parent-200-501
+    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-cross-parent-shared/project_root/.fanout/worktrees/shared-child-parent-200-501 'exec "${SHELL:-/bin/sh}" -lic '\''claude '\''\'\'''\''[fanout #501 of #200] shared-child-parent-200-501: Shared child. read /tmp/fanout-project_root-501.md and begin.'\''\'\'''\''; __fanout_status=$?; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T shared-child-parent-200-501
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
-    $ tmux send-keys -t <pane_id> 'claude '\''[fanout #501 of #200] shared-child-parent-200-501: Shared child. read /tmp/fanout-project_root-501.md and begin.'\''' Enter
 [ ok ] #501: dry-run complete
 [info] #502: B-only child
   briefing -> /tmp/fanout-project_root-502.md
@@ -35,12 +34,11 @@
     $ git -C <REPO>/tests/fixtures/scenario-cross-parent-shared/project_root branch -f main refs/remotes/origin/main
     # if the base is checked out elsewhere, fanout uses merge --ff-only in that worktree
     $ git -C <REPO>/tests/fixtures/scenario-cross-parent-shared/project_root worktree add -b fanout/b-only-child-502 <REPO>/tests/fixtures/scenario-cross-parent-shared/project_root/.fanout/worktrees/b-only-child-502 main
-    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-cross-parent-shared/project_root/.fanout/worktrees/b-only-child-502
+    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-cross-parent-shared/project_root/.fanout/worktrees/b-only-child-502 'exec "${SHELL:-/bin/sh}" -lic '\''claude '\''\'\'''\''[fanout #502 of #200] b-only-child-502: B-only child. read /tmp/fanout-project_root-502.md and begin.'\''\'\'''\''; __fanout_status=$?; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T b-only-child-502
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
-    $ tmux send-keys -t <pane_id> 'claude '\''[fanout #502 of #200] b-only-child-502: B-only child. read /tmp/fanout-project_root-502.md and begin.'\''' Enter
 [ ok ] #502: dry-run complete
 
 [ ok ] created: 2

--- a/tests/golden/scenario-idempotency.dry-run.txt
+++ b/tests/golden/scenario-idempotency.dry-run.txt
@@ -17,12 +17,11 @@
     $ git -C <REPO>/tests/fixtures/scenario-idempotency/project_root branch -f main refs/remotes/origin/main
     # if the base is checked out elsewhere, fanout uses merge --ff-only in that worktree
     $ git -C <REPO>/tests/fixtures/scenario-idempotency/project_root worktree add -b fanout/new-target-802 <REPO>/tests/fixtures/scenario-idempotency/project_root/.fanout/worktrees/new-target-802 main
-    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-idempotency/project_root/.fanout/worktrees/new-target-802
+    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-idempotency/project_root/.fanout/worktrees/new-target-802 'exec "${SHELL:-/bin/sh}" -lic '\''claude '\''\'\'''\''[fanout #802 of #800] new-target-802: New target. read /tmp/fanout-project_root-802.md and begin.'\''\'\'''\''; __fanout_status=$?; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T new-target-802
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
-    $ tmux send-keys -t <pane_id> 'claude '\''[fanout #802 of #800] new-target-802: New target. read /tmp/fanout-project_root-802.md and begin.'\''' Enter
 [ ok ] #802: dry-run complete
 
 [ ok ] created: 1

--- a/tests/golden/scenario-include.dry-run.txt
+++ b/tests/golden/scenario-include.dry-run.txt
@@ -17,12 +17,11 @@
     $ git -C <REPO>/tests/fixtures/scenario-include/project_root branch -f main refs/remotes/origin/main
     # if the base is checked out elsewhere, fanout uses merge --ff-only in that worktree
     $ git -C <REPO>/tests/fixtures/scenario-include/project_root worktree add -b fanout/included-child-a-401 <REPO>/tests/fixtures/scenario-include/project_root/.fanout/worktrees/included-child-a-401 main
-    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-include/project_root/.fanout/worktrees/included-child-a-401
+    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-include/project_root/.fanout/worktrees/included-child-a-401 'exec "${SHELL:-/bin/sh}" -lic '\''claude '\''\'\'''\''[fanout #401 of #400] included-child-a-401: Included child A. read /tmp/fanout-project_root-401.md and begin.'\''\'\'''\''; __fanout_status=$?; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T included-child-a-401
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
-    $ tmux send-keys -t <pane_id> 'claude '\''[fanout #401 of #400] included-child-a-401: Included child A. read /tmp/fanout-project_root-401.md and begin.'\''' Enter
 [ ok ] #401: dry-run complete
 [info] #402: Included child B
   briefing -> /tmp/fanout-project_root-402.md
@@ -36,12 +35,11 @@
     $ git -C <REPO>/tests/fixtures/scenario-include/project_root branch -f main refs/remotes/origin/main
     # if the base is checked out elsewhere, fanout uses merge --ff-only in that worktree
     $ git -C <REPO>/tests/fixtures/scenario-include/project_root worktree add -b fanout/included-child-b-402 <REPO>/tests/fixtures/scenario-include/project_root/.fanout/worktrees/included-child-b-402 main
-    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-include/project_root/.fanout/worktrees/included-child-b-402
+    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-include/project_root/.fanout/worktrees/included-child-b-402 'exec "${SHELL:-/bin/sh}" -lic '\''claude '\''\'\'''\''[fanout #402 of #400] included-child-b-402: Included child B. read /tmp/fanout-project_root-402.md and begin.'\''\'\'''\''; __fanout_status=$?; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T included-child-b-402
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
-    $ tmux send-keys -t <pane_id> 'claude '\''[fanout #402 of #400] included-child-b-402: Included child B. read /tmp/fanout-project_root-402.md and begin.'\''' Enter
 [ ok ] #402: dry-run complete
 
 [ ok ] created: 2

--- a/tests/golden/scenario-legacy-weak-signal.dry-run.txt
+++ b/tests/golden/scenario-legacy-weak-signal.dry-run.txt
@@ -17,12 +17,11 @@
     $ git -C <REPO>/tests/fixtures/scenario-legacy-weak-signal/project_root branch -f main refs/remotes/origin/main
     # if the base is checked out elsewhere, fanout uses merge --ff-only in that worktree
     $ git -C <REPO>/tests/fixtures/scenario-legacy-weak-signal/project_root worktree add -b fanout/first-task-601 <REPO>/tests/fixtures/scenario-legacy-weak-signal/project_root/.fanout/worktrees/first-task-601 main
-    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-legacy-weak-signal/project_root/.fanout/worktrees/first-task-601
+    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-legacy-weak-signal/project_root/.fanout/worktrees/first-task-601 'exec "${SHELL:-/bin/sh}" -lic '\''claude '\''\'\'''\''[fanout #601 of #600] first-task-601: First task. read /tmp/fanout-project_root-601.md and begin.'\''\'\'''\''; __fanout_status=$?; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T first-task-601
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
-    $ tmux send-keys -t <pane_id> 'claude '\''[fanout #601 of #600] first-task-601: First task. read /tmp/fanout-project_root-601.md and begin.'\''' Enter
 [ ok ] #601: dry-run complete
 [info] #602: Second task
   briefing -> /tmp/fanout-project_root-602.md
@@ -36,12 +35,11 @@
     $ git -C <REPO>/tests/fixtures/scenario-legacy-weak-signal/project_root branch -f main refs/remotes/origin/main
     # if the base is checked out elsewhere, fanout uses merge --ff-only in that worktree
     $ git -C <REPO>/tests/fixtures/scenario-legacy-weak-signal/project_root worktree add -b fanout/second-task-602 <REPO>/tests/fixtures/scenario-legacy-weak-signal/project_root/.fanout/worktrees/second-task-602 main
-    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-legacy-weak-signal/project_root/.fanout/worktrees/second-task-602
+    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-legacy-weak-signal/project_root/.fanout/worktrees/second-task-602 'exec "${SHELL:-/bin/sh}" -lic '\''claude '\''\'\'''\''[fanout #602 of #600] second-task-602: Second task. read /tmp/fanout-project_root-602.md and begin.'\''\'\'''\''; __fanout_status=$?; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T second-task-602
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
-    $ tmux send-keys -t <pane_id> 'claude '\''[fanout #602 of #600] second-task-602: Second task. read /tmp/fanout-project_root-602.md and begin.'\''' Enter
 [ ok ] #602: dry-run complete
 
 [ ok ] created: 2

--- a/tests/golden/scenario-limit.dry-run.txt
+++ b/tests/golden/scenario-limit.dry-run.txt
@@ -16,12 +16,11 @@
     $ git -C <REPO>/tests/fixtures/scenario-limit/project_root branch -f main refs/remotes/origin/main
     # if the base is checked out elsewhere, fanout uses merge --ff-only in that worktree
     $ git -C <REPO>/tests/fixtures/scenario-limit/project_root worktree add -b fanout/alpha-701 <REPO>/tests/fixtures/scenario-limit/project_root/.fanout/worktrees/alpha-701 main
-    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-limit/project_root/.fanout/worktrees/alpha-701
+    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-limit/project_root/.fanout/worktrees/alpha-701 'exec "${SHELL:-/bin/sh}" -lic '\''claude '\''\'\'''\''[fanout #701 of #700] alpha-701: Alpha. read /tmp/fanout-project_root-701.md and begin.'\''\'\'''\''; __fanout_status=$?; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T alpha-701
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
-    $ tmux send-keys -t <pane_id> 'claude '\''[fanout #701 of #700] alpha-701: Alpha. read /tmp/fanout-project_root-701.md and begin.'\''' Enter
 [ ok ] #701: dry-run complete
 [info] #702: Bravo
   briefing -> /tmp/fanout-project_root-702.md
@@ -35,12 +34,11 @@
     $ git -C <REPO>/tests/fixtures/scenario-limit/project_root branch -f main refs/remotes/origin/main
     # if the base is checked out elsewhere, fanout uses merge --ff-only in that worktree
     $ git -C <REPO>/tests/fixtures/scenario-limit/project_root worktree add -b fanout/bravo-702 <REPO>/tests/fixtures/scenario-limit/project_root/.fanout/worktrees/bravo-702 main
-    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-limit/project_root/.fanout/worktrees/bravo-702
+    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-limit/project_root/.fanout/worktrees/bravo-702 'exec "${SHELL:-/bin/sh}" -lic '\''claude '\''\'\'''\''[fanout #702 of #700] bravo-702: Bravo. read /tmp/fanout-project_root-702.md and begin.'\''\'\'''\''; __fanout_status=$?; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T bravo-702
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
-    $ tmux send-keys -t <pane_id> 'claude '\''[fanout #702 of #700] bravo-702: Bravo. read /tmp/fanout-project_root-702.md and begin.'\''' Enter
 [ ok ] #702: dry-run complete
 
 [ ok ] created: 2

--- a/tests/golden/scenario-only.dry-run.txt
+++ b/tests/golden/scenario-only.dry-run.txt
@@ -20,12 +20,11 @@ filtered out:
     $ git -C <REPO>/tests/fixtures/scenario-only/project_root branch -f main refs/remotes/origin/main
     # if the base is checked out elsewhere, fanout uses merge --ff-only in that worktree
     $ git -C <REPO>/tests/fixtures/scenario-only/project_root worktree add -b fanout/alpha-501 <REPO>/tests/fixtures/scenario-only/project_root/.fanout/worktrees/alpha-501 main
-    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-only/project_root/.fanout/worktrees/alpha-501
+    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-only/project_root/.fanout/worktrees/alpha-501 'exec "${SHELL:-/bin/sh}" -lic '\''claude '\''\'\'''\''[fanout #501 of #500] alpha-501: Alpha. read /tmp/fanout-project_root-501.md and begin.'\''\'\'''\''; __fanout_status=$?; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T alpha-501
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
-    $ tmux send-keys -t <pane_id> 'claude '\''[fanout #501 of #500] alpha-501: Alpha. read /tmp/fanout-project_root-501.md and begin.'\''' Enter
 [ ok ] #501: dry-run complete
 [info] #503: Charlie
   briefing -> /tmp/fanout-project_root-503.md
@@ -39,12 +38,11 @@ filtered out:
     $ git -C <REPO>/tests/fixtures/scenario-only/project_root branch -f main refs/remotes/origin/main
     # if the base is checked out elsewhere, fanout uses merge --ff-only in that worktree
     $ git -C <REPO>/tests/fixtures/scenario-only/project_root worktree add -b fanout/charlie-503 <REPO>/tests/fixtures/scenario-only/project_root/.fanout/worktrees/charlie-503 main
-    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-only/project_root/.fanout/worktrees/charlie-503
+    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-only/project_root/.fanout/worktrees/charlie-503 'exec "${SHELL:-/bin/sh}" -lic '\''claude '\''\'\'''\''[fanout #503 of #500] charlie-503: Charlie. read /tmp/fanout-project_root-503.md and begin.'\''\'\'''\''; __fanout_status=$?; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T charlie-503
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
-    $ tmux send-keys -t <pane_id> 'claude '\''[fanout #503 of #500] charlie-503: Charlie. read /tmp/fanout-project_root-503.md and begin.'\''' Enter
 [ ok ] #503: dry-run complete
 
 [ ok ] created: 2

--- a/tests/golden/scenario-project-basic.dry-run.txt
+++ b/tests/golden/scenario-project-basic.dry-run.txt
@@ -17,12 +17,11 @@
     $ git -C <REPO>/tests/fixtures/scenario-project-basic/project_root branch -f main refs/remotes/origin/main
     # if the base is checked out elsewhere, fanout uses merge --ff-only in that worktree
     $ git -C <REPO>/tests/fixtures/scenario-project-basic/project_root worktree add -b fanout/first-todo-item-901 <REPO>/tests/fixtures/scenario-project-basic/project_root/.fanout/worktrees/first-todo-item-901 main
-    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-project-basic/project_root/.fanout/worktrees/first-todo-item-901
+    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-project-basic/project_root/.fanout/worktrees/first-todo-item-901 'exec "${SHELL:-/bin/sh}" -lic '\''claude '\''\'\'''\''[fanout #901 of #https://github.com/users/butaosuinu/projects/3] first-todo-item-901: First todo item. read /tmp/fanout-project_root-901.md and begin.'\''\'\'''\''; __fanout_status=$?; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T first-todo-item-901
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
-    $ tmux send-keys -t <pane_id> 'claude '\''[fanout #901 of #https://github.com/users/butaosuinu/projects/3] first-todo-item-901: First todo item. read /tmp/fanout-project_root-901.md and begin.'\''' Enter
 [ ok ] #901: dry-run complete
 [info] #902: Second todo item
   briefing -> /tmp/fanout-project_root-902.md
@@ -36,12 +35,11 @@
     $ git -C <REPO>/tests/fixtures/scenario-project-basic/project_root branch -f main refs/remotes/origin/main
     # if the base is checked out elsewhere, fanout uses merge --ff-only in that worktree
     $ git -C <REPO>/tests/fixtures/scenario-project-basic/project_root worktree add -b fanout/second-todo-item-902 <REPO>/tests/fixtures/scenario-project-basic/project_root/.fanout/worktrees/second-todo-item-902 main
-    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-project-basic/project_root/.fanout/worktrees/second-todo-item-902
+    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-project-basic/project_root/.fanout/worktrees/second-todo-item-902 'exec "${SHELL:-/bin/sh}" -lic '\''claude '\''\'\'''\''[fanout #902 of #https://github.com/users/butaosuinu/projects/3] second-todo-item-902: Second todo item. read /tmp/fanout-project_root-902.md and begin.'\''\'\'''\''; __fanout_status=$?; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T second-todo-item-902
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
-    $ tmux send-keys -t <pane_id> 'claude '\''[fanout #902 of #https://github.com/users/butaosuinu/projects/3] second-todo-item-902: Second todo item. read /tmp/fanout-project_root-902.md and begin.'\''' Enter
 [ ok ] #902: dry-run complete
 
 [ ok ] created: 2

--- a/tests/golden/scenario-project-cross-repo.dry-run.txt
+++ b/tests/golden/scenario-project-cross-repo.dry-run.txt
@@ -18,12 +18,11 @@
     $ git -C <REPO>/tests/fixtures/scenario-project-cross-repo/project_root branch -f main refs/remotes/origin/main
     # if the base is checked out elsewhere, fanout uses merge --ff-only in that worktree
     $ git -C <REPO>/tests/fixtures/scenario-project-cross-repo/project_root worktree add -b fanout/self-repo-todo-921 <REPO>/tests/fixtures/scenario-project-cross-repo/project_root/.fanout/worktrees/self-repo-todo-921 main
-    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-project-cross-repo/project_root/.fanout/worktrees/self-repo-todo-921
+    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-project-cross-repo/project_root/.fanout/worktrees/self-repo-todo-921 'exec "${SHELL:-/bin/sh}" -lic '\''claude '\''\'\'''\''[fanout #921 of #https://github.com/users/butaosuinu/projects/3] self-repo-todo-921: Self-repo todo. read /tmp/fanout-project_root-921.md and begin.'\''\'\'''\''; __fanout_status=$?; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T self-repo-todo-921
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
-    $ tmux send-keys -t <pane_id> 'claude '\''[fanout #921 of #https://github.com/users/butaosuinu/projects/3] self-repo-todo-921: Self-repo todo. read /tmp/fanout-project_root-921.md and begin.'\''' Enter
 [ ok ] #921: dry-run complete
 
 [ ok ] created: 1

--- a/tests/golden/scenario-project-status-all.dry-run.txt
+++ b/tests/golden/scenario-project-status-all.dry-run.txt
@@ -17,12 +17,11 @@
     $ git -C <REPO>/tests/fixtures/scenario-project-status-all/project_root branch -f main refs/remotes/origin/main
     # if the base is checked out elsewhere, fanout uses merge --ff-only in that worktree
     $ git -C <REPO>/tests/fixtures/scenario-project-status-all/project_root worktree add -b fanout/todo-one-911 <REPO>/tests/fixtures/scenario-project-status-all/project_root/.fanout/worktrees/todo-one-911 main
-    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-project-status-all/project_root/.fanout/worktrees/todo-one-911
+    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-project-status-all/project_root/.fanout/worktrees/todo-one-911 'exec "${SHELL:-/bin/sh}" -lic '\''claude '\''\'\'''\''[fanout #911 of #https://github.com/users/butaosuinu/projects/3] todo-one-911: Todo one. read /tmp/fanout-project_root-911.md and begin.'\''\'\'''\''; __fanout_status=$?; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T todo-one-911
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
-    $ tmux send-keys -t <pane_id> 'claude '\''[fanout #911 of #https://github.com/users/butaosuinu/projects/3] todo-one-911: Todo one. read /tmp/fanout-project_root-911.md and begin.'\''' Enter
 [ ok ] #911: dry-run complete
 [info] #912: Todo two
   briefing -> /tmp/fanout-project_root-912.md
@@ -36,12 +35,11 @@
     $ git -C <REPO>/tests/fixtures/scenario-project-status-all/project_root branch -f main refs/remotes/origin/main
     # if the base is checked out elsewhere, fanout uses merge --ff-only in that worktree
     $ git -C <REPO>/tests/fixtures/scenario-project-status-all/project_root worktree add -b fanout/todo-two-912 <REPO>/tests/fixtures/scenario-project-status-all/project_root/.fanout/worktrees/todo-two-912 main
-    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-project-status-all/project_root/.fanout/worktrees/todo-two-912
+    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-project-status-all/project_root/.fanout/worktrees/todo-two-912 'exec "${SHELL:-/bin/sh}" -lic '\''claude '\''\'\'''\''[fanout #912 of #https://github.com/users/butaosuinu/projects/3] todo-two-912: Todo two. read /tmp/fanout-project_root-912.md and begin.'\''\'\'''\''; __fanout_status=$?; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T todo-two-912
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
-    $ tmux send-keys -t <pane_id> 'claude '\''[fanout #912 of #https://github.com/users/butaosuinu/projects/3] todo-two-912: Todo two. read /tmp/fanout-project_root-912.md and begin.'\''' Enter
 [ ok ] #912: dry-run complete
 [info] #913: Done item
   briefing -> /tmp/fanout-project_root-913.md
@@ -55,12 +53,11 @@
     $ git -C <REPO>/tests/fixtures/scenario-project-status-all/project_root branch -f main refs/remotes/origin/main
     # if the base is checked out elsewhere, fanout uses merge --ff-only in that worktree
     $ git -C <REPO>/tests/fixtures/scenario-project-status-all/project_root worktree add -b fanout/done-item-913 <REPO>/tests/fixtures/scenario-project-status-all/project_root/.fanout/worktrees/done-item-913 main
-    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-project-status-all/project_root/.fanout/worktrees/done-item-913
+    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-project-status-all/project_root/.fanout/worktrees/done-item-913 'exec "${SHELL:-/bin/sh}" -lic '\''claude '\''\'\'''\''[fanout #913 of #https://github.com/users/butaosuinu/projects/3] done-item-913: Done item. read /tmp/fanout-project_root-913.md and begin.'\''\'\'''\''; __fanout_status=$?; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T done-item-913
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
-    $ tmux send-keys -t <pane_id> 'claude '\''[fanout #913 of #https://github.com/users/butaosuinu/projects/3] done-item-913: Done item. read /tmp/fanout-project_root-913.md and begin.'\''' Enter
 [ ok ] #913: dry-run complete
 
 [ ok ] created: 3

--- a/tests/golden/scenario-settings-disabled.dry-run.txt
+++ b/tests/golden/scenario-settings-disabled.dry-run.txt
@@ -16,12 +16,11 @@
     $ git -C <REPO>/tests/fixtures/scenario-sub-issue-only/project_root branch -f main refs/remotes/origin/main
     # if the base is checked out elsewhere, fanout uses merge --ff-only in that worktree
     $ git -C <REPO>/tests/fixtures/scenario-sub-issue-only/project_root worktree add -b fanout/first-child-101 <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/first-child-101 main
-    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/first-child-101
+    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/first-child-101 'exec "${SHELL:-/bin/sh}" -lic '\''claude '\''\'\'''\''[fanout #101 of #100] first-child-101: First child. read /tmp/fanout-project_root-101.md and begin.'\''\'\'''\''; __fanout_status=$?; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T first-child-101
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
-    $ tmux send-keys -t <pane_id> 'claude '\''[fanout #101 of #100] first-child-101: First child. read /tmp/fanout-project_root-101.md and begin.'\''' Enter
 [ ok ] #101: dry-run complete
 [info] #102: Second child
   briefing -> /tmp/fanout-project_root-102.md
@@ -35,12 +34,11 @@
     $ git -C <REPO>/tests/fixtures/scenario-sub-issue-only/project_root branch -f main refs/remotes/origin/main
     # if the base is checked out elsewhere, fanout uses merge --ff-only in that worktree
     $ git -C <REPO>/tests/fixtures/scenario-sub-issue-only/project_root worktree add -b fanout/second-child-102 <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/second-child-102 main
-    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/second-child-102
+    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/second-child-102 'exec "${SHELL:-/bin/sh}" -lic '\''claude '\''\'\'''\''[fanout #102 of #100] second-child-102: Second child. read /tmp/fanout-project_root-102.md and begin.'\''\'\'''\''; __fanout_status=$?; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T second-child-102
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
-    $ tmux send-keys -t <pane_id> 'claude '\''[fanout #102 of #100] second-child-102: Second child. read /tmp/fanout-project_root-102.md and begin.'\''' Enter
 [ ok ] #102: dry-run complete
 
 [ ok ] created: 2

--- a/tests/golden/scenario-skip.dry-run.txt
+++ b/tests/golden/scenario-skip.dry-run.txt
@@ -20,12 +20,11 @@ filtered out:
     $ git -C <REPO>/tests/fixtures/scenario-skip/project_root branch -f main refs/remotes/origin/main
     # if the base is checked out elsewhere, fanout uses merge --ff-only in that worktree
     $ git -C <REPO>/tests/fixtures/scenario-skip/project_root worktree add -b fanout/alpha-601 <REPO>/tests/fixtures/scenario-skip/project_root/.fanout/worktrees/alpha-601 main
-    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-skip/project_root/.fanout/worktrees/alpha-601
+    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-skip/project_root/.fanout/worktrees/alpha-601 'exec "${SHELL:-/bin/sh}" -lic '\''claude '\''\'\'''\''[fanout #601 of #600] alpha-601: Alpha. read /tmp/fanout-project_root-601.md and begin.'\''\'\'''\''; __fanout_status=$?; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T alpha-601
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
-    $ tmux send-keys -t <pane_id> 'claude '\''[fanout #601 of #600] alpha-601: Alpha. read /tmp/fanout-project_root-601.md and begin.'\''' Enter
 [ ok ] #601: dry-run complete
 [info] #603: Charlie
   briefing -> /tmp/fanout-project_root-603.md
@@ -39,12 +38,11 @@ filtered out:
     $ git -C <REPO>/tests/fixtures/scenario-skip/project_root branch -f main refs/remotes/origin/main
     # if the base is checked out elsewhere, fanout uses merge --ff-only in that worktree
     $ git -C <REPO>/tests/fixtures/scenario-skip/project_root worktree add -b fanout/charlie-603 <REPO>/tests/fixtures/scenario-skip/project_root/.fanout/worktrees/charlie-603 main
-    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-skip/project_root/.fanout/worktrees/charlie-603
+    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-skip/project_root/.fanout/worktrees/charlie-603 'exec "${SHELL:-/bin/sh}" -lic '\''claude '\''\'\'''\''[fanout #603 of #600] charlie-603: Charlie. read /tmp/fanout-project_root-603.md and begin.'\''\'\'''\''; __fanout_status=$?; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T charlie-603
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
-    $ tmux send-keys -t <pane_id> 'claude '\''[fanout #603 of #600] charlie-603: Charlie. read /tmp/fanout-project_root-603.md and begin.'\''' Enter
 [ ok ] #603: dry-run complete
 
 [ ok ] created: 2

--- a/tests/golden/scenario-sub-issue-only-branch-override.dry-run.txt
+++ b/tests/golden/scenario-sub-issue-only-branch-override.dry-run.txt
@@ -17,12 +17,11 @@
     $ git -C <REPO>/tests/fixtures/scenario-sub-issue-only/project_root branch -f main refs/remotes/origin/main
     # if the base is checked out elsewhere, fanout uses merge --ff-only in that worktree
     $ git -C <REPO>/tests/fixtures/scenario-sub-issue-only/project_root worktree add -b feat/sub-issue-101-x <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/feat-x-101 main
-    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/feat-x-101
+    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/feat-x-101 'exec "${SHELL:-/bin/sh}" -lic '\''claude '\''\'\'''\''[fanout #101 of #100] feat-x-101: First child. read /tmp/fanout-project_root-101.md and begin.'\''\'\'''\''; __fanout_status=$?; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T 'Feature X'
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
-    $ tmux send-keys -t <pane_id> 'claude '\''[fanout #101 of #100] feat-x-101: First child. read /tmp/fanout-project_root-101.md and begin.'\''' Enter
 [ ok ] #101: dry-run complete
 [info] #102: Second child
   briefing -> /tmp/fanout-project_root-102.md
@@ -36,12 +35,11 @@
     $ git -C <REPO>/tests/fixtures/scenario-sub-issue-only/project_root branch -f main refs/remotes/origin/main
     # if the base is checked out elsewhere, fanout uses merge --ff-only in that worktree
     $ git -C <REPO>/tests/fixtures/scenario-sub-issue-only/project_root worktree add -b release/v2.0 <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/second-child-102 main
-    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/second-child-102
+    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/second-child-102 'exec "${SHELL:-/bin/sh}" -lic '\''claude '\''\'\'''\''[fanout #102 of #100] second-child-102: Second child. read /tmp/fanout-project_root-102.md and begin.'\''\'\'''\''; __fanout_status=$?; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T second-child-102
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
-    $ tmux send-keys -t <pane_id> 'claude '\''[fanout #102 of #100] second-child-102: Second child. read /tmp/fanout-project_root-102.md and begin.'\''' Enter
 [ ok ] #102: dry-run complete
 
 [ ok ] created: 2

--- a/tests/golden/scenario-sub-issue-only-codex.dry-run.txt
+++ b/tests/golden/scenario-sub-issue-only-codex.dry-run.txt
@@ -16,12 +16,11 @@
     $ git -C <REPO>/tests/fixtures/scenario-sub-issue-only/project_root branch -f main refs/remotes/origin/main
     # if the base is checked out elsewhere, fanout uses merge --ff-only in that worktree
     $ git -C <REPO>/tests/fixtures/scenario-sub-issue-only/project_root worktree add -b fanout/first-child-101 <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/first-child-101 main
-    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/first-child-101
+    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/first-child-101 'exec "${SHELL:-/bin/sh}" -lic '\''codex '\''\'\'''\''[fanout #101 of #100] first-child-101: First child. read /tmp/fanout-project_root-101.md and begin.'\''\'\'''\''; __fanout_status=$?; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T first-child-101
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
-    $ tmux send-keys -t <pane_id> 'codex '\''[fanout #101 of #100] first-child-101: First child. read /tmp/fanout-project_root-101.md and begin.'\''' Enter
 [ ok ] #101: dry-run complete
 [info] #102: Second child
   briefing -> /tmp/fanout-project_root-102.md
@@ -35,12 +34,11 @@
     $ git -C <REPO>/tests/fixtures/scenario-sub-issue-only/project_root branch -f main refs/remotes/origin/main
     # if the base is checked out elsewhere, fanout uses merge --ff-only in that worktree
     $ git -C <REPO>/tests/fixtures/scenario-sub-issue-only/project_root worktree add -b fanout/second-child-102 <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/second-child-102 main
-    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/second-child-102
+    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/second-child-102 'exec "${SHELL:-/bin/sh}" -lic '\''codex '\''\'\'''\''[fanout #102 of #100] second-child-102: Second child. read /tmp/fanout-project_root-102.md and begin.'\''\'\'''\''; __fanout_status=$?; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T second-child-102
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
-    $ tmux send-keys -t <pane_id> 'codex '\''[fanout #102 of #100] second-child-102: Second child. read /tmp/fanout-project_root-102.md and begin.'\''' Enter
 [ ok ] #102: dry-run complete
 
 [ ok ] created: 2

--- a/tests/golden/scenario-sub-issue-only.dry-run.txt
+++ b/tests/golden/scenario-sub-issue-only.dry-run.txt
@@ -16,12 +16,11 @@
     $ git -C <REPO>/tests/fixtures/scenario-sub-issue-only/project_root branch -f main refs/remotes/origin/main
     # if the base is checked out elsewhere, fanout uses merge --ff-only in that worktree
     $ git -C <REPO>/tests/fixtures/scenario-sub-issue-only/project_root worktree add -b fanout/first-child-101 <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/first-child-101 main
-    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/first-child-101
+    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/first-child-101 'exec "${SHELL:-/bin/sh}" -lic '\''claude '\''\'\'''\''[fanout #101 of #100] first-child-101: First child. read /tmp/fanout-project_root-101.md and begin.'\''\'\'''\''; __fanout_status=$?; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T first-child-101
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
-    $ tmux send-keys -t <pane_id> 'claude '\''[fanout #101 of #100] first-child-101: First child. read /tmp/fanout-project_root-101.md and begin.'\''' Enter
 [ ok ] #101: dry-run complete
 [info] #102: Second child
   briefing -> /tmp/fanout-project_root-102.md
@@ -35,12 +34,11 @@
     $ git -C <REPO>/tests/fixtures/scenario-sub-issue-only/project_root branch -f main refs/remotes/origin/main
     # if the base is checked out elsewhere, fanout uses merge --ff-only in that worktree
     $ git -C <REPO>/tests/fixtures/scenario-sub-issue-only/project_root worktree add -b fanout/second-child-102 <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/second-child-102 main
-    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/second-child-102
+    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/second-child-102 'exec "${SHELL:-/bin/sh}" -lic '\''claude '\''\'\'''\''[fanout #102 of #100] second-child-102: Second child. read /tmp/fanout-project_root-102.md and begin.'\''\'\'''\''; __fanout_status=$?; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T second-child-102
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
-    $ tmux send-keys -t <pane_id> 'claude '\''[fanout #102 of #100] second-child-102: Second child. read /tmp/fanout-project_root-102.md and begin.'\''' Enter
 [ ok ] #102: dry-run complete
 
 [ ok ] created: 2

--- a/tests/golden/scenario-union.dry-run.txt
+++ b/tests/golden/scenario-union.dry-run.txt
@@ -17,12 +17,11 @@
     $ git -C <REPO>/tests/fixtures/scenario-union/project_root branch -f main refs/remotes/origin/main
     # if the base is checked out elsewhere, fanout uses merge --ff-only in that worktree
     $ git -C <REPO>/tests/fixtures/scenario-union/project_root worktree add -b fanout/api-child-301 <REPO>/tests/fixtures/scenario-union/project_root/.fanout/worktrees/api-child-301 main
-    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-union/project_root/.fanout/worktrees/api-child-301
+    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-union/project_root/.fanout/worktrees/api-child-301 'exec "${SHELL:-/bin/sh}" -lic '\''claude '\''\'\'''\''[fanout #301 of #300] api-child-301: API child. read /tmp/fanout-project_root-301.md and begin.'\''\'\'''\''; __fanout_status=$?; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T api-child-301
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
-    $ tmux send-keys -t <pane_id> 'claude '\''[fanout #301 of #300] api-child-301: API child. read /tmp/fanout-project_root-301.md and begin.'\''' Enter
 [ ok ] #301: dry-run complete
 [info] #302: Body-only
   briefing -> /tmp/fanout-project_root-302.md
@@ -36,12 +35,11 @@
     $ git -C <REPO>/tests/fixtures/scenario-union/project_root branch -f main refs/remotes/origin/main
     # if the base is checked out elsewhere, fanout uses merge --ff-only in that worktree
     $ git -C <REPO>/tests/fixtures/scenario-union/project_root worktree add -b fanout/body-only-302 <REPO>/tests/fixtures/scenario-union/project_root/.fanout/worktrees/body-only-302 main
-    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-union/project_root/.fanout/worktrees/body-only-302
+    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-union/project_root/.fanout/worktrees/body-only-302 'exec "${SHELL:-/bin/sh}" -lic '\''claude '\''\'\'''\''[fanout #302 of #300] body-only-302: Body-only. read /tmp/fanout-project_root-302.md and begin.'\''\'\'''\''; __fanout_status=$?; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T body-only-302
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
-    $ tmux send-keys -t <pane_id> 'claude '\''[fanout #302 of #300] body-only-302: Body-only. read /tmp/fanout-project_root-302.md and begin.'\''' Enter
 [ ok ] #302: dry-run complete
 
 [ ok ] created: 2


### PR DESCRIPTION
## 概要

- agent command の絶対パス解決後も `PATH=...` prefix を維持し、`#!/usr/bin/env node` 型の shim が stale な tmux 環境でも動くように修正
- live agent launch では長い command を後から `send-keys` で入力せず、`tmux split-window` の shell-command 引数として渡すように変更
- shell-command はユーザーの shell startup path 経由で agent を起動し、agent 終了後は interactive shell に戻る wrapper にした
- dry-run / Tier2 golden / unit test / README / Codex skill の説明を新しい起動方式に合わせて更新

## 確認

- `go test ./internal/agent ./internal/tmuxrun ./cmd/fanout`
- `FANOUT_GOLDEN_UPDATE=1 make test-tier2`
- `make test`
- `make lint`
- `git diff --check`
- tmux smoke: pane `%549` で agent 役の command が exit 7 した後も pane が `zsh` として残り、終了ステータス表示後に shell prompt へ戻ることを確認
- live E2E: 一時 issue #134/#133 で実 pane `%546` を作成し、TTY 上で以下を確認
  - `node /Users/butaosuinu/.nodebrew/current/bin/codex ...`
  - native Codex binary process
  - Codex app-server process
- `./fanout-go 134 --status`
- `./fanout-go 134 --close 133` で pane/worktree/state cleanup

## Cleanup

- 一時 issue #133 / #134 は close 済み
- 一時 pane `%546` / `%549` は cleanup 済み
