### PR TITLE
docs: reposition fanout as standalone TUI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,11 @@ the README before changing CLI behavior.
 `fanout` is a standalone git worktree + tmux pane + agent launcher. Build with
 `make build-go` (output `./fanout-go`) and validate with `make test`.
 
-- Run it: `make build-go`, then `./fanout-go <parent-issue> --agent claude`.
+- Open the TUI console: `make build-go`, then `./fanout-go`. From a plain
+  shell it creates or attaches the repository's fanout-managed tmux session;
+  from inside tmux it uses the current pane.
+- Batch-create child panes: `./fanout-go <parent-issue> --agent claude` from
+  inside tmux.
 - Validate logic without creating worktrees or panes by appending `--dry-run`,
   e.g. `./fanout-go <parent-issue> --agent claude --dry-run`.
 - Lint with `make lint` (go vet + gofmt + a shellcheck of the bats test shims).
@@ -42,14 +46,17 @@ the README before changing CLI behavior.
 ## Architecture Notes
 
 The package map: `cmd/fanout` is the command flow (`main.go` dispatch and
-`executePlan`, `pane.go` creation orchestration, `plan.go` filtering,
-`status.go`, `lifecycle.go`, `report.go`). `internal/` holds `agent`,
+`executePlan`, `tui.go` no-argument console launch, `pane.go` creation
+orchestration, `plan.go` filtering, `status.go`, `lifecycle.go`, `report.go`).
+`internal/` holds `agent`,
 `cliflags`, `ghissue`, `runtime`, `worktree`, `tmuxrun`, `state`, `naming`,
 `blockers`, `displayname`, `briefing`, plus `atomicfs`/`log`/`tty`/`exitcode`.
 
 - Runtime discovery (`internal/runtime`) resolves the git repo root with
-  `git rev-parse --show-toplevel`, requires the caller to be inside tmux, and
-  targets the invoking pane (`$TMUX_PANE`) unless `--session` is supplied.
+  `git rev-parse --show-toplevel`, requires the caller to be inside tmux for
+  batch pane creation, and targets the invoking pane (`$TMUX_PANE`) unless
+  `--session` is supplied. No-argument TUI mode can start from a plain shell by
+  creating or attaching a fanout-managed tmux session for the repository.
 - Pane creation is direct: `worktree.Prepare` creates
   `.fanout/worktrees/<slug>/`, `tmuxrun.SplitPaneWithAgentCommand` runs
   `tmux split-window -d -h -P -F '#{pane_id}'`, and
@@ -79,9 +86,10 @@ The package map: `cmd/fanout` is the command flow (`main.go` dispatch and
 
 ## Be Careful
 
-- fanout must run inside tmux for pane-creation mode. `--status` and lifecycle
-  commands do not require a live tmux pane unless they need to kill a recorded
-  pane during cleanup.
+- fanout must run inside tmux for batch pane-creation mode. No-argument TUI
+  mode may start from a plain shell. `--status` and lifecycle commands do not
+  require a live tmux pane unless they need to kill a recorded pane during
+  cleanup.
 - Worktree creation refreshes the base branch by default. If a checked-out base
   branch is dirty or diverged, `worktree.Prepare` should fail rather than
   clobbering local work.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,11 @@ notes.
 
 Build the binary with `make build-go` and validate with `make test`.
 
-- Run it: `make build-go`, then `./fanout-go <parent-issue> --agent claude`.
+- Open the console: `make build-go`, then `./fanout-go`. From a plain shell it
+  creates or attaches the repository's fanout-managed tmux session; from inside
+  tmux it uses the current pane.
+- Batch-create child panes: `./fanout-go <parent-issue> --agent claude` from
+  inside tmux.
 - Verify changes without creating worktrees or panes:
   `./fanout-go <parent-issue> --agent claude --dry-run`.
 - Settings (`--auto-pr` / `--no-auto-pr`, `--pr-review-gate` /
@@ -59,9 +63,12 @@ Build the binary with `make build-go` and validate with `make test`.
   dashboard, handles reuse-if-running, token generation, browser open, and
   registers the `prefix + D` tmux keybinding (`bindDashboardKey`, also called
   after a live `executePlan`).
+- `cmd/fanout/tui.go` implements the no-argument persistent TUI console. Plain
+  shells are relaunched into a deterministic fanout-managed tmux session;
+  invocations already inside tmux use the current pane.
 - `internal/runtime` resolves the git repository root and the tmux target.
-  Action mode must be invoked from inside tmux. By default fanout targets the
-  invoking pane; `--session` targets a named tmux session.
+  Batch pane-creation mode must be invoked from inside tmux. By default fanout
+  targets the invoking pane; `--session` targets a named tmux session.
 - `internal/worktree` owns base branch resolution, refresh, local exclude
   setup, and `git worktree add` under `.fanout/worktrees/<slug>/`.
 - `internal/tmuxrun` owns direct tmux operations:
@@ -105,7 +112,7 @@ Build the binary with `make build-go` and validate with `make test`.
 - `fanout dashboard --web` is the one HTTP surface, and it is deliberately
   carved out: a read-only, `127.0.0.1`-bound, GET-only, token-gated localhost
   server that only ever reads state/tmux/gh and never mutates repo or GitHub
-  state. The "no HTTP/sockets" guidance elsewhere is about the old dmux
+  state. The "no HTTP/sockets" guidance elsewhere is about the legacy
   notification path (outbound only); #137/#142 explicitly delegated the Web UI
   decision to dashboard #117, which this implements standalone (no TUI
   dependency — the future TUI just reuses `internal/sessionview`). Keep it
@@ -120,6 +127,8 @@ Build the binary with `make build-go` and validate with `make test`.
 
 - Worktree refresh must preserve user work. If a local base branch is dirty,
   ahead, or diverged, fail rather than forcing it.
+- Keep the public TUI entrypoint as no-argument `fanout`; do not reintroduce a
+  user-facing `fanout tui` compatibility path.
 - Keep the state lock close to live launch behavior. Moving exclude setup or
   lock acquisition can leave dirty `.fanout/state.json.lock` artifacts or
   reintroduce launch races.

--- a/README.ja.md
+++ b/README.ja.md
@@ -4,9 +4,12 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-GitHub の親 issue に紐づく OPEN のサブ issue を、子ごとに 1 つの tmux ペインへ
-ファンアウトします。各ペインは独立した git worktree を持ち、issue ごとの
-ブリーフィングファイルを参照するプロンプトでエージェント CLI が起動します。
+`fanout` は、並列 issue 作業のための standalone な tmux ベースのコンソール兼
+ランチャーです。引数なしの `fanout` で現在のリポジトリ用の常駐 TUI コンソールを
+開き、manual agent pane の作成、既存 child pane への focus、close / merge /
+cleanup を行えます。既存の `fanout <parent-issue|project-url>` レーンでは、
+既知の親 issue / Project を子ごとに 1 つの tmux ペインへファンアウトし、各ペインに
+独立した git worktree と issue ごとの briefing file を渡した agent CLI を起動します。
 
 ## 常駐 TUI コンソール
 
@@ -14,6 +17,15 @@ GitHub の親 issue に紐づく OPEN のサブ issue を、子ごとに 1 つ�
 現在のリポジトリ用の deterministic な fanout 管理 tmux session を作成または
 attach し、その session 内でコンソールを開始します。tmux 内から起動した場合は、
 現在の pane をそのままコンソール画面にします。
+
+典型的な単体運用フロー:
+
+1. 対象リポジトリで `fanout` を実行する。
+2. `n` で manual agent pane を作成する。親 issue / Project を既存フラグ付きで
+   まとめて展開したい場合は、tmux 内から `fanout <parent>` を使う。
+3. `Enter` / `o` で live pane に focus し、`c` で close、`m` で branch を
+   fast-forward merge、`x` で merged/closed sibling を cleanup する。
+4. `q` でコンソールを離脱する。tmux session と子 pane は残る。
 
 コンソールは `<git-root>/.fanout/state.json` を読み、記録済み pane ID が tmux 上に
 まだ存在するかを確認し、`fanout <parent> --status` と同じ GitHub CLI 経路で
@@ -38,14 +50,15 @@ panel の read-only 出力スナップショットを更新します。記録は
 `x` で同じ親の merged/closed 子を cleanup できます。各 lifecycle 操作は確認を挟み、
 対応する `--close` / `--merge` / `--cleanup` CLI コマンドと同じコア処理を使います。
 
-## 直接 tmux ランタイム
+## 既存フラグでの一括 fan-out
 
-fanout は dmux を経由せずに子セッションを作ります。`git rev-parse --show-toplevel`
-でリポジトリルートを解決し、選択された base branch を fresh 化し、
-`.fanout/worktrees/<slug>/` を作成し、起動元 tmux pane を `tmux split-window`
-で分割し、選択された agent CLI を 1 行 briefing prompt 付きで起動します。
-作成した pane は `.fanout/state.json` に `(parent, issueNum)` キーで記録するため、
-同じ親での再実行では記録済みの子を重複作成しません。
+親 issue や Project URL が分かっている場合は、`fanout <target>` が一括作成レーンです。
+`git rev-parse --show-toplevel` でリポジトリルートを解決し、選択された base branch
+を fresh 化し、`.fanout/worktrees/<slug>/` を作成し、起動元 tmux pane を
+`tmux split-window` で分割し、選択された agent CLI を 1 行 briefing prompt 付きで
+起動します。作成した pane は `.fanout/state.json` に `(parent, issueNum)` キーで
+記録するため、同じ親での再実行では記録済みの子を重複作成しません。この経路は
+tmux を直接使い、dmux は不要です。
 
 ## Project モード
 
@@ -196,12 +209,14 @@ Tier 3 (live tmux E2E) は手動運用のままです。
 - **Project モード時のみ**: Project items を取得する GraphQL クエリのため、
   `gh` CLI に `read:project` スコープが必要です。`gh auth refresh -s read:project`
   で付与してください。issue モード（`fanout <N>`）では不要です。
-- fanout は tmux セッション内から実行してください。子ペインは dmux 経由ではなく
-  `tmux split-window` で直接作成し、`--session` 未指定時は起動元 pane を target
-  にします。
-- TUI モード（引数なしの `fanout`）は素のシェルから起動できます。
-  現在のリポジトリ用の fanout 管理 tmux session を作成または attach してから
-  コンソールを開始します。tmux 内から起動した場合は現在の session / pane を使います。
+- 起動レーンを選んでください:
+  - TUI モード（引数なしの `fanout`）は素のシェルから起動できます。現在の
+    リポジトリ用の fanout 管理 tmux session を作成または attach してから
+    コンソールを開始します。tmux 内から起動した場合は現在の session / pane を
+    使います。
+  - 一括 pane 作成モード（`fanout <parent-issue|project-url> ...`）は tmux
+    セッション内から実行してください。子ペインは `tmux split-window` で直接作成し、
+    `--session` 未指定時は起動元 pane を target にします。
 - **エージェント名が解決できること**: `--agent claude` / `--agent codex` を渡すか、
   `FANOUT_AGENT` を設定してください。未知の agent はペイン作成前に失敗し、実行時
   には agent CLI がインストール済みかも確認します。
@@ -216,7 +231,7 @@ Tier 3 (live tmux E2E) は手動運用のままです。
 
 ```
 fanout # 常駐 tmux コンソールを起動
-fanout <parent-issue|project-url>
+fanout <parent-issue|project-url>  # 一括 pane 作成; tmux 内から実行
        [--agent <name>] [--limit <N>] [--only <list>] [--skip <list>]
        [--include <list>] [--unblocked-only] [--project-status <name>]
        [--name <NUM>=<slug>[|<display>[|<branch>]]]
@@ -564,9 +579,9 @@ Codex CLI 向けの推奨連携 — スキルはこのリポジトリの `codex/
   Claude 版と同じく、同一リポジトリ内の子 issue、GitHub Sub-issues のリンク、
   親本文のタスクリスト、`## Blocked by` 注記を揃えます。
 
-上記の CLI 前提条件はそのまま適用されます: tmux 内で実行すること、対象リポジトリの
-worktree から実行すること、agent 名を明示すること。詳しくは **前提条件** と
-**トラブルシューティング** を参照してください。
+上記の CLI 前提条件はそのまま適用されます: TUI は対象リポジトリの worktree から
+起動し、一括 pane 作成では tmux 内で実行し、agent 名を明示してください。詳しくは
+**前提条件** と **トラブルシューティング** を参照してください。
 
 ## fanout が実際にやること
 
@@ -609,8 +624,10 @@ worktree から実行すること、agent 名を明示すること。詳しく�
 
 ### "fanout must be run inside tmux"
 
-対象リポジトリの worktree で tmux セッションを開始または attach してから再実行して
-ください。
+これは一括 pane 作成モード（`fanout <parent-issue|project-url>`）だけの制約です。
+対象リポジトリの worktree で tmux セッションを開始または attach してから、一括作成
+コマンドを再実行してください。素のシェルから常駐コンソールを開く場合は、引数なしの
+`fanout` を実行します。
 
 ### "agent is required"
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,13 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-Fans a GitHub parent issue's OPEN sub-issues out into one tmux pane per child.
-Each pane gets its own git worktree and an agent CLI launched with a prompt
-that points at a per-issue briefing file.
+`fanout` is a standalone tmux-based console and launcher for parallel issue
+work. Run `fanout` with no arguments to open the persistent TUI console for the
+current repository; from there you can create manual agent panes, focus existing
+child panes, and run close / merge / cleanup actions. The existing
+`fanout <parent-issue|project-url>` lane still fans a known target out into one
+tmux pane per child, with each pane getting its own git worktree and an agent
+CLI launched from a per-issue briefing file.
 
 ## Persistent TUI console
 
@@ -14,6 +18,17 @@ Run `fanout` with no arguments to start the persistent console. From a plain
 shell it creates a deterministic fanout-managed tmux session for the current
 repository, starts the console in that session, and attaches to it. From inside
 tmux it turns the current pane into the console.
+
+Typical single-tool flow:
+
+1. Start in the target repository and run `fanout`.
+2. Press `n` to create a manual agent pane, or use `fanout <parent>` from tmux
+   when you want to seed a whole parent issue / Project batch with existing
+   flags.
+3. Use `Enter` / `o` to focus a live pane, `c` to close it, `m` to
+   fast-forward merge its branch, and `x` to clean up merged or closed siblings.
+4. Press `q` to leave the console while keeping the tmux session and child
+   panes alive.
 
 The console reads `<git-root>/.fanout/state.json`, checks whether recorded pane
 IDs still exist in tmux, and periodically refreshes issue / closed-by PR state
@@ -41,15 +56,17 @@ branch, or `x` to clean up merged/closed siblings for the same parent. Each
 lifecycle action asks for confirmation and uses the same core path as the
 corresponding `--close`, `--merge`, or `--cleanup` CLI command.
 
-## Direct tmux runtime
+## Existing flag-driven fan-out
 
-fanout now creates child sessions without dmux: it resolves the repository
-root with `git rev-parse --show-toplevel`, refreshes the selected base branch,
-creates `.fanout/worktrees/<slug>/`, splits the invoking tmux pane with
+When you already know the parent issue or Project URL, `fanout <target>` is the
+batch creation lane. It resolves the repository root with
+`git rev-parse --show-toplevel`, refreshes the selected base branch, creates
+`.fanout/worktrees/<slug>/`, splits the invoking tmux pane with
 `tmux split-window`, and starts the selected agent CLI with the one-line
 briefing prompt. It records launched panes in `.fanout/state.json`, keyed by
 `(parent, issueNum)`, so reruns of the same parent skip children that already
-have a recorded fanout pane.
+have a recorded fanout pane. This path uses tmux directly and does not require
+dmux.
 
 ## Project mode
 
@@ -201,13 +218,15 @@ intentionally change dry-run output. Tier 3 (live tmux E2E) stays manual.
   the GraphQL query that lists Project items can succeed. Add it with
   `gh auth refresh -s read:project`. Issue-mode (`fanout <N>`) does not
   need this scope.
-- fanout must be invoked from inside a tmux session. It creates child panes
-  directly with `tmux split-window`, targeting the invoking pane unless
-  `--session` is supplied.
-- TUI mode (`fanout` with no arguments) can be invoked from a plain shell. It
-  creates or attaches a fanout-managed tmux session for the current repository
-  before starting the console. When invoked from inside tmux, it uses the
-  current session and pane.
+- Choose the launch lane:
+  - TUI mode (`fanout` with no arguments) can be invoked from a plain shell. It
+    creates or attaches a fanout-managed tmux session for the current
+    repository before starting the console. When invoked from inside tmux, it
+    uses the current session and pane.
+  - Batch pane-creation mode (`fanout <parent-issue|project-url> ...`) must be
+    invoked from inside a tmux session. It creates child panes directly with
+    `tmux split-window`, targeting the invoking pane unless `--session` is
+    supplied.
 - **An agent name must be resolvable**: pass `--agent claude`, `--agent codex`,
   or set `FANOUT_AGENT`. Unknown agents fail before pane creation; in live
   mode, fanout also checks that the agent CLI is installed.
@@ -223,7 +242,7 @@ intentionally change dry-run output. Tier 3 (live tmux E2E) stays manual.
 
 ```
 fanout # start the persistent tmux console
-fanout <parent-issue|project-url>
+fanout <parent-issue|project-url>  # batch pane creation; run from inside tmux
        [--agent <name>] [--limit <N>] [--only <list>] [--skip <list>]
        [--include <list>] [--unblocked-only] [--project-status <name>]
        [--name <NUM>=<slug>[|<display>[|<branch>]]]
@@ -645,7 +664,8 @@ Recommended integration for Codex CLI — the skill is bundled under
   It mirrors the Claude issue-creation skill: same-repo children, GitHub
   Sub-issues links, parent task-list rows, and `## Blocked by` annotations.
 
-The CLI prerequisites above still apply: run from inside tmux, pass
+The CLI prerequisites above still apply: start the TUI from the target
+repository worktree, and for batch pane creation run from inside tmux, pass
 `--agent` or set `FANOUT_AGENT`, and run from the repository whose children
 should branch from the selected base.
 
@@ -698,7 +718,10 @@ should branch from the selected base.
 
 ### "fanout must be run inside tmux"
 
-Start or attach a tmux session in the repository worktree, then rerun fanout.
+This only applies to batch pane-creation mode (`fanout <parent-issue|project-url>`).
+Start or attach a tmux session in the repository worktree, then rerun the batch
+command. To open the persistent console from a plain shell, run `fanout` with no
+arguments instead.
 
 ### "agent is required"
 

--- a/claude/commands/fanout.md
+++ b/claude/commands/fanout.md
@@ -1,9 +1,12 @@
 ---
-description: Fan out a parent GitHub issue's OPEN sub-issues — or a GitHub Projects v2 board's OPEN items — into parallel tmux panes with git worktrees via the fanout CLI.
-argument-hint: "[parent-issue | project-url] [--go] [extra fanout flags]"
+description: Start the fanout TUI console, or fan out a parent GitHub issue's OPEN sub-issues / GitHub Projects v2 board items into parallel tmux panes via the fanout CLI.
+argument-hint: "[parent-issue | project-url | dashboard] [--go] [extra fanout flags]"
 ---
 
-Invoke the `fanout` CLI to spawn one tmux pane per OPEN sub-issue of a parent GitHub issue, or per OPEN item of a GitHub Projects v2 board. See the `fanout` skill (`~/.claude/skills/fanout/SKILL.md`) for context on when and why to use this.
+Invoke the `fanout` CLI to start the persistent TUI console, or to spawn one
+tmux pane per OPEN sub-issue of a parent GitHub issue / OPEN item of a GitHub
+Projects v2 board. See the `fanout` skill
+(`~/.claude/skills/fanout/SKILL.md`) for context on when and why to use this.
 
 Arguments: `$ARGUMENTS`
 
@@ -11,15 +14,28 @@ If the user is only asking to check or update the `fanout` binary itself, stop
 this pane-creation workflow. Use `fanout --check-update` for read-only version
 checks, or `fanout update` for immediate replacement via install.sh.
 
-If the user is explicitly asking to start the persistent fanout TUI / console,
-stop this pane-creation workflow and run `fanout` with no arguments from the
-target repository worktree. TUI mode does not need a parent issue, Project URL,
-`--agent`, dry-run, generated pane names, or confirmation; after it opens the
-user can press `n` to create a manual prompt-based agent pane from the console.
+If `$ARGUMENTS` is empty, or the user is explicitly asking to start the
+persistent fanout TUI / console, stop this pane-creation workflow and run
+`fanout` with no arguments from the target repository worktree. TUI mode does
+not need a parent issue, Project URL, `--agent`, dry-run, generated pane names,
+or confirmation; after it opens the user can press `n` to create a manual
+prompt-based agent pane from the console.
 
 ## Steps
 
-0. **Dashboard subcommand short-circuit (before any target resolution).** For detection only, look at `$ARGUMENTS` with the wrapper-only flags `--go`/`--wait` ignored — but do NOT mutate `$ARGUMENTS` itself; Steps 2/3 still need to see `--go`/`--wait` for non-dashboard calls. If, ignoring those wrapper flags, the first token is `dashboard` (`/fanout dashboard ...`, `/fanout --go dashboard`, etc.): do NOT resolve a parent target, add an agent, or run the dry-run/name-generation path. Forward the dashboard arguments with `--go`/`--wait` stripped (e.g. `fanout dashboard --web --open`) — the `dashboard` parser rejects unknown flags like `--go`/`--wait` — and stop here; it starts the standalone read-only localhost web dashboard, which takes no parent argument. Otherwise, leave `$ARGUMENTS` untouched and continue to Step 1.
+0. **TUI / dashboard short-circuit (before any target resolution).** If
+   `$ARGUMENTS` is empty, run `fanout` with no arguments from the target
+   repository worktree and stop. For dashboard detection only, look at
+   `$ARGUMENTS` with the wrapper-only flags `--go`/`--wait` ignored — but do NOT
+   mutate `$ARGUMENTS` itself; Steps 2/3 still need to see `--go`/`--wait` for
+   non-dashboard calls. If, ignoring those wrapper flags, the first token is
+   `dashboard` (`/fanout dashboard ...`, `/fanout --go dashboard`, etc.): do
+   NOT resolve a parent target, add an agent, or run the dry-run/name-generation
+   path. Forward the dashboard arguments with `--go`/`--wait` stripped (e.g.
+   `fanout dashboard --web --open`) — the `dashboard` parser rejects unknown
+   flags like `--go`/`--wait` — and stop here; it starts the standalone
+   read-only localhost web dashboard, which takes no parent argument. Otherwise,
+   leave `$ARGUMENTS` untouched and continue to Step 1.
 
 1. **Resolve the parent target** from `$ARGUMENTS`. Two input shapes are accepted; the first matching token wins:
    - **Issue mode** — first token matching `^#?\d+$` → that integer is `N`. **Strip the leading `#` if present** before invoking `fanout`; the CLI only accepts bare digits in issue mode and rejects `#42`.
@@ -50,7 +66,9 @@ user can press `n` to create a manual prompt-based agent pane from the console.
    - Relay the `created / skipped / deferred / failed` summary.
    - If `--wait` was passed, the run exited 0, the target is an issue number, and this was not `--dry-run` or a lifecycle/read-only command, enter the wait-and-continue loop documented in `~/.claude/skills/fanout/SKILL.md`: use `ScheduleWakeup` with `prompt: "<<autonomous-loop-dynamic>>"` and poll `fanout --status <N>` until `summary.all_merged == true`, then refresh and merge the same base branch used for the fanout run before resuming parent-scope integration. Use the forwarded `--base-branch` when present; otherwise resolve fanout's default branch (`gh repo view defaultBranchRef`, then `origin/HEAD`, then `main`). Fetch the normalized remote branch and run `git merge --ff-only origin/<branch>` (or the equivalent `refs/remotes/origin/<branch>`). If the user intervenes, drop the loop.
 10. **On failure**: consult `/Users/butaosuinu/fanout/README.md` Troubleshooting and surface the most likely fix. Common cases:
-   - `fanout must be run inside tmux` → start or attach a tmux session first.
+   - `fanout must be run inside tmux` → batch pane creation needs a tmux
+     session; start or attach one first, or open the persistent console with
+     no-argument `fanout` from a plain shell.
    - `agent is required` → rerun with `--agent claude`, `--agent codex`, or set `FANOUT_AGENT`.
    - `unknown agent` / `agent ... is not installed` → choose or install a supported agent CLI.
    - `prepare worktree` → inspect the git error; use `--no-refresh` only when skipping base refresh is intentional.
@@ -58,7 +76,10 @@ user can press `n` to create a manual prompt-based agent pane from the console.
 
 ## Notes
 
-- `fanout` targets the invoking pane by default and uses detached splits, so it does not move focus away from the caller's pane; the agent keeps working on the parent issue in the current session. `--session` intentionally targets a named session instead.
+- Batch pane creation targets the invoking pane by default and uses detached
+  splits, so it does not move focus away from the caller's pane; the agent keeps
+  working on the parent issue in the current session. `--session` intentionally
+  targets a named session instead.
 - The command always invokes the stable `fanout` command name (the Go binary installed at `$(BINDIR)/fanout`).
 - Rerun is safe for recorded panes; action mode skips children already present in `.fanout/state.json` for the same `(parent, issueNum)`, and also skips unrecorded existing `.fanout/worktrees/<slug>` directories as a migration fallback. If the same issue is recorded for another parent, only an existing worktree matching the slug this current run would create is treated as fallback. `fanout --status` reads the same state store.
 - If the same child issue is already recorded for another parent or Project, fanout parent-qualifies the default slug/branch so the new run gets a separate worktree.
@@ -88,4 +109,4 @@ user can press `n` to create a manual prompt-based agent pane from the console.
 - `/fanout https://github.com/users/butaosuinu/projects/3/views/1` — canonical board-URL form (works the same as the bare project URL; `/views/N` is preserved verbatim and the CLI ignores it).
 - `/fanout https://github.com/users/butaosuinu/projects/3 --project-status all` — project mode, disable the Status filter, fan out every OPEN item.
 - `/fanout https://github.com/orgs/acme/projects/12 --project-status "In Progress" --limit 5` — organization Project, In Progress column, first 5 items only.
-- `/fanout` (no args in a session that started with "work on #456" or `https://github.com/.../projects/3`) — extract the issue ref or Project URL from context and proceed.
+- `/fanout` — start the persistent fanout TUI console for the current repository.

--- a/claude/skills/fanout/SKILL.md
+++ b/claude/skills/fanout/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fanout
-description: Spawn one tmux pane per OPEN sub-issue of a GitHub parent issue, or per OPEN item of a GitHub Projects v2 board (Project URL), via the fanout CLI. Use when the user is working in tmux and wants to parallelize a parent issue's children or a Project's Todo column across independent git worktrees/agent sessions.
+description: Start the fanout persistent TUI console, or spawn one tmux pane per OPEN sub-issue of a GitHub parent issue / GitHub Projects v2 board item via the fanout CLI. Use when the user wants fanout to manage parallel child work from its TUI console, or explicitly asks to fan out, parallelize, or split issue / Project work across independent git worktrees and agent sessions.
 ---
 
 # fanout
@@ -47,8 +47,9 @@ The CLI lives at `/Users/butaosuinu/.local/bin/fanout`; source and docs are in `
 
 Good fits:
 
-- The user is in tmux on a parent issue that has OPEN sub-issues, and asks (explicitly or implicitly) to parallelize the children.
-- The user is in tmux and asks to fan out the OPEN issues of a GitHub Projects v2 board (often phrased as "Todo 列を並列展開" / "fan out my project board"), supplying the Project URL.
+- The user asks to start, open, or return to the fanout console / TUI for the current repository.
+- The user asks (explicitly or implicitly) to parallelize a parent issue that has OPEN sub-issues.
+- The user asks to fan out the OPEN issues of a GitHub Projects v2 board (often phrased as "Todo 列を並列展開" / "fan out my project board"), supplying the Project URL.
 - The user asks whether the installed `fanout` binary is up to date; in that case use `fanout --check-update`, not the pane-creation workflow.
 - The user asks to update fanout itself; in that case run `fanout update` immediately.
 - The user asks to start the fanout console / TUI; in that case run `fanout` with no arguments directly from the target repository worktree, skipping parent resolution, dry-run, pane naming, and agent selection.
@@ -61,7 +62,7 @@ Do not invoke unprompted just because an issue has sub-issues. Pane creation is 
 Before running the real command:
 
 1. **Prerequisites** — `gh`, `jq`, `git`, `tmux`, and the `gh-sub-issue` extension must be installed. `fanout` validates these on startup and fails with install hints, so you can rely on its error output rather than re-checking.
-2. **Resolve the parent target** — first use any issue ref (`#N` or `N`) or Projects v2 URL in the user's request / recent context. If neither is clear, actively list candidates from the current repo/worktree instead of asking for a pasted number/URL:
+2. **Resolve the parent target for batch pane creation** — if the user's intent is the TUI console, skip target resolution and run `fanout` with no arguments. Otherwise, first use any issue ref (`#N` or `N`) or Projects v2 URL in the user's request / recent context. If neither is clear, actively list candidates from the current repo/worktree instead of asking for a pasted number/URL:
    1. Run `gh issue list --state open --json number,title --limit 100`.
    2. Get the repo owner login with `gh repo view --json owner -q .owner.login`.
    3. Run Project listing commands with `--limit 100`: `gh project list --format json --limit 100` for the current user's Projects, and `gh project list --owner <repo-owner> --format json --limit 100` for the repo owner's Projects. Run the repo-owner command even when the owner is a user, not only for orgs. Dedupe Projects by URL if the two lists overlap.
@@ -71,7 +72,7 @@ Before running the real command:
    7. Resolve the selection to the CLI positional arg: issues become bare digits with any leading `#` removed; Projects become the Project URL from `gh project list`.
 
    This is skill-side target resolution for non-TTY agent entrypoints. Do not change the Go `fanout` CLI for it; the CLI already accepts the resolved positional arg via `internal/cliflags.Parse()`.
-3. **Live tmux session** — pane-creation mode must be invoked from inside tmux. By default it targets the invoking pane, not the session's currently active pane; `--session` intentionally targets a named session instead. If it reports `fanout must be run inside tmux`, tell the user to start or attach a tmux session first. TUI mode can start from a plain shell because it creates or attaches its own tmux session.
+3. **Choose the launch lane** — TUI mode is `fanout` with no arguments; it can start from a plain shell because it creates or attaches the repository's fanout-managed tmux session, and from inside tmux it uses the current pane. Batch pane-creation mode is `fanout <parent-issue|project-url>`; it must be invoked from inside tmux. By default it targets the invoking pane, not the session's currently active pane; `--session` intentionally targets a named session instead. If batch mode reports `fanout must be run inside tmux`, tell the user to start or attach a tmux session first.
 4. **Agent name is required for pane creation** — pass `--agent claude` / `--agent codex`, or set `FANOUT_AGENT`. When this skill runs fanout and the user did not provide an agent, add `--agent codex` if the forwarded flags include `--codex-plan-mode`; otherwise add `--agent claude`. `--codex-plan-mode` is valid only with `--agent codex`; it uses Codex app-server to create the child Plan Mode thread, start the initial Plan turn with the fanout prompt, then attach the interactive Codex TUI to that remote session.
 5. **Body scan for implicit children** — **Issue mode only — skip this step entirely when the positional argument is a Project URL.** Project items are the source-of-truth in project mode; the Project has no parent body, and Project descriptions often reference epic / context issues that are *not* intended as children — running this scan there would push noise into `--include`. In issue mode, `fanout` itself only treats two things as children: issues returned by the Sub-issues API, and parent-body rows that match `^\s*-\s+\[[ xX]\] ... #N`. Parent issues in the wild often *describe* their children via prose instead, and those references must be surfaced to the user and forwarded as `--include`.
    1. Run `gh issue view <parent> --json body -q .body` to fetch the body.
@@ -102,7 +103,7 @@ Before running the real command:
    5. If the user runs `/fanout` with explicit `--name` flags of their own, respect those and don't override — merge so skill-generated names fill the gaps.
 8. **Dry-run** — run `fanout <N-or-URL> --dry-run <forwarded-flags>` (including any `--include` from step 5 and `--name` from step 7) and show the user: the mode banner (issue / project) the CLI prints, how many children, their titles, the briefing paths, generated names, worktree paths, and warnings. In project mode also surface any "cross-repo item skipped" warnings — those items are intentionally excluded from fan-out. This is the confirmation step for the targets themselves (not the names).
 
-Run fanout from the target repository worktree inside tmux so `git rev-parse --show-toplevel` resolves the intended project root.
+Run fanout from the target repository worktree so `git rev-parse --show-toplevel` resolves the intended project root. For batch pane creation, run it from inside tmux; for the no-argument TUI, a plain shell is fine.
 
 ## Running
 
@@ -121,7 +122,8 @@ Run fanout from the target repository worktree inside tmux so `git rev-parse --s
   `2` bad invocation or incomparable version, `3` latest-release lookup failed.
 - **Persistent TUI**: if the user's intent is to start the fanout console, run
   `fanout` with no arguments from the target repository worktree and skip
-  parent resolution, tmux pre-flight, dry-run, pane naming, and confirmation.
+  parent resolution, batch tmux pre-flight, dry-run, pane naming, and
+  confirmation.
   TUI mode does not need a parent issue, Project URL, or `--agent`.
 - **Default**: `fanout <N-or-URL> --agent claude --dry-run` → summarize → ask user to confirm → `fanout <N-or-URL> --agent claude`.
 - **Bypass**: if the user's invocation carries `--go`, skip the confirmation and run directly.
@@ -191,7 +193,7 @@ rollup comment; it writes to GitHub even though it is attached to `--status`.
 
 When `fanout` exits non-zero, point the user at `/Users/butaosuinu/fanout/README.md` Troubleshooting. Common cases:
 
-- `fanout must be run inside tmux` — start or attach a tmux session and rerun.
+- `fanout must be run inside tmux` — batch pane creation needs a tmux session; start or attach one and rerun, or start the persistent console with no-argument `fanout` from a plain shell.
 - `agent is required` — pass `--agent claude`, `--agent codex`, or set `FANOUT_AGENT`.
 - `unknown agent` — use one of the supported MVP agents (`claude`, `codex`).
 - `agent "<name>" is not installed` — install that CLI or choose another agent.

--- a/codex/skills/fanout/SKILL.md
+++ b/codex/skills/fanout/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: fanout
-description: Use the fanout CLI from Codex CLI to spawn one tmux pane per OPEN sub-issue of a GitHub parent issue, or per OPEN item of a GitHub Projects v2 board (Project URL). Use when the user is working in tmux and asks to fan out, parallelize, or split child issues / project items across independent git worktrees/agent sessions.
+description: Use the fanout CLI from Codex CLI to start the persistent TUI console, or spawn one tmux pane per OPEN sub-issue of a GitHub parent issue / GitHub Projects v2 board item. Use when the user wants fanout to manage parallel child work from its TUI console, or asks to fan out, parallelize, or split child issues / project items across independent git worktrees and agent sessions.
 metadata:
-  short-description: Fan out GitHub sub-issues or Projects v2 items into tmux panes
+  short-description: Open the fanout TUI or fan out GitHub child work
 ---
 
 # fanout
@@ -74,9 +74,10 @@ Always invoke the stable `fanout` command name.
 
 ## When To Use
 
-Use this skill when the user explicitly asks to fan out, parallelize, or split
-work for a GitHub parent issue or a GitHub Projects v2 board, including
-Japanese phrasing like `並列展開` or "プロジェクトの Todo 列を一気に着手".
+Use this skill when the user asks to start the fanout console / TUI, or when
+the user explicitly asks to fan out, parallelize, or split work for a GitHub
+parent issue or a GitHub Projects v2 board, including Japanese phrasing like
+`並列展開` or "プロジェクトの Todo 列を一気に着手".
 Also use it when the user asks whether the installed `fanout` binary is up to
 date; that path uses `fanout --check-update` instead of pane creation. If the
 user asks to update fanout itself, run `fanout update` immediately.
@@ -94,9 +95,12 @@ use this workflow directly.
 
 1. Prerequisites are `gh`, `jq`, `git`, `tmux`, and the `gh-sub-issue`
    extension. The CLI validates these on startup, so rely on its error output.
-2. Pane-creation mode must run inside tmux. If it reports `fanout must be run
-   inside tmux`, tell the user to start or attach a tmux session first. TUI mode
-   can be started from a plain shell; it creates or attaches its tmux session.
+2. Choose the launch lane. TUI mode is `fanout` with no arguments; it can start
+   from a plain shell because it creates or attaches the repository's
+   fanout-managed tmux session, and from inside tmux it uses the current pane.
+   Batch pane-creation mode is `fanout <parent-issue|project-url>` and must run
+   inside tmux. If batch mode reports `fanout must be run inside tmux`, tell
+   the user to start or attach a tmux session first.
 3. An agent name is required for pane creation. Pass `--agent <name>` or set
    `FANOUT_AGENT`. MVP supported agents are `claude` and `codex`.
 4. `--codex-plan-mode` is valid only with `--agent codex`. It uses Codex
@@ -108,8 +112,8 @@ use this workflow directly.
 
 If the user's intent is only to check the installed `fanout` binary version, run
 `fanout --check-update` and skip the rest of this workflow. It is read-only,
-creates no panes, and does not require dmux pre-flight, parent resolution,
-dry-run, pane naming, or confirmation.
+creates no panes, and does not require pane-creation pre-flight, parent
+resolution, dry-run, pane naming, or confirmation.
 
 If the user's intent is to update the `fanout` binary itself, run
 `fanout update` immediately. It downloads and runs the repository `install.sh`,
@@ -386,7 +390,9 @@ number, respect it and fill only missing segments.
 When fanout exits non-zero, use the README troubleshooting section and surface
 the likely next action:
 
-- `fanout must be run inside tmux`: start or attach a tmux session and rerun.
+- `fanout must be run inside tmux`: batch pane creation needs a tmux session;
+  start or attach one and rerun, or start the persistent console with
+  no-argument `fanout` from a plain shell.
 - `agent is required`: pass `--agent claude`, `--agent codex`, or set
   `FANOUT_AGENT`.
 - `unknown agent`: use one of the supported MVP agents (`claude`, `codex`).


### PR DESCRIPTION
## TL;DR
Reposition fanout docs and bundled integrations around the no-argument persistent TUI console as the primary entrypoint, with batch pane creation documented as the tmux-only flag-driven lane.

Review effort: 2

## Why
Issue #141 asks to remove remaining dmux-as-host assumptions from README / CLAUDE.md / AGENTS.md / bundled skills / slash command guidance, and to document how users can run fanout by itself for launch, parallel management, focus, close, merge, and cleanup. The intent is to make tmux the runtime prerequisite while making dmux unnecessary.

## Changes by file
<details><summary>Changed files</summary>

| File | What changed | Why |
|---|---|---|
| README.md | Reframed fanout as a standalone TUI console plus batch creation lane; added the single-tool TUI flow, launch-lane prerequisites, usage comment, and tmux troubleshooting split. | Establish the no-argument `fanout` workflow as the default user path while keeping `fanout <target>` clearly scoped to batch pane creation. |
| README.ja.md | Mirrored the English README repositioning in Japanese, including TUI flow, prerequisite split, usage comment, and troubleshooting. | Keep the Japanese user-facing surface aligned with the new standalone fanout positioning. |
| CLAUDE.md | Added no-argument console guidance, documented `cmd/fanout/tui.go`, narrowed runtime wording to batch creation, and called out no user-facing `fanout tui` path. | Keep repo-maintainer guidance consistent with the current public TUI entrypoint. |
| AGENTS.md | Added Codex-facing no-argument TUI guidance and clarified tmux requirements apply to batch pane creation. | Keep agent instructions aligned with the fanout-managed TUI session model. |
| claude/commands/fanout.md | Updated slash command metadata and flow so empty `/fanout` starts the TUI, while parent / Project args still use dry-run and batch creation. | Remove the old no-arg context-resolution behavior and match the no-argument CLI contract. |
| claude/skills/fanout/SKILL.md | Updated trigger/pre-flight wording to start from fanout TUI intent and separate TUI from batch pane creation. | Remove tmux-pane trigger assumptions from the Claude skill. |
| codex/skills/fanout/SKILL.md | Updated description, short description, pre-flight, workflow, and failure mapping around TUI-first usage. | Remove tmux-pane trigger assumptions from the Codex skill. |

</details>

## Risk
The slash-command guidance now treats empty `/fanout` as a console launch instead of inferring a parent issue from surrounding context; users must pass an issue or Project URL when they want batch pane creation from the slash command. Runtime code is unchanged.

## Test plan
- `make lint` — passed
- `make test` — passed
- `codex review --uncommitted` — passed with no introduced issues

Closes #141