### PR TITLE
feat(logo): 小型ロゴマークを「紙扇」デザインに刷新

### DIFF
--- a/internal/dashboard/static/index.html
+++ b/internal/dashboard/static/index.html
@@ -29,7 +29,7 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..700;1,9..144,300..700&family=M+PLUS+1+Code:wght@400;500&family=Zen+Kaku+Gothic+New:wght@400;500;700&display=swap" rel="stylesheet" media="print" onload="this.media='all'" />
 <noscript><link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..700;1,9..144,300..700&family=M+PLUS+1+Code:wght@400;500&family=Zen+Kaku+Gothic+New:wght@400;500;700&display=swap" rel="stylesheet" /></noscript>
-<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none'%3E%3Cpath d='M12 21 3.5 8M12 21 8.6 6.2M12 21l3.4-14.8M12 21 20.5 8' stroke='%23165E83' stroke-width='1.7' stroke-linecap='round'/%3E%3Ccircle cx='12' cy='21' r='2.2' fill='%2300A3AF'/%3E%3C/svg%3E" />
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none'%3E%3Cpath d='M1.17 14.25A12.5 12.5 0 0 1 22.83 14.25L17.2 17.5A6 6 0 0 0 6.8 17.5Z' fill='%23C9E8EC' stroke='%23165E83' stroke-width='1.4' stroke-linejoin='round'/%3E%3Cpath d='M12 20.5 1.17 14.25M12 20.5 5.75 9.68M12 20.5 12 8M12 20.5 18.25 9.68M12 20.5 22.83 14.25' stroke='%23165E83' stroke-width='1.9' stroke-linecap='round'/%3E%3Ccircle cx='12' cy='20.5' r='2.4' fill='%2300A3AF'/%3E%3C/svg%3E" />
 <link rel="stylesheet" href="style.css" />
 <script src="app.js" defer></script>
 </head>
@@ -39,11 +39,11 @@
   <div class="nav-inner">
     <a class="brand" href="#" aria-label="fanout dashboard">
       <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-        <path class="rib" d="M12 21 3.5 8M12 21 8.6 6.2M12 21l3.4-14.8M12 21 20.5 8"
-              stroke-width="1.7" stroke-linecap="round"/>
-        <path class="arc" d="M4.6 6.4C9 3.4 15 3.4 19.4 6.4" stroke-width="1.4"
-              stroke-linecap="round" stroke-dasharray="1 4"/>
-        <circle class="pivot" cx="12" cy="21" r="2.2"/>
+        <path class="leaf" d="M1.17 14.25A12.5 12.5 0 0 1 22.83 14.25L17.2 17.5A6 6 0 0 0 6.8 17.5Z"
+              stroke-width="1.2" stroke-linejoin="round"/>
+        <path class="rib" d="M12 20.5 1.17 14.25M12 20.5 5.75 9.68M12 20.5 12 8M12 20.5 18.25 9.68M12 20.5 22.83 14.25"
+              stroke-width="1.5" stroke-linecap="round"/>
+        <circle class="pivot" cx="12" cy="20.5" r="2.2"/>
       </svg>
       fanout
     </a>

--- a/internal/dashboard/static/style.css
+++ b/internal/dashboard/static/style.css
@@ -17,6 +17,7 @@
   --asagi:   #00A3AF;
   --byakugun:#C9E8EC;
   --byakugun-bg: rgba(201,232,236,.5);
+  --leaf:    #C9E8EC; /* ロゴの扇面 */
   --suna:    #E2D9C8;
   --suna-soft: rgba(226,217,200,.65);
   --ok:   #0E7A6E;
@@ -54,6 +55,7 @@ html[data-theme="dark"]{
   --asagi:   #33BFC9;
   --byakugun:#C9E8EC;
   --byakugun-bg: rgba(51,191,201,.13);
+  --leaf:    rgba(51,191,201,.22); /* ロゴの扇面 */
   --suna:    rgba(233,227,214,.16);
   --suna-soft: rgba(233,227,214,.10);
   --ok:   #58BFA4;
@@ -122,7 +124,7 @@ a:hover{ color:var(--asagi); }
 }
 .brand svg{ display:block; }
 .brand .rib{ stroke:var(--ai); }
-.brand .arc{ stroke:var(--suna); }
+.brand .leaf{ fill:var(--leaf); stroke:var(--ai); }
 .brand .pivot{ fill:var(--asagi); }
 .brand-sub{
   font-family:var(--f-body); font-size:11px; font-weight:700;

--- a/site/layouts/_partials/footer.html
+++ b/site/layouts/_partials/footer.html
@@ -1,9 +1,11 @@
 <footer class="site">
   <div class="wrap">
     <svg class="fmark" width="26" height="26" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-      <path d="M12 21 3.5 8M12 21 8.6 6.2M12 21l3.4-14.8M12 21 20.5 8"
-            stroke="currentColor" stroke-width="1.6" stroke-linecap="round"/>
-      <circle cx="12" cy="21" r="2" fill="#00A3AF"/>
+      <path d="M1.17 14.25A12.5 12.5 0 0 1 22.83 14.25L17.2 17.5A6 6 0 0 0 6.8 17.5Z"
+            fill="currentColor" fill-opacity=".15" stroke="currentColor" stroke-width="1.2" stroke-linejoin="round"/>
+      <path d="M12 20.5 1.17 14.25M12 20.5 5.75 9.68M12 20.5 12 8M12 20.5 18.25 9.68M12 20.5 22.83 14.25"
+            stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+      <circle cx="12" cy="20.5" r="2" fill="#00A3AF"/>
     </svg>
     <p class="fline">
       MIT License &middot;

--- a/site/layouts/_partials/head.html
+++ b/site/layouts/_partials/head.html
@@ -17,7 +17,7 @@
 <meta property="og:type" content="website">
 <meta property="og:url" content="{{ .Permalink }}">
 <meta property="og:description" content="{{ with .Description }}{{ . }}{{ else }}Fan a GitHub parent issue's OPEN sub-issues out into parallel tmux panes.{{ end }}">
-<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M12 21 3.5 8M12 21 8.6 6.2M12 21l3.4-14.8M12 21 20.5 8' stroke='%23165E83' stroke-width='1.7' stroke-linecap='round' fill='none'/%3E%3Ccircle cx='12' cy='21' r='2' fill='%2300A3AF'/%3E%3C/svg%3E">
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none'%3E%3Cpath d='M1.17 14.25A12.5 12.5 0 0 1 22.83 14.25L17.2 17.5A6 6 0 0 0 6.8 17.5Z' fill='%23C9E8EC' stroke='%23165E83' stroke-width='1.4' stroke-linejoin='round'/%3E%3Cpath d='M12 20.5 1.17 14.25M12 20.5 5.75 9.68M12 20.5 12 8M12 20.5 18.25 9.68M12 20.5 22.83 14.25' stroke='%23165E83' stroke-width='1.9' stroke-linecap='round'/%3E%3Ccircle cx='12' cy='20.5' r='2.4' fill='%2300A3AF'/%3E%3C/svg%3E">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..700;1,9..144,300..700&family=M+PLUS+1+Code:wght@400;500&family=Shippori+Mincho+B1:wght@500;600;700&family=Zen+Kaku+Gothic+New:wght@400;500;700&display=swap" rel="stylesheet">

--- a/site/layouts/_partials/nav.html
+++ b/site/layouts/_partials/nav.html
@@ -2,11 +2,11 @@
   <div class="nav-inner">
     <a class="brand" href="{{ site.Home.RelPermalink }}" aria-label="fanout home">
       <svg width="22" height="22" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-        <path d="M12 21 3.5 8M12 21 8.6 6.2M12 21l3.4-14.8M12 21 20.5 8"
-              stroke="#165E83" stroke-width="1.7" stroke-linecap="round"/>
-        <path d="M4.6 6.4C9 3.4 15 3.4 19.4 6.4" stroke="#E2D9C8" stroke-width="1.4"
-              stroke-linecap="round" stroke-dasharray="1 4"/>
-        <circle cx="12" cy="21" r="2.2" fill="#00A3AF"/>
+        <path d="M1.17 14.25A12.5 12.5 0 0 1 22.83 14.25L17.2 17.5A6 6 0 0 0 6.8 17.5Z"
+              fill="#C9E8EC" stroke="#165E83" stroke-width="1.2" stroke-linejoin="round"/>
+        <path d="M12 20.5 1.17 14.25M12 20.5 5.75 9.68M12 20.5 12 8M12 20.5 18.25 9.68M12 20.5 22.83 14.25"
+              stroke="#165E83" stroke-width="1.5" stroke-linecap="round"/>
+        <circle cx="12" cy="20.5" r="2.2" fill="#00A3AF"/>
       </svg>
       fanout
     </a>


### PR DESCRIPTION
## 概要

fanout の小型ロゴマークを、線画(骨4本+点線弧)から「扇」と一目で分かる塗り扇面デザインに刷新する。PAPER BREEZE パレットは維持(扇面: 白群 #C9E8EC / 骨・輪郭: 藍 #165E83 / 要: 浅葱 #00A3AF)。

レンダリング済みプレビュー(新旧比較・サイズ展開・ダーク2案・footer 変形)をユーザーに提示し、デザイン・ダーク扇面の濃さ(.22)・favicon 太め版の採用すべて承認済み。

## 変更内容

| 箇所 | 内容 |
|---|---|
| `site/layouts/_partials/nav.html` | ヘッダー 22px ロゴを新 SVG に置換(サイトはライト専用のためハードコード色) |
| `site/layouts/_partials/footer.html` | 26px マークを新形状に。currentColor + `fill-opacity=".15"` で既存の藍単色流儀を維持 |
| `site/layouts/_partials/head.html` | favicon data URL を太め版(骨1.9/輪郭1.4/要r2.4)に差し替え(16px 視認性) |
| `internal/dashboard/static/index.html` | favicon(サイトとバイト一致)+ nav SVG を `.leaf`/`.rib`/`.pivot` クラス方式で更新、旧 `.arc` 要素を削除 |
| `internal/dashboard/static/style.css` | `--leaf` 変数を light/dark で追加、`.brand .arc` 規則を `.brand .leaf` に置換 |

ランディングページの大型アニメ扇(`fan.html`)は既に扇らしいため意図的に現状維持。`docs/mockups/` の旧ロゴは歴史的成果物として残置。

## 検証

- `make test` 全147件パス
- Hugo ビルドで nav / footer / favicon の3箇所に新ロゴが出力されることを確認
- `fanout dashboard --web` を起動し、新 SVG と `--leaf` 入り CSS の配信を HTTP で確認
- 旧ロゴパス(`M12 21 3.5 8`)が site/ と internal/ から消滅していることを grep で確認
- /post-work-review 済み: code-review(9角度+検証+sweep)指摘0件、codex review 反復1で approve

🤖 Generated with [Claude Code](https://claude.com/claude-code)