### PR TITLE
feat(skills): fanout-issues スキルの gh sub-issue コマンドを gh api に置換

### DIFF
--- a/claude/skills/fanout-issues/SKILL.md
+++ b/claude/skills/fanout-issues/SKILL.md
@@ -12,7 +12,7 @@ Sub-issues relationship and same-repo task-list rows in the parent body.
 ## Preconditions
 
 - Use the repository the user is working in unless they provide `--repo OWNER/REPO` or name another repo.
-- Verify `gh` is authenticated and `gh sub-issue --help` works. If the extension is missing, tell the user to install `gh extension install yahsan2/gh-sub-issue`.
+- Verify `gh` is authenticated (`gh auth status`). Sub-issue linking uses the GitHub Sub-issues REST API through `gh api`.
 - Treat issue creation as a live GitHub mutation. Show the planned parent title, child list, dependency graph, labels/assignees, and target repo before creating issues. Proceed only after user confirmation unless the user explicitly asked to create them immediately.
 - Keep all child issues in the same repo as the parent. `fanout` skips cross-repo task-list references.
 
@@ -77,10 +77,10 @@ The `## Fanout children` rows must be same-repo task-list rows in the form
 
 ## Create Issues
 
-Prefer `gh issue create` plus `gh sub-issue add` over `gh sub-issue create`
-because `gh issue create --body-file` handles multiline bodies reliably.
-Write bodies to temporary Markdown files first instead of embedding large
-Markdown strings in shell commands.
+Create issues with `gh issue create --body-file` (it handles multiline bodies
+reliably), then link each child to its parent through the GitHub Sub-issues
+REST API with `gh api`. Write bodies to temporary Markdown files first instead
+of embedding large Markdown strings in shell commands.
 
 Recommended sequence:
 
@@ -97,7 +97,8 @@ child_url=$(gh issue create -R "$repo" \
   --body-file /tmp/fanout-child-1.md)
 child_num="${child_url##*/}"
 
-gh sub-issue add "$parent_num" "$child_num" -R "$repo"
+child_id=$(gh api "repos/$repo/issues/$child_num" --jq .id)
+gh api --silent -X POST "repos/$repo/issues/$parent_num/sub_issues" -F sub_issue_id="$child_id"
 ```
 
 For an existing parent, fetch and preserve its current body before appending or
@@ -111,7 +112,8 @@ gh issue edit "$parent_num" -R "$repo" --body-file /tmp/fanout-parent-final.md
 For an existing child, do not recreate it. Link it:
 
 ```bash
-gh sub-issue add "$parent_num" "$child_num" -R "$repo"
+child_id=$(gh api "repos/$repo/issues/$child_num" --jq .id)
+gh api --silent -X POST "repos/$repo/issues/$parent_num/sub_issues" -F sub_issue_id="$child_id"
 ```
 
 Forward user-provided labels, assignees, milestones, and projects to both
@@ -134,13 +136,14 @@ GitHub Sub-issues relationship:
 Run:
 
 ```bash
-gh sub-issue list "$parent_num" -R "$repo" --json number,title,state
+gh api --paginate "repos/$repo/issues/$parent_num/sub_issues" \
+  --jq '.[] | [.number, .state, .title] | @tsv'
 gh issue view "$parent_num" -R "$repo" --json body -q .body
 ```
 
 Confirm:
 
-- Every intended child appears in `gh sub-issue list` with `state` open.
+- Every intended child appears in the sub-issues API response with `state` open.
 - The parent body has a same-repo task-list row for every child.
 - Blocked children have both child-body `## Blocked by` references and parent-row `(blocked by #N)` trailers.
 - No cross-repo `owner/repo#N` row is required for fanout discovery.

--- a/codex/skills/fanout-issues/SKILL.md
+++ b/codex/skills/fanout-issues/SKILL.md
@@ -24,7 +24,7 @@ dependency graph, labels/assignees, and target repo before creating anything.
 ## Preconditions
 
 - Use the repository the user is working in unless they provide `--repo OWNER/REPO` or name another repo.
-- Verify `gh` is authenticated and `gh sub-issue --help` works. If the extension is missing, tell the user to install `gh extension install yahsan2/gh-sub-issue`.
+- Verify `gh` is authenticated (`gh auth status`). Sub-issue linking uses the GitHub Sub-issues REST API through `gh api`.
 - Keep all child issues in the same repo as the parent. `fanout` skips cross-repo task-list references.
 - Preserve user-provided labels, assignees, milestones, and projects when they are relevant to both parent and children.
 
@@ -89,10 +89,10 @@ The `## Fanout children` rows must be same-repo task-list rows in the form
 
 ## Create Issues
 
-Prefer `gh issue create` plus `gh sub-issue add` over `gh sub-issue create`
-because `gh issue create --body-file` handles multiline bodies reliably.
-Write bodies to temporary Markdown files first instead of embedding large
-Markdown strings in shell commands.
+Create issues with `gh issue create --body-file` (it handles multiline bodies
+reliably), then link each child to its parent through the GitHub Sub-issues
+REST API with `gh api`. Write bodies to temporary Markdown files first instead
+of embedding large Markdown strings in shell commands.
 
 Recommended sequence:
 
@@ -109,7 +109,8 @@ child_url=$(gh issue create -R "$repo" \
   --body-file /tmp/fanout-child-1.md)
 child_num="${child_url##*/}"
 
-gh sub-issue add "$parent_num" "$child_num" -R "$repo"
+child_id=$(gh api "repos/$repo/issues/$child_num" --jq .id)
+gh api --silent -X POST "repos/$repo/issues/$parent_num/sub_issues" -F sub_issue_id="$child_id"
 ```
 
 For an existing parent, fetch and preserve its current body before appending or
@@ -123,7 +124,8 @@ gh issue edit "$parent_num" -R "$repo" --body-file /tmp/fanout-parent-final.md
 For an existing child, do not recreate it. Link it:
 
 ```bash
-gh sub-issue add "$parent_num" "$child_num" -R "$repo"
+child_id=$(gh api "repos/$repo/issues/$child_num" --jq .id)
+gh api --silent -X POST "repos/$repo/issues/$parent_num/sub_issues" -F sub_issue_id="$child_id"
 ```
 
 ## Update Parent
@@ -142,13 +144,14 @@ GitHub Sub-issues relationship:
 Run:
 
 ```bash
-gh sub-issue list "$parent_num" -R "$repo" --json number,title,state
+gh api --paginate "repos/$repo/issues/$parent_num/sub_issues" \
+  --jq '.[] | [.number, .state, .title] | @tsv'
 gh issue view "$parent_num" -R "$repo" --json body -q .body
 ```
 
 Confirm:
 
-- Every intended child appears in `gh sub-issue list` with `state` open.
+- Every intended child appears in the sub-issues API response with `state` open.
 - The parent body has a same-repo task-list row for every child.
 - Blocked children have both child-body `## Blocked by` references and parent-row `(blocked by #N)` trailers.
 - No cross-repo `owner/repo#N` row is required for fanout discovery.


### PR DESCRIPTION
## TL;DR

fanout-issues スキル (claude/codex) の sub-issue リンク手順を、gh-sub-issue 拡張から GitHub Sub-issues REST API の `gh api` 直叩きに置換し、スキル実行時の拡張依存を外した。置換後のコマンド列は実 issue で動作確認済み。

Review effort: 1

## Why

依存削減 (親 #201) の wave 1。fanout-issues スキルは issue ツリー作成時に `gh sub-issue add` / `gh sub-issue list` (yahsan2/gh-sub-issue 拡張) を使っていたが、同じ操作は GitHub の Sub-issues REST API を `gh api` で直接叩けば実現でき、`--jq` は gh 内蔵のため外部 jq も不要。issue #204 はスキル 2 ファイルからの拡張依存除去を求めている (fanout/SKILL.md・fanout.md・README の更新は同じ行を触るため wave 2 の #206 に分離)。

## Changes by file

<details><summary>Changed files</summary>

| File | What changed | Why |
|---|---|---|
| `claude/skills/fanout-issues/SKILL.md` | Preconditions の「`gh sub-issue --help` 検証 + 拡張インストール案内」を `gh auth status` 確認に変更 (L15)。`gh sub-issue add` 2 箇所を `child_id` 取得 (`gh api ... --jq .id`) + `gh api --silent -X POST .../sub_issues -F sub_issue_id=` に置換 (L100-101, L115-116)。Validate の `gh sub-issue list` を `gh api --paginate .../sub_issues --jq` TSV 射影に置換 (L137-138)。「`gh sub-issue create` より優先」の方針文を新コマンド前提に書き直し (L80-83) | スキル実行時の gh-sub-issue 拡張依存を除去 (#204) |
| `codex/skills/fanout-issues/SKILL.md` | claude 側と同一の手順更新 (L27, L92-95, L112-113, L127-128, L145-146) | 受け入れ条件「claude 側と codex 側が同内容の手順」を満たす |

</details>

> [!WARNING]
> wave 2 (#206) が入るまで fanout CLI 本体の checkDeps (`cmd/fanout/main.go:523-525`) は issue モードで gh-sub-issue 拡張を要求し続ける。本スキルは「拡張不要」とは主張しない表現にしてあり矛盾はしないが、スキルが勧める `/fanout` 実行までを含むエンドツーエンドでは過渡期に拡張が必要なまま。

## Test plan

- 実機確認 (受け入れ条件): テスト用 issue #230 (親) / #231 (子) を作成し、置換後のコマンド列をそのまま実行 — `gh api repos/.../issues/231 --jq .id` で database id 取得 → `gh api --silent -X POST .../230/sub_issues -F sub_issue_id=` でリンク追加 (exit 0・stdout 空) → `gh api --paginate .../230/sub_issues --jq '.[] | [.number, .state, .title] | @tsv'` で #231 が列挙されることを確認 → `DELETE .../sub_issue` でリンク解除し両 issue を close 済み
- `grep -rn "gh.sub.issue\|gh-sub-issue" claude/skills/fanout-issues/ codex/skills/fanout-issues/` → 0 件 (受け入れ条件: 拡張への言及なし)
- 両ファイルの `## Create Issues` 以降を diff → 残差は既存の意図的差分 (`/fanout` vs `$fanout` 等) のみでコマンドブロック一致
- `make lint` → 0 issues / `make test` → Go unit + bats 全 pass (docs-only 変更)
- /code-review (マルチエージェント) + codex review を実施。code-review 指摘 2 件 (「no gh extension is required」の無条件主張が過渡期の CLI 要件と矛盾 / POST レスポンスが親 issue 全 JSON を出力) を修正済み。codex は approve (no blocking issues)

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)