### PR TITLE
Add status table diff stats

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -192,7 +192,8 @@ fanout <parent-issue|project-url>
        [--auto-pr|--no-auto-pr] [--pr-review-gate|--no-pr-review-gate]
        [--briefing-code-review|--no-briefing-code-review]
        [--agent-teams-hint|--no-agent-teams-hint]
-fanout <parent-issue> --status      # .fanout/state.json 由来の JSON 状態を読む
+fanout <parent-issue> --status [--format json|table]
+                                      # .fanout/state.json 由来の状態を読む
 fanout <parent-issue> --merge <NUM> # 記録済み子 branch を ff-only merge
 fanout <parent-issue> --close <NUM> # 記録済み子 worktree/pane を後始末
 fanout <parent-issue> --cleanup     # merge/close 済みの記録済み子を後始末
@@ -212,10 +213,13 @@ Projects v2 URL（Project モード、上記参照）のいずれか。`--projec
 `fanout <parent> --status` は読み取り専用です。`<git-root>/.fanout/state.json`
 （または `FANOUT_STATE_PATH` で指定した state file）から指定 parent の記録済み
 子 issue を列挙し、各子について `gh api graphql` で issue state と
-`closedByPullRequestsReferences` を取得して、既存の JSON schema
-（`children[].prs` / `summary.all_merged` など）で出力します。dmux や live tmux
-session は不要です。現在の JSON schema は issue parent 用なので、Projects v2 URL
-を parent にした `--status` は拒否します。
+`closedByPullRequestsReferences` を取得して、既定では既存の JSON schema
+（`children[].prs` / `summary.all_merged` など）で出力します。`--format table`
+を渡すと、PR の差分バー、変更ファイル数、Conventional-Commit 種別、PR リンクを
+含む人間向けの一覧を出力します。JSON mode では PR 差分統計を取得しないため、
+既定の schema と API call 数は変わりません。dmux や live tmux session は不要です。
+現在の JSON schema は issue parent 用なので、Projects v2 URL を parent にした
+`--status` は拒否します。
 
 Lifecycle コマンドも `.fanout/state.json` の記録を対象にします。任意の worktree を
 filesystem scan で探すことはしません。
@@ -374,11 +378,11 @@ fanout 123 --no-auto-pr
 # この shell では Agent Teams ヒントを無効化
 export FANOUT_AGENT_TEAMS_HINT=0
 
-# .fanout/state.json に記録された子 issue と closed-by PR の merge 状態を
-# JSON で読む。副作用は無い。内部的には子ごとに `gh api graphql` を呼び、
-# `closedByPullRequestsReferences(first: 100)` をカーソル追従して取得する。
+# .fanout/state.json に記録された子 issue と closed-by PR の merge 状態を読む。
+# 既定は automation 向け JSON、table は PR 差分統計の人間向け表示。副作用は無い。
 fanout 123 --status
 fanout 123 --status | jq '.summary.all_merged'
+fanout 123 --status --format table
 
 # 記録済み子 branch を parent worktree に fast-forward merge し、不要になった
 # child worktree/pane を後始末する

--- a/README.md
+++ b/README.md
@@ -195,7 +195,8 @@ fanout <parent-issue|project-url>
        [--auto-pr|--no-auto-pr] [--pr-review-gate|--no-pr-review-gate]
        [--briefing-code-review|--no-briefing-code-review]
        [--agent-teams-hint|--no-agent-teams-hint]
-fanout <parent-issue> --status      # JSON status of fanned children, no side effects
+fanout <parent-issue> --status [--format json|table]
+                                      # status of fanned children, no side effects
 fanout <parent-issue> --merge <NUM> # fast-forward merge a recorded child branch
 fanout <parent-issue> --close <NUM> # remove a recorded child worktree/pane
 fanout <parent-issue> --cleanup     # remove merged/closed recorded children
@@ -217,14 +218,16 @@ enumerate children already fanned out under that specific parent, queries
 each child through `gh api graphql` against
 `repository.issue.closedByPullRequestsReferences(first: 100)` (cursor-
 paginated when a child is closed by more than 100 PRs) so the response
-carries `state`/`mergedAt` directly, and prints one JSON document on
-stdout. It does not require dmux or a live tmux session. Issue-mode parents
-only — Projects v2 URLs as parent are rejected up-front for the current JSON
-schema. In a state file that has fanned multiple parents, children of other
-parents are filtered out so `summary.all_merged` reflects only the requested
-parent. Set `FANOUT_STATE_PATH` to point directly at a state file when reading
-from outside the repository checkout; otherwise fanout reads
-`<git-root>/.fanout/state.json`.
+carries `state`/`mergedAt` directly, and prints one JSON document on stdout by
+default. Pass `--format table` for a human-readable overview that adds PR diff
+bars, changed-file counts, Conventional-Commit type, and PR links. JSON mode
+does not fetch PR diff stats, so the default API surface and schema stay stable.
+It does not require dmux or a live tmux session. Issue-mode parents only —
+Projects v2 URLs as parent are rejected up-front for the current JSON schema.
+In a state file that has fanned multiple parents, children of other parents are
+filtered out so `summary.all_merged` reflects only the requested parent. Set
+`FANOUT_STATE_PATH` to point directly at a state file when reading from outside
+the repository checkout; otherwise fanout reads `<git-root>/.fanout/state.json`.
 
 ```json
 {
@@ -249,7 +252,8 @@ from outside the repository checkout; otherwise fanout reads
 
 `--status` exit codes are a separate lane from the default flow:
 
-- `0` — JSON emitted (check `summary.all_merged` for the actual state).
+- `0` — status emitted (check `summary.all_merged` in JSON mode for the
+  actual state).
 - `2` — cannot enumerate (bad invocation, unreadable or malformed state file,
   unusable project root, Projects v2 URL as parent). A missing state file is
   treated as an empty state.
@@ -436,10 +440,11 @@ fanout 123 --no-auto-pr
 # Disable the Agent Teams hint globally for this shell
 export FANOUT_AGENT_TEAMS_HINT=0
 
-# Read-only JSON status from .fanout/state.json: who's fanned out, what state
-# each child is in, and whether their closed-by PRs have merged. No side effects.
+# Read-only status from .fanout/state.json: default JSON for automation,
+# optional table for PR diff stats. No side effects.
 fanout 123 --status
 fanout 123 --status | jq '.summary.all_merged'
+fanout 123 --status --format table
 
 # Fast-forward a recorded child branch into the parent worktree, then remove
 # the child worktree/pane after it is no longer needed.

--- a/claude/skills/fanout/SKILL.md
+++ b/claude/skills/fanout/SKILL.md
@@ -18,7 +18,8 @@ fanout <parent-issue|project-url>
        [--auto-pr|--no-auto-pr] [--pr-review-gate|--no-pr-review-gate]
        [--briefing-code-review|--no-briefing-code-review]
        [--agent-teams-hint|--no-agent-teams-hint]
-fanout <parent-issue> --status      # JSON status of fanned children, no side effects
+fanout <parent-issue> --status [--format json|table]
+                                      # status of fanned children, no side effects
 fanout <parent-issue> --merge <NUM> # fast-forward merge a recorded child branch
 fanout <parent-issue> --close <NUM> # remove a recorded child worktree/pane
 fanout <parent-issue> --cleanup     # remove merged/closed recorded children
@@ -111,7 +112,7 @@ Run fanout from the target repository worktree inside tmux so `git rev-parse --s
   `2` bad invocation or incomparable version, `3` latest-release lookup failed.
 - **Default**: `fanout <N-or-URL> --agent claude --dry-run` → summarize → ask user to confirm → `fanout <N-or-URL> --agent claude`.
 - **Bypass**: if the user's invocation carries `--go`, skip the confirmation and run directly.
-- **Forward extra flags** (`--agent`, `--limit`, `--only`, `--skip`, `--include`, `--unblocked-only`, `--project-status`, `--name`, `--base-branch`, `--branch-prefix`, `--no-refresh`, `--session`, `--sleep`, `--popup-timeout`, `--debug`, `--auto-pr`, `--no-auto-pr`, `--pr-review-gate`, `--no-pr-review-gate`, `--briefing-code-review`, `--no-briefing-code-review`, `--agent-teams-hint`, `--no-agent-teams-hint`) verbatim to both the dry-run and the real run. Strip `--go` before forwarding — it is the slash command's own flag, not a `fanout` flag. If neither the user nor the environment supplies an agent, add `--agent claude`.
+- **Forward extra flags** (`--agent`, `--limit`, `--only`, `--skip`, `--include`, `--unblocked-only`, `--project-status`, `--format`, `--name`, `--base-branch`, `--branch-prefix`, `--no-refresh`, `--session`, `--sleep`, `--popup-timeout`, `--debug`, `--auto-pr`, `--no-auto-pr`, `--pr-review-gate`, `--no-pr-review-gate`, `--briefing-code-review`, `--no-briefing-code-review`, `--agent-teams-hint`, `--no-agent-teams-hint`) verbatim to both the dry-run and the real run. Strip `--go` before forwarding — it is the slash command's own flag, not a `fanout` flag. If neither the user nor the environment supplies an agent, add `--agent claude`.
 - `--only <list>` / `--skip <list>` take a comma-separated list of issue numbers (e.g. `--only 4,7,8,10`). They are mutually exclusive. `--only` numbers not in the parent's OPEN child set are warned and ignored by the CLI — if the user names issues that aren't children, relay that warning instead of silently retrying.
 - `--include <list>` takes a comma-separated list of issue numbers to force-add to the children set when the Sub-issues API and parent-body task-list scan don't surface them (e.g. `--include 123,456`). This is the channel for numbers produced by the "Body scan for implicit children" step above. Numbers that end up CLOSED or don't exist are warned and skipped by the CLI. Combines cleanly with `--only`/`--skip` (included first, then filtered).
 - `--unblocked-only` defers children whose blockers are still OPEN (blockers are parsed from the child body's `## Blocked by` section, a `(blocked by #X, #Y)` trailer on the parent's task-list row, or the `blocked` label as a weak signal). Prefer this over hand-maintained `--only` wave lists when the parent has explicit blocker annotations — a periodic rerun of the same command walks Wave 1 → 2 → … as blocker PRs merge. In project mode the parent-row trailer source is unavailable (no parent body), so blockers come only from the child body section and the `blocked` label.
@@ -141,7 +142,8 @@ Use this only when the user explicitly asks to wait until child PRs merge and
 then continue parent-scope work. After the real fanout run succeeds, poll
 `fanout --status <PARENT>` from the parent worktree. The command reads
 `.fanout/state.json` (or `FANOUT_STATE_PATH`) and returns
-`summary.all_merged` for the recorded children.
+`summary.all_merged` for the recorded children. Use the default JSON format for
+automation; `--format table` is for human review of PR diff stats and links.
 
 1. Continue any parent-scope work that does not depend on the children's merged output.
 2. When you reach a phase that requires the children's merged output, poll status via `ScheduleWakeup` with the autonomous-loop sentinel:

--- a/cmd/fanout/status.go
+++ b/cmd/fanout/status.go
@@ -3,7 +3,9 @@ package main
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/butaosuinu/fanout/internal/cliflags"
@@ -12,6 +14,10 @@ import (
 	"github.com/butaosuinu/fanout/internal/log"
 	"github.com/butaosuinu/fanout/internal/state"
 )
+
+const statusDiffBarWidth = 12
+
+var conventionalTypeRE = regexp.MustCompile(`^(feat|fix|docs|chore|refactor|test|perf|build|ci|style|revert)(\(.+\))?!?:`)
 
 type statusReport struct {
 	Parent   int           `json:"parent"`
@@ -33,6 +39,19 @@ type statusSummary struct {
 	AllMerged bool `json:"all_merged"`
 }
 
+type statusTableRow struct {
+	Issue      string
+	IssueState string
+	PR         string
+	PRState    string
+	Type       string
+	Files      string
+	Link       string
+	Additions  int
+	Deletions  int
+	HasDiff    bool
+}
+
 func cmdStatus(cfg *cliflags.Config, lg *log.Logger) exitcode.Code {
 	rt, code := resolveStateRuntimeForMode("--status", lg)
 	if code != exitcode.OK {
@@ -50,18 +69,26 @@ func cmdStatus(cfg *cliflags.Config, lg *log.Logger) exitcode.Code {
 	}
 	nums := sortedKeys(store.FannedNumbersForParent(cfg.ParentRef))
 	if len(nums) == 0 {
-		return writeStatusReport(statusReport{
+		report := statusReport{
 			Parent:   cfg.Parent,
 			Children: []statusChild{},
 			Summary:  statusSummary{AllMerged: false},
-		}, lg)
+		}
+		if cfg.Format == "table" {
+			return writeStatusTable(report, rt.projectRoot, lg)
+		}
+		return writeStatusReport(report, lg)
 	}
 
 	children, code := statusChildren(rt.projectRoot, nums, "--status", lg)
 	if code != exitcode.OK {
 		return code
 	}
-	return writeStatusReport(newStatusReport(cfg.Parent, children), lg)
+	report := newStatusReport(cfg.Parent, children)
+	if cfg.Format == "table" {
+		return writeStatusTable(report, rt.projectRoot, lg)
+	}
+	return writeStatusReport(report, lg)
 }
 
 func statusChildren(projectRoot string, nums []int, mode string, lg *log.Logger) ([]statusChild, exitcode.Code) {
@@ -123,6 +150,211 @@ func writeStatusReport(report statusReport, lg *log.Logger) exitcode.Code {
 	}
 	fmt.Fprintln(lg.Stdout(), string(out))
 	return exitcode.OK
+}
+
+func writeStatusTable(report statusReport, projectRoot string, lg *log.Logger) exitcode.Code {
+	rows, maxLines, addWidth, delWidth, code := statusTableRows(report, projectRoot, lg)
+	if code != exitcode.OK {
+		return code
+	}
+
+	out := lg.Stdout()
+	fmt.Fprintf(out, "fanout status #%d: total=%d merged=%d pending=%d all_merged=%t\n",
+		report.Parent, report.Summary.Total, report.Summary.Merged, report.Summary.Pending, report.Summary.AllMerged)
+	if len(rows) == 0 {
+		fmt.Fprintln(out, "(no recorded children)")
+		return exitcode.OK
+	}
+
+	diffWidth := statusDiffWidth(addWidth, delWidth)
+	widths := []int{
+		len("ISSUE"),
+		len("STATE"),
+		len("PR"),
+		len("PR_STATE"),
+		len("TYPE"),
+		len("FILES"),
+		diffWidth,
+		len("LINK"),
+	}
+	for _, row := range rows {
+		widths[0] = maxInt(widths[0], len(row.Issue))
+		widths[1] = maxInt(widths[1], len(row.IssueState))
+		widths[2] = maxInt(widths[2], len(row.PR))
+		widths[3] = maxInt(widths[3], len(row.PRState))
+		widths[4] = maxInt(widths[4], len(row.Type))
+		widths[5] = maxInt(widths[5], len(row.Files))
+	}
+
+	headers := []string{"ISSUE", "STATE", "PR", "PR_STATE", "TYPE", "FILES", "DIFF", "LINK"}
+	fmt.Fprintln(out, statusTableLine(headers, widths))
+	separators := []string{
+		strings.Repeat("-", widths[0]),
+		strings.Repeat("-", widths[1]),
+		strings.Repeat("-", widths[2]),
+		strings.Repeat("-", widths[3]),
+		strings.Repeat("-", widths[4]),
+		strings.Repeat("-", widths[5]),
+		strings.Repeat("-", diffWidth),
+		strings.Repeat("-", widths[7]),
+	}
+	fmt.Fprintln(out, statusTableLine(separators, widths))
+
+	colors := lg.Colors()
+	for _, row := range rows {
+		cols := []string{
+			row.Issue,
+			row.IssueState,
+			row.PR,
+			row.PRState,
+			row.Type,
+			row.Files,
+			renderStatusDiff(row, maxLines, addWidth, delWidth, diffWidth, colors),
+			row.Link,
+		}
+		fmt.Fprintln(out, statusTableLine(cols, widths))
+	}
+	return exitcode.OK
+}
+
+func statusTableRows(report statusReport, projectRoot string, lg *log.Logger) ([]statusTableRow, int, int, int, exitcode.Code) {
+	if len(report.Children) == 0 {
+		return nil, 0, len("+0"), len("-0"), exitcode.OK
+	}
+
+	gh := ghissue.Runner{Cwd: projectRoot}
+	nwo, err := gh.RepoNameWithOwner()
+	if err != nil {
+		lg.Err("--status: failed to resolve repo (gh repo view) in %s", projectRoot)
+		return nil, 0, 0, 0, exitcode.GitHub
+	}
+
+	rows := make([]statusTableRow, 0, len(report.Children))
+	maxLines := 0
+	addWidth := len("+0")
+	delWidth := len("-0")
+	for _, child := range report.Children {
+		if len(child.PRs) == 0 {
+			rows = append(rows, statusTableRow{
+				Issue:      "#" + strconv.Itoa(child.Num),
+				IssueState: dashIfEmpty(child.State),
+				PR:         "-",
+				PRState:    "-",
+				Type:       "-",
+				Files:      "-",
+				Link:       "-",
+			})
+			continue
+		}
+		for _, pr := range child.PRs {
+			stat, err := gh.PRDiffStat(pr.Number)
+			if err != nil {
+				lg.Err("--status: gh pr view #%d failed: %v", pr.Number, err)
+				return nil, 0, 0, 0, exitcode.GitHub
+			}
+			addWidth = maxInt(addWidth, len(fmt.Sprintf("+%d", stat.Additions)))
+			delWidth = maxInt(delWidth, len(fmt.Sprintf("-%d", stat.Deletions)))
+			maxLines = maxInt(maxLines, stat.Additions)
+			maxLines = maxInt(maxLines, stat.Deletions)
+			rows = append(rows, statusTableRow{
+				Issue:      "#" + strconv.Itoa(child.Num),
+				IssueState: dashIfEmpty(child.State),
+				PR:         "#" + strconv.Itoa(pr.Number),
+				PRState:    dashIfEmpty(pr.State),
+				Type:       conventionalType(stat.Title),
+				Files:      strconv.Itoa(stat.ChangedFiles),
+				Link:       fmt.Sprintf("https://github.com/%s/pull/%d", nwo, pr.Number),
+				Additions:  stat.Additions,
+				Deletions:  stat.Deletions,
+				HasDiff:    true,
+			})
+		}
+	}
+	return rows, maxLines, addWidth, delWidth, exitcode.OK
+}
+
+func conventionalType(title string) string {
+	m := conventionalTypeRE.FindStringSubmatch(title)
+	if len(m) < 2 {
+		return "-"
+	}
+	return m[1]
+}
+
+func renderStatusDiff(row statusTableRow, maxLines, addWidth, delWidth, diffWidth int, colors log.Palette) string {
+	if !row.HasDiff {
+		return padRight("-", diffWidth)
+	}
+	addNum := fmt.Sprintf("+%d", row.Additions)
+	delNum := fmt.Sprintf("-%d", row.Deletions)
+	addBar := strings.Repeat("+", scaledStatusBar(row.Additions, maxLines))
+	delBar := strings.Repeat("-", scaledStatusBar(row.Deletions, maxLines))
+	return colorPad(colors.Ok, colors.Reset, addNum, addWidth) + " " +
+		colorPad(colors.Ok, colors.Reset, addBar, statusDiffBarWidth) + "  " +
+		colorPad(colors.Err, colors.Reset, delNum, delWidth) + " " +
+		colorPad(colors.Err, colors.Reset, delBar, statusDiffBarWidth)
+}
+
+func statusDiffWidth(addWidth, delWidth int) int {
+	return addWidth + 1 + statusDiffBarWidth + 2 + delWidth + 1 + statusDiffBarWidth
+}
+
+func scaledStatusBar(value, maxValue int) int {
+	if value <= 0 || maxValue <= 0 {
+		return 0
+	}
+	n := (value*statusDiffBarWidth + maxValue - 1) / maxValue
+	if n < 1 {
+		return 1
+	}
+	if n > statusDiffBarWidth {
+		return statusDiffBarWidth
+	}
+	return n
+}
+
+func colorPad(color, reset, s string, width int) string {
+	return colorWrap(color, reset, s) + strings.Repeat(" ", maxInt(0, width-len(s)))
+}
+
+func colorWrap(color, reset, s string) string {
+	if color == "" || s == "" {
+		return s
+	}
+	return color + s + reset
+}
+
+func statusTableLine(cols []string, widths []int) string {
+	var b strings.Builder
+	for i, col := range cols {
+		if i > 0 {
+			b.WriteString("  ")
+		}
+		if i == len(cols)-1 {
+			b.WriteString(col)
+			continue
+		}
+		b.WriteString(padRight(col, widths[i]))
+	}
+	return b.String()
+}
+
+func padRight(s string, width int) string {
+	return s + strings.Repeat(" ", maxInt(0, width-len(s)))
+}
+
+func dashIfEmpty(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
 }
 
 func sortedKeys(set map[int]bool) []int {

--- a/codex/skills/fanout/SKILL.md
+++ b/codex/skills/fanout/SKILL.md
@@ -20,7 +20,8 @@ fanout <parent-issue|project-url>
        [--auto-pr|--no-auto-pr] [--pr-review-gate|--no-pr-review-gate]
        [--briefing-code-review|--no-briefing-code-review]
        [--agent-teams-hint|--no-agent-teams-hint]
-fanout <parent-issue> --status      # JSON status of fanned children, no side effects
+fanout <parent-issue> --status [--format json|table]
+                                      # status of fanned children, no side effects
 fanout <parent-issue> --merge <NUM> # fast-forward merge a recorded child branch
 fanout <parent-issue> --close <NUM> # remove a recorded child worktree/pane
 fanout <parent-issue> --cleanup     # remove merged/closed recorded children
@@ -137,8 +138,8 @@ environment or preflight failure, `2` bad invocation or incomparable version,
    positional arg via `internal/cliflags.Parse()`.
 2. Forward user-supplied fanout flags verbatim:
    `--agent`, `--limit`, `--only`, `--skip`, `--include`,
-   `--unblocked-only`, `--project-status` (project mode only), `--name`,
-   `--base-branch`, `--branch-prefix`, `--no-refresh`, `--session`,
+   `--unblocked-only`, `--project-status` (project mode only), `--format`,
+   `--name`, `--base-branch`, `--branch-prefix`, `--no-refresh`, `--session`,
    `--sleep`, `--popup-timeout`, `--debug`, `--auto-pr`,
    `--no-auto-pr`, `--pr-review-gate`, `--no-pr-review-gate`,
    `--briefing-code-review`, `--no-briefing-code-review`,
@@ -190,7 +191,8 @@ Use this only when the user explicitly asks to wait until child PRs merge and
 then continue parent-scope work. After the real fanout run succeeds, poll
 `fanout --status <PARENT>` from the parent worktree. The command reads
 `.fanout/state.json` (or `FANOUT_STATE_PATH`) and returns
-`summary.all_merged` for the recorded children.
+`summary.all_merged` for the recorded children. Use the default JSON format for
+automation; `--format table` is for human review of PR diff stats and links.
 
 1. Continue any parent-scope work that does not depend on the children's merged output.
 2. Periodically rerun `fanout --status <PARENT>`. Inspect `summary.all_merged`.

--- a/internal/cliflags/cliflags.go
+++ b/internal/cliflags/cliflags.go
@@ -18,6 +18,7 @@ const (
 	DefaultSleepBetween  = 4.0
 	DefaultPopupTimeout  = 20
 	DefaultProjectStatus = "Todo"
+	DefaultFormat        = "json"
 
 	ModeIssue   = "issue"
 	ModeProject = "project"
@@ -59,6 +60,7 @@ type Config struct {
 	PRReviewGate       *bool
 	BriefingCodeReview *bool
 	AgentTeamsHint     *bool
+	Format             string
 }
 
 // NameOverride represents a parsed `--name NUM=slug-hint|display-name|branch`
@@ -103,6 +105,7 @@ func Parse(args []string, lg *log.Logger, stdout io.Writer) ParseResult {
 		SleepBetween:    DefaultSleepBetween,
 		PopupTimeoutSec: DefaultPopupTimeout,
 		ProjectStatus:   DefaultProjectStatus,
+		Format:          DefaultFormat,
 	}
 
 	state := parseState{}
@@ -154,6 +157,16 @@ func Parse(args []string, lg *log.Logger, stdout io.Writer) ParseResult {
 		"--project-status": func(cfg *Config, _ *parseState, v string) error {
 			cfg.ProjectStatus = v
 			return nil
+		},
+		"--format": func(cfg *Config, state *parseState, v string) error {
+			switch v {
+			case "json", "table":
+				cfg.Format = v
+				state.formatExplicit = true
+				return nil
+			default:
+				return fmt.Errorf("--format must be one of json,table, got: %s", v)
+			}
 		},
 		"--sleep": func(_ *Config, state *parseState, v string) error {
 			state.sleepRaw = v
@@ -246,15 +259,16 @@ func Parse(args []string, lg *log.Logger, stdout io.Writer) ParseResult {
 }
 
 type parseState struct {
-	parent        string
-	limit         string
-	closeRaw      string
-	mergeRaw      string
-	sleepRaw      string
-	popupRaw      string
-	rawNames      []string
-	sleepExplicit bool
-	popupExplicit bool
+	parent         string
+	limit          string
+	closeRaw       string
+	mergeRaw       string
+	sleepRaw       string
+	popupRaw       string
+	rawNames       []string
+	sleepExplicit  bool
+	popupExplicit  bool
+	formatExplicit bool
 }
 
 type valueOption func(*Config, *parseState, string) error
@@ -301,6 +315,10 @@ func validateParsed(cfg *Config, state parseState, lg *log.Logger) ParseResult {
 	if cfg.ProjectStatus == "" {
 		lg.Err("--project-status must not be empty")
 		return ParseResult{Code: exitcode.Env}
+	}
+	if state.formatExplicit && !cfg.StatusMode {
+		lg.Err("--format can only be used with --status")
+		return ParseResult{Code: exitcode.Invocation}
 	}
 
 	if cfg.StatusMode {

--- a/internal/cliflags/cliflags_test.go
+++ b/internal/cliflags/cliflags_test.go
@@ -63,6 +63,40 @@ func TestParseWorktreeFlags(t *testing.T) {
 	}
 }
 
+func TestParseStatusFormat(t *testing.T) {
+	cfg := parseOK(t, "--status", "100", "--format", "table")
+	if cfg.Format != "table" {
+		t.Fatalf("Format = %q, want table", cfg.Format)
+	}
+
+	cfg = parseOK(t, "--status", "100")
+	if cfg.Format != DefaultFormat {
+		t.Fatalf("default Format = %q, want %q", cfg.Format, DefaultFormat)
+	}
+}
+
+func TestParseFormatRequiresStatus(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	res := Parse([]string{"100", "--format", "table"}, log.NewWith(&stdout, &stderr, false), io.Discard)
+	if res.Code != exitcode.Invocation {
+		t.Fatalf("Parse() code = %d, want %d", res.Code, exitcode.Invocation)
+	}
+	if got := stderr.String(); !strings.Contains(got, "--format can only be used with --status") {
+		t.Fatalf("stderr = %q, want --format requires --status message", got)
+	}
+}
+
+func TestParseFormatRejectsUnknownValue(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	res := Parse([]string{"--status", "100", "--format", "yaml"}, log.NewWith(&stdout, &stderr, false), io.Discard)
+	if res.Code != exitcode.Env {
+		t.Fatalf("Parse() code = %d, want %d", res.Code, exitcode.Env)
+	}
+	if got := stderr.String(); !strings.Contains(got, "--format must be one of json,table") {
+		t.Fatalf("stderr = %q, want invalid --format message", got)
+	}
+}
+
 func TestParseStatusRejectsSettingsBoolFlags(t *testing.T) {
 	for _, tc := range []struct {
 		flag string

--- a/internal/cliflags/usage.go
+++ b/internal/cliflags/usage.go
@@ -95,10 +95,14 @@ Options:
   --dry-run           Print the git worktree, tmux split-window, and agent
                       launch commands without executing them.
   --debug             Enable extra diagnostic logging.
-  --status            Read-only mode. Print JSON describing each fanned-out
+  --status            Read-only mode. Print status describing each fanned-out
                       child issue recorded in .fanout/state.json, including
                       issue state and closed-by PR merge status, then exit.
                       Exclusive with action-bearing flags.
+  --format <json|table>
+                      Output format for --status. Default: json. The table
+                      format adds PR diff bars, changed-file counts,
+                      Conventional-Commit type, and PR links for human scans.
   --close <NUM>       Remove the recorded child worktree for issue <NUM>,
                       kill its tmux pane when still present, update state,
                       and run git worktree prune.
@@ -129,7 +133,7 @@ Exit codes (default flow):
   2 bad invocation
 
 Exit codes (--status):
-  0 success (JSON emitted; check summary.all_merged for state)
+  0 success (status emitted; check summary.all_merged in JSON mode for state)
   2 cannot enumerate children or state
   3 gh API call failed
 

--- a/internal/ghissue/ghissue.go
+++ b/internal/ghissue/ghissue.go
@@ -36,6 +36,14 @@ type PRRef struct {
 	MergedAt *string `json:"mergedAt"`
 }
 
+type PRDiffStat struct {
+	Number       int    `json:"number"`
+	Additions    int    `json:"additions"`
+	Deletions    int    `json:"deletions"`
+	ChangedFiles int    `json:"changedFiles"`
+	Title        string `json:"title"`
+}
+
 // Runner abstracts `gh` invocation so tests can swap in a fake. The Tier 2
 // shim runs the real `gh` binary path through PATH, so the default execRunner
 // is sufficient and tests don't actually need to swap.
@@ -207,6 +215,18 @@ func (r Runner) IssueWithPRs(owner, repo string, num int) (state string, prs []P
 		cursor = next
 	}
 	return state, prs, nil
+}
+
+func (r Runner) PRDiffStat(num int) (PRDiffStat, error) {
+	out, err := r.gh("pr", "view", strconv.Itoa(num), "--json", "number,additions,deletions,changedFiles,title")
+	if err != nil {
+		return PRDiffStat{}, err
+	}
+	var stat PRDiffStat
+	if err := json.Unmarshal(out, &stat); err != nil {
+		return PRDiffStat{}, fmt.Errorf("parse gh pr view %d: %w", num, err)
+	}
+	return stat, nil
 }
 
 // HydrateBodyLabels fetches body and labels for an issue and merges them into

--- a/tests/bats/tier2_status.bats
+++ b/tests/bats/tier2_status.bats
@@ -29,6 +29,13 @@ load helpers
   assert_status_golden scenario-status-mixed
 }
 
+@test "scenario-status-mixed table: PR diff stats render in a human-readable table" {
+  use_fixture scenario-status-mixed
+  run_fanout_status 200 --format table
+  assert_success
+  assert_golden scenario-status-mixed status-table
+}
+
 @test "scenario-status-no-fanned-children: total=0, all_merged=false" {
   use_fixture scenario-status-no-fanned-children
   run_fanout_status 999

--- a/tests/bin/gh
+++ b/tests/bin/gh
@@ -23,6 +23,11 @@
 #         Project mode calls this to resolve the cross-repo filter target
 #         (typical fixture: {"nameWithOwner":"butaosuinu/fanout"}).
 #
+#   gh pr view <N> --json number,additions,deletions,changedFiles,title
+#       — echoes $FIXTURE_DIR/gh-pr-view-<N>.json verbatim.
+#         --status --format table uses this to render human-readable PR
+#         diff rows without changing the default JSON status schema.
+#
 #   gh release view -R butaosuinu/fanout --json tagName -q .tagName
 #       — echoes $FIXTURE_DIR/gh-release-view.json (with optional jq filter).
 #         --check-update calls this to resolve the latest release tag without
@@ -121,6 +126,15 @@ case "${1:-}" in
       shift 2
       jq_filter="$(extract_jq_filter "$@")"
       emit_fixture "$fixture/gh-repo-view.json" "$jq_filter" "gh repo view"
+      exit 0
+    fi
+    ;;
+  pr)
+    if [[ "${2:-}" == "view" ]]; then
+      num="${3:-}"
+      shift 3
+      jq_filter="$(extract_jq_filter "$@")"
+      emit_fixture "$fixture/gh-pr-view-$num.json" "$jq_filter" "gh pr view $num"
       exit 0
     fi
     ;;

--- a/tests/fixtures/scenario-status-mixed/gh-pr-view-601.json
+++ b/tests/fixtures/scenario-status-mixed/gh-pr-view-601.json
@@ -1,0 +1,1 @@
+{"number":601,"additions":120,"deletions":8,"changedFiles":5,"title":"feat(status): add table output"}

--- a/tests/fixtures/scenario-status-mixed/gh-pr-view-602.json
+++ b/tests/fixtures/scenario-status-mixed/gh-pr-view-602.json
@@ -1,0 +1,1 @@
+{"number":602,"additions":12,"deletions":40,"changedFiles":2,"title":"fix(status)!: retry PR diff lookup"}

--- a/tests/golden/scenario-status-mixed.status-table.txt
+++ b/tests/golden/scenario-status-mixed.status-table.txt
@@ -1,0 +1,6 @@
+fanout status #200: total=3 merged=1 pending=2 all_merged=false
+ISSUE  STATE   PR    PR_STATE  TYPE  FILES  DIFF                                 LINK
+-----  ------  ----  --------  ----  -----  -----------------------------------  ----
+#201   CLOSED  #601  MERGED    feat  5      +120 ++++++++++++  -8  -             https://github.com/butaosuinu/fanout-fixtures/pull/601
+#202   OPEN    #602  OPEN      fix   2      +12  ++            -40 ----          https://github.com/butaosuinu/fanout-fixtures/pull/602
+#203   OPEN    -     -         -     -      -                                    -


### PR DESCRIPTION
## Summary
- add --status --format table for human-readable PR diff stats
- fetch PR additions/deletions/changed files/title only in table mode
- add gh shim fixtures, table golden, and docs/skill updates

## Tests
- go test ./...
- FANOUT_BIN=/Users/butaosuinu/fanout/.dmux/worktrees/feat-issue-125-status-diff-table/fanout-go bats tests/bats/tier2_status.bats
- make test
- make lint
- codex review --uncommitted

Closes #125