### PR TITLE
feat(tui): TUI/CLI の配色をドキュメントサイトの PAPER BREEZE パレットに統一

### DIFF
--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/butaosuinu/fanout/internal/tty"
 )
@@ -34,17 +35,34 @@ func New(debug bool) *Logger {
 func NewWith(out, err io.Writer, debug bool) *Logger {
 	l := &Logger{out: out, err: err, color: tty.IsColorCapable(out), debug: debug}
 	if l.color {
-		// Match bash tput colors: blue, green, yellow, red, dim.
-		l.palette = Palette{
-			Info:  "\x1b[34m",
-			Ok:    "\x1b[32m",
-			Warn:  "\x1b[33m",
-			Err:   "\x1b[31m",
-			Dim:   "\x1b[2m",
-			Reset: "\x1b[0m",
-		}
+		l.palette = paletteFor(os.Getenv("TERM"), os.Getenv("COLORTERM"))
 	}
 	return l
+}
+
+// paletteFor picks the richest palette the terminal advertises.
+func paletteFor(term, colorterm string) Palette {
+	// Match bash tput colors: blue, green, yellow, red, dim.
+	p := Palette{
+		Info:  "\x1b[34m",
+		Ok:    "\x1b[32m",
+		Warn:  "\x1b[33m",
+		Err:   "\x1b[31m",
+		Dim:   "\x1b[2m",
+		Reset: "\x1b[0m",
+	}
+	if strings.Contains(term, "256color") || strings.Contains(term, "truecolor") ||
+		strings.EqualFold(colorterm, "truecolor") || strings.EqualFold(colorterm, "24bit") {
+		// 256-color approximations of the PAPER BREEZE palette
+		// (site/assets/css/main.css; keep in sync with the internal/tui
+		// AdaptiveColor palette): 藍, 青緑, 土, 紅 — mid-brightness values
+		// readable on both light and dark backgrounds.
+		p.Info = "\x1b[38;5;31m"
+		p.Ok = "\x1b[38;5;36m"
+		p.Warn = "\x1b[38;5;136m"
+		p.Err = "\x1b[38;5;167m"
+	}
+	return p
 }
 
 func (l *Logger) Info(format string, a ...any) {

--- a/internal/log/log_test.go
+++ b/internal/log/log_test.go
@@ -1,0 +1,33 @@
+package log
+
+import "testing"
+
+func TestPaletteForSelectsByTerminalCapability(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		term      string
+		colorterm string
+		wantErr   string
+	}{
+		{name: "plain xterm falls back to 16-color", term: "xterm", wantErr: "\x1b[31m"},
+		{name: "empty TERM falls back to 16-color", term: "", wantErr: "\x1b[31m"},
+		{name: "xterm-256color picks 256-color palette", term: "xterm-256color", wantErr: "\x1b[38;5;167m"},
+		{name: "tmux-256color picks 256-color palette", term: "tmux-256color", wantErr: "\x1b[38;5;167m"},
+		{name: "COLORTERM=truecolor upgrades plain TERM", term: "xterm", colorterm: "truecolor", wantErr: "\x1b[38;5;167m"},
+		{name: "COLORTERM=24bit upgrades plain TERM", term: "xterm-direct", colorterm: "24bit", wantErr: "\x1b[38;5;167m"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			p := paletteFor(tc.term, tc.colorterm)
+			if p.Err != tc.wantErr {
+				t.Errorf("paletteFor(%q, %q).Err = %q, want %q", tc.term, tc.colorterm, p.Err, tc.wantErr)
+			}
+			if p.Reset != "\x1b[0m" || p.Dim != "\x1b[2m" {
+				t.Errorf("paletteFor(%q, %q) Dim/Reset = %q/%q, want \\x1b[2m/\\x1b[0m", tc.term, tc.colorterm, p.Dim, p.Reset)
+			}
+		})
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -304,13 +304,25 @@ func (l actionLogger) Stderr() io.Writer {
 	return l.w
 }
 
+// PAPER BREEZE palette (site/assets/css/main.css; keep the internal/log
+// 256-color approximations in sync). Light = site values (紅 is an addition;
+// the site defines no red), dark = same hue lifted for dark backgrounds.
 var (
-	titleStyle = lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("34"))
-	dimStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("240"))
-	warnStyle  = lipgloss.NewStyle().Foreground(lipgloss.Color("33"))
-	errStyle   = lipgloss.NewStyle().Foreground(lipgloss.Color("31"))
-	panelStyle = lipgloss.NewStyle().Border(lipgloss.NormalBorder(), true, false, false, false).BorderForeground(lipgloss.Color("240"))
-	formStyle  = lipgloss.NewStyle().Border(lipgloss.NormalBorder()).Padding(1, 2).BorderForeground(lipgloss.Color("240"))
+	colorAi     = lipgloss.AdaptiveColor{Light: "#165E83", Dark: "#6FAECE"} // 藍
+	colorAsagi  = lipgloss.AdaptiveColor{Light: "#00A3AF", Dark: "#2BC4CF"} // 浅葱
+	colorInk    = lipgloss.AdaptiveColor{Light: "#797D80", Dark: "#8A9096"} // 墨60%
+	colorSuna   = lipgloss.AdaptiveColor{Light: "#E2D9C8", Dark: "#5C564C"} // 砂
+	colorTsuchi = lipgloss.AdaptiveColor{Light: "#9A6B2F", Dark: "#C9974F"} // 土
+	colorBeni   = lipgloss.AdaptiveColor{Light: "#B5495B", Dark: "#E07A8B"} // 紅
+)
+
+var (
+	titleStyle = lipgloss.NewStyle().Bold(true).Foreground(colorAi)
+	dimStyle   = lipgloss.NewStyle().Foreground(colorInk)
+	warnStyle  = lipgloss.NewStyle().Foreground(colorTsuchi)
+	errStyle   = lipgloss.NewStyle().Foreground(colorBeni)
+	panelStyle = lipgloss.NewStyle().Border(lipgloss.NormalBorder(), true, false, false, false).BorderForeground(colorSuna)
+	formStyle  = lipgloss.NewStyle().Border(lipgloss.NormalBorder()).Padding(1, 2).BorderForeground(colorSuna)
 )
 
 // Run starts the Bubble Tea TUI.
@@ -355,8 +367,8 @@ func newModel(opts Options) model {
 		table.WithHeight(12),
 	)
 	styles := table.DefaultStyles()
-	styles.Header = styles.Header.Bold(true).Foreground(lipgloss.Color("34"))
-	styles.Selected = styles.Selected.Bold(true).Foreground(lipgloss.Color("32"))
+	styles.Header = styles.Header.Bold(true).Foreground(colorAi)
+	styles.Selected = styles.Selected.Bold(true).Foreground(colorAsagi)
 	t.SetStyles(styles)
 
 	return model{


### PR DESCRIPTION
## 概要

TUI と CLI ログの配色を、ドキュメントサイト (butaosuinu.github.io/fanout) の PAPER BREEZE 和紙パレット (`site/assets/css/main.css`) に統一する。

## 変更内容

### `internal/tui/tui.go`
- スタイル定数を `lipgloss.AdaptiveColor` 化。伝統色名の 6 色 (藍 `#165E83`・浅葱 `#00A3AF`・墨60%・砂・土・紅) を定義し、ライト端末ではサイトの値そのまま、ダーク端末では同色相の明度を上げた値を適用
  - タイトル・テーブルヘッダー = 藍 / 選択行 = 浅葱 / dim = 墨60% / 枠線 = 砂 / warn = 土 / err = 紅
- 副次修正: 旧 `lipgloss.Color("31")`〜`("34")` は SGR コード (赤/緑/黄/青) のつもりが 256 色インデックス (teal/青/青/緑) として解釈されており、err が赤く表示されない潜在バグがあった。hex 指定化で解消

### `internal/log/log.go`
- `[info]`/`[ok]`/`[warn]`/`[err]` プレフィックス色のパレット選択を純関数 `paletteFor(term, colorterm)` に抽出
- `TERM` に `256color`/`truecolor`、または `COLORTERM` が `truecolor`/`24bit` なら 256 色のブランド近似 (藍 31・青緑 36・土 136・紅 167)、それ以外は従来の 16 色 SGR にフォールバック
- `Palette` struct と利用側 (`cmd/fanout/status.go`・`report.go`・`main.go`) は無変更

### `internal/log/log_test.go` (新規)
- `paletteFor` の TERM/COLORTERM 分岐を表駆動テスト 6 ケースで固定

## レビュー

post-work-review 済み:
- Pass 1 (code-review xhigh): COLORTERM 無視・同型リテラル重複・コメント不正確・命名不統一の 4 件を修正、パレット二重定義 (tui hex / log 256 色) は相互同期コメント付きの意図的トレードオフとして維持
- Pass 2 (codex review): 反復 1 で指摘なし (clean)

## テスト

- `make test` (Go unit + bats Tier 1/2) 全パス。Tier 2 ゴールデンは非 TTY 実行で無色のため再生成不要
- `make lint` 0 issues
- 目視: tmux 内で TUI を起動し `capture-pane -e` で藍/墨/砂の truecolor 出力を確認。CLI は疑似 TTY で `TERM=xterm-256color` → 紅 (`38;5;167`)、`TERM=xterm` → 従来 `31` へのフォールバックを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)