### PR TITLE
.golangci.yml 追加と gofumpt/goimports 一括整形(+ .git-blame-ignore-revs)

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# style(go): golangci-lint fmt による gofumpt/goimports 一括整形 (#191)
+5b8b9334950aaade59cb4abc70d7b8aa85b1b8d5

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,143 @@
+# golangci-lint v2 設定(v2.12.2 / config schema v2)。issue #191 で導入。
+#
+# 不採用 linter と根拠:
+# - gosec: exec.Command 35 箇所で G204 誤検出過多 — git/gh/tmux ラッパが製品の本質
+# - exhaustruct: 新規プロジェクト専用
+# - gochecknoglobals: ldflags 注入 version/commit・regexp・lipgloss スタイル・
+#   agent registry が全て正当
+# - funlen / gocognit / cyclop: codex_plan_tui.go 1144 行と TUI Update ループが即死
+# - lll / nlreturn / wsl_v5 / varnamelen / err113 / mnd / depguard / dupl /
+#   contextcheck: コミュニティ合意でノイズ
+# - forcetypeassert: errcheck の check-type-assertions で代替
+# - prealloc / perfsprint: 計測なし最適化
+# - ireturn: bubbletea の Update が tea.Model を返す規約と非両立
+
+version: "2"
+
+run:
+  timeout: 5m
+  tests: true
+
+linters:
+  default: standard            # errcheck / govet / ineffassign / staticcheck / unused
+  enable:
+    # バグ検出
+    - bodyclose                # selfupdate の HTTP レスポンス Body Close 漏れ
+    - copyloopvar              # Go 1.22+ で不要なループ変数コピー
+    - durationcheck
+    - errorlint                # errors.Is/As 不使用の比較・型アサーション
+    - exhaustive               # enum switch の網羅性
+    - makezero
+    - nilerr
+    - nilnesserr
+    - reassign
+    # コード品質
+    - gocritic                 # 既定チェックのみ。experimental は opt-in しない
+    - intrange                 # for i := range n(可変インクリメントの引数パーサ 3 箇所は対象外)
+    - modernize                # 回帰防止(一括 fix は先行 issue で実施済み)
+    - predeclared
+    - unconvert
+    - unparam
+    - usestdlibvars
+    # スタイル(低ノイズのみ)
+    - misspell                 # CLI のユーザー向け文言が多いため採用
+    - revive                   # 厳選 rules(exported / package-comments は外す)
+    # テスト品質
+    - thelper
+    - usetesting               # tenv の後継
+    # 運用ガード(現状違反ゼロのラチェット)
+    - gochecknoinits           # 現在 init() は 0 件
+    - nolintlint               # nolint に理由と linter 指定を必須化
+  settings:
+    errcheck:
+      check-type-assertions: true
+      # std-error-handling preset は使わない: worktree.go の書き込みパス defer f.Close()
+      # のような実害ケースを検出対象に残すため。fmt 出力系のみ精密除外。
+      exclude-functions:
+        - fmt.Print
+        - fmt.Printf
+        - fmt.Println
+        - fmt.Fprint
+        - fmt.Fprintf
+        - fmt.Fprintln
+        - (*strings.Builder).WriteString
+        - (*strings.Builder).WriteByte
+        - (*strings.Builder).WriteRune
+        - (*bytes.Buffer).WriteString
+    govet:
+      enable-all: true
+      disable:
+        - fieldalignment
+    staticcheck:
+      # v2.12.2 デフォルトの明示(将来のデフォルト変更に左右されない)
+      checks: ["all", "-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1021", "-ST1022"]
+    exhaustive:
+      default-signifies-exhaustive: true
+    misspell:
+      locale: US
+    revive:
+      rules:
+        - name: blank-imports
+        - name: context-as-argument
+        - name: context-keys-type
+        - name: dot-imports
+        - name: early-return
+        - name: error-naming
+        - name: error-return
+        - name: error-strings
+        - name: errorf
+        - name: increment-decrement
+        - name: indent-error-flow
+        - name: range
+        - name: receiver-naming
+        - name: redefines-builtin-id
+        - name: superfluous-else
+        - name: time-naming
+        - name: unexported-return
+        - name: unreachable-code
+        - name: var-declaration
+        - name: var-naming
+    nolintlint:
+      allow-unused: false
+      require-explanation: true
+      require-specific: true
+  exclusions:
+    generated: lax
+    warn-unused: true
+    presets:
+      - comments
+      - common-false-positives
+    rules:
+      - path: _test\.go
+        linters:
+          - errcheck
+          - unparam
+    paths:
+      # nested go.mod で通常自動除外されるが、パス指定実行・エディタ統合の事故防止
+      - \.dmux/
+      - \.fanout/
+      - \.cache/
+      - tests/tmp/
+
+formatters:
+  enable:
+    - gofumpt
+    - goimports
+  settings:
+    gofumpt:
+      module-path: github.com/butaosuinu/fanout
+      extra-rules: false
+    goimports:
+      local-prefixes:
+        - github.com/butaosuinu/fanout
+  exclusions:
+    generated: lax
+    paths:
+      - \.dmux/
+      - \.fanout/
+      - \.cache/
+      - tests/tmp/
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/cmd/fanout/codex_plan_tui.go
+++ b/cmd/fanout/codex_plan_tui.go
@@ -939,7 +939,7 @@ func requestUserInputResponse(raw json.RawMessage) map[string]any {
 				continue
 			}
 			answers[id] = map[string][]string{
-				"answers": []string{codexPlanUserInputFallbackAnswer},
+				"answers": {codexPlanUserInputFallbackAnswer},
 			}
 		}
 	}

--- a/cmd/fanout/pane.go
+++ b/cmd/fanout/pane.go
@@ -29,9 +29,7 @@ const (
 	codexPlanTUIStartupPoll    = 200 * time.Millisecond
 )
 
-var (
-	errCodexPlanStartupTimeout = errors.New("timed out waiting for Codex Plan TUI startup")
-)
+var errCodexPlanStartupTimeout = errors.New("timed out waiting for Codex Plan TUI startup")
 
 type paneRequest struct {
 	ParentRef           string

--- a/internal/cliflags/cliflags.go
+++ b/internal/cliflags/cliflags.go
@@ -286,8 +286,10 @@ type parseState struct {
 	formatExplicit bool
 }
 
-type valueOption func(*Config, *parseState, string) error
-type boolOption func(*Config)
+type (
+	valueOption func(*Config, *parseState, string) error
+	boolOption  func(*Config)
+)
 
 func setParent(parent *string, arg string, lg *log.Logger) bool {
 	if *parent == "" {

--- a/internal/tmuxrun/tmuxrun.go
+++ b/internal/tmuxrun/tmuxrun.go
@@ -9,9 +9,11 @@ import (
 	"strings"
 )
 
-const userShellExpr = `"${SHELL:-/bin/sh}"`
-const paneListFormat = "#{pane_id}:#{window_id}:#{pane_index}:#{pane_active}:#{pane_title}"
-const paneAlternateFormat = "#{alternate_on}"
+const (
+	userShellExpr       = `"${SHELL:-/bin/sh}"`
+	paneListFormat      = "#{pane_id}:#{window_id}:#{pane_index}:#{pane_active}:#{pane_title}"
+	paneAlternateFormat = "#{alternate_on}"
+)
 
 // PaneInfo describes a pane currently known to tmux.
 type PaneInfo struct {

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -14,6 +14,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/charmbracelet/bubbles/table"
+	"github.com/charmbracelet/bubbles/textinput"
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
 	"github.com/butaosuinu/fanout/internal/blockers"
 	"github.com/butaosuinu/fanout/internal/exitcode"
 	"github.com/butaosuinu/fanout/internal/ghissue"
@@ -22,11 +28,6 @@ import (
 	fanoutnotify "github.com/butaosuinu/fanout/internal/notify"
 	"github.com/butaosuinu/fanout/internal/state"
 	"github.com/butaosuinu/fanout/internal/tmuxrun"
-	"github.com/charmbracelet/bubbles/table"
-	"github.com/charmbracelet/bubbles/textinput"
-	"github.com/charmbracelet/bubbles/viewport"
-	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
 )
 
 const (
@@ -244,11 +245,14 @@ type panePeek struct {
 	Loading bool
 }
 
-type stateTickMsg time.Time
-type ghTickMsg time.Time
-type launchPaneMsg struct {
-	err error
-}
+type (
+	stateTickMsg  time.Time
+	ghTickMsg     time.Time
+	launchPaneMsg struct {
+		err error
+	}
+)
+
 type transitionNotifiedMsg struct {
 	count int
 	err   error

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -8,13 +8,14 @@ import (
 	"testing"
 	"time"
 
+	tea "github.com/charmbracelet/bubbletea"
+
 	"github.com/butaosuinu/fanout/internal/exitcode"
 	"github.com/butaosuinu/fanout/internal/ghissue"
 	"github.com/butaosuinu/fanout/internal/lifecycle"
 	fanoutnotify "github.com/butaosuinu/fanout/internal/notify"
 	"github.com/butaosuinu/fanout/internal/state"
 	"github.com/butaosuinu/fanout/internal/tmuxrun"
-	tea "github.com/charmbracelet/bubbletea"
 )
 
 var errBoom = errors.New("boom")


### PR DESCRIPTION
## TL;DR
golangci-lint v2.12.2 の設定 `.golangci.yml`(curated 23 linters + gofumpt/goimports formatters)を追加し、`golangci-lint fmt` の一括整形を純粋コミットとして適用、そのフルハッシュを新規 `.git-blame-ignore-revs` に記録した。

Review effort: 1

## Why
親 #188「Go 静的解析 2026 年化」の 3 番目。issue #191 は (1) issue 記載のドラフトどおりの `.golangci.yml` をルートに追加、(2) `golangci-lint fmt` の整形差分を設定コミットと分離した純粋コミットで積む、(3) 整形コミットのハッシュを `.git-blame-ignore-revs` に記録する、の 3 点を要求している。`golangci-lint run` の指摘解消と Makefile/CI への配線は明示的に後続 issue のスコープ。

## Changes by file
<details><summary>Changed files</summary>

| File | What changed | Why |
|---|---|---|
| `.golangci.yml` | 新規。issue ドラフトの YAML 全文 + 不採用 linter と根拠のコメントブロック | lint/format 設定の導入(`golangci-lint config verify` パス済み、enable した 23 linter すべて v2.12.2 に存在することを確認) |
| `.git-blame-ignore-revs` | 新規。整形コミット `5b8b9334950aaade59cb4abc70d7b8aa85b1b8d5` のフルハッシュを記録 | blame から機械的整形を除外 |
| `cmd/fanout/codex_plan_tui.go` | 複合リテラルの冗長な型省略(1 箇所) | gofumpt |
| `cmd/fanout/pane.go` | 単一宣言の var ブロック解除 | gofumpt |
| `internal/cliflags/cliflags.go` | 連続する type 宣言のグループ化 | gofumpt |
| `internal/tmuxrun/tmuxrun.go` | 連続する const 宣言のグループ化 | gofumpt |
| `internal/tui/tui.go` | type 宣言グループ化 + import を第三者/ローカルでグループ分け | gofumpt + goimports(local-prefixes) |
| `internal/tui/tui_test.go` | import のグループ分け | goimports(local-prefixes) |

</details>

整形コミットは .go 6 ファイルのみ(+27/−20)の純粋コミット。挙動変更なし。

> [!WARNING]
> この PR は **「Create a merge commit」でマージしてください**。squash / rebase merge では整形コミット `5b8b933…` が main に存在しなくなり、`.git-blame-ignore-revs` の記録が無効になります(squash したい場合は merge 後にハッシュ差し替えの follow-up が必要)。

## Test plan
- `golangci-lint config verify` — パス
- `golangci-lint linters` — enable した 23 linter すべて v2.12.2 に存在
- `golangci-lint fmt` 再実行 — 差分ゼロ(冪等)
- `gofmt -l cmd internal` — 0 件(既存 `make lint` の go-fmt-check と互換)
- `make lint` — go vet + gofmt + shellcheck 全パス
- `make test` — exit 0(go test + Tier1 + Tier2 golden 無差分、bats 全 ok)

補足: codex second-pass review の唯一の指摘は「`make lint` / CI に `.golangci.yml` が配線されていない」(P2)だが、これは issue #191 が「Makefile / CI への配線は後続 issue のスコープ(本 issue では手動実行でよい)」と明示しているため設計どおり。コードレベルの指摘はゼロ。

Closes #191

🤖 Generated with [Claude Code](https://claude.com/claude-code)