### PR TITLE
feat(dashboard): show PR review and CI state

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -246,15 +246,17 @@ launch を失敗扱いにし、pane/worktree を cleanup するため、同じ c
 `fanout <parent> --status` は読み取り専用です。`<git-root>/.fanout/state.json`
 （または `FANOUT_STATE_PATH` で指定した state file）から指定 parent の記録済み
 子 issue を列挙し、各子について `gh api graphql` で issue state と
-`closedByPullRequestsReferences` を取得して、既定では既存の JSON schema
-（`children[].prs` / `summary.all_merged` など）で出力します。`--format table`
-を渡すと、PR の差分バー、変更ファイル数、Conventional-Commit 種別、PR リンクを
-含む人間向けの一覧を出力します。`--post-dashboard` を渡すと、親 issue に
-marker 付きコメントを 1 つ upsert し、各子 PR の sub-issue 番号、PR リンク、
-差分規模、Conventional-Commit 種別、TL;DR、`Review effort` score を集約します。
-dashboard は GitHub の機械可読データと PR 本文だけから作り、LLM は呼びません。
-JSON mode では `--post-dashboard` を併用しない限り PR 差分統計を取得しないため、
-既定の schema と API call 数は変わりません。dmux や live tmux session は不要です。
+`closedByPullRequestsReferences` を取得して、PR の `reviewDecision` と最新 commit
+の CI rollup も含む JSON（`children[].prs` / `summary.all_merged` など）で
+出力します。`--format table` を渡すと、正規化した PR 状態（`open`、`draft`、
+`review-required`、`approved`、`changes-requested`、`merged`、`closed`）、CI、
+差分バー、変更ファイル数、Conventional-Commit 種別、PR リンクを含む人間向けの一覧を出力します。
+`--post-dashboard` を渡すと、親 issue に marker 付きコメントを 1 つ upsert し、
+各子 PR の sub-issue 番号、PR リンク、PR 状態、CI、差分規模、
+Conventional-Commit 種別、TL;DR、`Review effort` score を集約します。dashboard は
+GitHub の機械可読データと PR 本文だけから作り、LLM は呼びません。JSON mode では
+`--post-dashboard` を併用しない限り PR 差分統計を取得しないため、review/CI 追加
+field は同じ per-issue GraphQL lookup から取得します。dmux や live tmux session は不要です。
 現在の JSON schema は issue parent 用なので、Projects v2 URL を parent にした
 `--status` は拒否します。
 
@@ -430,8 +432,8 @@ fanout 123 --no-auto-pr
 # この shell では Agent Teams ヒントを無効化
 export FANOUT_AGENT_TEAMS_HINT=0
 
-# .fanout/state.json に記録された子 issue と closed-by PR の merge 状態を読む。
-# 既定は automation 向け JSON、table は PR 差分統計、任意で親 dashboard コメント。
+# .fanout/state.json に記録された子 issue と closed-by PR/review/CI 状態を読む。
+# 既定は automation 向け JSON、table は PR/CI/差分確認、任意で親 dashboard コメント。
 fanout 123 --status
 fanout 123 --status | jq '.summary.all_merged'
 fanout 123 --status --format table

--- a/README.md
+++ b/README.md
@@ -254,17 +254,20 @@ enumerate children already fanned out under that specific parent, queries
 each child through `gh api graphql` against
 `repository.issue.closedByPullRequestsReferences(first: 100)` (cursor-
 paginated when a child is closed by more than 100 PRs) so the response
-carries `state`/`mergedAt` directly, and prints one JSON document on stdout by
-default. Pass `--format table` for a human-readable overview that adds PR diff
-bars, changed-file counts, Conventional-Commit type, and PR links. Pass
-`--post-dashboard` to upsert one marker-based comment on the parent issue with
-sub-issue number, PR link, diff size, Conventional-Commit type, TL;DR, and
-`Review effort` score for each child PR. The dashboard is built from
-machine-readable GitHub data and PR bodies; it does not call an LLM. JSON mode
-does not fetch PR diff stats unless `--post-dashboard` is also set, so the
-default API surface and schema stay stable. It does not require dmux or a live
-tmux session. Issue-mode parents only — Projects v2 URLs as parent are rejected
-up-front for the current JSON schema.
+carries `state`, `mergedAt`, `reviewDecision`, and the latest commit's CI
+rollup when present, and prints one JSON document on stdout by default. Pass
+`--format table` for a human-readable overview that adds normalized PR state
+(`open`, `draft`, `review-required`, `approved`, `changes-requested`,
+`merged`, or `closed`), CI, PR diff bars, changed-file counts,
+Conventional-Commit type, and PR links.
+Pass `--post-dashboard` to upsert one marker-based comment on the parent issue
+with sub-issue number, PR link, PR state, CI, diff size, Conventional-Commit
+type, TL;DR, and `Review effort` score for each child PR. The dashboard is built
+from machine-readable GitHub data and PR bodies; it does not call an LLM. JSON
+mode does not fetch PR diff stats unless `--post-dashboard` is also set, so the
+additional review/CI fields come from the same per-issue GraphQL lookup. It does
+not require dmux or a live tmux session. Issue-mode parents only — Projects v2
+URLs as parent are rejected up-front for the current JSON schema.
 In a state file that has fanned multiple parents, children of other parents are
 filtered out so `summary.all_merged` reflects only the requested parent. Set
 `FANOUT_STATE_PATH` to point directly at a state file when reading from outside
@@ -276,7 +279,8 @@ the repository checkout; otherwise fanout reads `<git-root>/.fanout/state.json`.
   "children": [
     { "num": 4, "state": "CLOSED",
       "prs": [ { "number": 250, "state": "MERGED",
-                 "mergedAt": "2026-05-04T10:00:00Z" } ],
+                 "mergedAt": "2026-05-04T10:00:00Z",
+                 "reviewDecision": "APPROVED", "ci": "pass" } ],
       "has_merged_pr": true },
     { "num": 7, "state": "OPEN",
       "prs": [],
@@ -499,7 +503,7 @@ fanout 123 --no-auto-pr
 export FANOUT_AGENT_TEAMS_HINT=0
 
 # Status from .fanout/state.json: default JSON for automation, optional table
-# for PR diff stats, optional parent dashboard comment.
+# for PR state / CI / diff scans, optional parent dashboard comment.
 fanout 123 --status
 fanout 123 --status | jq '.summary.all_merged'
 fanout 123 --status --format table

--- a/claude/skills/fanout/SKILL.md
+++ b/claude/skills/fanout/SKILL.md
@@ -154,7 +154,8 @@ then continue parent-scope work. After the real fanout run succeeds, poll
 `fanout --status <PARENT>` from the parent worktree. The command reads
 `.fanout/state.json` (or `FANOUT_STATE_PATH`) and returns
 `summary.all_merged` for the recorded children. Use the default JSON format for
-automation; `--format table` is for human review of PR diff stats and links.
+automation; `--format table` is for human review of PR state, CI, diff stats,
+and links.
 Use `--post-dashboard` only when the user explicitly wants a parent issue
 rollup comment; it writes to GitHub even though it is attached to `--status`.
 

--- a/cmd/fanout/status.go
+++ b/cmd/fanout/status.go
@@ -48,6 +48,7 @@ type statusTableRow struct {
 	IssueState string
 	PR         string
 	PRState    string
+	CI         string
 	Type       string
 	Files      string
 	Link       string
@@ -57,12 +58,14 @@ type statusTableRow struct {
 }
 
 type dashboardRow struct {
-	Issue string
-	PR    string
-	Diff  string
-	Type  string
-	TLDR  string
-	Score string
+	Issue   string
+	PR      string
+	PRState string
+	CI      string
+	Diff    string
+	Type    string
+	TLDR    string
+	Score   string
 }
 
 func cmdStatus(cfg *cliflags.Config, lg *log.Logger) exitcode.Code {
@@ -228,12 +231,14 @@ func dashboardRows(report statusReport, projectRoot, nwo string, lg *log.Logger)
 	for _, child := range report.Children {
 		if len(child.PRs) == 0 {
 			rows = append(rows, dashboardRow{
-				Issue: "#" + strconv.Itoa(child.Num),
-				PR:    "-",
-				Diff:  "-",
-				Type:  "-",
-				TLDR:  "No PR yet",
-				Score: "-",
+				Issue:   "#" + strconv.Itoa(child.Num),
+				PR:      "-",
+				PRState: "-",
+				CI:      "-",
+				Diff:    "-",
+				Type:    "-",
+				TLDR:    "No PR yet",
+				Score:   "-",
 			})
 			continue
 		}
@@ -245,12 +250,14 @@ func dashboardRows(report statusReport, projectRoot, nwo string, lg *log.Logger)
 			}
 			tldr, score := extractDashboardPRBody(stat.Body)
 			rows = append(rows, dashboardRow{
-				Issue: "#" + strconv.Itoa(child.Num),
-				PR:    fmt.Sprintf("[#%d](https://github.com/%s/pull/%d)", pr.Number, nwo, pr.Number),
-				Diff:  dashboardDiff(stat),
-				Type:  conventionalType(stat.Title),
-				TLDR:  tldr,
-				Score: score,
+				Issue:   "#" + strconv.Itoa(child.Num),
+				PR:      fmt.Sprintf("[#%d](https://github.com/%s/pull/%d)", pr.Number, nwo, pr.Number),
+				PRState: dashIfEmpty(pr.DisplayState()),
+				CI:      dashIfEmpty(pr.CIStatus),
+				Diff:    dashboardDiff(stat),
+				Type:    conventionalType(stat.Title),
+				TLDR:    tldr,
+				Score:   score,
 			})
 		}
 	}
@@ -264,16 +271,18 @@ func buildDashboardBody(parent int, summary statusSummary, rows []dashboardRow) 
 	fmt.Fprintf(&b, "## fanout dashboard #%d\n\n", parent)
 	fmt.Fprintf(&b, "Total: %d | Merged: %d | Pending: %d | All merged: %t\n\n",
 		summary.Total, summary.Merged, summary.Pending, summary.AllMerged)
-	b.WriteString("| Sub-issue # | PR | +/- | Type | TL;DR | Score |\n")
-	b.WriteString("| --- | --- | --- | --- | --- | --- |\n")
+	b.WriteString("| Sub-issue # | PR | PR state | CI | +/- | Type | TL;DR | Score |\n")
+	b.WriteString("| --- | --- | --- | --- | --- | --- | --- | --- |\n")
 	if len(rows) == 0 {
-		b.WriteString("| - | - | - | - | No recorded children | - |\n")
+		b.WriteString("| - | - | - | - | - | - | No recorded children | - |\n")
 		return b.String()
 	}
 	for _, row := range rows {
-		fmt.Fprintf(&b, "| %s | %s | %s | %s | %s | %s |\n",
+		fmt.Fprintf(&b, "| %s | %s | %s | %s | %s | %s | %s | %s |\n",
 			markdownCell(row.Issue),
 			markdownCell(row.PR),
+			markdownCell(row.PRState),
+			markdownCell(row.CI),
 			markdownCell(row.Diff),
 			markdownCell(row.Type),
 			markdownCell(row.TLDR),
@@ -369,6 +378,7 @@ func writeStatusTable(report statusReport, projectRoot string, lg *log.Logger) e
 		len("STATE"),
 		len("PR"),
 		len("PR_STATE"),
+		len("CI"),
 		len("TYPE"),
 		len("FILES"),
 		diffWidth,
@@ -379,11 +389,12 @@ func writeStatusTable(report statusReport, projectRoot string, lg *log.Logger) e
 		widths[1] = maxInt(widths[1], len(row.IssueState))
 		widths[2] = maxInt(widths[2], len(row.PR))
 		widths[3] = maxInt(widths[3], len(row.PRState))
-		widths[4] = maxInt(widths[4], len(row.Type))
-		widths[5] = maxInt(widths[5], len(row.Files))
+		widths[4] = maxInt(widths[4], len(row.CI))
+		widths[5] = maxInt(widths[5], len(row.Type))
+		widths[6] = maxInt(widths[6], len(row.Files))
 	}
 
-	headers := []string{"ISSUE", "STATE", "PR", "PR_STATE", "TYPE", "FILES", "DIFF", "LINK"}
+	headers := []string{"ISSUE", "STATE", "PR", "PR_STATE", "CI", "TYPE", "FILES", "DIFF", "LINK"}
 	fmt.Fprintln(out, statusTableLine(headers, widths))
 	separators := []string{
 		strings.Repeat("-", widths[0]),
@@ -392,8 +403,9 @@ func writeStatusTable(report statusReport, projectRoot string, lg *log.Logger) e
 		strings.Repeat("-", widths[3]),
 		strings.Repeat("-", widths[4]),
 		strings.Repeat("-", widths[5]),
+		strings.Repeat("-", widths[6]),
 		strings.Repeat("-", diffWidth),
-		strings.Repeat("-", widths[7]),
+		strings.Repeat("-", widths[8]),
 	}
 	fmt.Fprintln(out, statusTableLine(separators, widths))
 
@@ -404,6 +416,7 @@ func writeStatusTable(report statusReport, projectRoot string, lg *log.Logger) e
 			row.IssueState,
 			row.PR,
 			row.PRState,
+			row.CI,
 			row.Type,
 			row.Files,
 			renderStatusDiff(row, maxLines, addWidth, delWidth, diffWidth, colors),
@@ -437,6 +450,7 @@ func statusTableRows(report statusReport, projectRoot string, lg *log.Logger) ([
 				IssueState: dashIfEmpty(child.State),
 				PR:         "-",
 				PRState:    "-",
+				CI:         "-",
 				Type:       "-",
 				Files:      "-",
 				Link:       "-",
@@ -457,7 +471,8 @@ func statusTableRows(report statusReport, projectRoot string, lg *log.Logger) ([
 				Issue:      "#" + strconv.Itoa(child.Num),
 				IssueState: dashIfEmpty(child.State),
 				PR:         "#" + strconv.Itoa(pr.Number),
-				PRState:    dashIfEmpty(pr.State),
+				PRState:    dashIfEmpty(pr.DisplayState()),
+				CI:         dashIfEmpty(pr.CIStatus),
 				Type:       conventionalType(stat.Title),
 				Files:      strconv.Itoa(stat.ChangedFiles),
 				Link:       fmt.Sprintf("https://github.com/%s/pull/%d", nwo, pr.Number),

--- a/cmd/fanout/status_test.go
+++ b/cmd/fanout/status_test.go
@@ -10,20 +10,24 @@ func TestBuildDashboardBody(t *testing.T) {
 		AllMerged: false,
 	}, []dashboardRow{
 		{
-			Issue: "#201",
-			PR:    "[#601](https://github.com/butaosuinu/fanout/pull/601)",
-			Diff:  "+120 / -8 (5 files)",
-			Type:  "feat",
-			TLDR:  "Adds the dashboard | status rollup.",
-			Score: "2",
+			Issue:   "#201",
+			PR:      "[#601](https://github.com/butaosuinu/fanout/pull/601)",
+			PRState: "merged",
+			CI:      "pass",
+			Diff:    "+120 / -8 (5 files)",
+			Type:    "feat",
+			TLDR:    "Adds the dashboard | status rollup.",
+			Score:   "2",
 		},
 		{
-			Issue: "#202",
-			PR:    "-",
-			Diff:  "-",
-			Type:  "-",
-			TLDR:  "No PR yet",
-			Score: "-",
+			Issue:   "#202",
+			PR:      "-",
+			PRState: "-",
+			CI:      "-",
+			Diff:    "-",
+			Type:    "-",
+			TLDR:    "No PR yet",
+			Score:   "-",
 		},
 	})
 	want := `<!-- fanout:dashboard parent=200 -->
@@ -31,10 +35,10 @@ func TestBuildDashboardBody(t *testing.T) {
 
 Total: 2 | Merged: 1 | Pending: 1 | All merged: false
 
-| Sub-issue # | PR | +/- | Type | TL;DR | Score |
-| --- | --- | --- | --- | --- | --- |
-| #201 | [#601](https://github.com/butaosuinu/fanout/pull/601) | +120 / -8 (5 files) | feat | Adds the dashboard \| status rollup. | 2 |
-| #202 | - | - | - | No PR yet | - |
+| Sub-issue # | PR | PR state | CI | +/- | Type | TL;DR | Score |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| #201 | [#601](https://github.com/butaosuinu/fanout/pull/601) | merged | pass | +120 / -8 (5 files) | feat | Adds the dashboard \| status rollup. | 2 |
+| #202 | - | - | - | - | - | No PR yet | - |
 `
 	if got != want {
 		t.Fatalf("buildDashboardBody() =\n%s\nwant\n%s", got, want)

--- a/codex/skills/fanout/SKILL.md
+++ b/codex/skills/fanout/SKILL.md
@@ -217,7 +217,8 @@ then continue parent-scope work. After the real fanout run succeeds, poll
 `fanout --status <PARENT>` from the parent worktree. The command reads
 `.fanout/state.json` (or `FANOUT_STATE_PATH`) and returns
 `summary.all_merged` for the recorded children. Use the default JSON format for
-automation; `--format table` is for human review of PR diff stats and links.
+automation; `--format table` is for human review of PR state, CI, diff stats,
+and links.
 Use `--post-dashboard` only when the user explicitly wants a parent issue
 rollup comment; it writes to GitHub even though it is attached to `--status`.
 

--- a/internal/cliflags/usage.go
+++ b/internal/cliflags/usage.go
@@ -109,17 +109,19 @@ Options:
   --debug             Enable extra diagnostic logging.
   --status            Status mode. Print status describing each fanned-out
                       child issue recorded in .fanout/state.json, including
-                      issue state and closed-by PR merge status, then exit.
+                      issue state plus closed-by PR merge/review/CI status,
+                      then exit.
                       Read-only unless --post-dashboard is also set.
                       Exclusive with action-bearing flags.
   --format <json|table>
                       Output format for --status. Default: json. The table
-                      format adds PR diff bars, changed-file counts,
-                      Conventional-Commit type, and PR links for human scans.
+                      format adds PR state, CI, diff bars, changed-file
+                      counts, Conventional-Commit type, and PR links.
   --post-dashboard    With --status, upsert one marker-based rollup comment
                       on the parent issue. The comment aggregates child PR
-                      links, diff size, Conventional-Commit type, TL;DR, and
-                      Review effort score from machine-readable PR data.
+                      links, PR state, CI, diff size, Conventional-Commit
+                      type, TL;DR, and Review effort score from
+                      machine-readable PR data.
   --close <NUM>       Remove the recorded child worktree for issue <NUM>,
                       kill its tmux pane when still present, update state,
                       and run git worktree prune.

--- a/internal/ghissue/ghissue.go
+++ b/internal/ghissue/ghissue.go
@@ -31,9 +31,37 @@ type Issue struct {
 }
 
 type PRRef struct {
-	Number   int     `json:"number"`
-	State    string  `json:"state"`
-	MergedAt *string `json:"mergedAt"`
+	Number         int     `json:"number"`
+	State          string  `json:"state"`
+	MergedAt       *string `json:"mergedAt"`
+	IsDraft        bool    `json:"isDraft,omitempty"`
+	ReviewDecision string  `json:"reviewDecision,omitempty"`
+	CIStatus       string  `json:"ci,omitempty"`
+}
+
+func (pr PRRef) DisplayState() string {
+	state := strings.ToUpper(strings.TrimSpace(pr.State))
+	if state == "MERGED" || pr.MergedAt != nil {
+		return "merged"
+	}
+	if state == "CLOSED" {
+		return "closed"
+	}
+	if pr.IsDraft {
+		return "draft"
+	}
+	switch strings.ToUpper(strings.TrimSpace(pr.ReviewDecision)) {
+	case "APPROVED":
+		return "approved"
+	case "CHANGES_REQUESTED":
+		return "changes-requested"
+	case "REVIEW_REQUIRED":
+		return "review-required"
+	}
+	if state == "" {
+		return ""
+	}
+	return strings.ToLower(state)
 }
 
 type PRDiffStat struct {
@@ -185,7 +213,22 @@ func (r Runner) IssueWithPRs(owner, repo string, num int) (state string, prs []P
           state
           closedByPullRequestsReferences(first: 100, after: $after) {
             pageInfo { hasNextPage endCursor }
-            nodes { number state mergedAt }
+            nodes {
+              number
+              state
+              mergedAt
+              isDraft
+              reviewDecision
+              commits(last: 1) {
+                nodes {
+                  commit {
+                    statusCheckRollup {
+                      state
+                    }
+                  }
+                }
+              }
+            }
           }
         }
       }
@@ -219,14 +262,16 @@ func (r Runner) IssueWithPRs(owner, repo string, num int) (state string, prs []P
 					HasNextPage bool   `json:"hasNextPage"`
 					EndCursor   string `json:"endCursor"`
 				} `json:"pageInfo"`
-				Nodes []PRRef `json:"nodes"`
+				Nodes []prRefGraphQL `json:"nodes"`
 			} `json:"closedByPullRequestsReferences"`
 		}
 		if err := json.Unmarshal(out, &page); err != nil {
 			return "", nil, fmt.Errorf("parse gh api graphql issue %d: %w", num, err)
 		}
 		state = page.State
-		prs = append(prs, page.Refs.Nodes...)
+		for _, pr := range page.Refs.Nodes {
+			prs = append(prs, pr.ref())
+		}
 		if !page.Refs.PageInfo.HasNextPage {
 			break
 		}
@@ -237,6 +282,56 @@ func (r Runner) IssueWithPRs(owner, repo string, num int) (state string, prs []P
 		cursor = next
 	}
 	return state, prs, nil
+}
+
+type prRefGraphQL struct {
+	Number         int     `json:"number"`
+	State          string  `json:"state"`
+	MergedAt       *string `json:"mergedAt"`
+	IsDraft        bool    `json:"isDraft"`
+	ReviewDecision string  `json:"reviewDecision"`
+	Commits        struct {
+		Nodes []struct {
+			Commit struct {
+				StatusCheckRollup *struct {
+					State string `json:"state"`
+				} `json:"statusCheckRollup"`
+			} `json:"commit"`
+		} `json:"nodes"`
+	} `json:"commits"`
+}
+
+func (pr prRefGraphQL) ref() PRRef {
+	return PRRef{
+		Number:         pr.Number,
+		State:          pr.State,
+		MergedAt:       pr.MergedAt,
+		IsDraft:        pr.IsDraft,
+		ReviewDecision: pr.ReviewDecision,
+		CIStatus:       normalizeCIStatus(pr.statusCheckRollupState()),
+	}
+}
+
+func (pr prRefGraphQL) statusCheckRollupState() string {
+	if len(pr.Commits.Nodes) == 0 || pr.Commits.Nodes[0].Commit.StatusCheckRollup == nil {
+		return ""
+	}
+	return pr.Commits.Nodes[0].Commit.StatusCheckRollup.State
+}
+
+func normalizeCIStatus(state string) string {
+	switch strings.ToUpper(strings.TrimSpace(state)) {
+	case "":
+		return ""
+	case "SUCCESS":
+		return "pass"
+	case "ERROR", "FAILURE":
+		return "fail"
+	case "EXPECTED", "PENDING":
+		return "pending"
+	default:
+		return strings.ToLower(strings.TrimSpace(state))
+	}
 }
 
 func (r Runner) PRDiffStat(num int) (PRDiffStat, error) {

--- a/internal/ghissue/ghissue_test.go
+++ b/internal/ghissue/ghissue_test.go
@@ -1,0 +1,45 @@
+package ghissue
+
+import "testing"
+
+func TestPRRefDisplayState(t *testing.T) {
+	mergedAt := "2026-06-09T00:00:00Z"
+	for _, tc := range []struct {
+		name string
+		pr   PRRef
+		want string
+	}{
+		{name: "merged state wins", pr: PRRef{State: "MERGED", IsDraft: true, ReviewDecision: "CHANGES_REQUESTED"}, want: "merged"},
+		{name: "merged timestamp wins", pr: PRRef{State: "CLOSED", MergedAt: &mergedAt}, want: "merged"},
+		{name: "closed", pr: PRRef{State: "CLOSED"}, want: "closed"},
+		{name: "draft", pr: PRRef{State: "OPEN", IsDraft: true, ReviewDecision: "APPROVED"}, want: "draft"},
+		{name: "approved", pr: PRRef{State: "OPEN", ReviewDecision: "APPROVED"}, want: "approved"},
+		{name: "changes requested", pr: PRRef{State: "OPEN", ReviewDecision: "CHANGES_REQUESTED"}, want: "changes-requested"},
+		{name: "review required", pr: PRRef{State: "OPEN", ReviewDecision: "REVIEW_REQUIRED"}, want: "review-required"},
+		{name: "open", pr: PRRef{State: "OPEN"}, want: "open"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.pr.DisplayState(); got != tc.want {
+				t.Fatalf("DisplayState() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeCIStatus(t *testing.T) {
+	for _, tc := range []struct {
+		in   string
+		want string
+	}{
+		{in: "SUCCESS", want: "pass"},
+		{in: "FAILURE", want: "fail"},
+		{in: "ERROR", want: "fail"},
+		{in: "PENDING", want: "pending"},
+		{in: "EXPECTED", want: "pending"},
+		{in: "", want: ""},
+	} {
+		if got := normalizeCIStatus(tc.in); got != tc.want {
+			t.Fatalf("normalizeCIStatus(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -46,6 +46,7 @@ type paneView struct {
 	TmuxTitle    string
 	IssueState   string
 	PRSummary    string
+	CIStatus     string
 	BranchName   string
 	WorktreePath string
 	Agent        string
@@ -251,7 +252,7 @@ func (m model) detailContent() string {
 	lines := []string{
 		fmt.Sprintf("%s #%d  %s", pane.Parent, pane.IssueNum, pane.Name),
 		fmt.Sprintf("pane=%s tmux=%s title=%s agent=%s", dash(pane.PaneID), pane.TmuxState, dash(pane.TmuxTitle), dash(pane.Agent)),
-		fmt.Sprintf("issue=%s pr=%s branch=%s", dash(pane.IssueState), dash(pane.PRSummary), dash(pane.BranchName)),
+		fmt.Sprintf("issue=%s pr=%s ci=%s branch=%s", dash(pane.IssueState), dash(pane.PRSummary), dash(pane.CIStatus), dash(pane.BranchName)),
 		fmt.Sprintf("worktree=%s", dash(pane.WorktreePath)),
 		fmt.Sprintf("created=%s", dash(pane.CreatedAt)),
 	}
@@ -333,6 +334,7 @@ func buildPaneViews(projectRoot string, panes []state.Pane, tmuxPanes []tmuxrun.
 			TmuxState:    tmuxState(pane.PaneID, tmuxByID, tmuxKnown),
 			IssueState:   "-",
 			PRSummary:    "-",
+			CIStatus:     "-",
 			BranchName:   pane.BranchName,
 			WorktreePath: relativePath(projectRoot, pane.WorktreePath),
 			Agent:        pane.Agent,
@@ -345,6 +347,7 @@ func buildPaneViews(projectRoot string, panes []state.Pane, tmuxPanes []tmuxrun.
 		if status, ok := issues[pane.IssueNum]; ok {
 			view.IssueState = dash(status.State)
 			view.PRSummary = summarizePRs(status.PRs)
+			view.CIStatus = summarizePRCI(status.PRs)
 		}
 		out = append(out, view)
 	}
@@ -364,6 +367,7 @@ func applyIssueStatuses(panes []paneView, issues map[int]issueStatus) []paneView
 		if status, ok := issues[out[i].IssueNum]; ok {
 			out[i].IssueState = dash(status.State)
 			out[i].PRSummary = summarizePRs(status.PRs)
+			out[i].CIStatus = summarizePRCI(status.PRs)
 		}
 	}
 	return out
@@ -376,22 +380,24 @@ func (p paneView) tableRow() table.Row {
 		truncate(p.Name, 28),
 		p.TmuxState,
 		dash(p.IssueState),
-		truncate(dash(p.PRSummary), 14),
-		truncate(dash(p.BranchName), 22),
+		truncate(dash(p.PRSummary), 12),
+		truncate(dash(p.CIStatus), 7),
+		truncate(dash(p.BranchName), 18),
 		dash(p.PaneID),
 	}
 }
 
 func columnsForWidth(width int) []table.Column {
-	nameWidth := clampInt(width/4, 14, 28)
-	branchWidth := clampInt(width/5, 10, 22)
+	nameWidth := clampInt(width/4, 14, 24)
+	branchWidth := clampInt(width/6, 10, 18)
 	return []table.Column{
 		{Title: "PARENT", Width: 10},
 		{Title: "ISSUE", Width: 7},
 		{Title: "NAME", Width: nameWidth},
 		{Title: "TMUX", Width: 8},
 		{Title: "STATE", Width: 8},
-		{Title: "PR", Width: 14},
+		{Title: "PR", Width: 12},
+		{Title: "CI", Width: 7},
 		{Title: "BRANCH", Width: branchWidth},
 		{Title: "PANE", Width: 8},
 	}
@@ -413,16 +419,31 @@ func issueNumbers(panes []state.Pane) []int {
 }
 
 func summarizePRs(prs []ghissue.PRRef) string {
-	if len(prs) == 0 {
+	pr, ok := selectedPR(prs)
+	if !ok {
 		return "-"
+	}
+	return "#" + strconv.Itoa(pr.Number) + " " + dash(pr.DisplayState())
+}
+
+func summarizePRCI(prs []ghissue.PRRef) string {
+	pr, ok := selectedPR(prs)
+	if !ok {
+		return "-"
+	}
+	return dash(pr.CIStatus)
+}
+
+func selectedPR(prs []ghissue.PRRef) (ghissue.PRRef, bool) {
+	if len(prs) == 0 {
+		return ghissue.PRRef{}, false
 	}
 	for _, pr := range prs {
 		if pr.State == "MERGED" {
-			return "#" + strconv.Itoa(pr.Number) + " MERGED"
+			return pr, true
 		}
 	}
-	pr := prs[0]
-	return "#" + strconv.Itoa(pr.Number) + " " + dash(pr.State)
+	return prs[0], true
 }
 
 func paneName(pane state.Pane) string {

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -38,7 +38,7 @@ func TestBuildPaneViewsMergesStateTmuxAndIssueStatuses(t *testing.T) {
 			State: "CLOSED",
 			PRs: []ghissue.PRRef{
 				{Number: 11, State: "OPEN"},
-				{Number: 12, State: "MERGED"},
+				{Number: 12, State: "MERGED", CIStatus: "pass"},
 			},
 		},
 	}
@@ -58,8 +58,8 @@ func TestBuildPaneViewsMergesStateTmuxAndIssueStatuses(t *testing.T) {
 	if second.TmuxState != "live" || second.TmuxTitle != "running title" {
 		t.Fatalf("tmux = %q/%q, want live/running title", second.TmuxState, second.TmuxTitle)
 	}
-	if second.IssueState != "CLOSED" || second.PRSummary != "#12 MERGED" {
-		t.Fatalf("issue/pr = %q/%q, want CLOSED/#12 MERGED", second.IssueState, second.PRSummary)
+	if second.IssueState != "CLOSED" || second.PRSummary != "#12 merged" || second.CIStatus != "pass" {
+		t.Fatalf("issue/pr/ci = %q/%q/%q, want CLOSED/#12 merged/pass", second.IssueState, second.PRSummary, second.CIStatus)
 	}
 	if second.WorktreePath != ".fanout/worktrees/second" {
 		t.Fatalf("WorktreePath = %q, want relative path", second.WorktreePath)

--- a/tests/bin/gh
+++ b/tests/bin/gh
@@ -62,7 +62,9 @@
 #         --jq .data.repository.issue server-side so the on-the-wire shape
 #         matches the fixture). With `-F after=<cursor>`, echoes
 #         $FIXTURE_DIR/gh-issue-view-<N>-after-<cursor>.json for
-#         closedByPullRequestsReferences pagination tests. The `num=`
+#         closedByPullRequestsReferences pagination tests. PR fixtures may
+#         include reviewDecision/isDraft plus the latest commit's nested
+#         commits.nodes[].commit.statusCheckRollup.state CI rollup. The `num=`
 #         dispatch takes precedence over the project-mode cursor branch
 #         when only `num=` is present without `after=`.
 #

--- a/tests/fixtures/scenario-status-mixed/gh-issue-view-201.json
+++ b/tests/fixtures/scenario-status-mixed/gh-issue-view-201.json
@@ -1,1 +1,1 @@
-{"state":"CLOSED","closedByPullRequestsReferences":{"nodes":[{"number":601,"state":"MERGED","mergedAt":"2026-05-03T12:00:00Z"}]}}
+{"state":"CLOSED","closedByPullRequestsReferences":{"nodes":[{"number":601,"state":"MERGED","mergedAt":"2026-05-03T12:00:00Z","reviewDecision":"APPROVED","commits":{"nodes":[{"commit":{"statusCheckRollup":{"state":"SUCCESS"}}}]}}]}}

--- a/tests/fixtures/scenario-status-mixed/gh-issue-view-202.json
+++ b/tests/fixtures/scenario-status-mixed/gh-issue-view-202.json
@@ -1,1 +1,1 @@
-{"state":"OPEN","closedByPullRequestsReferences":{"nodes":[{"number":602,"state":"OPEN","mergedAt":null}]}}
+{"state":"OPEN","closedByPullRequestsReferences":{"nodes":[{"number":602,"state":"OPEN","mergedAt":null,"reviewDecision":"CHANGES_REQUESTED","commits":{"nodes":[{"commit":{"statusCheckRollup":{"state":"FAILURE"}}}]}}]}}

--- a/tests/golden/scenario-status-mixed.status-table.txt
+++ b/tests/golden/scenario-status-mixed.status-table.txt
@@ -1,6 +1,6 @@
 fanout status #200: total=3 merged=1 pending=2 all_merged=false
-ISSUE  STATE   PR    PR_STATE  TYPE  FILES  DIFF                                 LINK
------  ------  ----  --------  ----  -----  -----------------------------------  ----
-#201   CLOSED  #601  MERGED    feat  5      +120 ++++++++++++  -8  -             https://github.com/butaosuinu/fanout-fixtures/pull/601
-#202   OPEN    #602  OPEN      fix   2      +12  ++            -40 ----          https://github.com/butaosuinu/fanout-fixtures/pull/602
-#203   OPEN    -     -         -     -      -                                    -
+ISSUE  STATE   PR    PR_STATE           CI    TYPE  FILES  DIFF                                 LINK
+-----  ------  ----  -----------------  ----  ----  -----  -----------------------------------  ----
+#201   CLOSED  #601  merged             pass  feat  5      +120 ++++++++++++  -8  -             https://github.com/butaosuinu/fanout-fixtures/pull/601
+#202   OPEN    #602  changes-requested  fail  fix   2      +12  ++            -40 ----          https://github.com/butaosuinu/fanout-fixtures/pull/602
+#203   OPEN    -     -                  -     -     -      -                                    -

--- a/tests/golden/scenario-status-mixed.status.txt
+++ b/tests/golden/scenario-status-mixed.status.txt
@@ -8,7 +8,9 @@
         {
           "number": 601,
           "state": "MERGED",
-          "mergedAt": "2026-05-03T12:00:00Z"
+          "mergedAt": "2026-05-03T12:00:00Z",
+          "reviewDecision": "APPROVED",
+          "ci": "pass"
         }
       ],
       "has_merged_pr": true
@@ -20,7 +22,9 @@
         {
           "number": 602,
           "state": "OPEN",
-          "mergedAt": null
+          "mergedAt": null,
+          "reviewDecision": "CHANGES_REQUESTED",
+          "ci": "fail"
         }
       ],
       "has_merged_pr": false


### PR DESCRIPTION
## TL;DR
Adds PR review/merge state and latest-commit CI rollup to `fanout --status`, table/dashboard output, and the persistent TUI. PRs without linked PR data continue to render as `-`.

Review effort: 3

## Why
Issue #109 asks each child row to show linked PR number, PR state, and CI state using `closedByPullRequestsReferences` plus the latest PR commit rollup, with PR-less children remaining stable.

```mermaid
flowchart LR
  A["internal/ghissue.IssueWithPRs"] --> B["ghissue.PRRef"]
  B --> C["cmd/fanout/status.go table/dashboard"]
  B --> D["internal/tui/tui.go console"]
```

## Changes by file

<details><summary>Changed files</summary>

| File | What changed | Why |
| --- | --- | --- |
| `internal/ghissue/ghissue.go` | Extends `PRRef`, maps display states including `review-required`, and reads nested `commits(last:1).nodes.commit.statusCheckRollup.state` at `internal/ghissue/ghissue.go:42`, `internal/ghissue/ghissue.go:221`, and `internal/ghissue/ghissue.go:225`. | Provide the shared PR review/CI schema requested by the issue. |
| `cmd/fanout/status.go` | Adds PR state and CI values to status table rows and dashboard rows at `cmd/fanout/status.go:255`, `cmd/fanout/status.go:274`, and `cmd/fanout/status.go:397`. | Make human status/dashboard rows show PR number, state, and CI. |
| `internal/tui/tui.go` | Adds a CI column/detail value and uses `PRRef.DisplayState()` in summaries at `internal/tui/tui.go:255`, `internal/tui/tui.go:400`, and `internal/tui/tui.go:426`. | Carry the same PR/CI state into the persistent console. |
| `internal/cliflags/usage.go` | Updates `--status`, `--format table`, and `--post-dashboard` help text at `internal/cliflags/usage.go:112`. | Keep CLI help aligned with the new columns. |
| `README.md` | Documents JSON PR metadata and normalized table states at `README.md:257` and `README.md:259`. | Update the user-facing status contract. |
| `README.ja.md` | Mirrors the English README updates in Japanese at `README.ja.md:249` and `README.ja.md:251`. | Keep Japanese docs current. |
| `codex/skills/fanout/SKILL.md` | Updates status table guidance at `codex/skills/fanout/SKILL.md:220`. | Keep repo Codex skill docs aligned. |
| `claude/skills/fanout/SKILL.md` | Updates status table guidance at `claude/skills/fanout/SKILL.md:157`. | Keep repo Claude skill docs aligned. |
| `internal/ghissue/ghissue_test.go` | Adds tests for PR display-state priority and CI normalization at `internal/ghissue/ghissue_test.go:5`. | Pin review and CI mapping behavior. |
| `cmd/fanout/status_test.go` | Updates dashboard body expectations with PR state and CI columns at `cmd/fanout/status_test.go:38`. | Cover dashboard Markdown output. |
| `internal/tui/tui_test.go` | Asserts TUI pane views carry merged PR state and CI at `internal/tui/tui_test.go:61`. | Cover console row data. |
| `tests/bin/gh` | Documents the nested statusCheckRollup fixture shape at `tests/bin/gh:66`. | Make fixture contract explicit. |
| `tests/fixtures/scenario-status-mixed/gh-issue-view-201.json` | Adds approved/pass PR metadata at `tests/fixtures/scenario-status-mixed/gh-issue-view-201.json:1`. | Exercise merged PR review/CI data. |
| `tests/fixtures/scenario-status-mixed/gh-issue-view-202.json` | Adds changes-requested/fail PR metadata at `tests/fixtures/scenario-status-mixed/gh-issue-view-202.json:1`. | Exercise non-merged PR review/CI data. |
| `tests/golden/scenario-status-mixed.status.txt` | Adds `reviewDecision` and `ci` to the status JSON golden at `tests/golden/scenario-status-mixed.status.txt:12`. | Pin the JSON schema extension. |
| `tests/golden/scenario-status-mixed.status-table.txt` | Adds PR state and CI columns to the table golden at `tests/golden/scenario-status-mixed.status-table.txt:2`. | Pin human-readable output. |

</details>

## Risk

> [!WARNING]
> `children[].prs` can now include `isDraft`, `reviewDecision`, and `ci` fields from the existing per-child GraphQL lookup. Consumers that validate exact PR object keys should allow these added fields.

## Test plan

- `go test ./...` - passed.
- `make test` - passed.
- `make lint` - passed.
- `codex review --uncommitted` - first run found the `REVIEW_REQUIRED` display gap; after fixing it, the final run reported no discrete correctness issues.

Closes #109