### PR TITLE
.git-blame-ignore-revs を #205 の squash コミットに差し替え

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,3 @@
-# style(go): golangci-lint fmt による gofumpt/goimports 一括整形 (#191)
-5b8b9334950aaade59cb4abc70d7b8aa85b1b8d5
+# #205 squash: .golangci.yml 追加と gofumpt/goimports 一括整形 (#191)
+# (整形差分のほか .golangci.yml と本ファイルの追加を含む squash コミット)
+cf435be5367f905af17b81ba66a41263dc7f214c


### PR DESCRIPTION
## TL;DR
PR #205 が squash merge されたため `.git-blame-ignore-revs` が main に存在しないハッシュを指す死にエントリになっていた。実際に land した squash コミット `cf435be5367f905af17b81ba66a41263dc7f214c` に差し替える。

Review effort: 0

## Why
#205 の Risk ブロックで予告していたフォールバック対応。記録していた整形コミット `5b8b933` は squash により main の祖先ではなくなり、ブランチ削除済みでいずれ GC される。`git blame` は存在しないハッシュをエラーにせず黙って無視する(検証済み)ため、現状は「壊れはしないが整形差分の blame 除外が一切効いていない」状態。

## Changes by file
<details><summary>Changed files</summary>

| File | What changed | Why |
|---|---|---|
| `.git-blame-ignore-revs` | ハッシュを `5b8b933`(消滅)→ `cf435be`(squash コミット)に差し替え、コメント更新 | blame 除外を実効化 |

</details>

検証(差し替え後、整形対象だった `internal/tmuxrun/tmuxrun.go:13-15` の blame が整形前のコミットに帰属):

```
$ git blame --ignore-revs-file=.git-blame-ignore-revs -L 12,16 internal/tmuxrun/tmuxrun.go
2dcbec6c ... 13)  userShellExpr       = `"${SHELL:-/bin/sh}"`
3e3e2b85 ... 14)  paneListFormat      = "#{pane_id}:..."
```

> [!NOTE]
> squash コミット `cf435be` には整形差分のほか `.golangci.yml` と本ファイルの新規追加も含まれるため、それらの行も blame 上 ignore 対象になる(新規ファイルなので実害なし。ファイル内コメントにも明記)。この PR 自体は **squash merge して問題ない**(記録ハッシュは既に main に存在するものを指すため)。

## Test plan
- `git blame --ignore-revs-file=.git-blame-ignore-revs` で整形行が整形前コミットに帰属することを確認(上記)
- code-review / codex review とも指摘ゼロ

Refs #191 / #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)