### PR TITLE
Document Codex SSH push failure handling

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -524,6 +524,20 @@ branch 名、stale/missing remote branch です。base を変えるには
 - 親 issue が存在しない、または拡張経由で紐づけられたサブ issue が無い:
   fanout は `no sub-issues on #<parent>` と出して exit 0 する。
 
+### Codex 子ペインで SSH の `git push` ができない
+
+Codex 子ペインで `git push`、`git ls-remote`、または `ssh -V` が
+`No user exists for uid 501` を返す場合、OpenSSH は GitHub へ到達する前に
+失敗しています。これは deploy key 不足やリポジトリ権限の問題ではなく、Codex 実行環境が
+ローカル macOS ユーザー情報を解決できていない状態です。`ssh-add -l` も
+`Error connecting to agent: Operation not permitted` を返すなら、同じ環境から
+継承された ssh-agent にも接続できていません。
+
+同じ SSH コマンドや escalation を繰り返さないでください。利用できる場合は GitHub
+connector/API 経由で publish するか、`id -un` が実ユーザー名を返し
+`ssh-add -l` が agent に接続できる通常の Terminal / Claude Code セッションから
+push してもらってください。
+
 ### slug や branch 名が意図と違う
 
 既定では `slugify(title)-<issueNum>` と `fanout/<slug>` を使います。特定 issue は

--- a/README.md
+++ b/README.md
@@ -597,6 +597,20 @@ local base/ref.
 - Parent issue doesn't exist or has no sub-issues tagged via the extension:
   fanout exits 0 with `no sub-issues on #<parent>`.
 
+### Codex child pane cannot `git push` over SSH
+
+If a Codex child pane reports `No user exists for uid 501` from `git push`,
+`git ls-remote`, or even `ssh -V`, OpenSSH is failing before it reaches
+GitHub. This is not a missing deploy key or repo permission issue. It means
+the Codex execution environment cannot resolve the local macOS user record.
+If `ssh-add -l` also reports `Error connecting to agent: Operation not
+permitted`, the same environment cannot reach the inherited ssh-agent.
+
+Do not keep retrying the same SSH command or escalation. Publish through the
+GitHub connector/API if available, or ask the user to run the push from a
+normal Terminal or Claude Code session where `id -un` resolves to the real
+username and `ssh-add -l` can reach the agent.
+
 ### Slug or branch names are not what you want
 
 By default, fanout uses `slugify(title)-<issueNum>` and

--- a/codex/skills/fanout/SKILL.md
+++ b/codex/skills/fanout/SKILL.md
@@ -353,6 +353,14 @@ the likely next action:
   Tell them to run `gh auth refresh -s read:project` and rerun.
 - Project mode `no items in Project (after status/repo filter). nothing to
   do.` is not a failure; fanout exits 0.
+- Codex child pane `git push` fails with `No user exists for uid 501`, or
+  `ssh -V` fails with the same message: this is a Codex execution-environment
+  failure before GitHub authentication. Do not keep retrying SSH or escalation.
+  Publish through the GitHub connector/API if available, or ask the user to
+  push from a normal Terminal or Claude Code session.
+- Codex child pane `ssh-add -l` fails with
+  `Error connecting to agent: Operation not permitted`: the sandbox cannot
+  reach the inherited ssh-agent. Treat it the same as the `uid 501` failure.
 
 ## Notes
 
@@ -368,7 +376,10 @@ the likely next action:
   pushes, or opens the PR. The review command should be treated as one
   blocking shell command: while it is running, do not open, resume, or inspect
   any Review Session and do not run `/codex:status` or other polling commands;
-  wait for the command to exit, then read the final output once.
+  wait for the command to exit, then read the final output once. If SSH publish
+  fails with `No user exists for uid 501` or ssh-agent `Operation not
+  permitted`, the child should stop retrying SSH and use the GitHub
+  connector/API path or ask for an external push.
 - The action path creates git worktrees itself, then uses detached
   `tmux split-window -t <invoking-pane> -d` with a shell launch command to start
   the selected agent CLI without moving focus away from the caller pane. The

--- a/internal/briefing/briefing.go
+++ b/internal/briefing/briefing.go
@@ -88,6 +88,13 @@ Before committing your final changes or opening a PR, run
 Only after the review loop is clean should you commit, push, and open the PR.
 If the review command is unavailable or fails for tooling/auth reasons, stop
 and report that instead of bypassing the gate.
+
+Codex SSH publish note: if ` + "`git push`" + ` or ` + "`ssh -V`" + ` fails with
+` + "`No user exists for uid 501`" + `, or ` + "`ssh-add -l`" + ` fails with
+` + "`Error connecting to agent: Operation not permitted`" + `, do not keep retrying
+SSH or escalation. Treat it as a Codex execution-environment problem: publish
+the branch via the GitHub connector/API if available, or stop and ask the user
+to push from a normal Terminal or Claude Code session.
 `
 
 const codexReviewWithoutPRSection = `
@@ -104,6 +111,13 @@ Before committing your final changes, run
 Only after the review loop is clean should you commit and push the branch.
 If the review command is unavailable or fails for tooling/auth reasons, stop
 and report that instead of bypassing the gate.
+
+Codex SSH publish note: if ` + "`git push`" + ` or ` + "`ssh -V`" + ` fails with
+` + "`No user exists for uid 501`" + `, or ` + "`ssh-add -l`" + ` fails with
+` + "`Error connecting to agent: Operation not permitted`" + `, do not keep retrying
+SSH or escalation. Treat it as a Codex execution-environment problem: publish
+the branch via the GitHub connector/API if available, or stop and ask the user
+to push from a normal Terminal or Claude Code session.
 `
 
 const codeReviewSection = `

--- a/tests/bats/tier1_briefing.bats
+++ b/tests/bats/tier1_briefing.bats
@@ -34,6 +34,9 @@ load helpers
   grep -q "do not run \`/codex:status\` or other polling" "$briefing"
   grep -q "Repeat until review reports no findings / no issues / clean" "$briefing"
   grep -q "Only after the review loop is clean should you commit, push, and open the PR" "$briefing"
+  grep -q "No user exists for uid 501" "$briefing"
+  grep -q "Error connecting to agent: Operation not permitted" "$briefing"
+  grep -q "do not keep retrying" "$briefing"
   grep -q "Make focused, minimal changes scoped to this single issue" "$briefing"
   grep -q "Closes #101" "$briefing"
 }
@@ -69,6 +72,7 @@ load helpers
   grep -q "codex review --uncommitted" "$briefing"
   grep -q "do not run \`/codex:status\` or other polling" "$briefing"
   grep -q "Only after the review loop is clean should you commit and push the branch" "$briefing"
+  grep -q "No user exists for uid 501" "$briefing"
   ! grep -q "Open a pull request with \"Closes #101\"" "$briefing"
   ! grep -q "opening a PR" "$briefing"
   ! grep -q "open the PR" "$briefing"

--- a/tests/golden/scenario-sub-issue-only-codex.dry-run.txt
+++ b/tests/golden/scenario-sub-issue-only-codex.dry-run.txt
@@ -10,7 +10,7 @@
   worktree -> <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/first-child-101
   branch -> fanout/first-child-101
   base -> main
-  briefing size: 1375 bytes
+  briefing size: 1781 bytes
     $ git -C <REPO>/tests/fixtures/scenario-sub-issue-only/project_root fetch --quiet --no-tags origin main
     # may fast-forward the local base before worktree creation
     $ git -C <REPO>/tests/fixtures/scenario-sub-issue-only/project_root branch -f main refs/remotes/origin/main
@@ -28,7 +28,7 @@
   worktree -> <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/second-child-102
   branch -> fanout/second-child-102
   base -> main
-  briefing size: 1376 bytes
+  briefing size: 1782 bytes
     $ git -C <REPO>/tests/fixtures/scenario-sub-issue-only/project_root fetch --quiet --no-tags origin main
     # may fast-forward the local base before worktree creation
     $ git -C <REPO>/tests/fixtures/scenario-sub-issue-only/project_root branch -f main refs/remotes/origin/main


### PR DESCRIPTION
## Summary
- Add a Codex-specific stop rule for SSH publish failures caused by `No user exists for uid 501` or `ssh-add -l` agent errors.
- Surface the same guidance in the fanout Codex skill and the English/Japanese README troubleshooting sections.
- Extend the Codex briefing tests and refresh the Codex dry-run golden for the new briefing text.

## Testing
- `make test`
- `make lint`
- Focused `bats` coverage for the Codex briefing and dry-run scenario passed