### PR TITLE
[codex] docs(self-update): README/help exit codes

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -275,8 +275,8 @@ exit code:
 
 - `0` — plan 表示、更新完了、ユーザー中断、または既に最新。
 - `1` — dev build、`curl`/`wget` 不在、`--yes` なしの非 tty stdin、書込不可
-  binary directory などの環境/preflight 失敗。
-- `2` — self-update の呼び出し不正、または version string 比較不能。
+  binary directory、option 値不足などの環境/preflight 失敗。
+- `2` — unknown option、想定外の argument、または version string 比較不能。
 - `3` — 最新 release lookup 失敗。
 
 ### Settings

--- a/README.md
+++ b/README.md
@@ -334,8 +334,9 @@ Exit codes:
 
 - `0` — plan printed, update completed, user aborted, or already up to date.
 - `1` — environment/preflight failure such as dev build, no `curl`/`wget`,
-  non-tty stdin without `--yes`, or an unwritable binary directory.
-- `2` — bad self-update invocation or incomparable version strings.
+  non-tty stdin without `--yes`, an unwritable binary directory, or a missing
+  option value.
+- `2` — unknown option, unexpected argument, or incomparable version strings.
 - `3` — latest release lookup failed.
 
 ### Settings

--- a/internal/cliflags/usage.go
+++ b/internal/cliflags/usage.go
@@ -142,6 +142,12 @@ Exit codes (--check-update):
   0 success (including update available, up-to-date, dev build)
   2 cannot compare version strings (MAJOR.MINOR.PATCH, optional v prefix)
   3 gh release lookup failed
+
+Exit codes (self-update):
+  0 success (plan printed, update completed, aborted, or already up to date)
+  1 prerequisite / environment problem, or missing option value
+  2 unknown option, unexpected argument, or cannot compare version strings
+  3 gh release lookup failed
 `
 
 // Usage writes the help text to w.

--- a/tests/bats/tier1_flags.bats
+++ b/tests/bats/tier1_flags.bats
@@ -32,6 +32,10 @@ load helpers
   run_fanout --help
   [ "$status" -eq 0 ]
   [[ "$output" == *"Usage: fanout"* ]]
+  [[ "$output" == *"self-update         Subcommand."* ]]
+  [[ "$output" == *"Exit codes (self-update):"* ]]
+  [[ "$output" == *"1 prerequisite / environment problem, or missing option value"* ]]
+  [[ "$output" == *"2 unknown option, unexpected argument, or cannot compare version strings"* ]]
 }
 
 @test "--check-update on dev build exits 0 without gh" {


### PR DESCRIPTION
## Summary
- README / README.ja の `self-update` exit code 説明を実装に合わせて明確化
- top-level `fanout --help` に `self-update` 専用 exit-code 表を追加
- Tier1 help テストで self-update subcommand と exit-code 表を固定

## Validation
- `make go-test`
- `make test-tier1`
- `make test-tier2`
- `make lint`
- `codex review --uncommitted` clean

Closes #102