### PR TITLE
feat(deps): jq の依存チェックを削除する

### DIFF
--- a/cmd/fanout/main.go
+++ b/cmd/fanout/main.go
@@ -515,7 +515,6 @@ func checkDeps(cfg *cliflags.Config) []string {
 	lifecycle := cfg.CloseNum > 0 || cfg.MergeNum > 0 || cfg.CleanupMode
 	if cfg.StatusMode || cfg.CleanupMode || !lifecycle {
 		check("gh", "gh (brew install gh)")
-		check("jq", "jq (brew install jq)")
 	}
 
 	if !cfg.StatusMode && !lifecycle {

--- a/internal/cliflags/usage.go
+++ b/internal/cliflags/usage.go
@@ -150,7 +150,7 @@ Options:
   -h, --help          Show this message.
 
 Prerequisites:
-  * gh, jq, git, tmux installed. gh-sub-issue extension is required for
+  * gh, git, tmux installed. gh-sub-issue extension is required for
     issue mode only; project mode uses gh api graphql.
   * fanout pane-creation mode is invoked from inside a tmux session. TUI mode
     can be started from a plain shell; it creates or attaches its tmux session.

--- a/tests/bats/tier1_flags.bats
+++ b/tests/bats/tier1_flags.bats
@@ -380,14 +380,6 @@ load helpers
   [[ "$output" == *"gh-sub-issue extension"* ]]
 }
 
-@test "missing jq: exit 1" {
-  force_missing jq
-  run_fanout 20 --agent claude
-  [ "$status" -eq 1 ]
-  [[ "$output" == *"missing dependencies"* ]]
-  [[ "$output" == *"jq (brew install jq)"* ]]
-}
-
 @test "missing tmux: exit 1" {
   force_missing tmux
   run_fanout 20 --agent claude


### PR DESCRIPTION
## TL;DR

Go コード内で一度も実行されない外部 `jq` の存在チェックを削除し、jq を必須依存から外す(`gh` の `--jq` は内蔵 gojq で処理される)。すべて削除のみの変更。

Review effort: 0

## Why

issue #202(親 #201「依存削減」wave 1)のとおり、`checkDeps()` が jq の存在をチェックしているが、fanout 本体は jq を一度も exec していない。jq 未インストール環境では `--dry-run` / `--status` すら exit 1 で落ちるため、チェックを消して必須依存から外す。README / site docs / SKILL.md の前提リスト更新は wave 2 の別 issue に分離されており、本 PR はコードとテストのみ。

## Changes by file

<details><summary>Changed files</summary>

| File | What changed | Why |
|---|---|---|
| `cmd/fanout/main.go` | `checkDeps()` から `check("jq", "jq (brew install jq)")` の 1 行を削除 | fanout は jq を実行しないため依存チェック不要 |
| `internal/cliflags/usage.go` | Prerequisites の `gh, jq, git, tmux installed.` から `jq` を除去 | usage 表記を実態に合わせる |
| `tests/bats/tier1_flags.bats` | `@test "missing jq: exit 1"` ブロックを削除 | チェック削除に伴い検証対象が消滅 |

</details>

`tests/bin/gh` シムが内部で jq を使う件は開発環境依存としてスコープ外(issue の Notes どおり維持)。

## Test plan

- `make build-go` — ビルド成功
- `make test` — Go unit + bats Tier1/Tier2 全通過(missing gh / tmux / git テストは維持)
- `make lint` — golangci-lint 0 issues + shellcheck 通過
- 受け入れ基準の実地確認: jq を含まない一時 PATH で `./fanout-go 999 --agent claude --dry-run` を実行し、missing dependencies エラーにならず gh の API 呼び出しまで到達することを確認

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)