### PR TITLE
docs: ドキュメント・前提リストから jq / gh-sub-issue を一括削除 (#206)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -208,9 +208,8 @@ Tier 3 (live tmux E2E) は手動運用のままです。
 
 ## 前提条件
 
-- 既定の fanout 作成フローでは `gh` CLI、`jq`、`git`、`tmux`、`gh-sub-issue`
-  拡張（`gh extension install yahsan2/gh-sub-issue`）が必要です。`--status` と
-  `--cleanup` は `gh`/`jq`/`git`、`--merge` と `--close` は `git` を使います
+- 既定の fanout 作成フローでは `gh` CLI、`git`、`tmux` が必要です。`--status` と
+  `--cleanup` は `gh`/`git`、`--merge` と `--close` は `git` を使います
   （`--close`/`--cleanup` の tmux pane kill は pane が既に無い場合 stale として
   扱います）。fanout は必要な依存を起動時にチェックし、失敗時には
   インストールのヒントを表示します。子 issue は
@@ -625,14 +624,15 @@ Codex CLI 向けの推奨連携 — スキルはこのリポジトリの `codex/
 
 ## fanout が実際にやること
 
-1. `gh`、`jq`、`git`、`tmux`、`gh-sub-issue` がインストールされているかを確認。
+1. `gh`、`git`、`tmux` がインストールされているかを確認。
 2. `git rev-parse --show-toplevel` でリポジトリルートを、`tmux display-message -p
    '#{session_name}'` で現在の tmux セッションを、`$TMUX_PANE`（fallback は
    `#{pane_id}`）で起動元 pane を解決する。
 3. `--agent` または `FANOUT_AGENT` から agent を解決する。live 実行では、その
    agent CLI が `PATH` 上にあることも確認する。
 4. 2 つのソースの和集合で子を列挙する（いずれもプロジェクトルートから実行）:
-   (a) `gh sub-issue list <parent>` で Sub-issues API に正式リンクされている
+   (a) GitHub Sub-issues API
+   （`gh api repos/{owner}/{repo}/issues/<N>/sub_issues`）で正式リンクされている
    子、(b) 親本文中の GitHub タスクリスト参照 — `^\s*-\s+\[[ xX]\] ... #NUM`
    にマッチする行の `#NUM` を拾う（同一リポジトリ内のみ。`owner/repo#NUM`
    形式はスキップ）。本文由来の番号は `gh issue view` で本体情報を引く。
@@ -684,12 +684,13 @@ branch 名、stale/missing remote branch です。base を変えるには
 `origin/<branch>` を指定できます。意図的に現在の local base/ref から切る場合にだけ
 `--no-refresh` を使ってください。
 
-### "gh sub-issue list failed"
+### "sub-issues fetch failed"
 
-- `gh-sub-issue` 拡張が無い: `gh extension install yahsan2/gh-sub-issue`。
 - 未認証: `gh auth status`。
-- 親 issue が存在しない、または拡張経由で紐づけられたサブ issue が無い:
-  fanout は `no sub-issues on #<parent>` と出して exit 0 する。
+- 親 issue が存在しない: Sub-issues API が HTTP 404 を返し、fanout は exit 1
+  する。issue 番号を確認すること。
+- リンクされたサブ issue がゼロなのはエラーではない: fanout は
+  `no sub-issues on #<parent>` と出して exit 0 する。
 
 ### slug や branch 名が意図と違う
 
@@ -716,8 +717,6 @@ fanout settings で `prReviewGate=false` になっている場合、子 Claude b
   `sh -c "<文字列>"` のような間接実行や、コミットメッセージ・PR コメントの本文に
   シェル演算子と一緒に `gh pr create` という文字列を書いた場合などは取りこぼし／過検知
   し得ます。その場合は `FANOUT_SKIP_PR_REVIEW=1` で回避してください。
-- jq が無い環境では fail-closed（PR 作成らしきコマンドを deny）になります。`jq` を
-  インストールするか `export FANOUT_SKIP_PR_REVIEW=1` してください。
 - `make install` は同名のグローバル `post-work-review` skill を上書きします。独自に
   管理しているコピーがある場合は事前にバックアップしてください。
 

--- a/README.md
+++ b/README.md
@@ -216,9 +216,8 @@ intentionally change dry-run output. Tier 3 (live tmux E2E) stays manual.
 
 ## Prerequisites
 
-- The default pane-creation flow needs `gh` CLI, `jq`, `git`, `tmux`, and the
-  `gh-sub-issue` extension (`gh extension install yahsan2/gh-sub-issue`).
-  `--status` and `--cleanup` use `gh`/`jq`/`git`; `--merge` and `--close` use
+- The default pane-creation flow needs `gh` CLI, `git`, and `tmux`.
+  `--status` and `--cleanup` use `gh`/`git`; `--merge` and `--close` use
   `git` (`--close`/`--cleanup` treat an already-missing tmux pane as stale).
   fanout checks the dependencies needed for the selected mode at startup and
   prints install hints on failure. Children can be declared via
@@ -713,15 +712,16 @@ should branch from the selected base.
 
 ## What fanout actually does
 
-1. Verifies `gh`, `jq`, `git`, `tmux`, and `gh-sub-issue` are installed.
+1. Verifies `gh`, `git`, and `tmux` are installed.
 2. Resolves the repository root with `git rev-parse --show-toplevel`, the
    current tmux session with `tmux display-message -p '#{session_name}'`, and
    the invoking pane from `$TMUX_PANE` (or `#{pane_id}` as a fallback).
 3. Resolves the agent from `--agent` or `FANOUT_AGENT`; live mode verifies the
    selected agent CLI is installed.
 4. Enumerates children by taking the union of two sources (run from the project
-   root): (a) `gh sub-issue list <parent>` for issues formally linked via the
-   Sub-issues API, and (b) GitHub task-list references in the parent body —
+   root): (a) the GitHub Sub-issues API
+   (`gh api repos/{owner}/{repo}/issues/<N>/sub_issues`) for formally linked
+   issues, and (b) GitHub task-list references in the parent body —
    any line matching `^\s*-\s+\[[ xX]\] ... #NUM` contributes `#NUM` (same-repo
    only; `owner/repo#NUM` is skipped). Body-sourced numbers are hydrated via
    `gh issue view`. Only `state == "OPEN"` children are processed.
@@ -781,12 +781,13 @@ base branch, an existing branch name, or a stale/missing remote branch. Use
 Use `--no-refresh` only when you intentionally want to branch from the current
 local base/ref.
 
-### "gh sub-issue list failed"
+### "sub-issues fetch failed"
 
-- No `gh-sub-issue` extension: `gh extension install yahsan2/gh-sub-issue`.
 - Not authenticated: `gh auth status`.
-- Parent issue doesn't exist or has no sub-issues tagged via the extension:
-  fanout exits 0 with `no sub-issues on #<parent>`.
+- Parent issue doesn't exist: the Sub-issues API returns HTTP 404 and fanout
+  exits 1 — check the issue number.
+- Zero linked sub-issues is not an error: fanout exits 0 with
+  `no sub-issues on #<parent>`.
 
 ### Slug or branch names are not what you want
 

--- a/claude/commands/fanout.md
+++ b/claude/commands/fanout.md
@@ -72,7 +72,7 @@ prompt-based agent pane from the console.
    - `agent is required` → rerun with `--agent claude`, `--agent codex`, or set `FANOUT_AGENT`.
    - `unknown agent` / `agent ... is not installed` → choose or install a supported agent CLI.
    - `prepare worktree` → inspect the git error; use `--no-refresh` only when skipping base refresh is intentional.
-   - Missing `gh-sub-issue` extension → `gh extension install yahsan2/gh-sub-issue`.
+   - `sub-issues fetch failed` → run `gh auth status`; an HTTP 404 means the parent issue number does not exist.
 
 ## Notes
 

--- a/claude/skills/fanout/SKILL.md
+++ b/claude/skills/fanout/SKILL.md
@@ -61,7 +61,7 @@ Do not invoke unprompted just because an issue has sub-issues. Pane creation is 
 
 Before running the real command:
 
-1. **Prerequisites** — `gh`, `jq`, `git`, `tmux`, and the `gh-sub-issue` extension must be installed. `fanout` validates these on startup and fails with install hints, so you can rely on its error output rather than re-checking.
+1. **Prerequisites** — `gh`, `git`, and `tmux` must be installed. `fanout` validates these on startup and fails with install hints, so you can rely on its error output rather than re-checking.
 2. **Resolve the parent target for batch pane creation** — if the user's intent is the TUI console, skip target resolution and run `fanout` with no arguments. Otherwise, first use any issue ref (`#N` or `N`) or Projects v2 URL in the user's request / recent context. If neither is clear, actively list candidates from the current repo/worktree instead of asking for a pasted number/URL:
    1. Run `gh issue list --state open --json number,title --limit 100`.
    2. Get the repo owner login with `gh repo view --json owner -q .owner.login`.
@@ -139,7 +139,7 @@ Run fanout from the target repository worktree so `git rev-parse --show-toplevel
 ## Project mode notes
 
 - **URL shape** — the CLI matches `^https://github\.com/(users|orgs)/<owner>/projects/<num>([/?].*)?$`. Both user-owned and organization-owned Projects v2 boards are supported, and any trailing `/views/<n>` segment or `?filterQuery=...` query string is preserved verbatim — the CLI extracts only the `users|orgs`, `<owner>`, and `<num>` it needs. Anything else is rejected at arg-parse time.
-- **Source of truth** — children come from the Project's `items` node via GraphQL (`gh api graphql`), all pages, in board order. The Sub-issues API and parent-body scan are **not** consulted in project mode. The parent body (which doesn't exist for a Project) is not read. In project mode the CLI also skips the `gh-sub-issue` extension dependency check, so a missing extension is not a blocker.
+- **Source of truth** — children come from the Project's `items` node via GraphQL (`gh api graphql`), all pages, in board order. The Sub-issues API and parent-body scan are **not** consulted in project mode. The parent body (which doesn't exist for a Project) is not read.
 - **`--project-status` filtering** — see the `## Running` section above. The default is `Todo`, which mirrors the common "queue everything I'm planning to start" workflow. Use `--project-status all` for a full fan-out, or a single explicit value for any other column.
 - **`gh` scope** — Projects v2 GraphQL requires the `read:project` scope. If `fanout` exits with an authorization failure on the `projectV2` query (`HTTP 401` / `Resource not accessible by integration`), tell the user to run `gh auth refresh -s read:project` and retry. The default `repo` scope alone is not sufficient.
 - **Cross-repo items are skipped** — items whose `content.repository.nameWithOwner` does not match the current git repository are warned and skipped. fanout's briefing / worktree paths assume a single repo (`/tmp/fanout-<repo>-<N>.md`, worktrees under the project root), so cross-repo items would create panes pointing at the wrong checkout. Surface the warning rather than retrying.
@@ -198,7 +198,7 @@ When `fanout` exits non-zero, point the user at `/Users/butaosuinu/fanout/README
 - `unknown agent` — use one of the supported MVP agents (`claude`, `codex`).
 - `agent "<name>" is not installed` — install that CLI or choose another agent.
 - `prepare worktree` — inspect the git error; `--no-refresh` can bypass base branch refresh only when the stale base is intentional.
-- `gh sub-issue list failed` — install `gh extension install yahsan2/gh-sub-issue` or run `gh auth status`.
+- `sub-issues fetch failed` — run `gh auth status`; an HTTP 404 means the parent issue number does not exist.
 - `no sub-issues on #<N>` is not a failure; fanout exits 0.
 - Project mode `HTTP 401` / `Resource not accessible by integration` against `projectV2` — the user's `gh` token lacks `read:project`. Tell them to run `gh auth refresh -s read:project` and rerun.
 - Project mode `no items in Project (after status/repo filter). nothing to do.` is not a failure; fanout exits 0.

--- a/codex/skills/fanout/SKILL.md
+++ b/codex/skills/fanout/SKILL.md
@@ -96,8 +96,8 @@ use this workflow directly.
 
 ## Pre-Flight
 
-1. Prerequisites are `gh`, `jq`, `git`, `tmux`, and the `gh-sub-issue`
-   extension. The CLI validates these on startup, so rely on its error output.
+1. Prerequisites are `gh`, `git`, and `tmux`. The CLI validates these on
+   startup, so rely on its error output.
 2. Choose the launch lane. TUI mode is `fanout` with no arguments; it can start
    from a plain shell because it creates or attaches the repository's
    fanout-managed tmux session, and from inside tmux it uses the current pane.
@@ -301,10 +301,8 @@ numbers as `--include A,B,C` to both dry-run and execution.
 ## Project Mode
 
 When the positional argument is a Projects v2 URL, fanout enumerates the
-Project's items via GraphQL (`gh api graphql`) instead of the Sub-issues API
-+ parent body. The `gh-sub-issue` extension dependency check is skipped in
-project mode, so a missing extension is not a blocker for project URLs.
-Key points:
+Project's items via GraphQL (`gh api graphql`) instead of the Sub-issues
+API + parent body. Key points:
 
 - **URL shape** — the CLI matches
   `^https://github\.com/(users|orgs)/<owner>/projects/<num>([/?].*)?$`.
@@ -402,8 +400,8 @@ the likely next action:
 - `agent "<name>" is not installed`: install that CLI or choose another agent.
 - `prepare worktree`: inspect the git error; `--no-refresh` can bypass base
   branch refresh only when the stale base is intentional.
-- `gh sub-issue list failed`: check `gh auth status` and install
-  `gh extension install yahsan2/gh-sub-issue`.
+- `sub-issues fetch failed`: check `gh auth status`; an HTTP 404 means the
+  parent issue number does not exist.
 - `no sub-issues on #<N>` is not a failure; fanout exits 0.
 - Project mode `HTTP 401` / `Resource not accessible by integration`
   against `projectV2`: the user's `gh` token lacks the `read:project` scope.

--- a/internal/cliflags/usage.go
+++ b/internal/cliflags/usage.go
@@ -150,8 +150,7 @@ Options:
   -h, --help          Show this message.
 
 Prerequisites:
-  * gh, git, tmux installed. gh-sub-issue extension is required for
-    issue mode only; project mode uses gh api graphql.
+  * gh, git, tmux installed.
   * fanout pane-creation mode is invoked from inside a tmux session. TUI mode
     can be started from a plain shell; it creates or attaches its tmux session.
   * --agent is given, or FANOUT_AGENT is set for pane-creation mode.

--- a/site/content/docs/installation.ja.md
+++ b/site/content/docs/installation.ja.md
@@ -14,12 +14,10 @@ yomi: install
 | ツール | 用途 |
 |---|---|
 | `gh` | GitHub CLI — issue、PR 状態、GraphQL |
-| `jq` | JSON 処理 |
 | `git` | worktree、branch、merge |
 | `tmux` | 子ペイン |
-| `gh-sub-issue` | Sub-issues の列挙 — `gh extension install yahsan2/gh-sub-issue` |
 
-fanout は選択されたモードに必要な依存を起動時にチェックし、失敗時にはインストールのヒントを表示します。`--status` と `--cleanup` は `gh`/`jq`/`git`、`--merge` と `--close` は `git` を使います。
+fanout は選択されたモードに必要な依存を起動時にチェックし、失敗時にはインストールのヒントを表示します。`--status` と `--cleanup` は `gh`/`git`、`--merge` と `--close` は `git` を使います。
 
 > **Project モード時のみ**: Project items を取得する GraphQL クエリのため、`gh` CLI に `read:project` スコープが必要です。`gh auth refresh -s read:project` で付与してください。issue モード(`fanout <N>`)では不要です。
 

--- a/site/content/docs/installation.md
+++ b/site/content/docs/installation.md
@@ -14,12 +14,10 @@ The default pane-creation flow needs these tools on your `PATH`:
 | Tool | Used for |
 |---|---|
 | `gh` | GitHub CLI — issues, PR state, GraphQL |
-| `jq` | JSON processing |
 | `git` | worktrees, branches, merges |
 | `tmux` | child panes |
-| `gh-sub-issue` | Sub-issues enumeration — `gh extension install yahsan2/gh-sub-issue` |
 
-fanout checks the dependencies needed for the selected mode at startup and prints install hints on failure. `--status` and `--cleanup` use `gh`/`jq`/`git`; `--merge` and `--close` use `git`.
+fanout checks the dependencies needed for the selected mode at startup and prints install hints on failure. `--status` and `--cleanup` use `gh`/`git`; `--merge` and `--close` use `git`.
 
 > **Project mode only:** the `gh` CLI must have the `read:project` scope so the GraphQL query that lists Project items can succeed. Add it with `gh auth refresh -s read:project`. Issue mode (`fanout <N>`) does not need this scope.
 

--- a/site/content/docs/quickstart.ja.md
+++ b/site/content/docs/quickstart.ja.md
@@ -34,13 +34,13 @@ fanout 123
 
 各子 issue は、現在の tmux セッション内のペイン、`.fanout/worktrees/<slug>/` 配下の独立した worktree、そして 1 行 briefing prompt 付きで起動した agent を得ます。
 
-> ペイン作成フローには `gh`、`jq`、`git`、`tmux`、`gh-sub-issue` 拡張が `PATH` 上に必要です。fanout は依存を起動時にチェックし、失敗時にはインストールのヒントを表示します — [インストール]({{< relref "/docs/installation" >}})を参照してください。
+> ペイン作成フローには `gh`、`git`、`tmux` が `PATH` 上に必要です。fanout は依存を起動時にチェックし、失敗時にはインストールのヒントを表示します — [インストール]({{< relref "/docs/installation" >}})を参照してください。
 
 ## 子 issue の宣言方法
 
 fanout は 2 つのソースの和集合で子を列挙します:
 
-- **Sub-issues API** に正式リンクされている issue（`gh-sub-issue` 拡張経由の `gh sub-issue list <parent>`）
+- **Sub-issues API** に正式リンクされている issue（`gh api repos/{owner}/{repo}/issues/<N>/sub_issues`）
 - **親本文のタスクリスト参照** — `- [ ] #NUM ...` にマッチする行の `#NUM`
 
 ```text
@@ -55,7 +55,7 @@ fanout は 2 つのソースの和集合で子を列挙します:
 
 live 実行は次のステップで進みます:
 
-1. `gh`、`jq`、`git`、`tmux`、`gh-sub-issue` がインストールされているかを確認する。
+1. `gh`、`git`、`tmux` がインストールされているかを確認する。
 2. `git rev-parse --show-toplevel` でリポジトリルートを、現在の tmux セッションと起動元 pane を、`--agent` または `FANOUT_AGENT` から agent を解決する。
 3. Sub-issues と親タスクリスト行の和集合で子を列挙する（OPEN の子のみ処理）。
 4. `.fanout/state.json` を読み、`(parent, issueNum)` ペアが記録済みの子はスキップする。

--- a/site/content/docs/quickstart.md
+++ b/site/content/docs/quickstart.md
@@ -34,13 +34,13 @@ fanout 123
 
 Each child gets a pane in the current tmux session, an isolated worktree under `.fanout/worktrees/<slug>/`, and the selected agent started with a one-line briefing prompt.
 
-> The pane-creation flow needs `gh`, `jq`, `git`, `tmux`, and the `gh-sub-issue` extension on your `PATH`. fanout checks the dependencies at startup and prints install hints on failure — see [Installation]({{< relref "/docs/installation" >}}).
+> The pane-creation flow needs `gh`, `git`, and `tmux` on your `PATH`. fanout checks the dependencies at startup and prints install hints on failure — see [Installation]({{< relref "/docs/installation" >}}).
 
 ## How child issues are declared
 
 fanout enumerates children by taking the union of two sources:
 
-- issues formally linked via the **Sub-issues API** (`gh sub-issue list <parent>`, through the `gh-sub-issue` extension), and
+- issues formally linked via the **Sub-issues API** (`gh api repos/{owner}/{repo}/issues/<N>/sub_issues`), and
 - **task-list references in the parent body** — any line matching `- [ ] #NUM ...` contributes `#NUM`.
 
 ```text
@@ -55,7 +55,7 @@ Task-list references are same-repo only; `owner/repo#NUM` is skipped. Body-sourc
 
 A live run walks these steps:
 
-1. Verifies `gh`, `jq`, `git`, `tmux`, and `gh-sub-issue` are installed.
+1. Verifies `gh`, `git`, and `tmux` are installed.
 2. Resolves the repository root with `git rev-parse --show-toplevel`, the current tmux session and invoking pane, and the agent from `--agent` or `FANOUT_AGENT`.
 3. Enumerates children as the union of Sub-issues and parent task-list rows; only OPEN children are processed.
 4. Reads `.fanout/state.json` and skips children whose `(parent, issueNum)` pair is already recorded.

--- a/site/content/docs/troubleshooting.ja.md
+++ b/site/content/docs/troubleshooting.ja.md
@@ -40,16 +40,16 @@ fanout 123 --base-branch origin/main
 
 `--no-refresh` は、意図的に現在の local base/ref から切りたいときにだけ使ってください。fanout は base branch を force で整えることはしません — 安全に refresh できない場合は、ユーザーのローカル作業を壊す代わりに失敗します。
 
-## "gh sub-issue list failed"
+## "sub-issues fetch failed"
 
-- `gh-sub-issue` 拡張が入っていない、または未認証:
+- 未認証:
 
 ```bash
-gh extension install yahsan2/gh-sub-issue
 gh auth status
 ```
 
-- 親 issue が存在しない、または拡張経由で紐づけられたサブ issue が無い。サブ issue ゼロはエラーではなく、fanout は次を表示して exit 0 します:
+- 親 issue が存在しない: Sub-issues API が HTTP 404 を返し、fanout は exit 1 します。issue 番号を確認してください。
+- リンクされたサブ issue がゼロなのはエラーではなく、fanout は次を表示して exit 0 します:
 
 ```text
 no sub-issues on #<parent>

--- a/site/content/docs/troubleshooting.md
+++ b/site/content/docs/troubleshooting.md
@@ -40,16 +40,16 @@ fanout 123 --base-branch origin/main
 
 Use `--no-refresh` only when you intentionally want to branch from the current local base/ref. fanout never forces the base branch into shape — if it cannot refresh it safely, it fails rather than destroying your local work.
 
-## "gh sub-issue list failed"
+## "sub-issues fetch failed"
 
-- The `gh-sub-issue` extension is not installed, or you are not authenticated:
+- You are not authenticated:
 
 ```bash
-gh extension install yahsan2/gh-sub-issue
 gh auth status
 ```
 
-- The parent issue does not exist, or has no sub-issues linked via the extension. Zero sub-issues is not an error — fanout exits 0 with:
+- The parent issue does not exist: the Sub-issues API returns HTTP 404 and fanout exits 1 — check the issue number.
+- Zero linked sub-issues is not an error — fanout exits 0 with:
 
 ```text
 no sub-issues on #<parent>


### PR DESCRIPTION
## TL;DR

wave 1 (#202-#204) でコードから除去済みの jq / gh-sub-issue 拡張依存を、README・site docs・スキル・CLI ヘルプの前提リストとトラブルシュートから一括削除し、エラー文言と exit code の記述を現実装に追従させた。

Review effort: 1

## Why

issue #206 のとおり、wave 1 の 3 issue(コード・テスト・スキルのコマンド置換)で fanout 本体は jq と gh-sub-issue 拡張に依存しなくなったが、ドキュメントと前提ツールリストは古いまま残っていた。両依存が同じ前提リスト行に同居しているため、競合回避としてこの issue に一括集約されている。`--status | jq ...` のパイプ例は issue の指示どおり任意ツールの例として残した。

## Changes by file

<details><summary>Changed files</summary>

| File | What changed | Why |
|---|---|---|
| `README.md` / `README.ja.md` | 前提条件を `gh`/`git`/`tmux` に縮小、step 1/step 4 を実装(公式 Sub-issues API)表記に変更、トラブルシュート見出しを実際のエラー文言 `sub-issues fetch failed` に変更し「存在しない親 = HTTP 404 → exit 1 / 子ゼロ = exit 0」を分離。ja のみ残っていた PR ゲートの古い jq fail-closed 注記を削除(hook は python3 ベース、en に対応注記なし) | `checkDeps` は `git`/`gh`/`tmux` のみチェック(cmd/fanout/main.go:506)、列挙は `gh api .../sub_issues`(internal/ghissue/ghissue.go:180)、エラー文言は cmd/fanout/main.go:286 |
| `site/content/docs/installation.md` / `.ja.md` | 前提表から `jq`・`gh-sub-issue` 行を削除、`--status`/`--cleanup` の使用ツールを `gh`/`git` に | README とペア更新 |
| `site/content/docs/quickstart.md` / `.ja.md` | callout・子列挙ソースの説明・run step 1 から jq / 拡張を削除し公式 API 表記に | 同上 |
| `site/content/docs/troubleshooting.md` / `.ja.md` | セクション見出しを `"sub-issues fetch failed"` に変更、拡張インストール手順を削除、404/exit 1 と子ゼロ/exit 0 を分離 | 実挙動との一致 |
| `claude/skills/fanout/SKILL.md` | Prerequisites 行、project mode の拡張スキップ注記、トラブルシュート行を更新 | 拡張がそもそも使われなくなったため |
| `codex/skills/fanout/SKILL.md` | 同上(+ 折り返しで行頭が `+ ` になり Markdown リストに誤認される箇所を直した) | 同上 |
| `claude/commands/fanout.md` | 「Missing gh-sub-issue extension → …」を `sub-issues fetch failed` の対処(auth / 404)に置換 | 同上 |
| `internal/cliflags/usage.go` | ヘルプの「gh-sub-issue extension is required for issue mode only」文を削除 | wave 1 の取り残し。コードはもう拡張をチェックしない |

</details>

## Test plan

- `make lint` — 0 issues(golangci-lint v2 + shellcheck)
- `make test` — exit 0(Go unit + bats Tier 1/Tier 2。dry-run 出力は不変のため golden 再生成なし)
- `rg -S 'gh-sub-issue|yahsan2'` — 残存は tests/ シム・docs/mockups のサンプルデータのみ
- `rg '\bjq\b'` — 残存は任意のパイプ例・`gh api --jq`(gh 組み込み)・テストシム・CI の shim 用インストールのみ
- /code-review(3 観点並列)+ codex review(approve)実施済み

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)