### PR TITLE
refactor(go): go fix ./... による一括 modernize (maxInt→max, sort→slices 等)

### DIFF
--- a/cmd/fanout/main.go
+++ b/cmd/fanout/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -457,12 +458,7 @@ func existingWorktreeNames(root string) []string {
 }
 
 func worktreeNameMatchesExact(names []string, slug string) bool {
-	for _, name := range names {
-		if name == slug {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(names, slug)
 }
 
 func worktreeNameMatchesIssue(names []string, exactSlug string, issueNum int) bool {
@@ -536,7 +532,7 @@ func ghSubIssueAvailable() bool {
 	if err != nil {
 		return false
 	}
-	for _, line := range strings.Split(string(out), "\n") {
+	for line := range strings.SplitSeq(string(out), "\n") {
 		if first, _, ok := strings.Cut(line, "\t"); ok && first == "gh sub-issue" {
 			return true
 		}

--- a/cmd/fanout/pane.go
+++ b/cmd/fanout/pane.go
@@ -336,10 +336,7 @@ func manualPaneSlug(title string, number int) string {
 	}
 	prefix := fmt.Sprintf("manual-%d-", number)
 	suffix := "-pane"
-	maxBase := naming.MaxSlugLength - len(prefix) - len(suffix)
-	if maxBase < 1 {
-		maxBase = 1
-	}
+	maxBase := max(naming.MaxSlugLength-len(prefix)-len(suffix), 1)
 	if len(base) > maxBase {
 		base = strings.Trim(base[:maxBase], "-")
 		if base == "" {

--- a/cmd/fanout/pane_test.go
+++ b/cmd/fanout/pane_test.go
@@ -173,7 +173,7 @@ func TestNewPaneRequestCarriesIssueWave(t *testing.T) {
 }
 
 func TestNewPaneRequestCodexPlanModeUsesPlanPromptAndBriefing(t *testing.T) {
-	cfg := &cliflags.Config{ParentRef: "200", Agent: "codex", CodexPlanMode: boolPtr(true)}
+	cfg := &cliflags.Config{ParentRef: "200", Agent: "codex", CodexPlanMode: new(true)}
 	issue := ghissue.Issue{Number: 501, Title: "Plan child", Body: "body"}
 
 	got := newPaneRequest(cfg, "/repo", issue, settings.Defaults(), false)
@@ -195,7 +195,7 @@ func TestNewPaneRequestCodexPlanModeUsesPlanPromptAndBriefing(t *testing.T) {
 }
 
 func TestBuildAgentCommandStartsCodexPlanTUIControllerInPlanModeDryRun(t *testing.T) {
-	cfg := &cliflags.Config{Agent: "codex", DryRun: true, CodexPlanMode: boolPtr(true)}
+	cfg := &cliflags.Config{Agent: "codex", DryRun: true, CodexPlanMode: new(true)}
 	req := paneRequest{
 		Number:              1,
 		Prompt:              "[fanout #1] plan",

--- a/cmd/fanout/report.go
+++ b/cmd/fanout/report.go
@@ -2,7 +2,8 @@ package main
 
 import (
 	"fmt"
-	"sort"
+	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/butaosuinu/fanout/internal/cliflags"
@@ -32,7 +33,7 @@ func logAlreadyFanned(skipped []int, lg *log.Logger) {
 	if len(skipped) == 0 {
 		return
 	}
-	sort.Ints(skipped)
+	slices.Sort(skipped)
 	parts := make([]string, len(skipped))
 	for i, num := range skipped {
 		parts[i] = fmt.Sprintf("#%d", num)
@@ -114,7 +115,7 @@ func printSummary(plan Plan, result executionResult, cfg *cliflags.Config, lg *l
 func issueCSV(issues []ghissue.Issue) string {
 	nums := make([]string, len(issues))
 	for i, issue := range issues {
-		nums[i] = fmt.Sprintf("%d", issue.Number)
+		nums[i] = strconv.Itoa(issue.Number)
 	}
 	return strings.Join(nums, ",")
 }

--- a/cmd/fanout/report_test.go
+++ b/cmd/fanout/report_test.go
@@ -42,11 +42,11 @@ func TestPrintSummaryPreservesSettingsFlagsInLimitRerunHint(t *testing.T) {
 	cfg := &cliflags.Config{
 		ParentRef:          "700",
 		Agent:              "claude",
-		AutoPullRequest:    boolPtr(false),
-		PRReviewGate:       boolPtr(true),
-		BriefingCodeReview: boolPtr(false),
-		AgentTeamsHint:     boolPtr(false),
-		PRVisualization:    boolPtr(true),
+		AutoPullRequest:    new(false),
+		PRReviewGate:       new(true),
+		BriefingCodeReview: new(false),
+		AgentTeamsHint:     new(false),
+		PRVisualization:    new(true),
 	}
 
 	printSummary(plan, executionResult{}, cfg, lg, log.Palette{}, "fanout-go")
@@ -67,7 +67,7 @@ func TestPrintSummaryPreservesCodexPlanModeInLimitRerunHint(t *testing.T) {
 	cfg := &cliflags.Config{
 		ParentRef:     "700",
 		Agent:         "codex",
-		CodexPlanMode: boolPtr(true),
+		CodexPlanMode: new(true),
 	}
 
 	printSummary(plan, executionResult{}, cfg, lg, log.Palette{}, "fanout-go")
@@ -180,8 +180,4 @@ func TestShellQuoteIsCopyPasteSafe(t *testing.T) {
 			}
 		})
 	}
-}
-
-func boolPtr(v bool) *bool {
-	return &v
 }

--- a/cmd/fanout/status.go
+++ b/cmd/fanout/status.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -439,13 +439,13 @@ func writeStatusTable(report statusReport, projectRoot string, lg *log.Logger) e
 		len("LINK"),
 	}
 	for _, row := range rows {
-		widths[0] = maxInt(widths[0], len(row.Issue))
-		widths[1] = maxInt(widths[1], len(row.IssueState))
-		widths[2] = maxInt(widths[2], len(row.PR))
-		widths[3] = maxInt(widths[3], len(row.PRState))
-		widths[4] = maxInt(widths[4], len(row.CI))
-		widths[5] = maxInt(widths[5], len(row.Type))
-		widths[6] = maxInt(widths[6], len(row.Files))
+		widths[0] = max(widths[0], len(row.Issue))
+		widths[1] = max(widths[1], len(row.IssueState))
+		widths[2] = max(widths[2], len(row.PR))
+		widths[3] = max(widths[3], len(row.PRState))
+		widths[4] = max(widths[4], len(row.CI))
+		widths[5] = max(widths[5], len(row.Type))
+		widths[6] = max(widths[6], len(row.Files))
 	}
 
 	headers := []string{"ISSUE", "STATE", "PR", "PR_STATE", "CI", "TYPE", "FILES", "DIFF", "LINK"}
@@ -517,10 +517,10 @@ func statusTableRows(report statusReport, projectRoot string, lg *log.Logger) ([
 				lg.Err("--status: gh pr view #%d failed: %v", pr.Number, err)
 				return nil, 0, 0, 0, exitcode.GitHub
 			}
-			addWidth = maxInt(addWidth, len(fmt.Sprintf("+%d", stat.Additions)))
-			delWidth = maxInt(delWidth, len(fmt.Sprintf("-%d", stat.Deletions)))
-			maxLines = maxInt(maxLines, stat.Additions)
-			maxLines = maxInt(maxLines, stat.Deletions)
+			addWidth = max(addWidth, len(fmt.Sprintf("+%d", stat.Additions)))
+			delWidth = max(delWidth, len(fmt.Sprintf("-%d", stat.Deletions)))
+			maxLines = max(maxLines, stat.Additions)
+			maxLines = max(maxLines, stat.Deletions)
 			rows = append(rows, statusTableRow{
 				Issue:      "#" + strconv.Itoa(child.Num),
 				IssueState: dashIfEmpty(child.State),
@@ -580,7 +580,7 @@ func scaledStatusBar(value, maxValue int) int {
 }
 
 func colorPad(color, reset, s string, width int) string {
-	return colorWrap(color, reset, s) + strings.Repeat(" ", maxInt(0, width-len(s)))
+	return colorWrap(color, reset, s) + strings.Repeat(" ", max(0, width-len(s)))
 }
 
 func colorWrap(color, reset, s string) string {
@@ -606,7 +606,7 @@ func statusTableLine(cols []string, widths []int) string {
 }
 
 func padRight(s string, width int) string {
-	return s + strings.Repeat(" ", maxInt(0, width-len(s)))
+	return s + strings.Repeat(" ", max(0, width-len(s)))
 }
 
 func dashIfEmpty(s string) string {
@@ -616,18 +616,11 @@ func dashIfEmpty(s string) string {
 	return s
 }
 
-func maxInt(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
-}
-
 func sortedKeys(set map[int]bool) []int {
 	nums := make([]int, 0, len(set))
 	for n := range set {
 		nums = append(nums, n)
 	}
-	sort.Ints(nums)
+	slices.Sort(nums)
 	return nums
 }

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 )
 
@@ -87,7 +87,7 @@ func Supported() []string {
 	for name := range registry {
 		names = append(names, name)
 	}
-	sort.Strings(names)
+	slices.Sort(names)
 	return names
 }
 

--- a/internal/blockers/blockers.go
+++ b/internal/blockers/blockers.go
@@ -5,7 +5,7 @@ package blockers
 
 import (
 	"regexp"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 )
@@ -23,7 +23,7 @@ var (
 func FromChildBody(body string) []int {
 	out := []int{}
 	inSection := false
-	for _, line := range strings.Split(body, "\n") {
+	for line := range strings.SplitSeq(body, "\n") {
 		lower := strings.ToLower(line)
 		if blockedBySectionStartRE.MatchString(lower) {
 			inSection = true
@@ -57,7 +57,7 @@ func FromParentRow(parentBody string, child int) []int {
 	rowPrefix := regexp.MustCompile(`^\s*-\s+\[[ xX]\]\s*#` + strconv.Itoa(child) + `(?:[^0-9]|$)`)
 	blockedByRE := regexp.MustCompile(`(?i)\(blocked by\s+([^)]+)\)`)
 	out := []int{}
-	for _, line := range strings.Split(parentBody, "\n") {
+	for line := range strings.SplitSeq(parentBody, "\n") {
 		if !rowPrefix.MatchString(line) {
 			continue
 		}
@@ -85,6 +85,6 @@ func Dedupe(a, b []int) []int {
 	for n := range seen {
 		out = append(out, n)
 	}
-	sort.Ints(out)
+	slices.Sort(out)
 	return out
 }

--- a/internal/cliflags/cliflags.go
+++ b/internal/cliflags/cliflags.go
@@ -195,20 +195,20 @@ func Parse(args []string, lg *log.Logger, stdout io.Writer) ParseResult {
 		"--status":                  func(cfg *Config) { cfg.StatusMode = true },
 		"--post-dashboard":          func(cfg *Config) { cfg.PostDashboard = true },
 		"--cleanup":                 func(cfg *Config) { cfg.CleanupMode = true },
-		"--auto-pr":                 func(cfg *Config) { cfg.AutoPullRequest = boolPtr(true) },
-		"--no-auto-pr":              func(cfg *Config) { cfg.AutoPullRequest = boolPtr(false) },
-		"--pr-review-gate":          func(cfg *Config) { cfg.PRReviewGate = boolPtr(true) },
-		"--no-pr-review-gate":       func(cfg *Config) { cfg.PRReviewGate = boolPtr(false) },
-		"--briefing-code-review":    func(cfg *Config) { cfg.BriefingCodeReview = boolPtr(true) },
-		"--no-briefing-code-review": func(cfg *Config) { cfg.BriefingCodeReview = boolPtr(false) },
-		"--agent-teams-hint":        func(cfg *Config) { cfg.AgentTeamsHint = boolPtr(true) },
-		"--no-agent-teams-hint":     func(cfg *Config) { cfg.AgentTeamsHint = boolPtr(false) },
-		"--codex-plan-mode":         func(cfg *Config) { cfg.CodexPlanMode = boolPtr(true) },
-		"--no-codex-plan-mode":      func(cfg *Config) { cfg.CodexPlanMode = boolPtr(false) },
-		"--pr-visualization":        func(cfg *Config) { cfg.PRVisualization = boolPtr(true) },
-		"--no-pr-visualization":     func(cfg *Config) { cfg.PRVisualization = boolPtr(false) },
-		"--dashboard-keybind":       func(cfg *Config) { cfg.DashboardKeybind = boolPtr(true) },
-		"--no-dashboard-keybind":    func(cfg *Config) { cfg.DashboardKeybind = boolPtr(false) },
+		"--auto-pr":                 func(cfg *Config) { cfg.AutoPullRequest = new(true) },
+		"--no-auto-pr":              func(cfg *Config) { cfg.AutoPullRequest = new(false) },
+		"--pr-review-gate":          func(cfg *Config) { cfg.PRReviewGate = new(true) },
+		"--no-pr-review-gate":       func(cfg *Config) { cfg.PRReviewGate = new(false) },
+		"--briefing-code-review":    func(cfg *Config) { cfg.BriefingCodeReview = new(true) },
+		"--no-briefing-code-review": func(cfg *Config) { cfg.BriefingCodeReview = new(false) },
+		"--agent-teams-hint":        func(cfg *Config) { cfg.AgentTeamsHint = new(true) },
+		"--no-agent-teams-hint":     func(cfg *Config) { cfg.AgentTeamsHint = new(false) },
+		"--codex-plan-mode":         func(cfg *Config) { cfg.CodexPlanMode = new(true) },
+		"--no-codex-plan-mode":      func(cfg *Config) { cfg.CodexPlanMode = new(false) },
+		"--pr-visualization":        func(cfg *Config) { cfg.PRVisualization = new(true) },
+		"--no-pr-visualization":     func(cfg *Config) { cfg.PRVisualization = new(false) },
+		"--dashboard-keybind":       func(cfg *Config) { cfg.DashboardKeybind = new(true) },
+		"--no-dashboard-keybind":    func(cfg *Config) { cfg.DashboardKeybind = new(false) },
 	}
 
 	requireValue := func(flag string, i int) (string, bool) {
@@ -288,10 +288,6 @@ type parseState struct {
 
 type valueOption func(*Config, *parseState, string) error
 type boolOption func(*Config)
-
-func boolPtr(v bool) *bool {
-	return &v
-}
 
 func setParent(parent *string, arg string, lg *log.Logger) bool {
 	if *parent == "" {

--- a/internal/dashboard/poller.go
+++ b/internal/dashboard/poller.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"sort"
+	"slices"
 	"sync"
 	"time"
 
@@ -259,6 +259,6 @@ func distinctIssueNums(store state.Store) []int {
 			nums = append(nums, p.IssueNum)
 		}
 	}
-	sort.Ints(nums)
+	slices.Sort(nums)
 	return nums
 }

--- a/internal/ghissue/ghissue.go
+++ b/internal/ghissue/ghissue.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"os/exec"
 	"regexp"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 )
@@ -664,7 +664,7 @@ var (
 func TaskListNumbers(parentBody string) []int {
 	seen := map[int]bool{}
 	var out []int
-	for _, line := range strings.Split(parentBody, "\n") {
+	for line := range strings.SplitSeq(parentBody, "\n") {
 		m := taskListRE.FindStringSubmatch(line)
 		if len(m) != 2 {
 			continue
@@ -676,7 +676,7 @@ func TaskListNumbers(parentBody string) []int {
 		seen[n] = true
 		out = append(out, n)
 	}
-	sort.Ints(out)
+	slices.Sort(out)
 	return out
 }
 
@@ -685,7 +685,7 @@ func TaskListNumbers(parentBody string) []int {
 func TaskListWaves(parentBody string) map[int]string {
 	out := map[int]string{}
 	currentWave := ""
-	for _, line := range strings.Split(parentBody, "\n") {
+	for line := range strings.SplitSeq(parentBody, "\n") {
 		if m := taskListRE.FindStringSubmatch(line); len(m) == 2 {
 			if currentWave == "" {
 				continue

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/butaosuinu/fanout/internal/exitcode"
@@ -293,7 +293,7 @@ func sortedUnique(nums []int) []int {
 	for num := range set {
 		out = append(out, num)
 	}
-	sort.Ints(out)
+	slices.Sort(out)
 	return out
 }
 

--- a/internal/naming/naming.go
+++ b/internal/naming/naming.go
@@ -21,10 +21,7 @@ func Slug(title string, num int) string {
 		base = "issue"
 	}
 	suffix := fmt.Sprintf("-%d", num)
-	maxBase := MaxSlugLength - len(suffix)
-	if maxBase < 1 {
-		maxBase = 1
-	}
+	maxBase := max(MaxSlugLength-len(suffix), 1)
 	if len(base) > maxBase {
 		base = strings.Trim(base[:maxBase], "-")
 		if base == "" {
@@ -87,10 +84,7 @@ func QualifySlugForParent(slug, parentRef string, issueNum int) string {
 	}
 	parentToken := parentToken(parentRef)
 	extra := "-" + parentToken + suffix
-	maxBase := MaxSlugLength - len(extra)
-	if maxBase < 1 {
-		maxBase = 1
-	}
+	maxBase := max(MaxSlugLength-len(extra), 1)
 	if len(base) > maxBase {
 		base = strings.Trim(base[:maxBase], "-")
 		if base == "" {

--- a/internal/sessionview/aggregate.go
+++ b/internal/sessionview/aggregate.go
@@ -1,8 +1,9 @@
 package sessionview
 
 import (
+	"cmp"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -119,7 +120,7 @@ func Build(repo, projectRoot string, c Collectors) Snapshot {
 	grouped := groupByParent(store.Panes)
 	for _, parent := range sortedParents(grouped) {
 		panes := grouped[parent]
-		sort.Slice(panes, func(i, j int) bool { return panes[i].IssueNum < panes[j].IssueNum })
+		slices.SortFunc(panes, func(a, b state.Pane) int { return cmp.Compare(a.IssueNum, b.IssueNum) })
 
 		session := Session{Parent: parent, Panes: make([]PaneView, 0, len(panes))}
 		for _, p := range panes {
@@ -192,18 +193,18 @@ func sortedParents(grouped map[string][]state.Pane) []string {
 	for k := range grouped {
 		keys = append(keys, k)
 	}
-	sort.Slice(keys, func(i, j int) bool {
-		ni, ei := strconv.Atoi(keys[i])
-		nj, ej := strconv.Atoi(keys[j])
+	slices.SortFunc(keys, func(a, b string) int {
+		na, ea := strconv.Atoi(a)
+		nb, eb := strconv.Atoi(b)
 		switch {
-		case ei == nil && ej == nil:
-			return ni < nj
-		case ei == nil:
-			return true // numeric before non-numeric
-		case ej == nil:
-			return false
+		case ea == nil && eb == nil:
+			return cmp.Compare(na, nb)
+		case ea == nil:
+			return -1 // numeric before non-numeric
+		case eb == nil:
+			return 1
 		default:
-			return keys[i] < keys[j]
+			return strings.Compare(a, b)
 		}
 	})
 	return keys

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -46,8 +46,8 @@ func TestResolvePriorityCLIEnvRepoUserBuiltin(t *testing.T) {
 	t.Setenv("FANOUT_SLACK_WEBHOOK_URL", "https://hooks.example/slack")
 
 	got := Resolve(repo, CLIOverrides{
-		AutoPullRequest: boolp(true),
-		PRVisualization: boolp(false),
+		AutoPullRequest: new(true),
+		PRVisualization: new(false),
 	}, t.Fatalf)
 
 	want := Settings{
@@ -222,10 +222,6 @@ func writeConfig(t *testing.T, path, body string) {
 	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
 		t.Fatalf("WriteFile(%q): %v", path, err)
 	}
-}
-
-func boolp(v bool) *bool {
-	return &v
 }
 
 func assertWarningContains(t *testing.T, warnings []string, want string) {

--- a/internal/tmuxrun/tmuxrun.go
+++ b/internal/tmuxrun/tmuxrun.go
@@ -86,7 +86,7 @@ func ListLivePanes() ([]LivePane, error) {
 		return nil, fmt.Errorf("tmux list-panes -a: %w", err)
 	}
 	var panes []LivePane
-	for _, line := range strings.Split(string(out), "\n") {
+	for line := range strings.SplitSeq(string(out), "\n") {
 		line = strings.TrimRight(line, "\r")
 		if strings.TrimSpace(line) == "" {
 			continue

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -3,11 +3,13 @@ package tui
 
 import (
 	"bytes"
+	"cmp"
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -604,7 +606,7 @@ func (m model) View() string {
 		lipgloss.Left,
 		header,
 		m.table.View(),
-		panelStyle.Width(maxInt(0, m.width)).Render(detail.View()),
+		panelStyle.Width(max(0, m.width)).Render(detail.View()),
 		footer,
 	)
 }
@@ -618,10 +620,7 @@ func (m *model) resize() {
 		m.newPane.prompt.Width = inputWidth
 		m.newPane.slug.Width = inputWidth
 	}
-	tableHeight := m.height - detailHeight - 5
-	if tableHeight < 4 {
-		tableHeight = 4
-	}
+	tableHeight := max(m.height-detailHeight-5, 4)
 	m.table.SetWidth(m.width)
 	m.table.SetHeight(tableHeight)
 	m.table.SetColumns(columnsForWidth(m.width))
@@ -857,7 +856,7 @@ func (m model) newPaneView() string {
 	if m.newPane.err != "" {
 		lines = append(lines, errStyle.Render("error: "+m.newPane.err))
 	}
-	return formStyle.Width(maxInt(0, m.width-4)).Render(strings.Join(lines, "\n"))
+	return formStyle.Width(max(0, m.width-4)).Render(strings.Join(lines, "\n"))
 }
 
 func (m model) newPaneFieldView(field newPaneField, label, value string) string {
@@ -926,7 +925,7 @@ func (m model) detailContent() string {
 	if pane.WorktreeErr != "" {
 		lines = append(lines, "worktree_error="+pane.WorktreeErr)
 	}
-	peekBudget := maxInt(2, m.detail.Height-len(lines)-1)
+	peekBudget := max(2, m.detail.Height-len(lines)-1)
 	lines = append(lines, m.peekContent(pane, peekBudget)...)
 	if pane.Prompt != "" && len(lines) < m.detail.Height {
 		lines = append(lines, "prompt="+pane.Prompt)
@@ -1018,7 +1017,7 @@ func (m model) peekContent(pane paneView, maxLines int) []string {
 	}
 	lines := []string{header + ":"}
 	for _, line := range tailLines(out, maxLines) {
-		lines = append(lines, truncatePreserveSpace(line, maxInt(20, m.detail.Width-2)))
+		lines = append(lines, truncatePreserveSpace(line, max(20, m.detail.Width-2)))
 	}
 	return lines
 }
@@ -1184,9 +1183,7 @@ func issueTransitionSnapshots(statuses map[issueKey]issueStatus) map[issueKey]is
 
 func mergePartialIssueTransitionSnapshots(previous map[issueKey]issueTransitionSnapshot, statuses map[issueKey]issueStatus) map[issueKey]issueTransitionSnapshot {
 	out := make(map[issueKey]issueTransitionSnapshot, len(previous))
-	for key, snapshot := range previous {
-		out[key] = snapshot
-	}
+	maps.Copy(out, previous)
 	for key, status := range statuses {
 		current := transitionSnapshot(status)
 		if prev, ok := previous[key]; ok {
@@ -1241,11 +1238,11 @@ func sortedIssueKeys(statuses map[issueKey]issueStatus) []issueKey {
 	for key := range statuses {
 		keys = append(keys, key)
 	}
-	sort.Slice(keys, func(i, j int) bool {
-		if keys[i].Parent != keys[j].Parent {
-			return keys[i].Parent < keys[j].Parent
+	slices.SortFunc(keys, func(a, b issueKey) int {
+		if c := cmp.Compare(a.Parent, b.Parent); c != 0 {
+			return c
 		}
-		return keys[i].Num < keys[j].Num
+		return cmp.Compare(a.Num, b.Num)
 	})
 	return keys
 }
@@ -1481,13 +1478,13 @@ func recordedParents(panes []state.Pane) []string {
 	for parent := range seen {
 		parents = append(parents, parent)
 	}
-	sort.Slice(parents, func(i, j int) bool {
-		left, leftErr := strconv.Atoi(parents[i])
-		right, rightErr := strconv.Atoi(parents[j])
+	slices.SortFunc(parents, func(a, b string) int {
+		left, leftErr := strconv.Atoi(a)
+		right, rightErr := strconv.Atoi(b)
 		if leftErr == nil && rightErr == nil {
-			return left < right
+			return cmp.Compare(left, right)
 		}
-		return parents[i] < parents[j]
+		return strings.Compare(a, b)
 	})
 	return parents
 }
@@ -1623,14 +1620,14 @@ func applyIssueStatuses(panes []paneView, issues map[issueKey]issueStatus) []pan
 }
 
 func sortPaneViews(panes []paneView) {
-	sort.Slice(panes, func(i, j int) bool {
-		if panes[i].Parent != panes[j].Parent {
-			return panes[i].Parent < panes[j].Parent
+	slices.SortFunc(panes, func(a, b paneView) int {
+		if c := cmp.Compare(a.Parent, b.Parent); c != 0 {
+			return c
 		}
-		if panes[i].Wave != panes[j].Wave {
-			return panes[i].Wave < panes[j].Wave
+		if c := cmp.Compare(a.Wave, b.Wave); c != 0 {
+			return c
 		}
-		return panes[i].IssueNum < panes[j].IssueNum
+		return cmp.Compare(a.IssueNum, b.IssueNum)
 	})
 }
 
@@ -1759,7 +1756,7 @@ func filterPaneViews(panes []paneView, query string) []paneView {
 
 func parsePaneFilter(query string) paneFilter {
 	var filter paneFilter
-	for _, token := range strings.Fields(strings.ToLower(strings.TrimSpace(query))) {
+	for token := range strings.FieldsSeq(strings.ToLower(strings.TrimSpace(query))) {
 		key, value, ok := splitFilterToken(token)
 		if !ok {
 			filter.terms = append(filter.terms, token)
@@ -2007,9 +2004,7 @@ func relativePath(root, path string) string {
 
 func cloneIssueStatuses(in map[issueKey]issueStatus) map[issueKey]issueStatus {
 	out := make(map[issueKey]issueStatus, len(in))
-	for k, v := range in {
-		out[k] = v
-	}
+	maps.Copy(out, in)
 	return out
 }
 
@@ -2107,11 +2102,4 @@ func clampInt(v, low, high int) int {
 		return high
 	}
 	return v
-}
-
-func maxInt(a, b int) int {
-	if a > b {
-		return a
-	}
-	return b
 }

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -299,8 +299,8 @@ func checkedOutWorktree(root, branch string) string {
 	sc := bufio.NewScanner(strings.NewReader(string(out)))
 	for sc.Scan() {
 		line := sc.Text()
-		if strings.HasPrefix(line, "worktree ") {
-			current = strings.TrimPrefix(line, "worktree ")
+		if after, ok := strings.CutPrefix(line, "worktree "); ok {
+			current = after
 			continue
 		}
 		if strings.TrimPrefix(line, "branch refs/heads/") == branch {

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -270,7 +270,7 @@ func TestEnsureLocalExcludeIsIdempotent(t *testing.T) {
 
 func countLines(body, want string) int {
 	var count int
-	for _, line := range strings.Split(body, "\n") {
+	for line := range strings.SplitSeq(body, "\n") {
 		if line == want {
 			count++
 		}


### PR DESCRIPTION
## TL;DR

Go 1.26 の `go fix ./...` を一括適用し、go fix が拾わない issue 明記分(手書き `maxInt` → 組み込み `max`、`sort.Ints/Strings/Slice` → `slices.*`、`fmt.Sprintf("%d")` → `strconv.Itoa`)を手動適用した。挙動・出力の変化はゼロ(Tier2 golden 無差分、dry-run 出力の前後一致で検証)。

Review effort: 1

## Why

#190 の意図どおり、後続の golangci-lint 導入(#191〜)前にチャーンの大きい機械的書き換えを単独 PR で済ませる。`go fix -diff` でドライランした結果、issue に「既知の確実ヒット」として列挙されていた maxInt / sort.* は go fix の対象外(minmax fixer は if 文のみ、slicessort は `s[i] < s[j]` 形式のみ)と判明したため、go fix 一括適用 + 手動適用の 2 段構成とした。

## Changes by file

<details><summary>Changed files</summary>

| File | What changed | Why |
|---|---|---|
| `cmd/fanout/main.go` | 線形探索 → `slices.Contains`、`strings.Split` ループ → `SplitSeq` | go fix (slicescontains, stringsseq) |
| `cmd/fanout/pane.go` | clamp if 文 → `max(...)` | go fix (minmax) |
| `cmd/fanout/pane_test.go` | `boolPtr(true)` → `new(true)` | go fix (newexpr inline) |
| `cmd/fanout/report.go` | `sort.Ints` → `slices.Sort`、`Sprintf("%d")` → `strconv.Itoa` | 手動(issue 明記) |
| `cmd/fanout/report_test.go` | `boolPtr(...)` → `new(...)`、未使用化した helper 削除 | go fix + dead code 削除 |
| `cmd/fanout/status.go` | `maxInt` 13 呼び出し → `max`、helper 削除、`sort.Ints` → `slices.Sort` | 手動(issue 明記) |
| `internal/agent/agent.go` | `sort.Strings` → `slices.Sort` | 手動(issue 明記) |
| `internal/blockers/blockers.go` | `SplitSeq` ×2、`sort.Ints` → `slices.Sort` | go fix + 手動 |
| `internal/cliflags/cliflags.go` | `boolPtr(v)` 14 箇所 → `new(true)`/`new(false)`、未使用化した helper 削除 | go fix (newexpr inline) + dead code 削除 |
| `internal/dashboard/poller.go` | `sort.Ints` → `slices.Sort` | 手動 |
| `internal/ghissue/ghissue.go` | `SplitSeq` ×2、`sort.Ints` → `slices.Sort` | go fix + 手動 |
| `internal/lifecycle/lifecycle.go` | `sort.Ints` → `slices.Sort` | 手動 |
| `internal/naming/naming.go` | clamp if 文 → `max(...)` ×2 | go fix (minmax) |
| `internal/sessionview/aggregate.go` | `sort.Slice` → `slices.SortFunc` ×2(less→cmp 変換) | 手動(issue 明記) |
| `internal/settings/settings_test.go` | `boolp(...)` → `new(...)`、未使用化した helper 削除 | go fix + dead code 削除 |
| `internal/tmuxrun/tmuxrun.go` | `SplitSeq` | go fix (stringsseq) |
| `internal/tui/tui.go` | `maps.Copy` ×2、`FieldsSeq`、clamp → `max`、`maxInt` 4 呼び出し → `max` + helper 削除、`sort.Slice` → `slices.SortFunc` ×3 | go fix + 手動 |
| `internal/worktree/worktree.go` | `HasPrefix`+`TrimPrefix` → `CutPrefix` | go fix (stringscutprefix) |
| `internal/worktree/worktree_test.go` | `SplitSeq` | go fix (stringsseq) |

</details>

## Risk

> [!WARNING]
> 手翻訳が入ったのは `sort.Slice` → `slices.SortFunc` のコンパレータ 5 箇所のみ(`internal/tui/tui.go:1240,1480,1622`、`internal/sessionview/aggregate.go:122,195`)。less(i,j) → cmp(a,b) の符号と同順位時の挙動が保存されていることは、Tier2 golden 無差分・dry-run 出力の前後一致・codex adversarial review(approve)で検証済み。なお `new(true)` は Go 1.26 の `new(expr)` 構文(`go tool fix help newexpr` 参照)で、go.mod は #198 で 1.26 に bump 済み。

## Test plan

- `go fix -diff ./...` → 差分ゼロ(冪等性 AC)✅
- `make lint`(go vet + gofmt + shellcheck)✅
- `make test` → Go 全パッケージ ok + bats 29/29 ok、Tier2 golden 無差分(`FANOUT_GOLDEN_UPDATE` 不使用)✅
- 変更前 HEAD のバイナリと `make build-go` 後の `./fanout-go 188 --dry-run --agent claude` 出力を diff → 完全一致 ✅
- `/post-work-review`: code-review(9 観点)指摘 0 件、codex adversarial review approve ✅

Closes #190