### PR TITLE
feat(self-update): self-update 本体（install.sh 再利用で置換）

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -228,6 +228,8 @@ fanout <parent-issue|project-url>
        [--agent-teams-hint|--no-agent-teams-hint]
 fanout <parent-issue> --status      # ファンアウト済み子 issue の JSON 状態を読む
 fanout --check-update               # この binary と最新 release を比較
+fanout self-update --check          # release 更新 plan だけ表示（副作用なし）
+fanout self-update --yes            # install.sh 経由で binary + integrations を置換
 fanout --help
 ```
 
@@ -249,6 +251,33 @@ exit code:
 - `2` — 現行 version または最新 tag が `MAJOR.MINOR.PATCH`
   （任意の `v` prefix 可）ではなく比較不能。
 - `3` — `gh release view -R butaosuinu/fanout` が失敗。
+
+### `self-update`
+
+`fanout self-update` は Installation で説明している同じ `install.sh` 経路を呼び、
+実行中の release binary を置換します。OS/arch 検出、release download、checksum
+検証、tar 展開、Claude/Codex skill 配置は `install.sh` に集約したままにします。
+
+既定では最新 release を解決し、埋め込み version と比較し、`EvalSymlinks` 後の
+現在の binary path を表示してから確認プロンプトを出します。非対話 automation では
+`--yes` を指定してください。`--yes` が無い場合、stdin が tty でなければ拒否します。
+ローカル dev build（`version == "dev"`、通常の `make build-go` を含む）は置換を
+拒否します。
+
+Options:
+
+- `--check` — 解決した plan だけ表示します。`install.sh` の取得や file 置換はしません。
+- `--version <tag>` — `FANOUT_VERSION=<tag>` を `install.sh` に渡し、pin した release
+  tag を install します。
+- `--no-skills` — `install.sh` に `--no-skills` を渡し、binary だけ更新します。
+
+exit code:
+
+- `0` — plan 表示、更新完了、ユーザー中断、または既に最新。
+- `1` — dev build、`curl`/`wget` 不在、`--yes` なしの非 tty stdin、書込不可
+  binary directory などの環境/preflight 失敗。
+- `2` — self-update の呼び出し不正、または version string 比較不能。
+- `3` — 最新 release lookup 失敗。
 
 ### Settings
 

--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ fanout <parent-issue|project-url>
        [--agent-teams-hint|--no-agent-teams-hint]
 fanout <parent-issue> --status      # JSON status of fanned children, no side effects
 fanout --check-update               # Compare this binary with the latest release
+fanout self-update --check          # Print the release update plan, no side effects
+fanout self-update --yes            # Replace this binary + integrations via install.sh
 fanout --help
 ```
 
@@ -305,6 +307,36 @@ Exit codes:
 - `2` — the current version or latest tag is not `MAJOR.MINOR.PATCH`
   (optionally prefixed with `v`).
 - `3` — `gh release view -R butaosuinu/fanout` failed.
+
+### `self-update`
+
+`fanout self-update` replaces the running release binary by invoking the same
+`install.sh` path documented under Installation, so OS/arch detection, release
+downloads, checksum verification, archive extraction, and Claude/Codex skill
+installation stay centralized in one script.
+
+By default it resolves the latest release, compares it with the embedded
+version, reports the current binary path (after `EvalSymlinks`), then asks for
+confirmation before running the installer. Use `--yes` for non-interactive
+automation. Without `--yes`, non-tty stdin is rejected. Local dev builds
+(`version == "dev"`, including plain `make build-go`) refuse replacement.
+
+Options:
+
+- `--check` — print the resolved plan only; does not fetch `install.sh` or
+  replace files.
+- `--version <tag>` — install a pinned release tag by passing
+  `FANOUT_VERSION=<tag>` to `install.sh`.
+- `--no-skills` — pass `--no-skills` through to `install.sh`, updating only the
+  binary.
+
+Exit codes:
+
+- `0` — plan printed, update completed, user aborted, or already up to date.
+- `1` — environment/preflight failure such as dev build, no `curl`/`wget`,
+  non-tty stdin without `--yes`, or an unwritable binary directory.
+- `2` — bad self-update invocation or incomparable version strings.
+- `3` — latest release lookup failed.
 
 ### Settings
 

--- a/claude/commands/fanout.md
+++ b/claude/commands/fanout.md
@@ -7,6 +7,11 @@ Invoke the `fanout` CLI to spawn one dmux pane per OPEN sub-issue of a parent Gi
 
 Arguments: `$ARGUMENTS`
 
+If the user is only asking to check or update the `fanout` binary itself, stop
+this pane-creation workflow and use the skill's self-update path:
+`fanout self-update --check`, then `fanout self-update --yes` after
+confirmation.
+
 ## Steps
 
 1. **Resolve the parent target** from `$ARGUMENTS`. Two input shapes are accepted; the first matching token wins:

--- a/claude/skills/fanout/SKILL.md
+++ b/claude/skills/fanout/SKILL.md
@@ -18,7 +18,9 @@ fanout <parent-issue|project-url>
        [--briefing-code-review|--no-briefing-code-review]
        [--agent-teams-hint|--no-agent-teams-hint]
 fanout <parent-issue> --status      # JSON status of fanned children, no side effects
-fanout --check-update               # Compare this binary with the latest release
+fanout self-update --check          # Print the release update plan, no side effects
+fanout self-update --yes            # Replace fanout via install.sh
+fanout --check-update               # Legacy read-only version comparison
 ```
 
 **Do not run `fanout --help`, `fanout -h`, or `which fanout`.** This SKILL.md is the source-of-truth for the CLI surface — every flag above is documented under "Running" below, and the binary path is `/Users/butaosuinu/.local/bin/fanout` (also stated in the next paragraph). Probing the CLI directly wastes a tool call and adds nothing.
@@ -35,7 +37,8 @@ Good fits:
 
 - The user is in a dmux-managed pane on a parent issue that has OPEN sub-issues, and asks (explicitly or implicitly) to parallelize the children.
 - The user is in a dmux-managed pane and asks to fan out the OPEN issues of a GitHub Projects v2 board (often phrased as "Todo 列を並列展開" / "fan out my project board"), supplying the Project URL.
-- The user asks whether the installed `fanout` binary is up to date; in that case use the self-update check below, not the pane-creation workflow.
+- The user asks whether the installed `fanout` binary is up to date; in that case use `fanout self-update --check`, not the pane-creation workflow.
+- The user asks to update fanout itself; in that case run `fanout self-update --check`, present the plan, then run `fanout self-update --yes` after they confirm.
 - The user types `/fanout` or mentions "fan out" / "並列展開".
 
 Do not invoke unprompted just because an issue has sub-issues. Pane creation is visible and the user has to close each pane manually if they change their mind — suggest first, wait for a "yes", and prefer routing through the `/fanout` slash command so there is one consistent entry point.
@@ -88,16 +91,26 @@ cwd does not matter. `fanout` discovers dmux via tmux session options (`@dmux_co
 
 ## Running
 
-- **Self-update check**: if the user's intent is only to check whether `fanout`
-  is up to date, run `fanout --check-update` directly. This is read-only and
-  does not create panes, so skip parent resolution, dmux pre-flight, dry-run,
-  pane naming, and confirmation. `fanout check-update` is the equivalent
-  subcommand form. Dev builds (`version == "dev"`, including plain
-  `make build-go`) print a dev-build message and exit 0 without calling `gh`.
-  Released builds call `gh release view -R butaosuinu/fanout --json tagName
-  -q .tagName` and compare MAJOR.MINOR.PATCH tags, with an optional `v`
-  prefix. Exit codes: `0` comparison completed or dev build, `2` cannot
-  compare version strings, `3` release lookup failed.
+- **Self-update**: if the user's intent is only to check or update the
+  `fanout` binary itself, run `fanout self-update --check` and skip parent
+  resolution, dmux pre-flight, dry-run, pane naming, and confirmation. It is
+  read-only, creates no panes, and prints the current binary path, target
+  version, installer URL, and whether skills will be installed. Released builds
+  resolve the latest GitHub release and compare MAJOR.MINOR.PATCH tags with an
+  optional `v` prefix. Dev builds (`version == "dev"`, including plain
+  `make build-go`) print a plan but cannot replace themselves.
+- **Self-update execution**: after user confirmation, run
+  `fanout self-update --yes` to download and run the repository `install.sh`.
+  The command passes `BIN_DIR=<current binary dir>` and
+  `FANOUT_VERSION=<target>` so the installer replaces the same `fanout`
+  command and refreshes bundled integrations. Use `--version <tag>` to pin a
+  release and `--no-skills` to skip Claude/Codex skill installation. Non-TTY
+  updates require `--yes`, and actual replacement is only supported when the
+  resolved executable basename is `fanout`. Exit codes: `0` plan/no-op/update
+  or user abort, `1` environment or preflight failure, `2` bad invocation or
+  incomparable version, `3` latest-release lookup failed. `fanout
+  --check-update` and `fanout check-update` remain legacy read-only comparison
+  forms.
 - **Default**: `fanout <N-or-URL> --dry-run` → summarize → ask user to confirm → `fanout <N-or-URL>`.
 - **Bypass**: if the user's invocation carries `--go`, skip the confirmation and run directly.
 - **Forward extra flags** (`--agent`, `--limit`, `--only`, `--skip`, `--include`, `--unblocked-only`, `--project-status`, `--name`, `--session`, `--sleep`, `--popup-timeout`, `--debug`, `--auto-pr`, `--no-auto-pr`, `--pr-review-gate`, `--no-pr-review-gate`, `--briefing-code-review`, `--no-briefing-code-review`, `--agent-teams-hint`, `--no-agent-teams-hint`) verbatim to both the dry-run and the real run. Strip `--go` before forwarding — it is the slash command's own flag, not a `fanout` flag.

--- a/cmd/fanout/main.go
+++ b/cmd/fanout/main.go
@@ -34,6 +34,9 @@ func main() {
 		fmt.Fprintln(os.Stdout, versionLine())
 		os.Exit(int(exitcode.OK))
 	}
+	if isSelfUpdateRequest(os.Args[1:]) {
+		os.Exit(int(cmdSelfUpdate(os.Args[2:], version, ghissue.Runner{}, lg)))
+	}
 	if isCheckUpdateRequest(os.Args[1:]) {
 		os.Exit(int(cmdCheckUpdate(version, ghissue.Runner{}, lg)))
 	}
@@ -68,6 +71,10 @@ func isVersionRequest(args []string) bool {
 
 func isCheckUpdateRequest(args []string) bool {
 	return len(args) == 1 && (args[0] == "--check-update" || args[0] == "check-update")
+}
+
+func isSelfUpdateRequest(args []string) bool {
+	return len(args) > 0 && args[0] == "self-update"
 }
 
 func versionLine() string {

--- a/cmd/fanout/main_test.go
+++ b/cmd/fanout/main_test.go
@@ -116,6 +116,26 @@ func TestIsCheckUpdateRequest(t *testing.T) {
 	}
 }
 
+func TestIsSelfUpdateRequest(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "subcommand", args: []string{"self-update"}, want: true},
+		{name: "subcommand with flags", args: []string{"self-update", "--version", "v1.2.3"}, want: true},
+		{name: "check-update", args: []string{"check-update"}, want: false},
+		{name: "top-level version", args: []string{"--version"}, want: false},
+		{name: "empty", args: nil, want: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isSelfUpdateRequest(tc.args); got != tc.want {
+				t.Fatalf("isSelfUpdateRequest(%#v) = %v, want %v", tc.args, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestVersionLineUsesInjectedValues(t *testing.T) {
 	oldVersion := version
 	oldCommit := commit

--- a/cmd/fanout/selfupdate.go
+++ b/cmd/fanout/selfupdate.go
@@ -2,12 +2,59 @@ package main
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/butaosuinu/fanout/internal/exitcode"
 	"github.com/butaosuinu/fanout/internal/ghissue"
 	"github.com/butaosuinu/fanout/internal/log"
 	"github.com/butaosuinu/fanout/internal/selfupdate"
 )
+
+func cmdSelfUpdate(args []string, current string, gh ghissue.Runner, lg *log.Logger) exitcode.Code {
+	req, err := selfupdate.ParseArgs(args)
+	if err != nil {
+		lg.Err("self-update: %s", err.Error())
+		if kind, ok := selfupdate.Kind(err); ok && kind == selfupdate.FailureInvocation {
+			fmt.Fprint(lg.Stderr(), selfupdate.UsageText)
+			return exitcode.Invocation
+		}
+		return exitcode.Env
+	}
+	if req.Help {
+		fmt.Fprint(lg.Stdout(), selfupdate.UsageText)
+		return exitcode.OK
+	}
+
+	_, err = selfupdate.Run(selfupdate.Options{
+		CurrentVersion: current,
+		Request:        req,
+		LatestTag:      gh.LatestReleaseTag,
+		Runner: selfupdate.ExecRunner{
+			Stdin:  os.Stdin,
+			Stdout: lg.Stdout(),
+			Stderr: lg.Stderr(),
+		},
+		Stdout: lg.Stdout(),
+		Stderr: lg.Stderr(),
+		Stdin:  os.Stdin,
+	})
+	if err == nil {
+		return exitcode.OK
+	}
+
+	lg.Err("self-update: %s", err.Error())
+	if kind, ok := selfupdate.Kind(err); ok {
+		switch kind {
+		case selfupdate.FailureInvocation:
+			return exitcode.Invocation
+		case selfupdate.FailureGitHub:
+			return exitcode.GitHub
+		default:
+			return exitcode.Env
+		}
+	}
+	return exitcode.Env
+}
 
 func cmdCheckUpdate(current string, gh ghissue.Runner, lg *log.Logger) exitcode.Code {
 	if selfupdate.Compare(current, "") == selfupdate.DevBuild {

--- a/codex/skills/fanout/SKILL.md
+++ b/codex/skills/fanout/SKILL.md
@@ -20,7 +20,9 @@ fanout <parent-issue|project-url>
        [--briefing-code-review|--no-briefing-code-review]
        [--agent-teams-hint|--no-agent-teams-hint]
 fanout <parent-issue> --status      # JSON status of fanned children, no side effects
-fanout --check-update               # Compare this binary with the latest release
+fanout self-update --check          # Print the release update plan, no side effects
+fanout self-update --yes            # Replace fanout via install.sh
+fanout --check-update               # Legacy read-only version comparison
 ```
 
 **Do not probe the CLI** with `fanout --help`, `fanout -h`, or
@@ -53,8 +55,9 @@ Use this skill when the user explicitly asks to fan out, parallelize, or split
 work for a GitHub parent issue or a GitHub Projects v2 board, including
 Japanese phrasing like `並列展開` or "プロジェクトの Todo 列を一気に着手".
 Also use it when the user asks whether the installed `fanout` binary is up to
-date; that path uses the read-only self-update check below instead of pane
-creation.
+date; that path uses `fanout self-update --check` instead of pane creation. If
+the user asks to update fanout itself, run `fanout self-update --check` first,
+present the plan, then run `fanout self-update --yes` after they confirm.
 Do not invoke fanout just because an issue has sub-issues; pane creation is
 visible and the user has to close unwanted panes manually.
 
@@ -77,16 +80,25 @@ use this workflow directly.
 
 ## Workflow
 
-If the user's intent is only to check whether `fanout` is up to date, run
-`fanout --check-update` directly and skip the rest of this workflow. It is
+If the user's intent is only to check or update the `fanout` binary itself, run
+`fanout self-update --check` and skip the rest of this workflow. It is
 read-only, creates no panes, and does not require dmux pre-flight, parent
-resolution, dry-run, pane naming, or confirmation. `fanout check-update` is
-the equivalent subcommand form. Dev builds (`version == "dev"`, including
-plain `make build-go`) print a dev-build message and exit 0 without calling
-`gh`. Released builds call `gh release view -R butaosuinu/fanout --json
-tagName -q .tagName` and compare MAJOR.MINOR.PATCH tags, with an optional
-`v` prefix. Exit codes: `0` comparison completed or dev build, `2` cannot
-compare version strings, `3` release lookup failed.
+resolution, dry-run, pane naming, or confirmation. Released builds resolve the
+latest GitHub release, compare MAJOR.MINOR.PATCH tags with an optional `v`
+prefix, print the current binary path, target version, installer URL, and
+whether skills will be installed. Dev builds (`version == "dev"`, including
+plain `make build-go`) print a plan but cannot replace themselves.
+
+For actual replacement, use `fanout self-update --yes` after user confirmation.
+It downloads and runs the repository `install.sh`, passing `BIN_DIR=<current
+binary dir>` and `FANOUT_VERSION=<target>` so the installer replaces the same
+`fanout` command and refreshes bundled integrations. Use `--version <tag>` to
+pin a release and `--no-skills` to skip Claude/Codex skill installation.
+Non-TTY updates require `--yes`, and actual replacement is only supported when
+the resolved executable basename is `fanout`. Exit codes: `0` plan/no-op/update
+or user abort, `1` environment or preflight failure, `2` bad invocation or
+incomparable version, `3` latest-release lookup failed. `fanout --check-update`
+and `fanout check-update` remain legacy read-only comparison forms.
 
 1. Resolve the parent target from the user's request or recent context. Two
    shapes are accepted; identify which one matches and pass the normalized

--- a/internal/cliflags/usage.go
+++ b/internal/cliflags/usage.go
@@ -105,6 +105,9 @@ Options:
   --status            Read-only mode. Print JSON describing each fanned-out
                       child issue's state and closed-by PR merge status, then
                       exit. Exclusive with action-bearing flags.
+  self-update         Subcommand. Replace this binary and bundled Claude/Codex
+                      integrations through install.sh. Supports
+                      --check, --yes, --version <tag>, and --no-skills.
   --check-update      Read-only mode. Fetch the latest fanout release tag,
                       compare it with this binary's version, print whether an
                       update is available, then exit. Also accepted as

--- a/internal/selfupdate/selfupdate.go
+++ b/internal/selfupdate/selfupdate.go
@@ -178,6 +178,8 @@ type Plan struct {
 
 func (p Plan) NeedsInstaller() bool {
 	switch p.Outcome {
+	case UpToDate:
+		return p.ExplicitTarget
 	case UpdateAvailable:
 		return true
 	case CurrentAhead:
@@ -353,6 +355,12 @@ func actionLine(plan Plan) string {
 	case DevBuild:
 		return "none (dev build cannot be self-updated)"
 	case UpToDate:
+		if plan.ExplicitTarget && plan.UnsupportedExecutableName() {
+			return "none (current executable is not named fanout)"
+		}
+		if plan.ExplicitTarget {
+			return "would run installer"
+		}
 		return "none (already up to date)"
 	case CurrentAhead:
 		if plan.ExplicitTarget && plan.UnsupportedExecutableName() {

--- a/internal/selfupdate/selfupdate.go
+++ b/internal/selfupdate/selfupdate.go
@@ -1,10 +1,20 @@
-// Package selfupdate compares the running fanout version with release tags.
+// Package selfupdate compares the running fanout version with release tags and
+// drives release self-updates through install.sh.
 package selfupdate
 
 import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 )
+
+const InstallScriptURL = "https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh"
 
 type Outcome int
 
@@ -58,6 +68,491 @@ func Compare(current, latest string) Outcome {
 		}
 	}
 	return UpToDate
+}
+
+const UsageText = `Usage: fanout self-update [--check] [--yes] [--version <tag>] [--no-skills]
+
+Updates this fanout binary and bundled Claude/Codex integrations by reusing
+the release install.sh script. Use --check to print the resolved plan without
+running the installer.
+
+Options:
+  --check          Resolve target release and print the install plan only.
+  --yes            Skip the interactive confirmation prompt.
+  --version <tag>  Install a pinned release tag, e.g. v0.2.0.
+  --no-skills      Update only the fanout binary.
+  -h, --help       Show this help.
+`
+
+type FailureKind int
+
+const (
+	FailureEnv FailureKind = iota
+	FailureInvocation
+	FailureGitHub
+)
+
+type Failure struct {
+	Kind FailureKind
+	Err  error
+}
+
+func (f *Failure) Error() string {
+	if f == nil || f.Err == nil {
+		return ""
+	}
+	return f.Err.Error()
+}
+
+func (f *Failure) Unwrap() error {
+	if f == nil {
+		return nil
+	}
+	return f.Err
+}
+
+func fail(kind FailureKind, format string, args ...any) error {
+	return &Failure{Kind: kind, Err: fmt.Errorf(format, args...)}
+}
+
+func Kind(err error) (FailureKind, bool) {
+	var f *Failure
+	if errors.As(err, &f) {
+		return f.Kind, true
+	}
+	return FailureEnv, false
+}
+
+type Request struct {
+	Check    bool
+	Yes      bool
+	NoSkills bool
+	Version  string
+	Help     bool
+}
+
+func ParseArgs(args []string) (Request, error) {
+	var req Request
+	for i := 0; i < len(args); {
+		switch arg := args[i]; arg {
+		case "--check":
+			req.Check = true
+			i++
+		case "--yes":
+			req.Yes = true
+			i++
+		case "--no-skills":
+			req.NoSkills = true
+			i++
+		case "--version":
+			if i+1 >= len(args) {
+				return req, fail(FailureEnv, "--version requires an argument")
+			}
+			req.Version = args[i+1]
+			i += 2
+		case "-h", "--help":
+			req.Help = true
+			i++
+		default:
+			if strings.HasPrefix(arg, "-") {
+				return req, fail(FailureInvocation, "unknown self-update option: %s", arg)
+			}
+			return req, fail(FailureInvocation, "unexpected self-update argument: %s", arg)
+		}
+	}
+	return req, nil
+}
+
+type Plan struct {
+	CurrentVersion string
+	TargetVersion  string
+	TargetSource   string
+	ExecutablePath string
+	ResolvedPath   string
+	BinDir         string
+	NoSkills       bool
+	Outcome        Outcome
+	InstallerURL   string
+	ExplicitTarget bool
+}
+
+func (p Plan) NeedsInstaller() bool {
+	switch p.Outcome {
+	case UpdateAvailable:
+		return true
+	case CurrentAhead:
+		return p.ExplicitTarget
+	default:
+		return false
+	}
+}
+
+func (p Plan) UnsupportedExecutableName() bool {
+	return filepath.Base(p.ResolvedPath) != "fanout"
+}
+
+type Options struct {
+	CurrentVersion string
+	Request        Request
+	LatestTag      func() (string, error)
+	Runner         CommandRunner
+	Stdout         io.Writer
+	Stderr         io.Writer
+	Stdin          io.Reader
+
+	Executable    func() (string, error)
+	EvalSymlinks  func(string) (string, error)
+	LookPath      func(string) (string, error)
+	WritableDir   func(string) error
+	StdinTerminal func(io.Reader) bool
+}
+
+func Run(opts Options) (Plan, error) {
+	opts = withDefaults(opts)
+	plan, err := ResolvePlan(opts)
+	if err != nil {
+		return plan, err
+	}
+
+	if opts.Request.Check {
+		if plan.Outcome == CannotCompare {
+			return plan, fail(FailureInvocation, "cannot compare current version %q with target release %q", plan.CurrentVersion, plan.TargetVersion)
+		}
+		PrintCheckPlan(opts.Stdout, plan)
+		return plan, nil
+	}
+
+	if plan.Outcome == DevBuild {
+		return plan, fail(FailureEnv, "fanout dev build: self-update only replaces released versions")
+	}
+	if plan.Outcome == CannotCompare {
+		return plan, fail(FailureInvocation, "cannot compare current version %q with target release %q", plan.CurrentVersion, plan.TargetVersion)
+	}
+	if !plan.NeedsInstaller() {
+		PrintNoop(opts.Stdout, plan)
+		return plan, nil
+	}
+	if plan.UnsupportedExecutableName() {
+		return plan, fail(FailureEnv, "self-update can only replace an executable named fanout; current executable is %s", plan.ResolvedPath)
+	}
+
+	if err := requireDownloader(opts.LookPath); err != nil {
+		return plan, err
+	}
+	if err := opts.WritableDir(plan.BinDir); err != nil {
+		return plan, fail(FailureEnv, "cannot write to binary directory %s: %w", plan.BinDir, err)
+	}
+
+	PrintUpdatePlan(opts.Stdout, plan)
+	if !opts.Request.Yes {
+		ok, err := confirm(opts.Stdin, opts.Stdout, opts.StdinTerminal)
+		if err != nil {
+			return plan, err
+		}
+		if !ok {
+			fmt.Fprintln(opts.Stdout, "self-update aborted")
+			return plan, nil
+		}
+	}
+
+	if err := opts.Runner.Run(BuildInstallerCommand(plan)); err != nil {
+		return plan, fail(FailureEnv, "install.sh failed: %w", err)
+	}
+	return plan, nil
+}
+
+func ResolvePlan(opts Options) (Plan, error) {
+	opts = withDefaults(opts)
+	req := opts.Request
+
+	exe, err := opts.Executable()
+	if err != nil {
+		return Plan{}, fail(FailureEnv, "cannot locate current executable: %w", err)
+	}
+	resolved, err := opts.EvalSymlinks(exe)
+	if err != nil {
+		return Plan{}, fail(FailureEnv, "cannot resolve current executable %s: %w", exe, err)
+	}
+
+	plan := Plan{
+		CurrentVersion: opts.CurrentVersion,
+		ExecutablePath: exe,
+		ResolvedPath:   resolved,
+		BinDir:         filepath.Dir(resolved),
+		NoSkills:       req.NoSkills,
+		InstallerURL:   InstallScriptURL,
+	}
+
+	if req.Version != "" {
+		plan.TargetSource = "pinned"
+		plan.ExplicitTarget = true
+		if _, ok := parseVersion(req.Version); !ok {
+			plan.TargetVersion = req.Version
+			plan.Outcome = CannotCompare
+			return plan, nil
+		}
+		plan.TargetVersion = normalizeReleaseTag(req.Version)
+		if Compare(opts.CurrentVersion, "") == DevBuild {
+			plan.Outcome = DevBuild
+			return plan, nil
+		}
+	} else if Compare(opts.CurrentVersion, "") == DevBuild {
+		plan.TargetVersion = "latest"
+		plan.TargetSource = "latest"
+		plan.Outcome = DevBuild
+		return plan, nil
+	} else {
+		latest, err := opts.LatestTag()
+		if err != nil {
+			return plan, fail(FailureGitHub, "failed to fetch latest release tag: %w", err)
+		}
+		plan.TargetVersion = latest
+		plan.TargetSource = "latest"
+	}
+
+	plan.Outcome = Compare(opts.CurrentVersion, plan.TargetVersion)
+	return plan, nil
+}
+
+func PrintCheckPlan(w io.Writer, plan Plan) {
+	printPlan(w, "fanout self-update check", plan)
+	fmt.Fprintf(w, "  action:          %s\n", actionLine(plan))
+}
+
+func PrintUpdatePlan(w io.Writer, plan Plan) {
+	printPlan(w, "fanout self-update", plan)
+	fmt.Fprintf(w, "  action:          run install.sh\n")
+}
+
+func PrintNoop(w io.Writer, plan Plan) {
+	switch plan.Outcome {
+	case UpToDate:
+		fmt.Fprintf(w, "fanout is already up to date: %s\n", plan.CurrentVersion)
+	case CurrentAhead:
+		fmt.Fprintf(w, "fanout %s is newer than latest release %s\n", plan.CurrentVersion, plan.TargetVersion)
+	default:
+		fmt.Fprintf(w, "fanout self-update: nothing to do (%s)\n", plan.Outcome)
+	}
+}
+
+func printPlan(w io.Writer, title string, plan Plan) {
+	fmt.Fprintln(w, title)
+	fmt.Fprintf(w, "  current version: %s\n", plan.CurrentVersion)
+	fmt.Fprintf(w, "  target version:  %s (%s)\n", plan.TargetVersion, plan.TargetSource)
+	fmt.Fprintf(w, "  current binary:  %s\n", plan.ResolvedPath)
+	if plan.ExecutablePath != plan.ResolvedPath {
+		fmt.Fprintf(w, "  invoked path:    %s\n", plan.ExecutablePath)
+	}
+	fmt.Fprintf(w, "  binary dir:      %s\n", plan.BinDir)
+	fmt.Fprintf(w, "  install script:  %s\n", plan.InstallerURL)
+	fmt.Fprintf(w, "  skills:          %s\n", yesNo(!plan.NoSkills))
+}
+
+func actionLine(plan Plan) string {
+	switch plan.Outcome {
+	case DevBuild:
+		return "none (dev build cannot be self-updated)"
+	case UpToDate:
+		return "none (already up to date)"
+	case CurrentAhead:
+		if plan.ExplicitTarget && plan.UnsupportedExecutableName() {
+			return "none (current executable is not named fanout)"
+		}
+		if plan.ExplicitTarget {
+			return "would run installer"
+		}
+		return "none (current version is newer than latest release)"
+	case UpdateAvailable:
+		if plan.UnsupportedExecutableName() {
+			return "none (current executable is not named fanout)"
+		}
+		return "would run installer"
+	default:
+		return "none (cannot compare versions)"
+	}
+}
+
+func yesNo(v bool) string {
+	if v {
+		return "yes"
+	}
+	return "no"
+}
+
+func normalizeReleaseTag(version string) string {
+	version = strings.TrimSpace(version)
+	if strings.HasPrefix(version, "v") {
+		return version
+	}
+	return "v" + version
+}
+
+type CommandSpec struct {
+	Name string
+	Args []string
+	Env  []string
+}
+
+type CommandRunner interface {
+	Run(CommandSpec) error
+}
+
+type CommandRunnerFunc func(CommandSpec) error
+
+func (f CommandRunnerFunc) Run(spec CommandSpec) error {
+	return f(spec)
+}
+
+type ExecRunner struct {
+	Stdin   io.Reader
+	Stdout  io.Writer
+	Stderr  io.Writer
+	Environ func() []string
+}
+
+func (r ExecRunner) Run(spec CommandSpec) error {
+	cmd := exec.Command(spec.Name, spec.Args...)
+	if r.Stdin != nil {
+		cmd.Stdin = r.Stdin
+	}
+	if r.Stdout != nil {
+		cmd.Stdout = r.Stdout
+	}
+	if r.Stderr != nil {
+		cmd.Stderr = r.Stderr
+	}
+	environ := os.Environ
+	if r.Environ != nil {
+		environ = r.Environ
+	}
+	cmd.Env = append(environ(), spec.Env...)
+	return cmd.Run()
+}
+
+func BuildInstallerCommand(plan Plan) CommandSpec {
+	args := []string{
+		"-c",
+		installerShellScript,
+		"fanout-self-update",
+		plan.InstallerURL,
+	}
+	if plan.NoSkills {
+		args = append(args, "--no-skills")
+	}
+	return CommandSpec{
+		Name: "sh",
+		Args: args,
+		Env: []string{
+			"BIN_DIR=" + plan.BinDir,
+			"FANOUT_VERSION=" + plan.TargetVersion,
+		},
+	}
+}
+
+const installerShellScript = `set -eu
+url=$1
+shift
+script=$(mktemp "${TMPDIR:-/tmp}/fanout-install.XXXXXX")
+trap 'rm -f "$script"' EXIT HUP INT TERM
+if command -v curl >/dev/null 2>&1; then
+  curl -fsSL "$url" -o "$script"
+elif command -v wget >/dev/null 2>&1; then
+  wget -qO "$script" "$url"
+else
+  echo "fanout self-update: curl or wget is required to fetch install.sh" >&2
+  exit 1
+fi
+sh "$script" "$@"`
+
+func withDefaults(opts Options) Options {
+	if opts.CurrentVersion == "" {
+		opts.CurrentVersion = "dev"
+	}
+	if opts.Stdout == nil {
+		opts.Stdout = io.Discard
+	}
+	if opts.Stderr == nil {
+		opts.Stderr = io.Discard
+	}
+	if opts.Stdin == nil {
+		opts.Stdin = strings.NewReader("")
+	}
+	if opts.LatestTag == nil {
+		opts.LatestTag = func() (string, error) {
+			return "", errors.New("latest release resolver is not configured")
+		}
+	}
+	if opts.Executable == nil {
+		opts.Executable = os.Executable
+	}
+	if opts.EvalSymlinks == nil {
+		opts.EvalSymlinks = filepath.EvalSymlinks
+	}
+	if opts.LookPath == nil {
+		opts.LookPath = exec.LookPath
+	}
+	if opts.WritableDir == nil {
+		opts.WritableDir = checkWritableDir
+	}
+	if opts.StdinTerminal == nil {
+		opts.StdinTerminal = isTerminalReader
+	}
+	if opts.Runner == nil {
+		opts.Runner = ExecRunner{Stdin: opts.Stdin, Stdout: opts.Stdout, Stderr: opts.Stderr}
+	}
+	return opts
+}
+
+func requireDownloader(lookPath func(string) (string, error)) error {
+	if _, err := lookPath("curl"); err == nil {
+		return nil
+	}
+	if _, err := lookPath("wget"); err == nil {
+		return nil
+	}
+	return fail(FailureEnv, "curl or wget is required to fetch install.sh")
+}
+
+func checkWritableDir(dir string) error {
+	f, err := os.CreateTemp(dir, ".fanout-self-update-*")
+	if err != nil {
+		return err
+	}
+	name := f.Name()
+	closeErr := f.Close()
+	removeErr := os.Remove(name)
+	if closeErr != nil {
+		return closeErr
+	}
+	return removeErr
+}
+
+func confirm(stdin io.Reader, stdout io.Writer, isTerminal func(io.Reader) bool) (bool, error) {
+	if !isTerminal(stdin) {
+		return false, fail(FailureEnv, "self-update requires --yes when stdin is not a terminal")
+	}
+	fmt.Fprint(stdout, "Proceed with self-update? [y/N] ")
+	line, err := bufio.NewReader(stdin).ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return false, fail(FailureEnv, "failed to read confirmation: %w", err)
+	}
+	answer := strings.ToLower(strings.TrimSpace(line))
+	return answer == "y" || answer == "yes", nil
+}
+
+func isTerminalReader(r io.Reader) bool {
+	f, ok := r.(*os.File)
+	if !ok {
+		return false
+	}
+	info, err := f.Stat()
+	if err != nil {
+		return false
+	}
+	if info.Mode()&os.ModeCharDevice == 0 {
+		return false
+	}
+	return isTerminalFile(f)
 }
 
 func parseVersion(s string) ([3]int, bool) {

--- a/internal/selfupdate/selfupdate_test.go
+++ b/internal/selfupdate/selfupdate_test.go
@@ -174,6 +174,53 @@ func TestRunPinnedVersionPassesFANOUTVersionAndNoSkillsToInstaller(t *testing.T)
 	}
 }
 
+func TestRunPinnedCurrentVersionStillRunsInstaller(t *testing.T) {
+	var got CommandSpec
+	var out bytes.Buffer
+	opts := testOptions(Request{Yes: true, Version: "0.1.0"}, &out, CommandRunnerFunc(func(spec CommandSpec) error {
+		got = spec
+		return nil
+	}))
+	opts.LatestTag = func() (string, error) {
+		t.Fatal("latest release lookup should not be called for pinned version")
+		return "", nil
+	}
+
+	plan, err := Run(opts)
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if plan.Outcome != UpToDate || !plan.NeedsInstaller() {
+		t.Fatalf("plan = %+v, want up-to-date explicit target that needs installer", plan)
+	}
+	env := envMap(got.Env)
+	if got, want := env["FANOUT_VERSION"], "v0.1.0"; got != want {
+		t.Fatalf("FANOUT_VERSION = %q, want %q", got, want)
+	}
+	if got.Name != "sh" {
+		t.Fatalf("command name = %q, want sh", got.Name)
+	}
+}
+
+func TestCheckPlanPinnedCurrentVersionWouldRunInstaller(t *testing.T) {
+	var out bytes.Buffer
+	opts := testOptions(Request{Check: true, Version: "0.1.0"}, &out, CommandRunnerFunc(func(CommandSpec) error {
+		t.Fatal("installer runner should not be called")
+		return nil
+	}))
+
+	plan, err := Run(opts)
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if plan.Outcome != UpToDate || !plan.NeedsInstaller() {
+		t.Fatalf("plan = %+v, want up-to-date explicit target that needs installer", plan)
+	}
+	if got := out.String(); !strings.Contains(got, "action:          would run installer") {
+		t.Fatalf("output = %q, want installer action", got)
+	}
+}
+
 func TestRunDevBuildRejectsReplacementBeforeLookupOrInstaller(t *testing.T) {
 	var out bytes.Buffer
 	latestCalled := false

--- a/internal/selfupdate/selfupdate_test.go
+++ b/internal/selfupdate/selfupdate_test.go
@@ -1,6 +1,13 @@
 package selfupdate
 
-import "testing"
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+)
 
 func TestCompare(t *testing.T) {
 	for _, tc := range []struct {
@@ -27,5 +34,350 @@ func TestCompare(t *testing.T) {
 				t.Fatalf("Compare(%q, %q) = %s, want %s", tc.current, tc.latest, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestBuildInstallerCommandMapsVersionEnvAndNoSkills(t *testing.T) {
+	spec := BuildInstallerCommand(Plan{
+		BinDir:        "/opt/fanout/bin",
+		TargetVersion: "v9.8.7",
+		NoSkills:      true,
+		InstallerURL:  InstallScriptURL,
+	})
+
+	if spec.Name != "sh" {
+		t.Fatalf("command name = %q, want sh", spec.Name)
+	}
+	if len(spec.Args) != 5 {
+		t.Fatalf("args = %#v, want shell script plus URL and --no-skills", spec.Args)
+	}
+	if spec.Args[0] != "-c" {
+		t.Fatalf("args[0] = %q, want -c", spec.Args[0])
+	}
+	if spec.Args[2] != "fanout-self-update" {
+		t.Fatalf("args[2] = %q, want fanout-self-update", spec.Args[2])
+	}
+	if spec.Args[3] != InstallScriptURL {
+		t.Fatalf("installer URL = %q, want %q", spec.Args[3], InstallScriptURL)
+	}
+	if spec.Args[4] != "--no-skills" {
+		t.Fatalf("last arg = %q, want --no-skills", spec.Args[4])
+	}
+	if strings.Contains(spec.Args[1], "| sh") {
+		t.Fatalf("installer script pipes downloader into sh, which hides download failures:\n%s", spec.Args[1])
+	}
+	for _, want := range []string{
+		`curl -fsSL "$url" -o "$script"`,
+		`wget -qO "$script" "$url"`,
+		`sh "$script" "$@"`,
+	} {
+		if !strings.Contains(spec.Args[1], want) {
+			t.Fatalf("installer script missing %q:\n%s", want, spec.Args[1])
+		}
+	}
+
+	env := envMap(spec.Env)
+	if got, want := env["BIN_DIR"], "/opt/fanout/bin"; got != want {
+		t.Fatalf("BIN_DIR = %q, want %q", got, want)
+	}
+	if got, want := env["FANOUT_VERSION"], "v9.8.7"; got != want {
+		t.Fatalf("FANOUT_VERSION = %q, want %q", got, want)
+	}
+}
+
+func TestRunCheckPrintsPlanWithoutRunningInstaller(t *testing.T) {
+	var out bytes.Buffer
+	called := false
+	plan, err := Run(testOptions(Request{Check: true}, &out, CommandRunnerFunc(func(CommandSpec) error {
+		called = true
+		return nil
+	})))
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if called {
+		t.Fatal("installer runner was called in --check mode")
+	}
+	if plan.TargetVersion != "v0.2.0" || plan.Outcome != UpdateAvailable {
+		t.Fatalf("plan = %+v, want target v0.2.0 update available", plan)
+	}
+	got := out.String()
+	for _, want := range []string{
+		"fanout self-update check",
+		"current version: v0.1.0",
+		"target version:  v0.2.0 (latest)",
+		"current binary:  /tmp/fanout-real/fanout",
+		"action:          would run installer",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("check output missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestRunCheckRejectsIncomparablePinnedVersion(t *testing.T) {
+	var out bytes.Buffer
+	_, err := Run(testOptions(Request{Check: true, Version: "not-semver"}, &out, CommandRunnerFunc(func(CommandSpec) error {
+		t.Fatal("installer runner should not be called")
+		return nil
+	})))
+	if err == nil {
+		t.Fatal("Run returned nil error, want incomparable-version failure")
+	}
+	assertFailureKind(t, err, FailureInvocation)
+	if !strings.Contains(err.Error(), "cannot compare current version") {
+		t.Fatalf("error = %v, want compare message", err)
+	}
+}
+
+func TestRunCheckRejectsIncomparablePinnedVersionOnDevBuild(t *testing.T) {
+	var out bytes.Buffer
+	opts := testOptions(Request{Check: true, Version: "not-semver"}, &out, CommandRunnerFunc(func(CommandSpec) error {
+		t.Fatal("installer runner should not be called")
+		return nil
+	}))
+	opts.CurrentVersion = "dev"
+
+	_, err := Run(opts)
+	if err == nil {
+		t.Fatal("Run returned nil error, want incomparable-version failure")
+	}
+	assertFailureKind(t, err, FailureInvocation)
+}
+
+func TestRunPinnedVersionPassesFANOUTVersionAndNoSkillsToInstaller(t *testing.T) {
+	var got CommandSpec
+	var out bytes.Buffer
+	plan, err := Run(testOptions(Request{Yes: true, Version: "9.9.9", NoSkills: true}, &out, CommandRunnerFunc(func(spec CommandSpec) error {
+		got = spec
+		return nil
+	})))
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if got, want := plan.TargetVersion, "v9.9.9"; got != want {
+		t.Fatalf("TargetVersion = %q, want %q", got, want)
+	}
+
+	env := envMap(got.Env)
+	if got, want := env["BIN_DIR"], "/tmp/fanout-real"; got != want {
+		t.Fatalf("BIN_DIR = %q, want %q", got, want)
+	}
+	if got, want := env["FANOUT_VERSION"], "v9.9.9"; got != want {
+		t.Fatalf("FANOUT_VERSION = %q, want %q", got, want)
+	}
+	if got.Name != "sh" {
+		t.Fatalf("command name = %q, want sh", got.Name)
+	}
+	if got.Args[len(got.Args)-1] != "--no-skills" {
+		t.Fatalf("args = %#v, want --no-skills forwarded", got.Args)
+	}
+}
+
+func TestRunDevBuildRejectsReplacementBeforeLookupOrInstaller(t *testing.T) {
+	var out bytes.Buffer
+	latestCalled := false
+	runnerCalled := false
+	opts := testOptions(Request{Yes: true}, &out, CommandRunnerFunc(func(CommandSpec) error {
+		runnerCalled = true
+		return nil
+	}))
+	opts.CurrentVersion = "dev"
+	opts.LatestTag = func() (string, error) {
+		latestCalled = true
+		return "v0.2.0", nil
+	}
+
+	_, err := Run(opts)
+	if err == nil {
+		t.Fatal("Run returned nil error, want dev-build failure")
+	}
+	assertFailureKind(t, err, FailureEnv)
+	if latestCalled {
+		t.Fatal("latest release lookup was called for dev replacement")
+	}
+	if runnerCalled {
+		t.Fatal("installer runner was called for dev replacement")
+	}
+}
+
+func TestRunUpToDateSkipsInstaller(t *testing.T) {
+	var out bytes.Buffer
+	called := false
+	opts := testOptions(Request{Yes: true}, &out, CommandRunnerFunc(func(CommandSpec) error {
+		called = true
+		return nil
+	}))
+	opts.CurrentVersion = "v0.2.0"
+
+	_, err := Run(opts)
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if called {
+		t.Fatal("installer runner was called for up-to-date version")
+	}
+	if got := out.String(); !strings.Contains(got, "fanout is already up to date: v0.2.0") {
+		t.Fatalf("output = %q, want already up-to-date message", got)
+	}
+}
+
+func TestRunRejectsNonFanoutExecutableName(t *testing.T) {
+	var out bytes.Buffer
+	opts := testOptions(Request{Yes: true}, &out, CommandRunnerFunc(func(CommandSpec) error {
+		t.Fatal("installer runner should not be called")
+		return nil
+	}))
+	opts.EvalSymlinks = func(string) (string, error) {
+		return "/tmp/fanout-real/fanout-v0.1.0", nil
+	}
+
+	_, err := Run(opts)
+	if err == nil {
+		t.Fatal("Run returned nil error, want executable-name failure")
+	}
+	assertFailureKind(t, err, FailureEnv)
+	if !strings.Contains(err.Error(), "executable named fanout") {
+		t.Fatalf("error = %v, want executable-name message", err)
+	}
+}
+
+func TestCheckPlanMarksNonFanoutExecutableAsNotRunnable(t *testing.T) {
+	var out bytes.Buffer
+	opts := testOptions(Request{Check: true}, &out, CommandRunnerFunc(func(CommandSpec) error {
+		t.Fatal("installer runner should not be called")
+		return nil
+	}))
+	opts.EvalSymlinks = func(string) (string, error) {
+		return "/tmp/fanout-real/fanout-v0.1.0", nil
+	}
+
+	_, err := Run(opts)
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if got := out.String(); !strings.Contains(got, "action:          none (current executable is not named fanout)") {
+		t.Fatalf("output = %q, want non-runnable action", got)
+	}
+}
+
+func TestRunRequiresDownloader(t *testing.T) {
+	var out bytes.Buffer
+	opts := testOptions(Request{Yes: true}, &out, CommandRunnerFunc(func(CommandSpec) error {
+		t.Fatal("installer runner should not be called")
+		return nil
+	}))
+	opts.LookPath = func(string) (string, error) {
+		return "", errors.New("not found")
+	}
+
+	_, err := Run(opts)
+	if err == nil {
+		t.Fatal("Run returned nil error, want downloader failure")
+	}
+	assertFailureKind(t, err, FailureEnv)
+	if !strings.Contains(err.Error(), "curl or wget is required") {
+		t.Fatalf("error = %v, want curl/wget message", err)
+	}
+}
+
+func TestRunRejectsUnwritableBinDir(t *testing.T) {
+	var out bytes.Buffer
+	opts := testOptions(Request{Yes: true}, &out, CommandRunnerFunc(func(CommandSpec) error {
+		t.Fatal("installer runner should not be called")
+		return nil
+	}))
+	opts.WritableDir = func(string) error {
+		return errors.New("permission denied")
+	}
+
+	_, err := Run(opts)
+	if err == nil {
+		t.Fatal("Run returned nil error, want writable-dir failure")
+	}
+	assertFailureKind(t, err, FailureEnv)
+	if !strings.Contains(err.Error(), "cannot write to binary directory /tmp/fanout-real") {
+		t.Fatalf("error = %v, want binary directory message", err)
+	}
+}
+
+func TestRunRequiresYesForNonTTY(t *testing.T) {
+	var out bytes.Buffer
+	opts := testOptions(Request{}, &out, CommandRunnerFunc(func(CommandSpec) error {
+		t.Fatal("installer runner should not be called")
+		return nil
+	}))
+	opts.StdinTerminal = func(io.Reader) bool { return false }
+
+	_, err := Run(opts)
+	if err == nil {
+		t.Fatal("Run returned nil error, want non-tty confirmation failure")
+	}
+	assertFailureKind(t, err, FailureEnv)
+	if !strings.Contains(err.Error(), "requires --yes") {
+		t.Fatalf("error = %v, want --yes message", err)
+	}
+}
+
+func TestIsTerminalReaderRejectsDevNull(t *testing.T) {
+	f, err := os.Open(os.DevNull)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	if isTerminalReader(f) {
+		t.Fatal("isTerminalReader(os.DevNull) = true, want false")
+	}
+}
+
+func testOptions(req Request, out *bytes.Buffer, runner CommandRunner) Options {
+	return Options{
+		CurrentVersion: "v0.1.0",
+		Request:        req,
+		LatestTag: func() (string, error) {
+			return "v0.2.0", nil
+		},
+		Runner: runner,
+		Stdout: out,
+		Stderr: out,
+		Stdin:  strings.NewReader(""),
+		Executable: func() (string, error) {
+			return "/tmp/fanout-link/fanout", nil
+		},
+		EvalSymlinks: func(string) (string, error) {
+			return "/tmp/fanout-real/fanout", nil
+		},
+		LookPath: func(string) (string, error) {
+			return "/usr/bin/downloader", nil
+		},
+		WritableDir: func(string) error {
+			return nil
+		},
+		StdinTerminal: func(io.Reader) bool {
+			return true
+		},
+	}
+}
+
+func envMap(env []string) map[string]string {
+	out := map[string]string{}
+	for _, pair := range env {
+		k, v, ok := strings.Cut(pair, "=")
+		if ok {
+			out[k] = v
+		}
+	}
+	return out
+}
+
+func assertFailureKind(t *testing.T, err error, want FailureKind) {
+	t.Helper()
+	got, ok := Kind(err)
+	if !ok {
+		t.Fatalf("Kind(%v) not available", err)
+	}
+	if got != want {
+		t.Fatalf("Kind(%v) = %v, want %v", err, got, want)
 	}
 }

--- a/internal/selfupdate/tty_darwin.go
+++ b/internal/selfupdate/tty_darwin.go
@@ -1,0 +1,15 @@
+//go:build darwin
+
+package selfupdate
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+func isTerminalFile(f *os.File) bool {
+	var termios syscall.Termios
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, f.Fd(), uintptr(syscall.TIOCGETA), uintptr(unsafe.Pointer(&termios)))
+	return errno == 0
+}

--- a/internal/selfupdate/tty_linux.go
+++ b/internal/selfupdate/tty_linux.go
@@ -1,0 +1,15 @@
+//go:build linux
+
+package selfupdate
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+func isTerminalFile(f *os.File) bool {
+	var termios syscall.Termios
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, f.Fd(), uintptr(syscall.TCGETS), uintptr(unsafe.Pointer(&termios)))
+	return errno == 0
+}

--- a/internal/selfupdate/tty_other.go
+++ b/internal/selfupdate/tty_other.go
@@ -1,0 +1,9 @@
+//go:build !darwin && !linux
+
+package selfupdate
+
+import "os"
+
+func isTerminalFile(*os.File) bool {
+	return false
+}

--- a/tests/bats/tier1_flags.bats
+++ b/tests/bats/tier1_flags.bats
@@ -139,6 +139,25 @@ load helpers
   [[ "$output" == *"action:          would run installer"* ]]
 }
 
+@test "self-update --check pinned current version still plans installer" {
+  local release_dir="$BATS_TEST_TMPDIR/release-pinned-current"
+  mkdir -p "$release_dir"
+  local release_bin="$release_dir/fanout"
+  GOCACHE="$REPO_ROOT/.cache/go-build" go build \
+    -ldflags "-X main.version=v0.1.0 -X main.commit=test" \
+    -o "$release_bin" ./cmd/fanout
+  force_missing gh
+
+  local old_bin="$FANOUT_BIN"
+  FANOUT_BIN="$release_bin"
+  run_fanout self-update --check --version 0.1.0
+  FANOUT_BIN="$old_bin"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"target version:  v0.1.0 (pinned)"* ]]
+  [[ "$output" == *"action:          would run installer"* ]]
+}
+
 @test "self-update dev build rejects replacement before gh/downloader" {
   force_missing gh curl wget
   run_fanout self-update --yes

--- a/tests/bats/tier1_flags.bats
+++ b/tests/bats/tier1_flags.bats
@@ -65,6 +65,126 @@ load helpers
   [[ "$output" == *"fanout update available: v0.1.0 -> v0.2.0"* ]]
 }
 
+@test "self-update --help prints usage and exits 0" {
+  run_fanout self-update --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: fanout self-update"* ]]
+}
+
+@test "self-update unknown flag: error + usage + exit 2" {
+  run_fanout self-update --bogus
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unknown self-update option: --bogus"* ]]
+  [[ "$output" == *"Usage: fanout self-update"* ]]
+}
+
+@test "self-update --version missing value: exit 1" {
+  run_fanout self-update --version
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"--version requires an argument"* ]]
+}
+
+@test "self-update --check release build reports plan without installer" {
+  local release_dir="$BATS_TEST_TMPDIR/release-check"
+  mkdir -p "$release_dir"
+  local release_bin="$release_dir/fanout"
+  GOCACHE="$REPO_ROOT/.cache/go-build" go build \
+    -ldflags "-X main.version=v0.1.0 -X main.commit=test" \
+    -o "$release_bin" ./cmd/fanout
+  use_fixture scenario-check-update
+
+  local old_bin="$FANOUT_BIN"
+  FANOUT_BIN="$release_bin"
+  run_fanout self-update --check
+  FANOUT_BIN="$old_bin"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"fanout self-update check"* ]]
+  [[ "$output" == *"target version:  v0.2.0 (latest)"* ]]
+  [[ "$output" == *"action:          would run installer"* ]]
+}
+
+@test "self-update --check with invalid pinned version exits 2" {
+  local release_dir="$BATS_TEST_TMPDIR/release-invalid"
+  mkdir -p "$release_dir"
+  local release_bin="$release_dir/fanout"
+  GOCACHE="$REPO_ROOT/.cache/go-build" go build \
+    -ldflags "-X main.version=v0.1.0 -X main.commit=test" \
+    -o "$release_bin" ./cmd/fanout
+
+  local old_bin="$FANOUT_BIN"
+  FANOUT_BIN="$release_bin"
+  run_fanout self-update --check --version not-semver
+  FANOUT_BIN="$old_bin"
+
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"cannot compare current version"* ]]
+}
+
+@test "self-update --check normalizes pinned version without v prefix" {
+  local release_dir="$BATS_TEST_TMPDIR/release-pinned-normalized"
+  mkdir -p "$release_dir"
+  local release_bin="$release_dir/fanout"
+  GOCACHE="$REPO_ROOT/.cache/go-build" go build \
+    -ldflags "-X main.version=v0.1.0 -X main.commit=test" \
+    -o "$release_bin" ./cmd/fanout
+
+  local old_bin="$FANOUT_BIN"
+  FANOUT_BIN="$release_bin"
+  run_fanout self-update --check --version 0.2.0
+  FANOUT_BIN="$old_bin"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"target version:  v0.2.0 (pinned)"* ]]
+  [[ "$output" == *"action:          would run installer"* ]]
+}
+
+@test "self-update dev build rejects replacement before gh/downloader" {
+  force_missing gh curl wget
+  run_fanout self-update --yes
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"fanout dev build"* ]]
+  [[ "$output" == *"self-update only replaces released versions"* ]]
+}
+
+@test "self-update release build requires curl or wget before installer" {
+  local release_dir="$BATS_TEST_TMPDIR/release-missing-downloader"
+  mkdir -p "$release_dir"
+  local release_bin="$release_dir/fanout"
+  GOCACHE="$REPO_ROOT/.cache/go-build" go build \
+    -ldflags "-X main.version=v0.1.0 -X main.commit=test" \
+    -o "$release_bin" ./cmd/fanout
+  use_fixture scenario-check-update
+  force_missing curl wget
+
+  local old_bin="$FANOUT_BIN"
+  FANOUT_BIN="$release_bin"
+  run_fanout self-update --yes
+  FANOUT_BIN="$old_bin"
+
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"curl or wget is required"* ]]
+}
+
+@test "self-update already latest skips installer" {
+  local release_dir="$BATS_TEST_TMPDIR/release-current"
+  mkdir -p "$release_dir"
+  local release_bin="$release_dir/fanout"
+  GOCACHE="$REPO_ROOT/.cache/go-build" go build \
+    -ldflags "-X main.version=v0.2.0 -X main.commit=test" \
+    -o "$release_bin" ./cmd/fanout
+  use_fixture scenario-check-update
+  force_missing curl wget
+
+  local old_bin="$FANOUT_BIN"
+  FANOUT_BIN="$release_bin"
+  run_fanout self-update --yes
+  FANOUT_BIN="$old_bin"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"fanout is already up to date: v0.2.0"* ]]
+}
+
 @test "no positional argument: usage + exit 2" {
   run_fanout
   [ "$status" -eq 2 ]


### PR DESCRIPTION
## Summary
- add fanout self-update with --check, --yes, --version, and --no-skills
- reuse install.sh with BIN_DIR/FANOUT_VERSION and preflight checks
- update README and bundled Claude/Codex integrations for the new workflow

## Tests
- make go-test
- make test-tier1
- make lint
- make test
- codex review --uncommitted

Closes #101