### PR TITLE
feat: add tmuxrun TUI helpers

### DIFF
--- a/internal/tmuxrun/tmuxrun.go
+++ b/internal/tmuxrun/tmuxrun.go
@@ -11,6 +11,7 @@ import (
 
 const userShellExpr = `"${SHELL:-/bin/sh}"`
 const paneListFormat = "#{pane_id}:#{window_id}:#{pane_index}:#{pane_active}:#{pane_title}"
+const paneAlternateFormat = "#{alternate_on}"
 
 // PaneInfo describes a pane currently known to tmux.
 type PaneInfo struct {
@@ -100,7 +101,16 @@ func shouldListSessionPanes(target string) bool {
 }
 
 func exactSessionTarget(name string) string {
+	if isQualifiedSessionTarget(name) {
+		return name
+	}
 	return "=" + name
+}
+
+func isQualifiedSessionTarget(name string) bool {
+	return strings.HasPrefix(name, "=") ||
+		strings.HasPrefix(name, "$") ||
+		strings.ContainsAny(name, "*?[")
 }
 
 func parseListPanesOutput(out string) ([]PaneInfo, error) {
@@ -152,10 +162,17 @@ func CapturePaneOutput(paneID string, lines int) (string, error) {
 	if lines < 0 {
 		return "", fmt.Errorf("lines must be non-negative")
 	}
-	if out, err := capturePaneOutput(paneID, 0, true); err == nil {
-		return out, nil
+	if paneAlternateOn(paneID) {
+		if out, err := capturePaneOutput(paneID, 0, true); err == nil {
+			return out, nil
+		}
 	}
 	return capturePaneOutput(paneID, lines, false)
+}
+
+func paneAlternateOn(paneID string) bool {
+	out, err := exec.Command("tmux", "display-message", "-p", "-t", paneID, paneAlternateFormat).Output()
+	return err == nil && strings.TrimSpace(string(out)) == "1"
 }
 
 func capturePaneOutput(paneID string, lines int, alternateScreen bool) (string, error) {
@@ -173,14 +190,14 @@ func capturePaneOutput(paneID string, lines int, alternateScreen bool) (string, 
 	return string(out), nil
 }
 
-// SelectPane selects paneID within its containing tmux window.
+// SelectPane selects paneID and brings its containing tmux window on screen.
 func SelectPane(paneID string) error {
 	paneID = strings.TrimSpace(paneID)
 	if paneID == "" {
 		return fmt.Errorf("pane id is required")
 	}
-	if err := exec.Command("tmux", "select-pane", "-t", paneID).Run(); err != nil {
-		return fmt.Errorf("tmux select-pane: %w", err)
+	if err := exec.Command("tmux", "switch-client", "-t", paneID).Run(); err != nil {
+		return fmt.Errorf("tmux switch-client: %w", err)
 	}
 	return nil
 }

--- a/internal/tmuxrun/tmuxrun.go
+++ b/internal/tmuxrun/tmuxrun.go
@@ -3,11 +3,23 @@ package tmuxrun
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 )
 
 const userShellExpr = `"${SHELL:-/bin/sh}"`
+const paneListFormat = "#{pane_id}:#{window_id}:#{pane_index}:#{pane_active}:#{pane_title}"
+
+// PaneInfo describes a pane currently known to tmux.
+type PaneInfo struct {
+	ID       string
+	WindowID string
+	Index    int
+	Active   bool
+	Title    string
+}
 
 // SplitPane splits the target pane/session rooted at worktreePath and returns its pane id.
 func SplitPane(target, worktreePath string) (string, error) {
@@ -60,6 +72,178 @@ func SelectTiled(session string) error {
 	args = append(args, "tiled")
 	if err := exec.Command("tmux", args...).Run(); err != nil {
 		return fmt.Errorf("tmux select-layout tiled: %w", err)
+	}
+	return nil
+}
+
+// ListPanes returns pane metadata for a target pane, window, or session.
+func ListPanes(target string) ([]PaneInfo, error) {
+	target = strings.TrimSpace(target)
+	args := []string{"list-panes"}
+	if target != "" {
+		if shouldListSessionPanes(target) {
+			args = append(args, "-s")
+			target = exactSessionTarget(target)
+		}
+		args = append(args, "-t", target)
+	}
+	args = append(args, "-F", paneListFormat)
+	out, err := exec.Command("tmux", args...).Output()
+	if err != nil {
+		return nil, fmt.Errorf("tmux list-panes: %w", err)
+	}
+	return parseListPanesOutput(string(out))
+}
+
+func shouldListSessionPanes(target string) bool {
+	return HasSession(target)
+}
+
+func exactSessionTarget(name string) string {
+	return "=" + name
+}
+
+func parseListPanesOutput(out string) ([]PaneInfo, error) {
+	var panes []PaneInfo
+	for lineNum, line := range strings.Split(strings.TrimRight(out, "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		fields := strings.SplitN(line, ":", 5)
+		if len(fields) != 5 {
+			return nil, fmt.Errorf("parse tmux list-panes line %d: expected 5 fields, got %d", lineNum+1, len(fields))
+		}
+		index, err := strconv.Atoi(fields[2])
+		if err != nil {
+			return nil, fmt.Errorf("parse tmux list-panes line %d index: %w", lineNum+1, err)
+		}
+		active, err := parsePaneActive(fields[3])
+		if err != nil {
+			return nil, fmt.Errorf("parse tmux list-panes line %d active: %w", lineNum+1, err)
+		}
+		panes = append(panes, PaneInfo{
+			ID:       fields[0],
+			WindowID: fields[1],
+			Index:    index,
+			Active:   active,
+			Title:    fields[4],
+		})
+	}
+	return panes, nil
+}
+
+func parsePaneActive(raw string) (bool, error) {
+	switch raw {
+	case "1":
+		return true, nil
+	case "0":
+		return false, nil
+	default:
+		return false, fmt.Errorf("expected 0 or 1, got %q", raw)
+	}
+}
+
+// CapturePaneOutput returns a read-only output snapshot from a tmux pane.
+func CapturePaneOutput(paneID string, lines int) (string, error) {
+	paneID = strings.TrimSpace(paneID)
+	if paneID == "" {
+		return "", fmt.Errorf("pane id is required")
+	}
+	if lines < 0 {
+		return "", fmt.Errorf("lines must be non-negative")
+	}
+	if out, err := capturePaneOutput(paneID, 0, true); err == nil {
+		return out, nil
+	}
+	return capturePaneOutput(paneID, lines, false)
+}
+
+func capturePaneOutput(paneID string, lines int, alternateScreen bool) (string, error) {
+	args := []string{"capture-pane", "-p", "-t", paneID}
+	if alternateScreen {
+		args = []string{"capture-pane", "-a", "-p", "-t", paneID}
+	}
+	if !alternateScreen && lines > 0 {
+		args = append(args, "-S", fmt.Sprintf("-%d", lines))
+	}
+	out, err := exec.Command("tmux", args...).Output()
+	if err != nil {
+		return "", fmt.Errorf("tmux capture-pane: %w", err)
+	}
+	return string(out), nil
+}
+
+// SelectPane selects paneID within its containing tmux window.
+func SelectPane(paneID string) error {
+	paneID = strings.TrimSpace(paneID)
+	if paneID == "" {
+		return fmt.Errorf("pane id is required")
+	}
+	if err := exec.Command("tmux", "select-pane", "-t", paneID).Run(); err != nil {
+		return fmt.Errorf("tmux select-pane: %w", err)
+	}
+	return nil
+}
+
+// IsPaneAlive reports whether tmux can resolve the pane id.
+func IsPaneAlive(paneID string) bool {
+	paneID = strings.TrimSpace(paneID)
+	if paneID == "" {
+		return false
+	}
+	return exec.Command("tmux", "display-message", "-p", "-t", paneID).Run() == nil
+}
+
+// InsideTmux reports whether the current process is running under tmux.
+func InsideTmux() bool {
+	return strings.TrimSpace(os.Getenv("TMUX")) != ""
+}
+
+// HasSession reports whether a tmux session exists.
+func HasSession(name string) bool {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return false
+	}
+	return exec.Command("tmux", "has-session", "-t", exactSessionTarget(name)).Run() == nil
+}
+
+// NewSession creates a detached tmux session rooted at startDir.
+func NewSession(name, startDir string) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return fmt.Errorf("session name is required")
+	}
+	args := []string{"new-session", "-d", "-s", name}
+	if strings.TrimSpace(startDir) != "" {
+		args = append(args, "-c", startDir)
+	}
+	if err := exec.Command("tmux", args...).Run(); err != nil {
+		return fmt.Errorf("tmux new-session: %w", err)
+	}
+	return nil
+}
+
+// AttachOrSwitch attaches to a session outside tmux or switches clients inside tmux.
+func AttachOrSwitch(name string) error {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return fmt.Errorf("session name is required")
+	}
+	target := exactSessionTarget(name)
+	insideTmux := InsideTmux()
+	args := []string{"attach-session", "-t", target}
+	if insideTmux {
+		args = []string{"switch-client", "-t", target}
+	}
+	cmd := exec.Command("tmux", args...)
+	if !insideTmux {
+		cmd.Stdin = os.Stdin
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+	}
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("tmux %s: %w", args[0], err)
 	}
 	return nil
 }

--- a/internal/tmuxrun/tmuxrun_test.go
+++ b/internal/tmuxrun/tmuxrun_test.go
@@ -3,9 +3,40 @@ package tmuxrun
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
+
+func installTmuxShim(t *testing.T, script string) string {
+	t.Helper()
+	dir := t.TempDir()
+	argsPath := filepath.Join(dir, "args.txt")
+	tmuxPath := filepath.Join(dir, "tmux")
+	if err := os.WriteFile(tmuxPath, []byte("#!/bin/sh\n"+script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TMUXRUN_ARGS", argsPath)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return argsPath
+}
+
+func readTmuxArgs(t *testing.T, argsPath string) []string {
+	t.Helper()
+	body, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return strings.Split(strings.TrimRight(string(body), "\n"), "\n")
+}
+
+func assertTmuxArgs(t *testing.T, argsPath string, want []string) {
+	t.Helper()
+	got := readTmuxArgs(t, argsPath)
+	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("tmux args = %#v, want %#v", got, want)
+	}
+}
 
 func TestSplitPaneTargetsSession(t *testing.T) {
 	dir := t.TempDir()
@@ -89,4 +120,227 @@ func TestBuildPaneLaunchCommandUsesUserShellAndKeepsPaneOpen(t *testing.T) {
 			t.Fatalf("BuildPaneLaunchCommand() = %q, want substring %q", got, want)
 		}
 	}
+}
+
+func TestParseListPanesOutput(t *testing.T) {
+	input := "%1:@1:0:1:main\n%2:@1:1:0:title:with:colons\n"
+
+	got, err := parseListPanesOutput(input)
+	if err != nil {
+		t.Fatalf("parseListPanesOutput() failed: %v", err)
+	}
+
+	want := []PaneInfo{
+		{ID: "%1", WindowID: "@1", Index: 0, Active: true, Title: "main"},
+		{ID: "%2", WindowID: "@1", Index: 1, Active: false, Title: "title:with:colons"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseListPanesOutput() = %#v, want %#v", got, want)
+	}
+}
+
+func TestParseListPanesOutputRejectsMalformedLines(t *testing.T) {
+	for _, input := range []string{
+		"%1:@1:0:1",
+		"%1:@1:not-int:1:title",
+		"%1:@1:0:yes:title",
+	} {
+		if _, err := parseListPanesOutput(input); err == nil {
+			t.Fatalf("parseListPanesOutput(%q) succeeded, want error", input)
+		}
+	}
+}
+
+func TestListPanesBuildsArgsAndParsesOutput(t *testing.T) {
+	argsPath := installTmuxShim(t, `printf '%s\n' "$@" > "$TMUXRUN_ARGS"
+printf '%%3:@2:4:1:fanout pane\n'
+`)
+
+	got, err := ListPanes("target-session")
+	if err != nil {
+		t.Fatalf("ListPanes() failed: %v", err)
+	}
+
+	wantPanes := []PaneInfo{{ID: "%3", WindowID: "@2", Index: 4, Active: true, Title: "fanout pane"}}
+	if !reflect.DeepEqual(got, wantPanes) {
+		t.Fatalf("ListPanes() = %#v, want %#v", got, wantPanes)
+	}
+	assertTmuxArgs(t, argsPath, []string{"list-panes", "-s", "-t", "=target-session", "-F", paneListFormat})
+}
+
+func TestListPanesPreservesPaneTargetArgs(t *testing.T) {
+	argsPath := installTmuxShim(t, `if [ "$1" = "has-session" ]; then
+	exit 1
+fi
+printf '%s\n' "$@" > "$TMUXRUN_ARGS"
+`)
+
+	if _, err := ListPanes("%3"); err != nil {
+		t.Fatalf("ListPanes() failed: %v", err)
+	}
+	assertTmuxArgs(t, argsPath, []string{"list-panes", "-t", "%3", "-F", paneListFormat})
+}
+
+func TestListPanesPreservesSimpleNonSessionTargetArgs(t *testing.T) {
+	argsPath := installTmuxShim(t, `if [ "$1" = "has-session" ]; then
+	exit 1
+fi
+printf '%s\n' "$@" > "$TMUXRUN_ARGS"
+`)
+
+	if _, err := ListPanes("window-name"); err != nil {
+		t.Fatalf("ListPanes() failed: %v", err)
+	}
+	assertTmuxArgs(t, argsPath, []string{"list-panes", "-t", "window-name", "-F", paneListFormat})
+}
+
+func TestListPanesUsesSessionFlagForPunctuatedSessionTarget(t *testing.T) {
+	argsPath := installTmuxShim(t, `if [ "$1" = "has-session" ]; then
+	exit 0
+fi
+printf '%s\n' "$@" > "$TMUXRUN_ARGS"
+`)
+
+	if _, err := ListPanes("project.dev"); err != nil {
+		t.Fatalf("ListPanes() failed: %v", err)
+	}
+	assertTmuxArgs(t, argsPath, []string{"list-panes", "-s", "-t", "=project.dev", "-F", paneListFormat})
+}
+
+func TestCapturePaneOutputUsesAlternateScreenWhenAvailable(t *testing.T) {
+	argsPath := installTmuxShim(t, `printf '%s\n' "$@" > "$TMUXRUN_ARGS"
+printf 'alternate\n'
+`)
+
+	got, err := CapturePaneOutput("%7", 25)
+	if err != nil {
+		t.Fatalf("CapturePaneOutput() failed: %v", err)
+	}
+	if got != "alternate\n" {
+		t.Fatalf("CapturePaneOutput() = %q, want alternate output", got)
+	}
+	assertTmuxArgs(t, argsPath, []string{"capture-pane", "-a", "-p", "-t", "%7"})
+}
+
+func TestCapturePaneOutputFallsBackToNormalCaptureArgs(t *testing.T) {
+	argsPath := installTmuxShim(t, `if [ "$2" = "-a" ]; then
+	exit 1
+fi
+printf '%s\n' "$@" > "$TMUXRUN_ARGS"
+printf 'line 1\nline 2\n'
+`)
+
+	got, err := CapturePaneOutput("%7", 25)
+	if err != nil {
+		t.Fatalf("CapturePaneOutput() failed: %v", err)
+	}
+	if got != "line 1\nline 2\n" {
+		t.Fatalf("CapturePaneOutput() = %q, want captured output", got)
+	}
+	assertTmuxArgs(t, argsPath, []string{"capture-pane", "-p", "-t", "%7", "-S", "-25"})
+}
+
+func TestCapturePaneOutputOmitsStartWhenLinesZero(t *testing.T) {
+	argsPath := installTmuxShim(t, `if [ "$2" = "-a" ]; then
+	exit 1
+fi
+printf '%s\n' "$@" > "$TMUXRUN_ARGS"
+`)
+
+	if _, err := CapturePaneOutput("%8", 0); err != nil {
+		t.Fatalf("CapturePaneOutput() failed: %v", err)
+	}
+	assertTmuxArgs(t, argsPath, []string{"capture-pane", "-p", "-t", "%8"})
+}
+
+func TestSelectPaneBuildsArgs(t *testing.T) {
+	argsPath := installTmuxShim(t, `printf '%s\n' "$@" > "$TMUXRUN_ARGS"
+`)
+
+	if err := SelectPane("%9"); err != nil {
+		t.Fatalf("SelectPane() failed: %v", err)
+	}
+	assertTmuxArgs(t, argsPath, []string{"select-pane", "-t", "%9"})
+}
+
+func TestIsPaneAliveBuildsArgs(t *testing.T) {
+	argsPath := installTmuxShim(t, `printf '%s\n' "$@" > "$TMUXRUN_ARGS"
+`)
+
+	if !IsPaneAlive("%10") {
+		t.Fatalf("IsPaneAlive() = false, want true")
+	}
+	assertTmuxArgs(t, argsPath, []string{"display-message", "-p", "-t", "%10"})
+}
+
+func TestIsPaneAliveReturnsFalseWhenTmuxCannotResolvePane(t *testing.T) {
+	installTmuxShim(t, `exit 1
+`)
+
+	if IsPaneAlive("%404") {
+		t.Fatalf("IsPaneAlive() = true, want false")
+	}
+}
+
+func TestInsideTmux(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/tmux-501/default,123,0")
+	if !InsideTmux() {
+		t.Fatalf("InsideTmux() = false, want true")
+	}
+
+	t.Setenv("TMUX", "")
+	if InsideTmux() {
+		t.Fatalf("InsideTmux() = true, want false")
+	}
+}
+
+func TestHasSessionBuildsArgs(t *testing.T) {
+	argsPath := installTmuxShim(t, `printf '%s\n' "$@" > "$TMUXRUN_ARGS"
+`)
+
+	if !HasSession("fanout") {
+		t.Fatalf("HasSession() = false, want true")
+	}
+	assertTmuxArgs(t, argsPath, []string{"has-session", "-t", "=fanout"})
+}
+
+func TestHasSessionReturnsFalseWhenMissing(t *testing.T) {
+	installTmuxShim(t, `exit 1
+`)
+
+	if HasSession("missing") {
+		t.Fatalf("HasSession() = true, want false")
+	}
+}
+
+func TestNewSessionBuildsArgs(t *testing.T) {
+	argsPath := installTmuxShim(t, `printf '%s\n' "$@" > "$TMUXRUN_ARGS"
+`)
+
+	if err := NewSession("fanout", "/tmp/work tree"); err != nil {
+		t.Fatalf("NewSession() failed: %v", err)
+	}
+	assertTmuxArgs(t, argsPath, []string{"new-session", "-d", "-s", "fanout", "-c", "/tmp/work tree"})
+}
+
+func TestAttachOrSwitchAttachesOutsideTmux(t *testing.T) {
+	t.Setenv("TMUX", "")
+	argsPath := installTmuxShim(t, `printf '%s\n' "$@" > "$TMUXRUN_ARGS"
+`)
+
+	if err := AttachOrSwitch("fanout"); err != nil {
+		t.Fatalf("AttachOrSwitch() failed: %v", err)
+	}
+	assertTmuxArgs(t, argsPath, []string{"attach-session", "-t", "=fanout"})
+}
+
+func TestAttachOrSwitchSwitchesInsideTmux(t *testing.T) {
+	t.Setenv("TMUX", "/tmp/tmux-501/default,123,0")
+	argsPath := installTmuxShim(t, `printf '%s\n' "$@" > "$TMUXRUN_ARGS"
+`)
+
+	if err := AttachOrSwitch("fanout"); err != nil {
+		t.Fatalf("AttachOrSwitch() failed: %v", err)
+	}
+	assertTmuxArgs(t, argsPath, []string{"switch-client", "-t", "=fanout"})
 }

--- a/internal/tmuxrun/tmuxrun_test.go
+++ b/internal/tmuxrun/tmuxrun_test.go
@@ -207,8 +207,38 @@ printf '%s\n' "$@" > "$TMUXRUN_ARGS"
 	assertTmuxArgs(t, argsPath, []string{"list-panes", "-s", "-t", "=project.dev", "-F", paneListFormat})
 }
 
+func TestListPanesPreservesQualifiedSessionTargetArgs(t *testing.T) {
+	argsPath := installTmuxShim(t, `if [ "$1" = "has-session" ]; then
+	exit 0
+fi
+printf '%s\n' "$@" > "$TMUXRUN_ARGS"
+`)
+
+	if _, err := ListPanes("=fanout"); err != nil {
+		t.Fatalf("ListPanes() failed: %v", err)
+	}
+	assertTmuxArgs(t, argsPath, []string{"list-panes", "-s", "-t", "=fanout", "-F", paneListFormat})
+}
+
+func TestListPanesPreservesSessionIDTargetArgs(t *testing.T) {
+	argsPath := installTmuxShim(t, `if [ "$1" = "has-session" ]; then
+	exit 0
+fi
+printf '%s\n' "$@" > "$TMUXRUN_ARGS"
+`)
+
+	if _, err := ListPanes("$1"); err != nil {
+		t.Fatalf("ListPanes() failed: %v", err)
+	}
+	assertTmuxArgs(t, argsPath, []string{"list-panes", "-s", "-t", "$1", "-F", paneListFormat})
+}
+
 func TestCapturePaneOutputUsesAlternateScreenWhenAvailable(t *testing.T) {
-	argsPath := installTmuxShim(t, `printf '%s\n' "$@" > "$TMUXRUN_ARGS"
+	argsPath := installTmuxShim(t, `if [ "$1" = "display-message" ]; then
+	printf '1\n'
+	exit 0
+fi
+printf '%s\n' "$@" > "$TMUXRUN_ARGS"
 printf 'alternate\n'
 `)
 
@@ -223,7 +253,11 @@ printf 'alternate\n'
 }
 
 func TestCapturePaneOutputFallsBackToNormalCaptureArgs(t *testing.T) {
-	argsPath := installTmuxShim(t, `if [ "$2" = "-a" ]; then
+	argsPath := installTmuxShim(t, `if [ "$1" = "display-message" ]; then
+	printf '1\n'
+	exit 0
+fi
+if [ "$2" = "-a" ]; then
 	exit 1
 fi
 printf '%s\n' "$@" > "$TMUXRUN_ARGS"
@@ -240,8 +274,34 @@ printf 'line 1\nline 2\n'
 	assertTmuxArgs(t, argsPath, []string{"capture-pane", "-p", "-t", "%7", "-S", "-25"})
 }
 
+func TestCapturePaneOutputUsesNormalScreenWhenAlternateOff(t *testing.T) {
+	argsPath := installTmuxShim(t, `if [ "$1" = "display-message" ]; then
+	printf '0\n'
+	exit 0
+fi
+if [ "$2" = "-a" ]; then
+	exit 2
+fi
+printf '%s\n' "$@" > "$TMUXRUN_ARGS"
+printf 'normal\n'
+`)
+
+	got, err := CapturePaneOutput("%7", 25)
+	if err != nil {
+		t.Fatalf("CapturePaneOutput() failed: %v", err)
+	}
+	if got != "normal\n" {
+		t.Fatalf("CapturePaneOutput() = %q, want normal output", got)
+	}
+	assertTmuxArgs(t, argsPath, []string{"capture-pane", "-p", "-t", "%7", "-S", "-25"})
+}
+
 func TestCapturePaneOutputOmitsStartWhenLinesZero(t *testing.T) {
-	argsPath := installTmuxShim(t, `if [ "$2" = "-a" ]; then
+	argsPath := installTmuxShim(t, `if [ "$1" = "display-message" ]; then
+	printf '0\n'
+	exit 0
+fi
+if [ "$2" = "-a" ]; then
 	exit 1
 fi
 printf '%s\n' "$@" > "$TMUXRUN_ARGS"
@@ -253,14 +313,14 @@ printf '%s\n' "$@" > "$TMUXRUN_ARGS"
 	assertTmuxArgs(t, argsPath, []string{"capture-pane", "-p", "-t", "%8"})
 }
 
-func TestSelectPaneBuildsArgs(t *testing.T) {
+func TestSelectPaneSwitchesClientToPaneTarget(t *testing.T) {
 	argsPath := installTmuxShim(t, `printf '%s\n' "$@" > "$TMUXRUN_ARGS"
 `)
 
 	if err := SelectPane("%9"); err != nil {
 		t.Fatalf("SelectPane() failed: %v", err)
 	}
-	assertTmuxArgs(t, argsPath, []string{"select-pane", "-t", "%9"})
+	assertTmuxArgs(t, argsPath, []string{"switch-client", "-t", "%9"})
 }
 
 func TestIsPaneAliveBuildsArgs(t *testing.T) {
@@ -304,6 +364,26 @@ func TestHasSessionBuildsArgs(t *testing.T) {
 	assertTmuxArgs(t, argsPath, []string{"has-session", "-t", "=fanout"})
 }
 
+func TestHasSessionPreservesQualifiedTargets(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		want string
+	}{
+		{name: "=fanout", want: "=fanout"},
+		{name: "$1", want: "$1"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			argsPath := installTmuxShim(t, `printf '%s\n' "$@" > "$TMUXRUN_ARGS"
+`)
+
+			if !HasSession(tc.name) {
+				t.Fatalf("HasSession() = false, want true")
+			}
+			assertTmuxArgs(t, argsPath, []string{"has-session", "-t", tc.want})
+		})
+	}
+}
+
 func TestHasSessionReturnsFalseWhenMissing(t *testing.T) {
 	installTmuxShim(t, `exit 1
 `)
@@ -329,6 +409,17 @@ func TestAttachOrSwitchAttachesOutsideTmux(t *testing.T) {
 `)
 
 	if err := AttachOrSwitch("fanout"); err != nil {
+		t.Fatalf("AttachOrSwitch() failed: %v", err)
+	}
+	assertTmuxArgs(t, argsPath, []string{"attach-session", "-t", "=fanout"})
+}
+
+func TestAttachOrSwitchPreservesQualifiedTarget(t *testing.T) {
+	t.Setenv("TMUX", "")
+	argsPath := installTmuxShim(t, `printf '%s\n' "$@" > "$TMUXRUN_ARGS"
+`)
+
+	if err := AttachOrSwitch("=fanout"); err != nil {
 		t.Fatalf("AttachOrSwitch() failed: %v", err)
 	}
 	assertTmuxArgs(t, argsPath, []string{"attach-session", "-t", "=fanout"})


### PR DESCRIPTION
TL;DR: Add internal/tmuxrun helpers for TUI pane discovery, pane output capture, pane focus, liveness checks, and tmux session attach/switch flows.

Review effort: 3

## Why
The upcoming TUI work needs a small tmux access layer that can list fanout panes, read pane output, focus panes, and manage tmux sessions without duplicating command construction across callers.

## Changes by file
<details>
<summary>Changed files</summary>

| File | Changes |
| --- | --- |
| `internal/tmuxrun/tmuxrun.go` | Adds `PaneInfo`, pane-list parsing/execution, capture helpers with alternate-screen fallback, pane focus/liveness helpers, tmux/session detection, session creation, and attach/switch support. |
| `internal/tmuxrun/tmuxrun_test.go` | Adds parser coverage and tmux shim tests for list, capture, select, alive, inside-tmux, session, new-session, and attach/switch argument construction. |

</details>

## Call flow
```mermaid
flowchart LR
  ListPanes --> HasSession
  HasSession --> TmuxHas[tmux has-session]
  ListPanes --> TmuxList[tmux list-panes]
  CapturePaneOutput --> AltCapture[tmux capture-pane -a]
  CapturePaneOutput --> NormalCapture[tmux capture-pane]
```

## Risk
The main behavior nuance is tmux target resolution: `ListPanes` checks exact session existence before using session-wide `list-panes -s`, so pane/window targets keep normal tmux target behavior.

## Test plan
- `go test ./internal/tmuxrun`
- `make lint`
- `make test`
- `codex review --uncommitted`

Closes #135
