### PR TITLE
fix(lint): golangci-lint v2.12.2 指摘 82 件を全解消しゼロベースライン化

### DIFF
--- a/cmd/fanout/codex_plan_tui.go
+++ b/cmd/fanout/codex_plan_tui.go
@@ -192,7 +192,7 @@ func runCodexPlanTUI(cfg codexPlanTUIConfig, stdout, stderr io.Writer) (err erro
 	if err != nil {
 		return err
 	}
-	if err := startCodexPlanTurn(client, thread, cwd, cfg.Prompt); err != nil {
+	if err = startCodexPlanTurn(client, thread, cwd, cfg.Prompt); err != nil {
 		return err
 	}
 
@@ -225,7 +225,7 @@ func runCodexPlanTUI(cfg codexPlanTUIConfig, stdout, stderr io.Writer) (err erro
 	case <-time.After(codexRemoteTUIStartupGrace):
 	}
 
-	if err := writeCodexPlanTUIStatus(cfg.StatusFile, codexPlanTUIStatus{
+	if err = writeCodexPlanTUIStatus(cfg.StatusFile, codexPlanTUIStatus{
 		Status:    codexPlanTUIStatusReady,
 		ThreadID:  thread.ID,
 		SessionID: thread.SessionID,
@@ -397,7 +397,8 @@ func freeLocalPort() (int, error) {
 	if err != nil {
 		return 0, fmt.Errorf("reserve localhost port for Codex app-server: %w", err)
 	}
-	defer ln.Close()
+	// Close error is irrelevant: the listener only reserved the port.
+	defer func() { _ = ln.Close() }()
 	addr, ok := ln.Addr().(*net.TCPAddr)
 	if !ok {
 		return 0, fmt.Errorf("reserve localhost port for Codex app-server: unexpected address %s", ln.Addr())
@@ -409,8 +410,8 @@ func connectCodexRemoteAppClient(server *codexRemoteAppServer, timeout time.Dura
 	deadline := time.Now().Add(timeout)
 	var lastErr error
 	for time.Now().Before(deadline) {
-		if err, ok := server.Exited(); ok {
-			return nil, fmt.Errorf("codex app-server exited before websocket connection: %v%s", err, serverLogSuffix(server))
+		if ok, err := server.Exited(); ok {
+			return nil, fmt.Errorf("codex app-server exited before websocket connection: %w%s", err, serverLogSuffix(server))
 		}
 		conn, err := dialWebSocket(server.Addr, time.Second)
 		if err == nil {
@@ -440,17 +441,17 @@ func serverLogSuffix(server *codexRemoteAppServer) string {
 	return "; app-server output: " + logs
 }
 
-func (s *codexRemoteAppServer) Exited() (error, bool) {
+func (s *codexRemoteAppServer) Exited() (bool, error) {
 	if s == nil {
-		return nil, true
+		return true, nil
 	}
 	select {
 	case <-s.done:
 		s.mu.Lock()
 		defer s.mu.Unlock()
-		return s.err, true
+		return true, s.err
 	default:
-		return nil, false
+		return false, nil
 	}
 }
 
@@ -458,7 +459,7 @@ func (s *codexRemoteAppServer) Close() {
 	if s == nil || s.cmd == nil || s.cmd.Process == nil {
 		return
 	}
-	if _, ok := s.Exited(); ok {
+	if ok, _ := s.Exited(); ok {
 		return
 	}
 	_ = syscall.Kill(-s.cmd.Process.Pid, syscall.SIGKILL)
@@ -520,13 +521,13 @@ func dialWebSocket(rawURL string, timeout time.Duration) (*websocketJSONConn, er
 	if err != nil {
 		return nil, err
 	}
-	if err := conn.SetDeadline(time.Now().Add(timeout)); err != nil {
+	if err = conn.SetDeadline(time.Now().Add(timeout)); err != nil {
 		_ = conn.Close()
 		return nil, err
 	}
 	br := bufio.NewReader(conn)
 	keyBytes := make([]byte, 16)
-	if _, err := rand.Read(keyBytes); err != nil {
+	if _, err = rand.Read(keyBytes); err != nil {
 		_ = conn.Close()
 		return nil, fmt.Errorf("generate websocket key: %w", err)
 	}
@@ -544,7 +545,7 @@ func dialWebSocket(rawURL string, timeout time.Duration) (*websocketJSONConn, er
 		"Connection: Upgrade\r\n" +
 		"Sec-WebSocket-Key: " + key + "\r\n" +
 		"Sec-WebSocket-Version: 13\r\n\r\n"
-	if _, err := io.WriteString(conn, req); err != nil {
+	if _, err = io.WriteString(conn, req); err != nil {
 		_ = conn.Close()
 		return nil, fmt.Errorf("write websocket handshake: %w", err)
 	}
@@ -553,6 +554,9 @@ func dialWebSocket(rawURL string, timeout time.Duration) (*websocketJSONConn, er
 		_ = conn.Close()
 		return nil, fmt.Errorf("read websocket handshake: %w", err)
 	}
+	// The handshake response body is unused: a 101 carries no body, and for any
+	// other status the connection is discarded below. Close never reads from br.
+	_ = resp.Body.Close()
 	if resp.StatusCode != http.StatusSwitchingProtocols {
 		_ = conn.Close()
 		return nil, fmt.Errorf("websocket handshake returned %s", resp.Status)
@@ -561,7 +565,7 @@ func dialWebSocket(rawURL string, timeout time.Duration) (*websocketJSONConn, er
 		_ = conn.Close()
 		return nil, fmt.Errorf("websocket handshake accept mismatch")
 	}
-	if err := conn.SetDeadline(time.Time{}); err != nil {
+	if err = conn.SetDeadline(time.Time{}); err != nil {
 		_ = conn.Close()
 		return nil, err
 	}
@@ -582,13 +586,11 @@ func (w *websocketJSONConn) Send(v any) error {
 }
 
 func (w *websocketJSONConn) Receive() (appServerMessage, error) {
-	for {
-		payload, err := w.readTextMessage()
-		if err != nil {
-			return appServerMessage{}, err
-		}
-		return parseAppServerLine(payload)
+	payload, err := w.readTextMessage()
+	if err != nil {
+		return appServerMessage{}, err
 	}
+	return parseAppServerLine(payload)
 }
 
 func (w *websocketJSONConn) Close() error {
@@ -1003,14 +1005,14 @@ func resolveCodexModel(client *codexAppClient, cwd string) (string, error) {
 	})
 	if modelErr != nil {
 		if configErr != nil {
-			return "", fmt.Errorf("resolve codex model: config/read failed: %v; model/list failed: %w", configErr, modelErr)
+			return "", fmt.Errorf("resolve codex model: config/read failed: %w; model/list failed: %w", configErr, modelErr)
 		}
 		return "", fmt.Errorf("resolve codex model from model/list: %w", modelErr)
 	}
 	model, err := modelListDefault(modelResult)
 	if err != nil {
 		if configErr != nil {
-			return "", fmt.Errorf("resolve codex model: config/read failed: %v; model/list failed: %w", configErr, err)
+			return "", fmt.Errorf("resolve codex model: config/read failed: %w; model/list failed: %w", configErr, err)
 		}
 		return "", err
 	}

--- a/cmd/fanout/dashboard.go
+++ b/cmd/fanout/dashboard.go
@@ -64,7 +64,7 @@ func cmdDashboard(args []string, lg *log.Logger) exitcode.Code {
 	// Install local excludes BEFORE creating any .fanout artifact (the startup
 	// lock, the run file), so none of them ever surface in `git status` even if
 	// startup fails early (e.g. a port-in-use bind error).
-	if err := worktree.EnsureLocalExclude(root); err != nil {
+	if err = worktree.EnsureLocalExclude(root); err != nil {
 		lg.Debug("dashboard: ensure local exclude: %v", err)
 	}
 

--- a/cmd/fanout/main.go
+++ b/cmd/fanout/main.go
@@ -481,13 +481,13 @@ func executePlan(cfg *cliflags.Config, lg *log.Logger, info *fanoutruntime.Info,
 				issue.Body = detail.Body
 			}
 		}
-		if createPaneForIssue(cfg, lg, info, issue, resolvedSettings, recorder, sharedAcrossParents[issue.Number], c, commandName) {
-			result.Created++
-			result.CreatedNums = append(result.CreatedNums, issue.Number)
-		} else {
+		// Fail fast: stop after the first failed child launch.
+		if !createPaneForIssue(cfg, lg, info, issue, resolvedSettings, recorder, sharedAcrossParents[issue.Number], c, commandName) {
 			result.Failed++
 			break
 		}
+		result.Created++
+		result.CreatedNums = append(result.CreatedNums, issue.Number)
 		if i < len(targets)-1 {
 			if cfg.SleepBetween > 0 {
 				sleepBetweenIssues(time.Duration(cfg.SleepBetween * float64(time.Second)))

--- a/cmd/fanout/pane.go
+++ b/cmd/fanout/pane.go
@@ -84,7 +84,7 @@ func createPane(cfg *cliflags.Config, lg *log.Logger, info *fanoutruntime.Info, 
 	}
 
 	if req.BriefingPath != "" && (!cfg.DryRun || req.WriteBriefingDryRun) {
-		if err := os.WriteFile(req.BriefingPath, []byte(req.BriefingBody), 0o644); err != nil {
+		if err = os.WriteFile(req.BriefingPath, []byte(req.BriefingBody), 0o644); err != nil {
 			lg.Err("#%d: write briefing: %v", req.Number, err)
 			return false
 		}
@@ -410,7 +410,7 @@ func waitForCodexPlanTUIReady(statusPath string, timeout time.Duration) error {
 				return nil
 			case codexPlanTUIStatusFailed:
 				if status.Error == "" {
-					return fmt.Errorf("Codex Plan TUI setup failed")
+					return fmt.Errorf("Codex Plan TUI setup failed") //nolint:staticcheck // ST1005: "Codex Plan TUI" is a proper noun
 				}
 				return errors.New(status.Error)
 			default:
@@ -421,7 +421,7 @@ func waitForCodexPlanTUIReady(statusPath string, timeout time.Duration) error {
 		}
 		if time.Now().After(deadline) {
 			if lastErr != nil {
-				return fmt.Errorf("%w after %s; last status error: %v", errCodexPlanStartupTimeout, timeout, lastErr)
+				return fmt.Errorf("%w after %s; last status error: %w", errCodexPlanStartupTimeout, timeout, lastErr)
 			}
 			return fmt.Errorf("%w after %s; no status file at %s", errCodexPlanStartupTimeout, timeout, statusPath)
 		}

--- a/cmd/fanout/report.go
+++ b/cmd/fanout/report.go
@@ -199,7 +199,7 @@ func shellQuote(s string) string {
 		return "''"
 	}
 	if strings.IndexFunc(s, func(r rune) bool {
-		return !(r == '/' || r == ':' || r == '.' || r == '-' || r == '_' || (r >= '0' && r <= '9') || (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z'))
+		return r != '/' && r != ':' && r != '.' && r != '-' && r != '_' && (r < '0' || r > '9') && (r < 'A' || r > 'Z') && (r < 'a' || r > 'z')
 	}) < 0 {
 		return s
 	}

--- a/cmd/fanout/status.go
+++ b/cmd/fanout/status.go
@@ -95,10 +95,10 @@ func cmdStatus(cfg *cliflags.Config, lg *log.Logger) exitcode.Code {
 			Summary:  statusSummary{AllMerged: false},
 		}
 		if cfg.Format == "table" {
-			if code := writeStatusTable(report, rt.projectRoot, lg); code != exitcode.OK {
+			if code = writeStatusTable(report, rt.projectRoot, lg); code != exitcode.OK {
 				return code
 			}
-		} else if code := writeStatusReport(report, lg); code != exitcode.OK {
+		} else if code = writeStatusReport(report, lg); code != exitcode.OK {
 			return code
 		}
 		if cfg.PostDashboard {

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -97,7 +97,7 @@ func ShellQuote(s string) string {
 		return "''"
 	}
 	if strings.IndexFunc(s, func(r rune) bool {
-		return !(r == '/' || r == ':' || r == '.' || r == '-' || r == '_' || (r >= '0' && r <= '9') || (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z'))
+		return r != '/' && r != ':' && r != '.' && r != '-' && r != '_' && (r < '0' || r > '9') && (r < 'A' || r > 'Z') && (r < 'a' || r > 'z')
 	}) < 0 {
 		return s
 	}

--- a/internal/atomicfs/atomicfs.go
+++ b/internal/atomicfs/atomicfs.go
@@ -19,21 +19,23 @@ func WriteFile(path string, data []byte, perm os.FileMode) error {
 		return err
 	}
 	tmpPath := tmp.Name()
+	// Cleanup errors below are discarded deliberately: the write/close/chmod/
+	// rename error is the actionable one, and a stray tempfile is harmless.
 	if _, err := tmp.Write(data); err != nil {
-		tmp.Close()
-		os.Remove(tmpPath)
+		_ = tmp.Close()
+		_ = os.Remove(tmpPath)
 		return err
 	}
 	if err := tmp.Close(); err != nil {
-		os.Remove(tmpPath)
+		_ = os.Remove(tmpPath)
 		return err
 	}
 	if err := os.Chmod(tmpPath, perm); err != nil {
-		os.Remove(tmpPath)
+		_ = os.Remove(tmpPath)
 		return err
 	}
 	if err := os.Rename(tmpPath, path); err != nil {
-		os.Remove(tmpPath)
+		_ = os.Remove(tmpPath)
 		return err
 	}
 	return nil

--- a/internal/dashboard/poller.go
+++ b/internal/dashboard/poller.go
@@ -93,7 +93,7 @@ func newLazyPoller(projectRoot string, resolve func() (string, GHProvider, error
 // loop. The first GitHub refresh runs inside the loop goroutine, not here, so a
 // slow gh on a large repo never blocks the HTTP server from coming up or Ctrl-C
 // from being handled. The loop stops and closes all SSE subscribers when ctx is
-// cancelled.
+// canceled.
 func (p *poller) Start(ctx context.Context) {
 	p.rebuildAndBroadcast()
 	go p.loop(ctx)

--- a/internal/dashboard/runfile.go
+++ b/internal/dashboard/runfile.go
@@ -80,7 +80,7 @@ func RemoveRunFile(projectRoot string) error {
 func RemoveOwnRunFile(projectRoot, token string, pid int) error {
 	rf, err := ReadRunFile(projectRoot)
 	if err != nil || rf == nil {
-		return nil
+		return nil //nolint:nilerr // an unreadable run file cannot be proven ours; leave it rather than clobber a newer server's record
 	}
 	if rf.PID != pid {
 		return nil
@@ -126,7 +126,8 @@ func (rf *RunFile) IsLive() bool {
 	if err != nil {
 		return false
 	}
-	defer resp.Body.Close()
+	// Read-only health probe; the body is never read, so the Close error is moot.
+	defer func() { _ = resp.Body.Close() }()
 	return resp.StatusCode == http.StatusOK
 }
 
@@ -165,7 +166,8 @@ func LockStartup(projectRoot string) (*os.File, error) {
 		return nil, err
 	}
 	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
-		f.Close()
+		// Cleanup of the never-locked handle; the flock error is the one to report.
+		_ = f.Close()
 		return nil, err
 	}
 	return f, nil

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -41,7 +41,7 @@ type Options struct {
 
 // Server is a bound, ready-to-run dashboard. New binds the listener (so a
 // port-in-use error surfaces synchronously) and computes the URL; Run serves
-// until the context is cancelled.
+// until the context is canceled.
 type Server struct {
 	listener   net.Listener
 	httpServer *http.Server
@@ -61,7 +61,8 @@ func New(opts Options) (*Server, error) {
 	}
 	addr, ok := ln.Addr().(*net.TCPAddr)
 	if !ok {
-		ln.Close()
+		// Cleanup of a listener we will never serve on; the type error is the one to report.
+		_ = ln.Close()
 		return nil, fmt.Errorf("unexpected listener address %T", ln.Addr())
 	}
 
@@ -76,7 +77,8 @@ func New(opts Options) (*Server, error) {
 	}
 	handler, err := s.handler()
 	if err != nil {
-		ln.Close()
+		// Same cleanup-only close as above.
+		_ = ln.Close()
 		return nil, err
 	}
 	s.httpServer = &http.Server{Handler: handler}
@@ -111,7 +113,7 @@ func (s *Server) Start(ctx context.Context) {
 	}()
 }
 
-// Wait blocks until ctx is cancelled (then shuts down gracefully) or the server
+// Wait blocks until ctx is canceled (then shuts down gracefully) or the server
 // stops on its own. ErrServerClosed (the normal shutdown path) is reported nil.
 func (s *Server) Wait(ctx context.Context) error {
 	select {
@@ -125,7 +127,7 @@ func (s *Server) Wait(ctx context.Context) error {
 	}
 }
 
-// Run starts polling and serves until ctx is cancelled, then shuts down
+// Run starts polling and serves until ctx is canceled, then shuts down
 // gracefully.
 func (s *Server) Run(ctx context.Context) error {
 	s.Start(ctx)
@@ -184,7 +186,8 @@ func (s *Server) requireToken(next http.HandlerFunc) http.HandlerFunc {
 func (s *Server) handleSnapshot(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Cache-Control", "no-store")
-	w.Write(s.poller.snapshotJSON())
+	// A failed response write means the client went away; nothing to do here.
+	_, _ = w.Write(s.poller.snapshotJSON())
 }
 
 func (s *Server) handleStream(w http.ResponseWriter, r *http.Request) {
@@ -215,8 +218,10 @@ func (s *Server) handleStream(w http.ResponseWriter, r *http.Request) {
 	ch := s.hub.subscribe()
 	defer s.hub.unsubscribe(ch)
 
-	// Paint immediately so a fresh tab doesn't wait for the next tick.
-	w.Write(sseFrame(s.poller.snapshotJSON()))
+	// Paint immediately so a fresh tab doesn't wait for the next tick. Write
+	// errors here and below mean the client disconnected; the loop exits via
+	// r.Context().Done() rather than by inspecting them.
+	_, _ = w.Write(sseFrame(s.poller.snapshotJSON()))
 	flusher.Flush()
 
 	heartbeat := time.NewTicker(sseHeartbeat)
@@ -230,10 +235,10 @@ func (s *Server) handleStream(w http.ResponseWriter, r *http.Request) {
 			if !ok {
 				return // hub closed on shutdown
 			}
-			w.Write(payload)
+			_, _ = w.Write(payload)
 			flusher.Flush()
 		case <-heartbeat.C:
-			w.Write([]byte(": ping\n\n"))
+			_, _ = w.Write([]byte(": ping\n\n"))
 			flusher.Flush()
 		}
 	}

--- a/internal/displayname/metadata.go
+++ b/internal/displayname/metadata.go
@@ -31,7 +31,7 @@ func WriteFanoutMetadata(worktreePath string, meta FanoutMetadata) error {
 	path := filepath.Join(dir, "worktree-metadata.json")
 	m := map[string]any{}
 	if data, err := os.ReadFile(path); err == nil {
-		if err := json.Unmarshal(data, &m); err != nil {
+		if err = json.Unmarshal(data, &m); err != nil {
 			return fmt.Errorf("parse existing metadata %s: %w", path, err)
 		}
 		if m == nil {

--- a/internal/ghissue/ghissue.go
+++ b/internal/ghissue/ghissue.go
@@ -99,7 +99,8 @@ func (r Runner) gh(args ...string) ([]byte, error) {
 	}
 	out, err := cmd.Output()
 	if err != nil {
-		if ee, ok := err.(*exec.ExitError); ok {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
 			return out, fmt.Errorf("gh %s: %s", strings.Join(args, " "), strings.TrimSpace(string(ee.Stderr)))
 		}
 		return out, err
@@ -107,20 +108,20 @@ func (r Runner) gh(args ...string) ([]byte, error) {
 	return out, nil
 }
 
-func (r Runner) ghWithInput(input string, args ...string) ([]byte, error) {
+func (r Runner) ghWithInput(input string, args ...string) error {
 	cmd := exec.Command("gh", args...)
 	if r.Cwd != "" {
 		cmd.Dir = r.Cwd
 	}
 	cmd.Stdin = strings.NewReader(input)
-	out, err := cmd.Output()
-	if err != nil {
-		if ee, ok := err.(*exec.ExitError); ok {
-			return out, fmt.Errorf("gh %s: %s", strings.Join(args, " "), strings.TrimSpace(string(ee.Stderr)))
+	if _, err := cmd.Output(); err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			return fmt.Errorf("gh %s: %s", strings.Join(args, " "), strings.TrimSpace(string(ee.Stderr)))
 		}
-		return out, err
+		return err
 	}
-	return out, nil
+	return nil
 }
 
 // RepoNameWithOwner runs `gh repo view --json nameWithOwner -q .nameWithOwner`.
@@ -413,14 +414,12 @@ func parseIssueCommentPages(out []byte) ([][]issueCommentPageItem, error) {
 }
 
 func (r Runner) PostIssueComment(parent int, body string) error {
-	_, err := r.ghWithInput(body, "issue", "comment", strconv.Itoa(parent), "--body-file", "-")
-	return err
+	return r.ghWithInput(body, "issue", "comment", strconv.Itoa(parent), "--body-file", "-")
 }
 
 func (r Runner) EditIssueComment(owner, repo, id, body string) error {
 	path := fmt.Sprintf("/repos/%s/%s/issues/comments/%s", owner, repo, id)
-	_, err := r.ghWithInput(body, "api", "-X", "PATCH", path, "-F", "body=@-")
-	return err
+	return r.ghWithInput(body, "api", "-X", "PATCH", path, "-F", "body=@-")
 }
 
 func commentID(raw json.RawMessage, databaseID int, url string) string {
@@ -536,7 +535,7 @@ query($owner: String!, $number: Int!, $first: Int!, $after: String) {
 				// Mirror the shell's actionable message, including the
 				// canonical project URL so the user can check it.
 				projectURL := fmt.Sprintf("https://github.com/%s/%s/projects/%d", ownerType, owner, number)
-				return result, fmt.Errorf("%s: %s (check the URL, token scopes, and project visibility)", err, projectURL)
+				return result, fmt.Errorf("%w: %s (check the URL, token scopes, and project visibility)", err, projectURL)
 			}
 			return result, err
 		}
@@ -619,7 +618,7 @@ type projectItem struct {
 // syntactically valid URL whose project number is wrong or whose token can't
 // see it. ProjectItems wraps it with the project URL + actionable guidance to
 // match the shell's `die "Project not found or not accessible: $parent (...)"`.
-var errProjectNotFound = errors.New("Project not found or not accessible")
+var errProjectNotFound = errors.New("Project not found or not accessible") //nolint:staticcheck // ST1005: "Project" (GitHub Projects) is a proper noun, and the text must match the shell's die message
 
 func parseProjectPage(raw []byte, entryField string) (projectPage, error) {
 	var root struct {

--- a/internal/gitstat/gitstat.go
+++ b/internal/gitstat/gitstat.go
@@ -2,6 +2,7 @@
 package gitstat
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -58,7 +59,8 @@ func (r Runner) git(args ...string) ([]byte, error) {
 	cmd.Env = gitEnv()
 	out, err := cmd.Output()
 	if err != nil {
-		if ee, ok := err.(*exec.ExitError); ok {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
 			return out, fmt.Errorf("git %s: %s", strings.Join(args, " "), strings.TrimSpace(string(ee.Stderr)))
 		}
 		return out, err

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -47,7 +47,7 @@ func Close(opts Options, parent string, issueNum int, lg Logger) exitcode.Code {
 	}
 	defer unlockState("--close", locked, lg)
 
-	panes := panesForIssue(locked.Store.PanesForParent(parent), issueNum)
+	panes := panesForIssue(locked.PanesForParent(parent), issueNum)
 	if len(panes) == 0 {
 		lg.Err("--close: #%d is not recorded for parent %s in %s", issueNum, parent, opts.StatePath)
 		return exitcode.Invocation
@@ -102,7 +102,7 @@ func Cleanup(opts Options, parent string, lg Logger) exitcode.Code {
 	}
 	defer unlockState("--cleanup", locked, lg)
 
-	panes := locked.Store.PanesForParent(parent)
+	panes := locked.PanesForParent(parent)
 	if len(panes) == 0 {
 		lg.Info("--cleanup: no recorded panes for parent %s", parent)
 		return exitcode.OK

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -222,7 +222,8 @@ func (s ntfySink) Notify(event Event) error {
 	if err != nil {
 		return fmt.Errorf("ntfy post: %w", err)
 	}
-	defer resp.Body.Close()
+	// Fire-and-forget notification; only the status code matters, not the body.
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("ntfy post: status %d", resp.StatusCode)
 	}
@@ -238,7 +239,8 @@ func (s slackSink) Notify(event Event) error {
 	if err != nil {
 		return fmt.Errorf("slack post: %w", err)
 	}
-	defer resp.Body.Close()
+	// Fire-and-forget notification; only the status code matters, not the body.
+	defer func() { _ = resp.Body.Close() }()
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("slack post: status %d", resp.StatusCode)
 	}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -25,7 +25,7 @@ func Resolve(sessionOverride string) (*Info, error) {
 		return nil, err
 	}
 	if sessionOverride != "" {
-		if err := validateTmuxSession(sessionOverride); err != nil {
+		if err = validateTmuxSession(sessionOverride); err != nil {
 			return nil, err
 		}
 		session = sessionOverride

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -12,7 +12,7 @@ func TestResolveAcceptsExistingSessionOverride(t *testing.T) {
 	repo := newGitRepo(t)
 	installTmuxShim(t)
 	t.Setenv("TMUX_PANE", "%caller")
-	chdir(t, repo)
+	t.Chdir(repo)
 
 	info, err := Resolve("target")
 	if err != nil {
@@ -37,7 +37,7 @@ func TestResolveTargetsInvokingPaneByDefault(t *testing.T) {
 	repo := newGitRepo(t)
 	installTmuxShim(t)
 	t.Setenv("TMUX_PANE", "%caller")
-	chdir(t, repo)
+	t.Chdir(repo)
 
 	info, err := Resolve("")
 	if err != nil {
@@ -55,7 +55,7 @@ func TestResolveFallsBackToTmuxPaneID(t *testing.T) {
 	repo := newGitRepo(t)
 	installTmuxShim(t)
 	t.Setenv("TMUX_PANE", "")
-	chdir(t, repo)
+	t.Chdir(repo)
 
 	info, err := Resolve("")
 	if err != nil {
@@ -70,7 +70,7 @@ func TestResolveRejectsMissingSessionOverride(t *testing.T) {
 	repo := newGitRepo(t)
 	installTmuxShim(t)
 	t.Setenv("TMUX_PANE", "%caller")
-	chdir(t, repo)
+	t.Chdir(repo)
 
 	_, err := Resolve("missing")
 	if err == nil {
@@ -90,22 +90,6 @@ func newGitRepo(t *testing.T) string {
 		t.Fatalf("git init failed: %v\n%s", err, out)
 	}
 	return repo
-}
-
-func chdir(t *testing.T, dir string) {
-	t.Helper()
-	old, err := os.Getwd()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := os.Chdir(dir); err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() {
-		if err := os.Chdir(old); err != nil {
-			t.Fatalf("restore cwd: %v", err)
-		}
-	})
 }
 
 func installTmuxShim(t *testing.T) {

--- a/internal/selfupdate/selfupdate.go
+++ b/internal/selfupdate/selfupdate.go
@@ -254,7 +254,8 @@ func ResolvePlan(opts Options) (Plan, error) {
 		InstallerURL:   InstallScriptURL,
 	}
 
-	if req.Version != "" {
+	switch {
+	case req.Version != "":
 		plan.TargetSource = "pinned"
 		plan.ExplicitTarget = true
 		if _, ok := parseVersion(req.Version); !ok {
@@ -267,12 +268,12 @@ func ResolvePlan(opts Options) (Plan, error) {
 			plan.Outcome = DevBuild
 			return plan, nil
 		}
-	} else if Compare(opts.CurrentVersion, "") == DevBuild {
+	case Compare(opts.CurrentVersion, "") == DevBuild:
 		plan.TargetVersion = "latest"
 		plan.TargetSource = "latest"
 		plan.Outcome = DevBuild
 		return plan, nil
-	} else {
+	default:
 		latest, err := opts.LatestTag()
 		if err != nil {
 			return plan, fail(FailureGitHub, "failed to fetch latest release tag: %w", err)

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -202,15 +202,10 @@ func clearEnv(t *testing.T) {
 		"FANOUT_NTFY_URL",
 		"FANOUT_SLACK_WEBHOOK_URL",
 	} {
-		old, hadOld := os.LookupEnv(name)
+		// t.Setenv registers restoration of the original value (or unset state);
+		// the follow-up Unsetenv leaves the variable unset for the test body.
+		t.Setenv(name, "")
 		os.Unsetenv(name)
-		t.Cleanup(func() {
-			if hadOld {
-				_ = os.Setenv(name, old)
-			} else {
-				_ = os.Unsetenv(name)
-			}
-		})
 	}
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -84,14 +84,16 @@ func Lock(path string) (*LockedStore, error) {
 	if err != nil {
 		return nil, fmt.Errorf("open fanout state lock %s: %w", lockPath, err)
 	}
-	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
-		f.Close()
+	if err = syscall.Flock(int(f.Fd()), syscall.LOCK_EX); err != nil {
+		// Cleanup of the never-locked handle; the flock error is the one to report.
+		_ = f.Close()
 		return nil, fmt.Errorf("lock fanout state %s: %w", lockPath, err)
 	}
 	store, err := Load(path)
 	if err != nil {
+		// Best-effort unwind; the Load error is the one to report.
 		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
-		f.Close()
+		_ = f.Close()
 		return nil, err
 	}
 	return &LockedStore{path: path, file: f, Store: store}, nil
@@ -111,12 +113,12 @@ func (l *LockedStore) Unlock() error {
 }
 
 func (l *LockedStore) RecordPane(p Pane) error {
-	l.Store.Upsert(p)
+	l.Upsert(p)
 	return save(l.path, l.Store)
 }
 
 func (l *LockedStore) RemovePane(parent string, issueNum int) error {
-	if !l.Store.Remove(parent, issueNum) {
+	if !l.Remove(parent, issueNum) {
 		return nil
 	}
 	return save(l.path, l.Store)

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -110,10 +110,10 @@ func TestRecordPaneReplacesSameParentIssue(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = locked.Unlock() })
 
-	if err := locked.RecordPane(Pane{Parent: "81", IssueNum: 83, PaneID: "%1"}); err != nil {
+	if err = locked.RecordPane(Pane{Parent: "81", IssueNum: 83, PaneID: "%1"}); err != nil {
 		t.Fatal(err)
 	}
-	if err := locked.RecordPane(Pane{Parent: "81", IssueNum: 83, PaneID: "%2"}); err != nil {
+	if err = locked.RecordPane(Pane{Parent: "81", IssueNum: 83, PaneID: "%2"}); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/tmuxrun/tmuxrun.go
+++ b/internal/tmuxrun/tmuxrun.go
@@ -427,7 +427,7 @@ func shellQuote(s string) string {
 		return "''"
 	}
 	if strings.IndexFunc(s, func(r rune) bool {
-		return !(r == '/' || r == ':' || r == '.' || r == '-' || r == '_' || (r >= '0' && r <= '9') || (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z'))
+		return r != '/' && r != ':' && r != '.' && r != '-' && r != '_' && (r < '0' || r > '9') && (r < 'A' || r > 'Z') && (r < 'a' || r > 'z')
 	}) < 0 {
 		return s
 	}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -642,7 +642,7 @@ func (m model) updatePendingAction(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.actionMessage = lifecycleRunningMessage(pending)
 		return m, m.lifecycleCmd(pending)
 	case "n", "esc", "q", "ctrl+c":
-		m.actionMessage = fmt.Sprintf("%s cancelled", m.pendingAction.action)
+		m.actionMessage = fmt.Sprintf("%s canceled", m.pendingAction.action)
 		m.pendingAction = nil
 		return m, nil
 	}
@@ -762,8 +762,7 @@ func newNewPaneForm(defaultAgent string, width int) newPaneForm {
 
 func (m model) updateNewPane(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if m.newPane.launching {
-		switch msg.String() {
-		case "ctrl+c":
+		if msg.String() == "ctrl+c" {
 			return m, tea.Quit
 		}
 		return m, nil
@@ -793,6 +792,8 @@ func (m model) updateNewPane(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.newPane.prompt, cmd = m.newPane.prompt.Update(msg)
 	case newPaneFieldSlug:
 		m.newPane.slug, cmd = m.newPane.slug.Update(msg)
+	default:
+		// The agent field is a toggle, not a text input; no message routing.
 	}
 	return m, cmd
 }
@@ -872,8 +873,7 @@ func (m model) newPaneFieldView(field newPaneField, label, value string) string 
 }
 
 func (m model) agentSelectorView() string {
-	claude := "claude"
-	codex := "codex"
+	var claude, codex string
 	if m.newPane.agent == "claude" {
 		claude = titleStyle.Render("[claude]")
 		codex = dimStyle.Render(" codex ")
@@ -1579,8 +1579,7 @@ func buildPaneViews(projectRoot string, panes []state.Pane, tmuxPanes []tmuxrun.
 }
 
 func applyIssueStatuses(panes []paneView, issues map[issueKey]issueStatus) []paneView {
-	out := make([]paneView, len(panes))
-	copy(out, panes)
+	out := slices.Clone(panes)
 	seen := map[issueKey]bool{}
 	for i := range out {
 		key := keyForIssue(out[i].Parent, out[i].IssueNum)
@@ -2037,27 +2036,27 @@ func formatClock(t time.Time) string {
 	return t.Format("15:04:05")
 }
 
-func truncate(s string, max int) string {
+func truncate(s string, maxLen int) string {
 	s = strings.TrimSpace(s)
-	return truncateRunes(s, max)
+	return truncateRunes(s, maxLen)
 }
 
-func truncatePreserveSpace(s string, max int) string {
-	return truncateRunes(s, max)
+func truncatePreserveSpace(s string, maxLen int) string {
+	return truncateRunes(s, maxLen)
 }
 
-func truncateRunes(s string, max int) string {
+func truncateRunes(s string, maxLen int) string {
 	runes := []rune(s)
-	if max <= 0 || len(runes) <= max {
+	if maxLen <= 0 || len(runes) <= maxLen {
 		return s
 	}
-	if max <= 1 {
-		return string(runes[:max])
+	if maxLen <= 1 {
+		return string(runes[:maxLen])
 	}
-	if max <= 3 {
-		return string(runes[:max])
+	if maxLen <= 3 {
+		return string(runes[:maxLen])
 	}
-	return string(runes[:max-3]) + "..."
+	return string(runes[:maxLen-3]) + "..."
 }
 
 func trimLastRune(s string) string {
@@ -2076,13 +2075,13 @@ func compactMessage(s string) string {
 	return truncate(strings.Join(fields, " "), 160)
 }
 
-func tailLines(s string, max int) []string {
-	if max <= 0 {
+func tailLines(s string, maxLen int) []string {
+	if maxLen <= 0 {
 		return nil
 	}
 	raw := strings.Split(s, "\n")
-	if len(raw) > max {
-		raw = raw[len(raw)-max:]
+	if len(raw) > maxLen {
+		raw = raw[len(raw)-maxLen:]
 	}
 	out := make([]string, 0, len(raw))
 	for _, line := range raw {

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -233,7 +233,7 @@ func TestGHUpdateNotifiesTransitionsOnceAfterInitialSnapshot(t *testing.T) {
 		t.Fatalf("notice = %q, want transition summary", m.notice)
 	}
 
-	updated, cmd = m.Update(ghLoadedMsg{issues: nextIssues, at: time.Unix(3, 0)})
+	_, cmd = m.Update(ghLoadedMsg{issues: nextIssues, at: time.Unix(3, 0)})
 	if cmd != nil {
 		t.Fatal("unchanged GH snapshot returned notification command, want nil")
 	}
@@ -305,7 +305,7 @@ func TestGHUpdateDoesNotOverwriteNotificationBaselineOnPartialError(t *testing.T
 	}
 	m = updated.(model)
 
-	updated, cmd = m.Update(ghLoadedMsg{issues: initial, at: time.Unix(3, 0)})
+	_, cmd = m.Update(ghLoadedMsg{issues: initial, at: time.Unix(3, 0)})
 	if cmd != nil {
 		t.Fatal("recovered unchanged waiting snapshot returned notification command, want nil")
 	}
@@ -343,7 +343,7 @@ func TestGHUpdateNotifiesUsableTransitionOnPartialError(t *testing.T) {
 		{Parent: "100", Num: 101}: {Title: "visible", State: "CLOSED", PRs: []ghissue.PRRef{{Number: 901, State: "MERGED", CIStatus: "pass"}}},
 		{Parent: "100", Num: 102}: {Title: "omitted", State: "OPEN", PRs: []ghissue.PRRef{{Number: 902, State: "OPEN", CIStatus: "pass"}}},
 	}
-	updated, cmd = m.Update(ghLoadedMsg{issues: recovered, at: time.Unix(3, 0)})
+	_, cmd = m.Update(ghLoadedMsg{issues: recovered, at: time.Unix(3, 0)})
 	if cmd != nil {
 		t.Fatal("recovered already-notified snapshot returned notification command, want nil")
 	}

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -105,7 +105,7 @@ func Prepare(opts Options) (Result, error) {
 }
 
 // EnsureLocalExclude keeps generated fanout runtime files out of the user's git status.
-func EnsureLocalExclude(root string) error {
+func EnsureLocalExclude(root string) (err error) {
 	excludePath, err := gitTrim(root, "rev-parse", "--git-path", "info/exclude")
 	if err != nil {
 		return fmt.Errorf("resolve git exclude path: %w", err)
@@ -123,22 +123,28 @@ func EnsureLocalExclude(root string) error {
 	}
 	missing := missingExcludePatterns(body)
 
-	if err := os.MkdirAll(filepath.Dir(excludePath), 0o755); err != nil {
+	if err = os.MkdirAll(filepath.Dir(excludePath), 0o755); err != nil {
 		return fmt.Errorf("create git exclude directory: %w", err)
 	}
 	f, err := os.OpenFile(excludePath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
 	if err != nil {
 		return fmt.Errorf("open git exclude: %w", err)
 	}
-	defer f.Close()
+	// This is a write path: a failed Close can mean the appended patterns were
+	// never flushed, so propagate it instead of discarding.
+	defer func() {
+		if cerr := f.Close(); cerr != nil && err == nil {
+			err = fmt.Errorf("close git exclude: %w", cerr)
+		}
+	}()
 
 	if len(body) > 0 && body[len(body)-1] != '\n' {
-		if _, err := f.WriteString("\n"); err != nil {
+		if _, err = f.WriteString("\n"); err != nil {
 			return fmt.Errorf("append git exclude newline: %w", err)
 		}
 	}
 	for _, pattern := range missing {
-		if _, err := f.WriteString(pattern + "\n"); err != nil {
+		if _, err = f.WriteString(pattern + "\n"); err != nil {
 			return fmt.Errorf("append git exclude pattern: %w", err)
 		}
 	}
@@ -240,7 +246,7 @@ func RefreshBase(root, base string) error {
 	if err != nil {
 		return err
 	}
-	if _, err := git(root, "fetch", "--quiet", "--no-tags", "origin", details.FetchBranch); err != nil {
+	if _, err = git(root, "fetch", "--quiet", "--no-tags", "origin", details.FetchBranch); err != nil {
 		return fmt.Errorf("git fetch origin %s: %w", details.FetchBranch, err)
 	}
 	originSHA, err := gitTrim(root, "rev-parse", "--verify", details.OriginRef)
@@ -254,7 +260,7 @@ func RefreshBase(root, base string) error {
 	localRef := "refs/heads/" + details.LocalBranch
 	localSHA, err := gitTrim(root, "rev-parse", "--verify", localRef)
 	if err != nil {
-		if _, err := git(root, "branch", details.LocalBranch, originSHA); err != nil {
+		if _, err = git(root, "branch", details.LocalBranch, originSHA); err != nil {
 			return fmt.Errorf("create local base branch %s: %w", details.LocalBranch, err)
 		}
 		return nil
@@ -269,7 +275,7 @@ func RefreshBase(root, base string) error {
 	if mergeBase != localSHA {
 		return fmt.Errorf("local branch %s has diverged from origin/%s", details.LocalBranch, details.FetchBranch)
 	}
-	if _, err := git(root, "branch", "-f", details.LocalBranch, originSHA); err == nil {
+	if _, err = git(root, "branch", "-f", details.LocalBranch, originSHA); err == nil {
 		return nil
 	}
 
@@ -327,7 +333,7 @@ func git(dir string, args ...string) ([]byte, error) {
 		if msg == "" {
 			return out, err
 		}
-		return out, fmt.Errorf("%v: %s", err, msg)
+		return out, fmt.Errorf("%w: %s", err, msg)
 	}
 	return out, nil
 }


### PR DESCRIPTION
## TL;DR

ピン版 golangci-lint v2.12.2(#191 で導入した `.golangci.yml`、max-same-issues: 0)で検出された既存コードの指摘 **82 件を全て解消**し、`golangci-lint run ./...` の指摘ゼロベースラインを確立。`.golangci.yml` 側の無効化はゼロ、nolint は理由・linter 指定付きの 3 件のみ。

Review effort: 2

## Why

#188(Go 静的解析 2026 年化)の直列チェーンの 3 番目。#191 が設定とフォーマッタ一括整形を入れたのに対し、本 issue は残った lint 指摘(errcheck 19 / govet shadow 18 / staticcheck 10 / errorlint 9 / revive 6 / misspell 5 / ineffassign 5 / usetesting 3 / gocritic 2 / bodyclose・exhaustive・makezero・nilerr・unparam 各 1)を、issue 記載のトリアージ方針(修正 / `_ =` 明示破棄 + 理由 / 根拠付き nolint)で個別に潰してゼロにする。単一ルール最大は shadow の 18 件で、チャーン上限ガード(20 件超で設定側無効化)はどのルールも非該当だった。後続 #193 が Makefile/CI 配線を担うため、本 PR はコード修正のみで Makefile・CI には触れていない。

## Changes by file

<details><summary>Changed files (26)</summary>

| File | What changed | Why |
|---|---|---|
| `internal/worktree/worktree.go` | `EnsureLocalExclude` を named return 化し、書き込みパスの `defer f.Close()` のエラーを伝播(worktree.go:130-139)。shadow 3 箇所を `=` 化、`git()` の `%v`→`%w` | errcheck(issue 指定の実バグ寄り)/ govet / errorlint |
| `internal/atomicfs/atomicfs.go` | エラーパスの `tmp.Close`/`os.Remove` ×5 を `_ =` + 理由コメント | errcheck(意図的破棄の規約) |
| `cmd/fanout/codex_plan_tui.go` | `Exited()` を `(bool, error)` に入替(呼出元 2 箇所追随)、websocket handshake 応答の body close 追加、`Receive()` の dead loop 除去、shadow 6 箇所 `=` 化、`%v`→`%w` ×3、`freeLocalPort` の close 明示破棄 | revive error-return / bodyclose / SA4004 / govet / errorlint / errcheck |
| `cmd/fanout/main.go` | `executePlan` の成功/失敗分岐を early-return 形に反転(main.go:485-490、fail-fast 挙動は同一) | revive early-return |
| `cmd/fanout/pane.go` | ST1005 に理由付き nolint(固有名詞 "Codex Plan TUI")、shadow 1 箇所、`%v`→`%w`(複数 %w) | staticcheck / govet / errorlint |
| `cmd/fanout/status.go` | `code` の shadow 2 箇所を `=` 化 | govet |
| `cmd/fanout/report.go` | rune 述語を De Morgan 書換 | QF1001 |
| `cmd/fanout/dashboard.go` | shadow 1 箇所を `=` 化 | govet |
| `internal/agent/agent.go` | rune 述語を De Morgan 書換 | QF1001 |
| `internal/tmuxrun/tmuxrun.go` | rune 述語を De Morgan 書換 | QF1001 |
| `internal/dashboard/server.go` | `ln.Close`/`w.Write` ×6 を明示破棄 + 理由、cancelled→canceled ×3 | errcheck / misspell |
| `internal/dashboard/runfile.go` | `Body.Close`/`f.Close` 明示破棄、`RemoveOwnRunFile` に理由付き nolint:nilerr | errcheck / nilerr |
| `internal/dashboard/poller.go` | cancelled→canceled(コメント) | misspell |
| `internal/notify/notify.go` | `defer resp.Body.Close()` ×2 を明示破棄 + 理由 | errcheck |
| `internal/state/state.go` | `Lock` エラーパスの `_ = f.Close()` ×2、shadow 1 箇所、`l.Store.X`→`l.X`(ロックの構造・順序は不変) | errcheck / govet / QF1008 |
| `internal/state/state_test.go` | shadow 2 箇所を `=` 化 | govet |
| `internal/lifecycle/lifecycle.go` | `locked.Store.PanesForParent`→`locked.PanesForParent` ×2 | QF1008 |
| `internal/ghissue/ghissue.go` | `errors.As` 化 ×2、`ghWithInput` の戻り値を `error` のみに(全呼出元が破棄済み)、`errProjectNotFound` に ST1005 nolint、`%s`→`%w` | errorlint / unparam / staticcheck |
| `internal/gitstat/gitstat.go` | `errors.As` 化 | errorlint |
| `internal/selfupdate/selfupdate.go` | if-else 連鎖を `switch {}` 化 | gocritic ifElseChain |
| `internal/displayname/metadata.go` | shadow 1 箇所を `=` 化 | govet |
| `internal/runtime/runtime.go` | shadow 1 箇所を `=` 化 | govet |
| `internal/runtime/runtime_test.go` | 自前 `chdir` ヘルパを削除し `t.Chdir` ×4 に置換 | usetesting |
| `internal/settings/settings_test.go` | `clearEnv` を `t.Setenv("")` + `os.Unsetenv` イディオムに簡約(復元意味論は同一) | usetesting |
| `internal/tui/tui.go` | exhaustive 用 `default:` 追加、単一 case switch を `if` 化、`var claude, codex`、`make`+`copy`→`slices.Clone`、`max`→`maxLen` ×4、cancelled→canceled(TUI 文言) | exhaustive / gocritic / ineffassign / makezero / revive / misspell |
| `internal/tui/tui_test.go` | 未使用代入 `updated` を `_` 化 ×3 | ineffassign |

</details>

## Risk

> [!WARNING]
> 機械的書換が大半だが、挙動が変わる箇所が 2 系統ある。
> 1. `EnsureLocalExclude`(internal/worktree/worktree.go:130-139)が Close 失敗時にエラーを返すようになった。呼び出し元はエラー処理済み(cmd/fanout/dashboard.go:67 は Debug ログ、pane 作成パスは launch 失敗扱い)。
> 2. `%v`→`%w` 化 ×6 でラップ対象が `errors.Is/As` で辿れるようになる(マッチ範囲が広がる方向のみ)。`internal/tui/tui.go:645` の TUI 文言 "cancelled"→"canceled" はユーザー可視だが golden 非掲載を確認済み。

## Test plan

- `go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2 run ./...` → **0 issues**(受け入れ基準)
- `make test`(Go unit + bats Tier1 98 件 + Tier2 29 件)→ 全グリーン、Tier2 golden 無差分(`git status` clean)
- `make lint`(go vet + gofmt + shellcheck)→ pass
- /code-review(9 角度 + 検証 + スイープ)指摘 0 件、codex review approve(no actionable defects)

Closes #192