### PR TITLE
refactor(pane): createPaneForIssue を createPane に分解

### DIFF
--- a/cmd/fanout/pane.go
+++ b/cmd/fanout/pane.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/butaosuinu/fanout/internal/agent"
@@ -28,6 +29,7 @@ type paneRequest struct {
 	Body                string
 	BriefingPath        string
 	BriefingBody        string
+	WriteBriefingDryRun bool
 	ShortTitle          string
 	Slug                string
 	DisplayNameOverride string
@@ -69,7 +71,7 @@ func createPane(cfg *cliflags.Config, lg *log.Logger, info *fanoutruntime.Info, 
 		return false
 	}
 
-	if req.BriefingPath != "" {
+	if req.BriefingPath != "" && (!cfg.DryRun || req.WriteBriefingDryRun) {
 		if err := os.WriteFile(req.BriefingPath, []byte(req.BriefingBody), 0o644); err != nil {
 			lg.Err("#%d: write briefing: %v", req.Number, err)
 			return false
@@ -167,9 +169,11 @@ func newPaneRequest(cfg *cliflags.Config, projectRoot string, issue ghissue.Issu
 		Title:        issue.Title,
 		Body:         issue.Body,
 		BriefingPath: briefing.Path(projectRoot, issue.Number),
-		ShortTitle:   shortIssueTitle(issue.Title),
-		Slug:         slug,
-		Agent:        cfg.Agent,
+		// Existing issue dry-runs write briefings; Tier 1 tests depend on that.
+		WriteBriefingDryRun: true,
+		ShortTitle:          shortIssueTitle(issue.Title),
+		Slug:                slug,
+		Agent:               cfg.Agent,
 	}
 	if name := cfg.FindName(issue.Number); name != nil {
 		if name.SlugHint != "" {
@@ -213,6 +217,13 @@ func newManualPaneRequest(cfg *cliflags.Config, projectRoot string, store state.
 	if prompt == "" {
 		prompt = title
 	}
+	briefingPath := ""
+	briefingBody := ""
+	if opts.Body != "" {
+		briefingPath = briefing.Path(projectRoot, number)
+		briefingBody = opts.Body
+		prompt = manualPromptWithBriefing(prompt, briefingPath)
+	}
 	branchName := naming.BranchName(opts.BranchName, cfg.BranchPrefix, slug)
 	return paneRequest{
 		ParentRef:    manualPaneParentRef,
@@ -224,9 +235,22 @@ func newManualPaneRequest(cfg *cliflags.Config, projectRoot string, store state.
 		BranchName:   branchName,
 		Prompt:       prompt,
 		Agent:        agentName,
-		BriefingBody: opts.Body,
+		BriefingPath: briefingPath,
+		BriefingBody: briefingBody,
 		Worktree:     worktree.BuildPlan(worktree.Options{ProjectRoot: projectRoot, Slug: slug, BranchName: branchName, BaseBranch: cfg.BaseBranch, NoRefresh: cfg.NoRefresh}),
 	}
+}
+
+func manualPromptWithBriefing(prompt, briefingPath string) string {
+	prompt = strings.TrimSpace(prompt)
+	if strings.Contains(prompt, briefingPath) {
+		return prompt
+	}
+	prompt = strings.TrimRight(prompt, ".")
+	if prompt == "" {
+		return fmt.Sprintf("read %s and begin.", briefingPath)
+	}
+	return fmt.Sprintf("%s. read %s for additional context and begin.", prompt, briefingPath)
 }
 
 func nextSyntheticPaneNumber(store state.Store, parentRef string) int {

--- a/cmd/fanout/pane.go
+++ b/cmd/fanout/pane.go
@@ -19,17 +19,32 @@ import (
 	"github.com/butaosuinu/fanout/internal/worktree"
 )
 
+const manualPaneParentRef = "@manual"
+
 type paneRequest struct {
-	Issue               ghissue.Issue
+	ParentRef           string
+	Number              int
+	Title               string
+	Body                string
 	BriefingPath        string
 	BriefingBody        string
 	ShortTitle          string
 	Slug                string
 	DisplayNameOverride string
 	BranchName          string
-	OneLinePrompt       string
+	Prompt              string
+	Agent               string
 	AgentCommand        string
 	Worktree            worktree.Plan
+}
+
+type manualPaneOptions struct {
+	Title      string
+	Body       string
+	Slug       string
+	BranchName string
+	Agent      string
+	Prompt     string
 }
 
 type paneStateRecorder interface {
@@ -39,20 +54,26 @@ type paneStateRecorder interface {
 
 func createPaneForIssue(cfg *cliflags.Config, lg *log.Logger, info *fanoutruntime.Info, issue ghissue.Issue, resolvedSettings settings.Settings, recorder paneStateRecorder, sharedAcrossParents bool, c log.Palette) bool {
 	req := newPaneRequest(cfg, info.ProjectRoot, issue, resolvedSettings, sharedAcrossParents)
-	agentCmd, err := buildAgentCommand(cfg, req.OneLinePrompt)
+	return createPane(cfg, lg, info, req, recorder, c)
+}
+
+func createPane(cfg *cliflags.Config, lg *log.Logger, info *fanoutruntime.Info, req paneRequest, recorder paneStateRecorder, c log.Palette) bool {
+	agentCmd, err := buildAgentCommand(cfg, req.Agent, req.Prompt)
 	if err != nil {
-		lg.Err("#%d: %v", req.Issue.Number, err)
+		lg.Err("#%d: %v", req.Number, err)
 		return false
 	}
 	req.AgentCommand = agentCmd
 	if req.Worktree.Refresh && req.Worktree.RefreshError != nil {
-		lg.Err("#%d: prepare worktree: %v", req.Issue.Number, req.Worktree.RefreshError)
+		lg.Err("#%d: prepare worktree: %v", req.Number, req.Worktree.RefreshError)
 		return false
 	}
 
-	if err := os.WriteFile(req.BriefingPath, []byte(req.BriefingBody), 0o644); err != nil {
-		lg.Err("#%d: write briefing: %v", req.Issue.Number, err)
-		return false
+	if req.BriefingPath != "" {
+		if err := os.WriteFile(req.BriefingPath, []byte(req.BriefingBody), 0o644); err != nil {
+			lg.Err("#%d: write briefing: %v", req.Number, err)
+			return false
+		}
 	}
 
 	logPaneRequest(req, lg)
@@ -70,70 +91,70 @@ func createPaneForIssue(cfg *cliflags.Config, lg *log.Logger, info *fanoutruntim
 		NoRefresh:   cfg.NoRefresh,
 	})
 	if err != nil {
-		lg.Err("#%d: prepare worktree: %v", req.Issue.Number, err)
+		lg.Err("#%d: prepare worktree: %v", req.Number, err)
 		return false
 	}
 	if prepared.AlreadyExists {
-		lg.Err("#%d: worktree path already exists during launch: %s (duplicate slug or concurrent fanout run)", req.Issue.Number, prepared.WorktreePath)
+		lg.Err("#%d: worktree path already exists during launch: %s (duplicate slug or concurrent fanout run)", req.Number, prepared.WorktreePath)
 		return false
 	}
 
 	paneID, err := tmuxrun.SplitPaneWithAgentCommand(info.Target, prepared.WorktreePath, req.AgentCommand)
 	if err != nil {
-		lg.Err("#%d: %v", req.Issue.Number, err)
-		cleanupFailedLaunch(req.Issue.Number, "", prepared, lg)
+		lg.Err("#%d: %v", req.Number, err)
+		cleanupFailedLaunch(req.Number, "", prepared, lg)
 		return false
 	}
 	if err := tmuxrun.SetPaneTitle(paneID, paneTitle(req)); err != nil {
-		lg.Warn("#%d: %v", req.Issue.Number, err)
+		lg.Warn("#%d: %v", req.Number, err)
 	}
 	if err := tmuxrun.SelectTiled(info.Target); err != nil {
-		lg.Warn("#%d: %v", req.Issue.Number, err)
+		lg.Warn("#%d: %v", req.Number, err)
 	}
 	if recorder != nil {
-		entry := statePane(cfg, req, paneID, prepared.WorktreePath, time.Now().UTC())
+		entry := statePane(req, paneID, prepared.WorktreePath, time.Now().UTC())
 		if err := recorder.RecordPane(entry); err != nil {
-			lg.Err("#%d: write fanout state: %v", req.Issue.Number, err)
-			cleanupFailedLaunch(req.Issue.Number, paneID, prepared, lg)
+			lg.Err("#%d: write fanout state: %v", req.Number, err)
+			cleanupFailedLaunch(req.Number, paneID, prepared, lg)
 			return false
 		}
 	}
 	if err := displayname.WriteFanoutMetadata(prepared.WorktreePath, displayname.FanoutMetadata{
-		Agent:        cfg.Agent,
+		Agent:        req.Agent,
 		DisplayName:  paneTitle(req),
 		BranchName:   req.BranchName,
 		Slug:         req.Slug,
 		WorktreePath: prepared.WorktreePath,
 	}); err != nil {
-		lg.Err("#%d: write worktree metadata: %v", req.Issue.Number, err)
-		rollbackState(recorder, cfg.ParentRef, req.Issue.Number, lg)
-		cleanupFailedLaunch(req.Issue.Number, paneID, prepared, lg)
+		lg.Err("#%d: write worktree metadata: %v", req.Number, err)
+		rollbackState(recorder, req.ParentRef, req.Number, lg)
+		cleanupFailedLaunch(req.Number, paneID, prepared, lg)
 		return false
 	}
-	lg.Ok("#%d: pane %s created in %s", req.Issue.Number, paneID, prepared.WorktreePath)
+	lg.Ok("#%d: pane %s created in %s", req.Number, paneID, prepared.WorktreePath)
 	return true
 }
 
-func statePane(cfg *cliflags.Config, req paneRequest, paneID, worktreePath string, now time.Time) state.Pane {
+func statePane(req paneRequest, paneID, worktreePath string, now time.Time) state.Pane {
 	return state.Pane{
-		Parent:       cfg.ParentRef,
-		IssueNum:     req.Issue.Number,
+		Parent:       req.ParentRef,
+		IssueNum:     req.Number,
 		Slug:         req.Slug,
 		BranchName:   req.BranchName,
 		PaneID:       paneID,
-		Agent:        cfg.Agent,
+		Agent:        req.Agent,
 		DisplayName:  paneTitle(req),
 		WorktreePath: worktreePath,
-		Prompt:       req.OneLinePrompt,
+		Prompt:       req.Prompt,
 		CreatedAt:    now.Format(time.RFC3339),
 	}
 }
 
-func buildAgentCommand(cfg *cliflags.Config, prompt string) (string, error) {
+func buildAgentCommand(cfg *cliflags.Config, agentName, prompt string) (string, error) {
 	if cfg.DryRun {
-		return agent.BuildCommand(cfg.Agent, prompt)
+		return agent.BuildCommand(agentName, prompt)
 	}
-	return agent.BuildResolvedCommand(cfg.Agent, prompt)
+	return agent.BuildResolvedCommand(agentName, prompt)
 }
 
 func newPaneRequest(cfg *cliflags.Config, projectRoot string, issue ghissue.Issue, resolvedSettings settings.Settings, sharedAcrossParents bool) paneRequest {
@@ -141,10 +162,14 @@ func newPaneRequest(cfg *cliflags.Config, projectRoot string, issue ghissue.Issu
 	slugOverridden := false
 	branchOverride := ""
 	req := paneRequest{
-		Issue:        issue,
+		ParentRef:    cfg.ParentRef,
+		Number:       issue.Number,
+		Title:        issue.Title,
+		Body:         issue.Body,
 		BriefingPath: briefing.Path(projectRoot, issue.Number),
 		ShortTitle:   shortIssueTitle(issue.Title),
 		Slug:         slug,
+		Agent:        cfg.Agent,
 	}
 	if name := cfg.FindName(issue.Number); name != nil {
 		if name.SlugHint != "" {
@@ -166,8 +191,63 @@ func newPaneRequest(cfg *cliflags.Config, projectRoot string, issue ghissue.Issu
 		NoRefresh:   cfg.NoRefresh,
 	})
 	req.BriefingBody = briefing.Render(issue.Number, issue.Title, issue.Body, cfg.Agent, req.Worktree.BaseBranch, resolvedSettings)
-	req.OneLinePrompt = oneLinePrompt(cfg.ParentRef, req)
+	req.Prompt = oneLinePrompt(req.ParentRef, req)
 	return req
+}
+
+func newManualPaneRequest(cfg *cliflags.Config, projectRoot string, store state.Store, opts manualPaneOptions) paneRequest {
+	number := nextSyntheticPaneNumber(store, manualPaneParentRef)
+	title := opts.Title
+	if title == "" {
+		title = "Manual agent"
+	}
+	slug := opts.Slug
+	if slug == "" {
+		slug = manualPaneSlug(title, number)
+	}
+	agentName := opts.Agent
+	if agentName == "" {
+		agentName = cfg.Agent
+	}
+	prompt := opts.Prompt
+	if prompt == "" {
+		prompt = title
+	}
+	branchName := naming.BranchName(opts.BranchName, cfg.BranchPrefix, slug)
+	return paneRequest{
+		ParentRef:    manualPaneParentRef,
+		Number:       number,
+		Title:        title,
+		Body:         opts.Body,
+		ShortTitle:   shortIssueTitle(title),
+		Slug:         slug,
+		BranchName:   branchName,
+		Prompt:       prompt,
+		Agent:        agentName,
+		BriefingBody: opts.Body,
+		Worktree:     worktree.BuildPlan(worktree.Options{ProjectRoot: projectRoot, Slug: slug, BranchName: branchName, BaseBranch: cfg.BaseBranch, NoRefresh: cfg.NoRefresh}),
+	}
+}
+
+func nextSyntheticPaneNumber(store state.Store, parentRef string) int {
+	next := -1
+	for _, pane := range store.PanesForParent(parentRef) {
+		if pane.IssueNum <= next {
+			next = pane.IssueNum - 1
+		}
+	}
+	return next
+}
+
+func manualPaneSlug(title string, number int) string {
+	base := naming.Slugify(title)
+	if base == "" {
+		base = "manual"
+	}
+	if number < 0 {
+		number = -number
+	}
+	return fmt.Sprintf("%s-%d", base, number)
 }
 
 func shortIssueTitle(title string) string {
@@ -183,12 +263,14 @@ func shortIssueTitle(title string) string {
 }
 
 func oneLinePrompt(parentRef string, req paneRequest) string {
-	return fmt.Sprintf("%s%d of #%s] %s: %s. read %s and begin.", fanoutTagPrefix, req.Issue.Number, parentRef, req.Slug, req.ShortTitle, req.BriefingPath)
+	return fmt.Sprintf("%s%d of #%s] %s: %s. read %s and begin.", fanoutTagPrefix, req.Number, parentRef, req.Slug, req.ShortTitle, req.BriefingPath)
 }
 
 func logPaneRequest(req paneRequest, lg *log.Logger) {
-	lg.Info("#%d: %s", req.Issue.Number, req.ShortTitle)
-	lg.Dim("  briefing -> %s", req.BriefingPath)
+	lg.Info("#%d: %s", req.Number, req.ShortTitle)
+	if req.BriefingPath != "" {
+		lg.Dim("  briefing -> %s", req.BriefingPath)
+	}
 	lg.Dim("  slug -> %s", req.Slug)
 	lg.Dim("  worktree -> %s", req.Worktree.WorktreePath)
 	lg.Dim("  branch -> %s", req.BranchName)
@@ -199,7 +281,9 @@ func logPaneRequest(req paneRequest, lg *log.Logger) {
 }
 
 func printPaneDryRun(req paneRequest, target string, lg *log.Logger, c log.Palette) {
-	fmt.Fprintf(lg.Stdout(), "  %sbriefing size%s: %d bytes\n", c.Dim, c.Reset, len(req.BriefingBody))
+	if req.BriefingPath != "" || req.BriefingBody != "" {
+		fmt.Fprintf(lg.Stdout(), "  %sbriefing size%s: %d bytes\n", c.Dim, c.Reset, len(req.BriefingBody))
+	}
 	if req.Worktree.Refresh {
 		details := req.Worktree.RefreshDetails
 		fmt.Fprintf(lg.Stdout(), "    %s$ git -C %s fetch --quiet --no-tags origin %s%s\n", c.Dim, shellQuote(req.Worktree.ProjectRoot), shellQuote(details.FetchBranch), c.Reset)
@@ -231,7 +315,7 @@ func printPaneDryRun(req paneRequest, target string, lg *log.Logger, c log.Palet
 	}
 	fmt.Fprintf(lg.Stdout(), "    %s# would write .fanout/state.json with paneId <pane_id>%s\n", c.Dim, c.Reset)
 	fmt.Fprintf(lg.Stdout(), "    %s# would write .fanout/worktree-metadata.json in the child worktree%s\n", c.Dim, c.Reset)
-	lg.Ok("#%d: dry-run complete", req.Issue.Number)
+	lg.Ok("#%d: dry-run complete", req.Number)
 }
 
 func paneTitle(req paneRequest) string {

--- a/cmd/fanout/pane_test.go
+++ b/cmd/fanout/pane_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 	"time"
@@ -8,7 +9,10 @@ import (
 
 	"github.com/butaosuinu/fanout/internal/cliflags"
 	"github.com/butaosuinu/fanout/internal/ghissue"
+	"github.com/butaosuinu/fanout/internal/log"
+	fanoutruntime "github.com/butaosuinu/fanout/internal/runtime"
 	"github.com/butaosuinu/fanout/internal/settings"
+	"github.com/butaosuinu/fanout/internal/state"
 )
 
 func TestShortIssueTitleTruncatesOnRuneBoundary(t *testing.T) {
@@ -38,15 +42,16 @@ func TestShortIssueTitleKeepsSixtyRunes(t *testing.T) {
 func TestStatePaneCapturesCreatedPaneFields(t *testing.T) {
 	now := time.Date(2026, 6, 4, 1, 2, 3, 0, time.UTC)
 	req := paneRequest{
-		Issue:               ghissue.Issue{Number: 83},
+		ParentRef:           "81",
+		Number:              83,
 		Slug:                "state-idempotency-83",
 		DisplayNameOverride: "State Idempotency",
 		BranchName:          "fanout/state-idempotency-83",
-		OneLinePrompt:       "[fanout #83 of #81] state-idempotency-83: read /tmp/fanout-fanout-83.md and begin.",
+		Prompt:              "[fanout #83 of #81] state-idempotency-83: read /tmp/fanout-fanout-83.md and begin.",
+		Agent:               "codex",
 	}
-	cfg := &cliflags.Config{ParentRef: "81", Agent: "codex"}
 
-	got := statePane(cfg, req, "%42", "/repo/.fanout/worktrees/state-idempotency-83", now)
+	got := statePane(req, "%42", "/repo/.fanout/worktrees/state-idempotency-83", now)
 
 	if got.Parent != "81" || got.IssueNum != 83 || got.PaneID != "%42" {
 		t.Fatalf("state pane identity = %+v", got)
@@ -56,6 +61,42 @@ func TestStatePaneCapturesCreatedPaneFields(t *testing.T) {
 	}
 	if got.CreatedAt != "2026-06-04T01:02:03Z" {
 		t.Fatalf("createdAt = %q", got.CreatedAt)
+	}
+}
+
+func TestCreatePaneAcceptsManualRequestWithoutParentIssue(t *testing.T) {
+	cfg := &cliflags.Config{Agent: "claude", DryRun: true, NoRefresh: true}
+	if got := newManualPaneRequest(cfg, "/repo", state.Store{}, manualPaneOptions{Title: "First Manual"}); got.Number != -1 {
+		t.Fatalf("first manual number = %d, want -1", got.Number)
+	}
+	store := state.Store{Panes: []state.Pane{{Parent: manualPaneParentRef, IssueNum: -1}}}
+	req := newManualPaneRequest(cfg, "/repo", store, manualPaneOptions{
+		Title:  "Manual Diagnostics",
+		Slug:   "manual-diagnostics",
+		Agent:  "codex",
+		Prompt: "inspect the workspace",
+	})
+	if req.ParentRef != manualPaneParentRef || req.Number != -2 {
+		t.Fatalf("manual identity = parent %q number %d, want %q -2", req.ParentRef, req.Number, manualPaneParentRef)
+	}
+	if req.Prompt != "inspect the workspace" || req.Agent != "codex" {
+		t.Fatalf("manual launch = prompt %q agent %q", req.Prompt, req.Agent)
+	}
+
+	var stdout, stderr bytes.Buffer
+	lg := log.NewWith(&stdout, &stderr, false)
+	info := &fanoutruntime.Info{Target: "%caller", ProjectRoot: "/repo"}
+	if !createPane(cfg, lg, info, req, nil, log.Palette{}) {
+		t.Fatalf("createPane() = false, stderr:\n%s", stderr.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{"#-2: Manual Diagnostics", "slug -> manual-diagnostics", "dry-run complete"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("stdout missing %q:\n%s", want, out)
+		}
 	}
 }
 
@@ -71,8 +112,8 @@ func TestNewPaneRequestQualifiesDefaultSlugForSharedChild(t *testing.T) {
 	if got.BranchName != "fanout/shared-child-parent-200-501" {
 		t.Fatalf("branch = %q, want fanout/shared-child-parent-200-501", got.BranchName)
 	}
-	if !strings.Contains(got.OneLinePrompt, "[fanout #501 of #200] shared-child-parent-200-501:") {
-		t.Fatalf("prompt = %q, want parent-qualified slug", got.OneLinePrompt)
+	if !strings.Contains(got.Prompt, "[fanout #501 of #200] shared-child-parent-200-501:") {
+		t.Fatalf("prompt = %q, want parent-qualified slug", got.Prompt)
 	}
 }
 

--- a/cmd/fanout/pane_test.go
+++ b/cmd/fanout/pane_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -72,6 +73,7 @@ func TestCreatePaneAcceptsManualRequestWithoutParentIssue(t *testing.T) {
 	store := state.Store{Panes: []state.Pane{{Parent: manualPaneParentRef, IssueNum: -1}}}
 	req := newManualPaneRequest(cfg, "/repo", store, manualPaneOptions{
 		Title:  "Manual Diagnostics",
+		Body:   "extra context",
 		Slug:   "manual-diagnostics",
 		Agent:  "codex",
 		Prompt: "inspect the workspace",
@@ -79,9 +81,17 @@ func TestCreatePaneAcceptsManualRequestWithoutParentIssue(t *testing.T) {
 	if req.ParentRef != manualPaneParentRef || req.Number != -2 {
 		t.Fatalf("manual identity = parent %q number %d, want %q -2", req.ParentRef, req.Number, manualPaneParentRef)
 	}
-	if req.Prompt != "inspect the workspace" || req.Agent != "codex" {
+	if req.Agent != "codex" || !strings.Contains(req.Prompt, "inspect the workspace") {
 		t.Fatalf("manual launch = prompt %q agent %q", req.Prompt, req.Agent)
 	}
+	if req.BriefingPath != "/tmp/fanout-repo--2.md" || req.BriefingBody != "extra context" {
+		t.Fatalf("manual briefing = path %q body %q", req.BriefingPath, req.BriefingBody)
+	}
+	if !strings.Contains(req.Prompt, "read /tmp/fanout-repo--2.md for additional context and begin") {
+		t.Fatalf("manual prompt does not reference briefing path: %q", req.Prompt)
+	}
+	_ = os.Remove(req.BriefingPath)
+	t.Cleanup(func() { _ = os.Remove(req.BriefingPath) })
 
 	var stdout, stderr bytes.Buffer
 	lg := log.NewWith(&stdout, &stderr, false)
@@ -97,6 +107,9 @@ func TestCreatePaneAcceptsManualRequestWithoutParentIssue(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Fatalf("stdout missing %q:\n%s", want, out)
 		}
+	}
+	if _, err := os.Stat(req.BriefingPath); !os.IsNotExist(err) {
+		t.Fatalf("manual dry-run wrote briefing file %s: %v", req.BriefingPath, err)
 	}
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -19,6 +19,10 @@ type Store struct {
 	Panes         []Pane `json:"panes"`
 }
 
+// Pane records one launched agent pane. Parent and IssueNum form the
+// idempotency key: issue fanout uses the parent issue or Project ref plus the
+// GitHub issue number, while synthetic launches use a reserved parent such as
+// @manual with non-GitHub numbers that only need to be unique under that parent.
 type Pane struct {
 	Parent       string `json:"parent"`
 	IssueNum     int    `json:"issueNum"`


### PR DESCRIPTION
## TL;DR
`createPaneForIssue` を薄いアダプタにし、worktree/tmux/state記録の中核を issue 非依存の `createPane` に分けました。Review effort: 2

## Why
Issue #136 は、TUI から parent issue に紐づかない任意エージェント起動を実装する土台として、`ghissue.Issue` 前提だった pane 作成フローを汎用リクエストで呼べる形にする意図です。

## Changes by file
<details><summary>Changed files</summary>

| File | What changed | Why |
| --- | --- | --- |
| `cmd/fanout/pane.go` | `paneRequest` を `ParentRef`/`Number`/`Agent`/`Prompt` などの issue 非依存フィールドに変更し、`createPaneForIssue` は `newPaneRequest` から `createPane` を呼ぶだけにしました (`cmd/fanout/pane.go:24`, `cmd/fanout/pane.go:55`, `cmd/fanout/pane.go:60`)。 | 既存 issue fanout と将来の手動/TUI起動で worktree 準備、tmux pane 作成、state 記録、metadata 書き込みの同じ中核フローを共有するため。 |
| `cmd/fanout/pane.go` | `statePane` が `cfg` ではなく `paneRequest` 由来の parent/number/agent/prompt を記録するようにし、`@manual` と負番号採番の手動リクエスト生成を追加しました (`cmd/fanout/pane.go:138`, `cmd/fanout/pane.go:198`, `cmd/fanout/pane.go:232`)。 | parent issue に紐づかない pane でも `(parent, issueNum)` の既存 idempotency key に衝突せず記録できるようにするため。 |
| `cmd/fanout/pane_test.go` | `statePane` テストを新しい request 形に更新し、手動リクエストを `createPane` に dry-run で渡す単体テストを追加しました (`cmd/fanout/pane_test.go:42`, `cmd/fanout/pane_test.go:67`)。 | 既存 state 記録のフィールド保持と、parent issue 抜きの任意 prompt/agent/slug 呼び出しを固定するため。 |
| `internal/state/state.go` | `state.Pane` の `Parent`/`IssueNum` が idempotency key であり、通常 fanout と synthetic launch で意味が違うことをdoc commentに明記しました (`internal/state/state.go:22`)。 | 手動起動で `@manual` と非GitHub番号を使う前提を state 側の意味づけとして残すため。 |

</details>

## Risk
既存 issue fanout の dry-run 出力は Tier2 golden で固定されており、再生成なしで通過しています。手動起動ヘルパーはまだ CLI/TUI に接続していないため、このPR単体では既存ユーザーの操作面は変わりません。

## Test plan
- `go test ./cmd/fanout ./internal/state` - passed
- `make test` - passed
- `make lint` - passed
- `codex review --uncommitted` - passed with no findings

Closes #136
