### PR TITLE
feat(tui): focus panes and peek output

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -17,8 +17,11 @@ attach し、その session 内でコンソールを開始します。tmux 内�
 
 コンソールは `<git-root>/.fanout/state.json` を読み、記録済み pane ID が tmux 上に
 まだ存在するかを確認し、`fanout <parent> --status` と同じ GitHub CLI 経路で
-issue / closed-by PR 状態を定期更新します。`q` でコンソールを離脱できますが、
-tmux session と子 pane は残ります。
+issue / closed-by PR 状態を定期更新します。live 行で `Enter` または `o` を押すと
+その pane にフォーカスし、`p` で detail panel の read-only 出力スナップショットを
+更新します。記録はあるものの tmux 上に存在しない pane は `stale!` と表示し、
+focus / peek の対象から除外します。`q` でコンソールを離脱できますが、tmux session
+と子 pane は残ります。
 
 ## 直接 tmux ランタイム
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,11 @@ tmux it turns the current pane into the console.
 The console reads `<git-root>/.fanout/state.json`, checks whether recorded pane
 IDs still exist in tmux, and periodically refreshes issue / closed-by PR state
 through the same GitHub CLI source used by `fanout <parent> --status`. Press
-`q` to leave the console; the tmux session and child panes are left running.
+`Enter` or `o` on a live row to focus that pane, and press `p` to refresh the
+read-only output snapshot shown in the detail panel. Rows whose recorded pane no
+longer exists in tmux are marked `stale!` and are skipped by focus/peek actions.
+Press `q` to leave the console; the tmux session and child panes are left
+running.
 
 ## Direct tmux runtime
 

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -2,6 +2,7 @@
 package tui
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"sort"
@@ -21,15 +22,19 @@ import (
 const (
 	defaultStateInterval = 2 * time.Second
 	defaultGHInterval    = 20 * time.Second
-	detailHeight         = 7
+	detailHeight         = 13
+	peekLines            = 80
 )
 
 // Options configures the TUI monitor.
 type Options struct {
-	ProjectRoot   string
-	Session       string
-	StateInterval time.Duration
-	GHInterval    time.Duration
+	ProjectRoot       string
+	Session           string
+	StateInterval     time.Duration
+	GHInterval        time.Duration
+	FocusPane         func(string) error
+	PaneAlive         func(string) bool
+	CapturePaneOutput func(string, int) (string, error)
 }
 
 type issueStatus struct {
@@ -65,6 +70,8 @@ type model struct {
 	lastGH    time.Time
 	stateErr  string
 	ghErr     string
+	notice    string
+	peek      panePeek
 }
 
 type stateLoadedMsg struct {
@@ -79,8 +86,30 @@ type ghLoadedMsg struct {
 	err    error
 }
 
+type paneFocusedMsg struct {
+	paneID string
+	err    error
+}
+
+type panePeekLoadedMsg struct {
+	paneID string
+	output string
+	at     time.Time
+	err    error
+}
+
+type panePeek struct {
+	PaneID  string
+	Output  string
+	At      time.Time
+	Err     string
+	Loading bool
+}
+
 type stateTickMsg time.Time
 type ghTickMsg time.Time
+
+var errPaneNotAlive = errors.New("pane is no longer live")
 
 var (
 	titleStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("34"))
@@ -104,6 +133,15 @@ func normalizeOptions(opts Options) Options {
 	}
 	if opts.GHInterval <= 0 {
 		opts.GHInterval = defaultGHInterval
+	}
+	if opts.FocusPane == nil {
+		opts.FocusPane = tmuxrun.SelectPane
+	}
+	if opts.PaneAlive == nil {
+		opts.PaneAlive = tmuxrun.IsPaneAlive
+	}
+	if opts.CapturePaneOutput == nil {
+		opts.CapturePaneOutput = tmuxrun.CapturePaneOutput
 	}
 	return opts
 }
@@ -144,10 +182,21 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch msg.String() {
 		case "q", "ctrl+c":
 			return m, tea.Quit
+		case "enter", "o":
+			cmd := m.focusSelectedCmd()
+			return m, cmd
+		case "p":
+			cmd := m.peekSelectedCmd(true)
+			return m, cmd
 		}
+		oldCursor := m.table.Cursor()
 		next, cmd := m.table.Update(msg)
 		m.table = next
 		m.refreshDetail()
+		if m.table.Cursor() != oldCursor {
+			peekCmd := m.peekSelectedCmd(false)
+			return m, tea.Batch(cmd, peekCmd)
+		}
 		return m, cmd
 	case stateLoadedMsg:
 		if msg.err != nil {
@@ -158,7 +207,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.panes = msg.panes
 		m.lastState = msg.at
 		m.refreshRows()
-		return m, tea.Tick(m.opts.StateInterval, func(t time.Time) tea.Msg { return stateTickMsg(t) })
+		peekCmd := m.peekSelectedCmd(false)
+		return m, tea.Batch(
+			tea.Tick(m.opts.StateInterval, func(t time.Time) tea.Msg { return stateTickMsg(t) }),
+			peekCmd,
+		)
 	case ghLoadedMsg:
 		if msg.err != nil {
 			m.ghErr = msg.err.Error()
@@ -173,6 +226,28 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.loadStateCmd()
 	case ghTickMsg:
 		return m, m.loadGHCmd()
+	case paneFocusedMsg:
+		if msg.err != nil {
+			m.notice = fmt.Sprintf("focus skipped for %s: %v", dash(msg.paneID), msg.err)
+			if errors.Is(msg.err, errPaneNotAlive) {
+				m.markPaneStale(msg.paneID)
+				m.refreshRows()
+			}
+		} else {
+			m.notice = fmt.Sprintf("focused %s; return to the fanout tui pane to continue", msg.paneID)
+		}
+		return m, nil
+	case panePeekLoadedMsg:
+		if pane, ok := m.selectedPane(); ok && pane.PaneID != msg.paneID {
+			return m, nil
+		}
+		if msg.err != nil {
+			m.peek = panePeek{PaneID: msg.paneID, At: msg.at, Err: msg.err.Error()}
+		} else {
+			m.peek = panePeek{PaneID: msg.paneID, Output: msg.output, At: msg.at}
+		}
+		m.refreshDetail()
+		return m, nil
 	}
 	return m, nil
 }
@@ -189,7 +264,10 @@ func (m model) View() string {
 		header += " " + dimStyle.Render(m.opts.ProjectRoot)
 	}
 
-	footer := dimStyle.Render("q quit  j/k move  state " + formatClock(m.lastState) + "  gh " + formatClock(m.lastGH))
+	footer := dimStyle.Render("q quit  j/k move  enter/o focus  p peek  state " + formatClock(m.lastState) + "  gh " + formatClock(m.lastGH))
+	if m.notice != "" {
+		footer += "\n" + warnStyle.Render(m.notice)
+	}
 	if m.stateErr != "" {
 		footer += "\n" + errStyle.Render("state/tmux: "+m.stateErr)
 	}
@@ -243,11 +321,10 @@ func (m model) detailContent() string {
 	if len(m.panes) == 0 {
 		return "No recorded fanout panes in .fanout/state.json."
 	}
-	idx := m.table.Cursor()
-	if idx < 0 || idx >= len(m.panes) {
-		idx = 0
+	pane, ok := m.selectedPane()
+	if !ok {
+		return "No recorded fanout panes in .fanout/state.json."
 	}
-	pane := m.panes[idx]
 	lines := []string{
 		fmt.Sprintf("%s #%d  %s", pane.Parent, pane.IssueNum, pane.Name),
 		fmt.Sprintf("pane=%s tmux=%s title=%s agent=%s", dash(pane.PaneID), pane.TmuxState, dash(pane.TmuxTitle), dash(pane.Agent)),
@@ -255,10 +332,110 @@ func (m model) detailContent() string {
 		fmt.Sprintf("worktree=%s", dash(pane.WorktreePath)),
 		fmt.Sprintf("created=%s", dash(pane.CreatedAt)),
 	}
-	if pane.Prompt != "" {
+	peekBudget := maxInt(2, m.detail.Height-len(lines)-1)
+	lines = append(lines, m.peekContent(pane, peekBudget)...)
+	if pane.Prompt != "" && len(lines) < m.detail.Height {
 		lines = append(lines, "prompt="+pane.Prompt)
 	}
 	return strings.Join(lines, "\n")
+}
+
+func (m model) selectedPane() (paneView, bool) {
+	if len(m.panes) == 0 {
+		return paneView{}, false
+	}
+	idx := m.table.Cursor()
+	if idx < 0 || idx >= len(m.panes) {
+		idx = 0
+	}
+	return m.panes[idx], true
+}
+
+func (m *model) focusSelectedCmd() tea.Cmd {
+	pane, ok := m.selectedPane()
+	if !ok {
+		m.notice = "no pane selected"
+		return nil
+	}
+	if !pane.canFocus() {
+		m.notice = fmt.Sprintf("focus skipped for %s: tmux state is %s", dash(pane.PaneID), pane.TmuxState)
+		return nil
+	}
+
+	paneID := pane.PaneID
+	alive := m.opts.PaneAlive
+	focus := m.opts.FocusPane
+	m.notice = fmt.Sprintf("focusing %s...", paneID)
+	return func() tea.Msg {
+		if !alive(paneID) {
+			return paneFocusedMsg{paneID: paneID, err: errPaneNotAlive}
+		}
+		return paneFocusedMsg{paneID: paneID, err: focus(paneID)}
+	}
+}
+
+func (m *model) peekSelectedCmd(force bool) tea.Cmd {
+	pane, ok := m.selectedPane()
+	if !ok {
+		m.peek = panePeek{}
+		return nil
+	}
+	if !pane.canPeek() {
+		m.peek = panePeek{PaneID: pane.PaneID, At: time.Now(), Err: fmt.Sprintf("tmux state is %s", pane.TmuxState)}
+		return nil
+	}
+	if !force && m.peek.PaneID == pane.PaneID && (m.peek.Loading || m.peek.Output != "" || m.peek.Err != "") {
+		return nil
+	}
+
+	paneID := pane.PaneID
+	capture := m.opts.CapturePaneOutput
+	m.peek = panePeek{PaneID: paneID, Loading: true}
+	return func() tea.Msg {
+		out, err := capture(paneID, peekLines)
+		return panePeekLoadedMsg{paneID: paneID, output: out, at: time.Now(), err: err}
+	}
+}
+
+func (m model) peekContent(pane paneView, maxLines int) []string {
+	header := "peek"
+	if !m.peek.At.IsZero() {
+		header += " " + formatClock(m.peek.At)
+	}
+	if pane.PaneID == "" {
+		return []string{header + ": no pane id recorded"}
+	}
+	if !pane.canPeek() {
+		return []string{header + ": unavailable (" + pane.TmuxState + ")"}
+	}
+	if m.peek.PaneID != pane.PaneID {
+		return []string{header + ": waiting for capture"}
+	}
+	if m.peek.Loading {
+		return []string{header + ": loading..."}
+	}
+	if m.peek.Err != "" {
+		return []string{header + ": " + m.peek.Err}
+	}
+
+	out := strings.TrimRight(m.peek.Output, "\r\n")
+	if out == "" {
+		return []string{header + ": no output"}
+	}
+	lines := []string{header + ":"}
+	for _, line := range tailLines(out, maxLines) {
+		lines = append(lines, truncatePreserveSpace(line, maxInt(20, m.detail.Width-2)))
+	}
+	return lines
+}
+
+func (m *model) markPaneStale(paneID string) {
+	for i := range m.panes {
+		if m.panes[i].PaneID == paneID {
+			m.panes[i].TmuxState = "stale"
+			return
+		}
+	}
 }
 
 func (m model) loadStateCmd() tea.Cmd {
@@ -370,16 +547,28 @@ func applyIssueStatuses(panes []paneView, issues map[int]issueStatus) []paneView
 }
 
 func (p paneView) tableRow() table.Row {
+	tmuxState := p.TmuxState
+	if tmuxState == "stale" {
+		tmuxState = "stale!"
+	}
 	return table.Row{
 		compactParent(p.Parent),
 		"#" + strconv.Itoa(p.IssueNum),
 		truncate(p.Name, 28),
-		p.TmuxState,
+		tmuxState,
 		dash(p.IssueState),
 		truncate(dash(p.PRSummary), 14),
 		truncate(dash(p.BranchName), 22),
 		dash(p.PaneID),
 	}
+}
+
+func (p paneView) canFocus() bool {
+	return strings.TrimSpace(p.PaneID) != "" && p.TmuxState != "stale" && p.TmuxState != "-"
+}
+
+func (p paneView) canPeek() bool {
+	return p.canFocus()
 }
 
 func columnsForWidth(width int) []table.Column {
@@ -490,6 +679,14 @@ func formatClock(t time.Time) string {
 
 func truncate(s string, max int) string {
 	s = strings.TrimSpace(s)
+	return truncateRunes(s, max)
+}
+
+func truncatePreserveSpace(s string, max int) string {
+	return truncateRunes(s, max)
+}
+
+func truncateRunes(s string, max int) string {
 	runes := []rune(s)
 	if max <= 0 || len(runes) <= max {
 		return s
@@ -501,6 +698,21 @@ func truncate(s string, max int) string {
 		return string(runes[:max])
 	}
 	return string(runes[:max-3]) + "..."
+}
+
+func tailLines(s string, max int) []string {
+	if max <= 0 {
+		return nil
+	}
+	raw := strings.Split(s, "\n")
+	if len(raw) > max {
+		raw = raw[len(raw)-max:]
+	}
+	out := make([]string, 0, len(raw))
+	for _, line := range raw {
+		out = append(out, strings.TrimRight(line, "\r"))
+	}
+	return out
 }
 
 func dash(s string) string {

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -2,11 +2,13 @@ package tui
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/butaosuinu/fanout/internal/ghissue"
 	"github.com/butaosuinu/fanout/internal/state"
 	"github.com/butaosuinu/fanout/internal/tmuxrun"
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 func TestBuildPaneViewsMergesStateTmuxAndIssueStatuses(t *testing.T) {
@@ -93,6 +95,157 @@ func TestRefreshRowsClampsCursorWhenRowsShrink(t *testing.T) {
 	}
 	if got := len(m.table.Rows()); got != 1 {
 		t.Fatalf("rows after shrink = %d, want 1", got)
+	}
+}
+
+func TestFocusSelectedPaneUsesInjectedFocus(t *testing.T) {
+	var focused string
+	m := newModel(Options{
+		FocusPane: func(paneID string) error {
+			focused = paneID
+			return nil
+		},
+		PaneAlive: func(string) bool { return true },
+	})
+	m.panes = []paneView{{IssueNum: 1, Name: "one", PaneID: "%1", TmuxState: "live"}}
+	m.refreshRows()
+
+	cmd := m.focusSelectedCmd()
+	if cmd == nil {
+		t.Fatalf("focusSelectedCmd() returned nil, want focus command")
+	}
+	msg, ok := cmd().(paneFocusedMsg)
+	if !ok {
+		t.Fatalf("focusSelectedCmd() msg = %T, want paneFocusedMsg", msg)
+	}
+	next, _ := m.Update(msg)
+	m = next.(model)
+
+	if focused != "%1" {
+		t.Fatalf("focused pane = %q, want %%1", focused)
+	}
+	if !strings.Contains(m.notice, "focused %1") {
+		t.Fatalf("notice = %q, want focused message", m.notice)
+	}
+}
+
+func TestFocusSelectedPaneSkipsStaleRows(t *testing.T) {
+	called := false
+	m := newModel(Options{
+		FocusPane: func(string) error {
+			called = true
+			return nil
+		},
+		PaneAlive: func(string) bool { return true },
+	})
+	m.panes = []paneView{{IssueNum: 1, Name: "one", PaneID: "%1", TmuxState: "stale"}}
+	m.refreshRows()
+
+	if cmd := m.focusSelectedCmd(); cmd != nil {
+		t.Fatalf("focusSelectedCmd() returned a command for stale pane")
+	}
+	if called {
+		t.Fatalf("FocusPane was called for stale pane")
+	}
+	if !strings.Contains(m.notice, "focus skipped") {
+		t.Fatalf("notice = %q, want skipped message", m.notice)
+	}
+}
+
+func TestFocusSelectedPaneMarksDeadPaneStale(t *testing.T) {
+	called := false
+	m := newModel(Options{
+		FocusPane: func(string) error {
+			called = true
+			return nil
+		},
+		PaneAlive: func(string) bool { return false },
+	})
+	m.panes = []paneView{{IssueNum: 1, Name: "one", PaneID: "%1", TmuxState: "live"}}
+	m.refreshRows()
+
+	cmd := m.focusSelectedCmd()
+	if cmd == nil {
+		t.Fatalf("focusSelectedCmd() returned nil, want alive-check command")
+	}
+	msg := cmd()
+	next, _ := m.Update(msg)
+	m = next.(model)
+
+	if called {
+		t.Fatalf("FocusPane was called after PaneAlive returned false")
+	}
+	if m.panes[0].TmuxState != "stale" {
+		t.Fatalf("TmuxState = %q, want stale", m.panes[0].TmuxState)
+	}
+	if got := m.table.Rows()[0][3]; got != "stale!" {
+		t.Fatalf("table tmux cell = %q, want stale!", got)
+	}
+}
+
+func TestPeekSelectedPaneLoadsOutputIntoDetail(t *testing.T) {
+	var capturedPane string
+	var capturedLines int
+	m := newModel(Options{
+		CapturePaneOutput: func(paneID string, lines int) (string, error) {
+			capturedPane = paneID
+			capturedLines = lines
+			return "line 1\n  line 2\n\tline 3\n", nil
+		},
+	})
+	m.detail.Width = 80
+	m.detail.Height = 9
+	m.panes = []paneView{{IssueNum: 1, Name: "one", PaneID: "%1", TmuxState: "live"}}
+	m.refreshRows()
+
+	cmd := m.peekSelectedCmd(true)
+	if cmd == nil {
+		t.Fatalf("peekSelectedCmd() returned nil, want capture command")
+	}
+	if !m.peek.Loading {
+		t.Fatalf("peek.Loading = false, want true before command returns")
+	}
+	msg := cmd()
+	next, _ := m.Update(msg)
+	m = next.(model)
+
+	if capturedPane != "%1" {
+		t.Fatalf("captured pane = %q, want %%1", capturedPane)
+	}
+	if capturedLines != peekLines {
+		t.Fatalf("captured lines = %d, want %d", capturedLines, peekLines)
+	}
+	got := m.detailContent()
+	if !strings.Contains(got, "peek") || !strings.Contains(got, "\tline 3") || !strings.Contains(got, "  line 2") {
+		t.Fatalf("detailContent() = %q, want peek output", got)
+	}
+}
+
+func TestKeySelectionChangeStartsPeekCapture(t *testing.T) {
+	var capturedPane string
+	m := newModel(Options{
+		CapturePaneOutput: func(paneID string, lines int) (string, error) {
+			capturedPane = paneID
+			return "selected\n", nil
+		},
+	})
+	m.panes = []paneView{
+		{IssueNum: 1, Name: "one", PaneID: "%1", TmuxState: "live"},
+		{IssueNum: 2, Name: "two", PaneID: "%2", TmuxState: "live"},
+	}
+	m.refreshRows()
+
+	next, cmd := m.Update(tea.KeyMsg{Type: tea.KeyDown})
+	m = next.(model)
+	if cmd == nil {
+		t.Fatalf("Update(down) returned nil command, want peek command")
+	}
+	msg := cmd()
+	if _, ok := msg.(panePeekLoadedMsg); !ok {
+		t.Fatalf("Update(down) cmd msg = %T, want panePeekLoadedMsg", msg)
+	}
+	if capturedPane != "%2" {
+		t.Fatalf("captured pane = %q, want %%2", capturedPane)
 	}
 }
 


### PR DESCRIPTION
**TL;DR**
Adds TUI row actions for focusing live tmux panes and peeking at selected pane output without leaving the console. Review effort: 3

**Why**
Issue #139 asks for the persistent TUI to move from observation-only to a dmux-like workflow where a user can scan fanned panes, peek at output, and jump to a live pane.

**Changes by file**
<details><summary>Changed files</summary>

| File | What changed | Why |
|---|---|---|
| `internal/tui/tui.go` | Adds injected tmux action hooks, `Enter`/`o` focus, `p`/selection peek capture, stale focus exclusion, `stale!` row display, and whitespace-preserving peek truncation. `Enter`/`o` and `p` are handled in `Update` (`internal/tui/tui.go:181`), focus checks `PaneAlive` before `SelectPane` (`internal/tui/tui.go:354`), peek uses `CapturePaneOutput` (`internal/tui/tui.go:377`), and stale rows render as `stale!` and cannot focus/peek (`internal/tui/tui.go:549`). | Make the TUI support pane navigation and read-only output inspection while avoiding dead pane targets. |
| `internal/tui/tui_test.go` | Adds focused tests for live focus, stale skip, dead-pane stale marking, peek detail output, whitespace preservation, and selection-change capture. | Pin behavior without requiring a real tmux server. |
| `README.md` | Documents TUI focus/peek keys and stale row behavior (`README.md:18`). | Keep user-facing CLI docs aligned. |
| `README.ja.md` | Documents the same TUI behavior in Japanese (`README.ja.md:18`). | Keep Japanese docs aligned. |

</details>

```mermaid
flowchart LR
  Key[internal/tui.Update key event] --> Selected[selected paneView]
  Selected --> Live{TmuxState live or unknown}
  Live -- no --> Stale[stale row skips focus and peek]
  Live -- yes --> Alive[tmuxrun.IsPaneAlive]
  Alive -- false --> Mark[markPaneStale]
  Alive -- true --> Focus[tmuxrun.SelectPane]
  Selected --> Peek[tmuxrun.CapturePaneOutput]
  Peek --> Detail[detail viewport snapshot]
```

**Risk**
> [!WARNING]
> I did not run a live interactive tmux TUI E2E. The behavior is covered by injected unit tests plus existing tmuxrun tests, but terminal focus behavior can still vary by tmux client/session layout.

**Test plan**
- `go test ./internal/tui` - passed
- `go test ./...` - passed
- `make build-go` - passed with exit 0; Go emitted a sandbox stat-cache warning while writing under `/Users/butaosuinu/gocode/pkg/mod/cache/...`
- `make test` - passed
- `make lint` - passed
- `codex review --uncommitted` - clean after fixing the whitespace-preservation finding

Closes #139
