### PR TITLE
feat(team): fan-out 統合 — --team + peers レジストリ seed + briefing roster [wave2]

### DIFF
--- a/cmd/fanout/main.go
+++ b/cmd/fanout/main.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/butaosuinu/fanout/internal/agent"
+	"github.com/butaosuinu/fanout/internal/briefing"
 	"github.com/butaosuinu/fanout/internal/cliflags"
 	"github.com/butaosuinu/fanout/internal/exitcode"
 	"github.com/butaosuinu/fanout/internal/ghissue"
@@ -200,7 +201,12 @@ func run(cfg *cliflags.Config, lg *log.Logger, commandName string) exitcode.Code
 		printDryRunPlan(plan, lg, c)
 	}
 
-	result := executePlan(cfg, lg, rt.info, rt.gh, plan.Targets, resolvedSettings, recorder, otherParentFanned, c, commandName)
+	var teamCtx *briefing.TeamContext
+	if cfg.Team {
+		teamCtx = buildTeamContext(rt.info.ProjectRoot, cfg.ParentRef, plan.Targets)
+	}
+
+	result := executePlan(cfg, lg, rt.info, rt.gh, plan.Targets, resolvedSettings, recorder, otherParentFanned, c, commandName, teamCtx)
 	printSummary(plan, result, cfg, lg, c, commandName)
 
 	// Register the tmux keybinding so the user can pop the read-only dashboard
@@ -209,6 +215,17 @@ func run(cfg *cliflags.Config, lg *log.Logger, commandName string) exitcode.Code
 	// repos. Best-effort, live runs only.
 	if !cfg.DryRun && result.Created > 0 {
 		bindDashboardKey(lg, resolvedSettings.DashboardKeybind)
+	}
+
+	// Seed the peers registry for --team runs, fail-fast partial successes
+	// included. Best-effort: this runs outside the executePlan loop and a
+	// failure only warns, never changes the exit code.
+	if cfg.Team && len(result.CreatedNums) > 0 {
+		if cfg.DryRun {
+			fmt.Fprintf(lg.Stdout(), "%s# would seed team registry: %d peer(s) -> %s%s\n", c.Dim, len(result.CreatedNums), teamCtx.DBPath, c.Reset)
+		} else {
+			seedTeamRegistry(lg, teamCtx.DBPath, recorder.Store, cfg.ParentRef, result.CreatedNums)
+		}
 	}
 
 	if result.Failed > 0 {
@@ -471,7 +488,7 @@ func worktreeNameMatchesIssue(names []string, exactSlug string, issueNum int) bo
 	return false
 }
 
-func executePlan(cfg *cliflags.Config, lg *log.Logger, info *fanoutruntime.Info, gh ghissue.Runner, targets []ghissue.Issue, resolvedSettings settings.Settings, recorder paneStateRecorder, sharedAcrossParents map[int]bool, c log.Palette, commandName string) executionResult {
+func executePlan(cfg *cliflags.Config, lg *log.Logger, info *fanoutruntime.Info, gh ghissue.Runner, targets []ghissue.Issue, resolvedSettings settings.Settings, recorder paneStateRecorder, sharedAcrossParents map[int]bool, c log.Palette, commandName string, teamCtx *briefing.TeamContext) executionResult {
 	var result executionResult
 	for i, issue := range targets {
 		// Hydrate body lazily for issues that came from the Sub-issues API
@@ -482,7 +499,7 @@ func executePlan(cfg *cliflags.Config, lg *log.Logger, info *fanoutruntime.Info,
 			}
 		}
 		// Fail fast: stop after the first failed child launch.
-		if !createPaneForIssue(cfg, lg, info, issue, resolvedSettings, recorder, sharedAcrossParents[issue.Number], c, commandName) {
+		if !createPaneForIssue(cfg, lg, info, issue, resolvedSettings, recorder, sharedAcrossParents[issue.Number], c, commandName, teamCtx) {
 			result.Failed++
 			break
 		}

--- a/cmd/fanout/main_test.go
+++ b/cmd/fanout/main_test.go
@@ -44,7 +44,7 @@ func TestExecutePlanSleepsBetweenDryRunIssues(t *testing.T) {
 		{Number: 2, Title: "two", State: "OPEN", Body: "body"},
 	}
 
-	result := executePlan(cfg, lg, info, ghissue.Runner{}, targets, settings.Defaults(), nil, nil, log.Palette{}, "fanout")
+	result := executePlan(cfg, lg, info, ghissue.Runner{}, targets, settings.Defaults(), nil, nil, log.Palette{}, "fanout", nil)
 
 	if result.Created != 2 || result.Failed != 0 {
 		t.Fatalf("executePlan result = %+v, want 2 created and 0 failed", result)
@@ -81,7 +81,7 @@ func TestCreatePaneForIssueFailsWhenWorktreeAppearsDuringLaunch(t *testing.T) {
 	}
 	issue := ghissue.Issue{Number: 77, Title: "Duplicate Title", State: "OPEN", Body: "body"}
 
-	if createPaneForIssue(cfg, lg, info, issue, settings.Defaults(), nil, false, log.Palette{}, "fanout") {
+	if createPaneForIssue(cfg, lg, info, issue, settings.Defaults(), nil, false, log.Palette{}, "fanout", nil) {
 		t.Fatal("createPaneForIssue() = true, want false for launch-time worktree collision")
 	}
 	if got := stderr.String(); !strings.Contains(got, "worktree path already exists during launch") {
@@ -106,7 +106,7 @@ func TestCreatePaneForIssueRejectsUnsupportedRefreshBaseInDryRun(t *testing.T) {
 	}
 	issue := ghissue.Issue{Number: 77, Title: "Bad Base", State: "OPEN", Body: "body"}
 
-	if createPaneForIssue(cfg, lg, info, issue, settings.Defaults(), nil, false, log.Palette{}, "fanout") {
+	if createPaneForIssue(cfg, lg, info, issue, settings.Defaults(), nil, false, log.Palette{}, "fanout", nil) {
 		t.Fatal("createPaneForIssue() = true, want false for unsupported refresh base")
 	}
 	if got := stderr.String(); !strings.Contains(got, `base branch "refs/heads/main" is not refreshable`) {

--- a/cmd/fanout/pane.go
+++ b/cmd/fanout/pane.go
@@ -66,8 +66,8 @@ type paneStateRecorder interface {
 	RemovePane(parent string, issueNum int) error
 }
 
-func createPaneForIssue(cfg *cliflags.Config, lg *log.Logger, info *fanoutruntime.Info, issue ghissue.Issue, resolvedSettings settings.Settings, recorder paneStateRecorder, sharedAcrossParents bool, c log.Palette, commandName string) bool {
-	req := newPaneRequest(cfg, info.ProjectRoot, issue, resolvedSettings, sharedAcrossParents)
+func createPaneForIssue(cfg *cliflags.Config, lg *log.Logger, info *fanoutruntime.Info, issue ghissue.Issue, resolvedSettings settings.Settings, recorder paneStateRecorder, sharedAcrossParents bool, c log.Palette, commandName string, teamCtx *briefing.TeamContext) bool {
+	req := newPaneRequest(cfg, info.ProjectRoot, issue, resolvedSettings, sharedAcrossParents, teamCtx)
 	return createPane(cfg, lg, info, req, recorder, c, commandName)
 }
 
@@ -217,7 +217,7 @@ func buildCodexPlanTUILaunchCommand(fanoutPath, codexPath, prompt, statusPath st
 	return strings.Join(quoted, " ")
 }
 
-func newPaneRequest(cfg *cliflags.Config, projectRoot string, issue ghissue.Issue, resolvedSettings settings.Settings, sharedAcrossParents bool) paneRequest {
+func newPaneRequest(cfg *cliflags.Config, projectRoot string, issue ghissue.Issue, resolvedSettings settings.Settings, sharedAcrossParents bool, teamCtx *briefing.TeamContext) paneRequest {
 	slug := naming.Slug(issue.Title, issue.Number)
 	slugOverridden := false
 	branchOverride := ""
@@ -254,7 +254,7 @@ func newPaneRequest(cfg *cliflags.Config, projectRoot string, issue ghissue.Issu
 		BaseBranch:  cfg.BaseBranch,
 		NoRefresh:   cfg.NoRefresh,
 	})
-	req.BriefingBody = briefing.Render(issue.Number, issue.Title, issue.Body, cfg.Agent, req.Worktree.BaseBranch, resolvedSettings, req.CodexPlanMode)
+	req.BriefingBody = briefing.Render(issue.Number, issue.Title, issue.Body, cfg.Agent, req.Worktree.BaseBranch, resolvedSettings, req.CodexPlanMode, teamCtx)
 	req.Prompt = oneLinePrompt(req.ParentRef, req)
 	if req.CodexPlanMode {
 		req.CodexPlanStatusPath = codexPlanStatusPath(projectRoot, issue.Number, cfg.DryRun)

--- a/cmd/fanout/pane_test.go
+++ b/cmd/fanout/pane_test.go
@@ -145,7 +145,7 @@ func TestNewPaneRequestQualifiesDefaultSlugForSharedChild(t *testing.T) {
 	cfg := &cliflags.Config{ParentRef: "200", Agent: "claude"}
 	issue := ghissue.Issue{Number: 501, Title: "Shared child", Body: "body"}
 
-	got := newPaneRequest(cfg, "/repo", issue, settings.Defaults(), true)
+	got := newPaneRequest(cfg, "/repo", issue, settings.Defaults(), true, nil)
 
 	if got.Slug != "shared-child-parent-200-501" {
 		t.Fatalf("slug = %q, want shared-child-parent-200-501", got.Slug)
@@ -162,7 +162,7 @@ func TestNewPaneRequestPassesResolvedBaseBranchToBriefing(t *testing.T) {
 	cfg := &cliflags.Config{ParentRef: "200", Agent: "claude", BaseBranch: "release/v1"}
 	issue := ghissue.Issue{Number: 501, Title: "Release child", Body: "body"}
 
-	got := newPaneRequest(cfg, "/repo", issue, settings.Defaults(), false)
+	got := newPaneRequest(cfg, "/repo", issue, settings.Defaults(), false, nil)
 
 	if !strings.Contains(got.BriefingBody, "git diff --name-only release/v1...HEAD") {
 		t.Fatalf("briefing did not include selected base branch:\n%s", got.BriefingBody)
@@ -173,7 +173,7 @@ func TestNewPaneRequestCarriesIssueWave(t *testing.T) {
 	cfg := &cliflags.Config{ParentRef: "200", Agent: "claude"}
 	issue := ghissue.Issue{Number: 501, Title: "Wave child", Body: "body", Wave: "wave5"}
 
-	got := newPaneRequest(cfg, "/repo", issue, settings.Defaults(), false)
+	got := newPaneRequest(cfg, "/repo", issue, settings.Defaults(), false, nil)
 
 	if got.Wave != "wave5" {
 		t.Fatalf("Wave = %q, want wave5", got.Wave)
@@ -184,7 +184,7 @@ func TestNewPaneRequestCodexPlanModeUsesPlanPromptAndBriefing(t *testing.T) {
 	cfg := &cliflags.Config{ParentRef: "200", Agent: "codex", CodexPlanMode: new(true)}
 	issue := ghissue.Issue{Number: 501, Title: "Plan child", Body: "body"}
 
-	got := newPaneRequest(cfg, "/repo", issue, settings.Defaults(), false)
+	got := newPaneRequest(cfg, "/repo", issue, settings.Defaults(), false, nil)
 
 	if !got.CodexPlanMode {
 		t.Fatal("CodexPlanMode = false, want true")

--- a/cmd/fanout/report.go
+++ b/cmd/fanout/report.go
@@ -97,12 +97,13 @@ func printSummary(plan Plan, result executionResult, cfg *cliflags.Config, lg *l
 		if cfg.ParentMode == cliflags.ModeProject && cfg.ProjectStatus != cliflags.DefaultProjectStatus {
 			statusFlag = optFlag("--project-status", cfg.ProjectStatus)
 		}
-		fmt.Fprintf(lg.Stdout(), "  %s %s%s --include %s --only %s%s%s%s%s%s%s%s\n",
+		fmt.Fprintf(lg.Stdout(), "  %s %s%s --include %s --only %s%s%s%s%s%s%s%s%s\n",
 			shellQuote(commandName), shellQuote(cfg.ParentRef),
 			statusFlag,
 			shellQuote(deferredCSV),
 			shellQuote(deferredCSV),
 			boolFlag(" --unblocked-only", cfg.UnblockedOnly),
+			boolFlag(" --team", cfg.Team),
 			codexPlanModeFlag(cfg),
 			settingsFlags(cfg),
 			worktreeFlags(cfg),

--- a/cmd/fanout/team.go
+++ b/cmd/fanout/team.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/butaosuinu/fanout/internal/briefing"
+	"github.com/butaosuinu/fanout/internal/ghissue"
+	"github.com/butaosuinu/fanout/internal/log"
+	"github.com/butaosuinu/fanout/internal/state"
+	"github.com/butaosuinu/fanout/internal/team"
+)
+
+// buildTeamContext assembles the per-run --team data exactly once: the DB
+// path (so the briefing and the registry seed can never disagree) and the
+// sibling roster from this run's plan targets. Pure; it never touches the DB,
+// which keeps --team --dry-run free of side effects.
+func buildTeamContext(projectRoot, parentRef string, targets []ghissue.Issue) *briefing.TeamContext {
+	siblings := make([]briefing.TeamSibling, 0, len(targets))
+	for _, issue := range targets {
+		siblings = append(siblings, briefing.TeamSibling{Num: issue.Number, Title: issue.Title})
+	}
+	return &briefing.TeamContext{
+		ParentLabel: teamParentLabel(parentRef),
+		DBPath:      team.DBPath(projectRoot, parentRef),
+		Siblings:    siblings,
+	}
+}
+
+// teamParentLabel mirrors team.ParentDBSlug's issue-number classification
+// (strconv-based, leading zeros collapsed) so the briefing identity line and
+// the DB path shown next to it always agree on the parent spelling;
+// non-numeric refs (Project URLs, @manual) read verbatim.
+func teamParentLabel(parentRef string) string {
+	if n, err := strconv.Atoi(strings.TrimSpace(parentRef)); err == nil && n >= 0 {
+		return fmt.Sprintf("#%d", n)
+	}
+	return parentRef
+}
+
+// seedTeamRegistry upserts the panes created this run into the per-parent
+// peers table. Messaging is best-effort by design: every failure is a warning
+// and the fan-out result is never affected.
+func seedTeamRegistry(lg *log.Logger, dbPath string, st state.Store, parentRef string, created []int) {
+	db, err := team.Open(dbPath)
+	if err != nil {
+		lg.Warn("team: %v", err)
+		return
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			lg.Warn("team: close registry db: %v", err)
+		}
+	}()
+	if err := team.EnsureSchema(db); err != nil {
+		lg.Warn("team: %v", err)
+		return
+	}
+
+	// One timestamp for the run so a cohort launched together joins together.
+	now := team.Now()
+	seeded := 0
+	for _, num := range created {
+		pane, ok := st.Find(parentRef, num)
+		if !ok {
+			lg.Warn("team: #%d: no state row to seed into the peers registry", num)
+			continue
+		}
+		if err := team.UpsertPeer(db, pane, now); err != nil {
+			lg.Warn("team: %v", err)
+			continue
+		}
+		seeded++
+	}
+	if seeded > 0 {
+		lg.Ok("team: seeded %d peer(s) -> %s", seeded, dbPath)
+	}
+}

--- a/cmd/fanout/team_test.go
+++ b/cmd/fanout/team_test.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/butaosuinu/fanout/internal/ghissue"
+	"github.com/butaosuinu/fanout/internal/log"
+	"github.com/butaosuinu/fanout/internal/state"
+	"github.com/butaosuinu/fanout/internal/team"
+)
+
+func TestBuildTeamContext(t *testing.T) {
+	t.Setenv(team.DBPathEnv, "")
+	targets := []ghissue.Issue{
+		{Number: 101, Title: "First child"},
+		{Number: 102, Title: "Second child"},
+	}
+	got := buildTeamContext("/repo/project_root", "100", targets)
+	if got.ParentLabel != "#100" {
+		t.Errorf("ParentLabel = %q, want %q", got.ParentLabel, "#100")
+	}
+	if got.DBPath != "/tmp/fanout-project_root-100.db" {
+		t.Errorf("DBPath = %q, want the team.DBPath convention", got.DBPath)
+	}
+	if len(got.Siblings) != 2 || got.Siblings[0].Num != 101 || got.Siblings[1].Title != "Second child" {
+		t.Errorf("Siblings = %+v, want the targets in plan order", got.Siblings)
+	}
+}
+
+func TestTeamParentLabel(t *testing.T) {
+	for _, tc := range []struct {
+		parentRef string
+		want      string
+	}{
+		{"100", "#100"},
+		// Leading zeros collapse exactly like team.ParentDBSlug, so the
+		// identity line agrees with the DB path shown next to it.
+		{"0068", "#68"},
+		{"https://github.com/users/butaosuinu/projects/3", "https://github.com/users/butaosuinu/projects/3"},
+		{"@manual", "@manual"},
+	} {
+		if got := teamParentLabel(tc.parentRef); got != tc.want {
+			t.Errorf("teamParentLabel(%q) = %q, want %q", tc.parentRef, got, tc.want)
+		}
+	}
+}
+
+func TestSeedTeamRegistryUpsertsCreatedPanes(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "team.db")
+	st := state.Store{Panes: []state.Pane{
+		{Parent: "100", IssueNum: 101, PaneID: "%5", Slug: "first-child-101", Agent: "claude", DisplayName: "first-child-101", WorktreePath: "/repo/.fanout/worktrees/first-child-101"},
+		{Parent: "100", IssueNum: 102, PaneID: "%6", Slug: "second-child-102", Agent: "claude", DisplayName: "second-child-102", WorktreePath: "/repo/.fanout/worktrees/second-child-102"},
+	}}
+	var stdout, stderr bytes.Buffer
+	lg := log.NewWith(&stdout, &stderr, false)
+
+	// 103 has no state row: it must warn and not abort the remaining seeds.
+	seedTeamRegistry(lg, dbPath, st, "100", []int{101, 103, 102})
+
+	if got := stderr.String(); !strings.Contains(got, "#103: no state row") {
+		t.Errorf("stderr = %q, want a missing-row warning for #103", got)
+	}
+	if got := stdout.String(); !strings.Contains(got, "seeded 2 peer(s)") {
+		t.Errorf("stdout = %q, want a seeded 2 peer(s) line", got)
+	}
+
+	db, err := team.Open(dbPath)
+	if err != nil {
+		t.Fatalf("reopen seeded db: %v", err)
+	}
+	defer db.Close()
+	var count int
+	if err := db.QueryRow("SELECT COUNT(*) FROM peers").Scan(&count); err != nil {
+		t.Fatalf("count peers: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("peers rows = %d, want 2", count)
+	}
+	var paneID string
+	if err := db.QueryRow("SELECT pane_id FROM peers WHERE issue = ?", 102).Scan(&paneID); err != nil {
+		t.Fatalf("select peer 102: %v", err)
+	}
+	if paneID != "%6" {
+		t.Errorf("peer 102 pane_id = %q, want %%6", paneID)
+	}
+}
+
+func TestSeedTeamRegistryWarnsWhenDBUnavailable(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	lg := log.NewWith(&stdout, &stderr, false)
+	// A missing parent directory makes team.Open fail; seeding must only warn.
+	seedTeamRegistry(lg, filepath.Join(t.TempDir(), "no-such-dir", "team.db"), state.Store{}, "100", []int{101})
+	if got := stderr.String(); !strings.Contains(got, "team:") {
+		t.Errorf("stderr = %q, want a team: warning", got)
+	}
+}

--- a/internal/briefing/briefing.go
+++ b/internal/briefing/briefing.go
@@ -21,9 +21,27 @@ func Path(projectRoot string, num int) string {
 	return fmt.Sprintf("/tmp/fanout-%s-%d.md", repo, num)
 }
 
+// TeamSibling is one roster entry of a --team run: a child pane created
+// alongside this briefing's issue.
+type TeamSibling struct {
+	Num   int
+	Title string
+}
+
+// TeamContext carries the --team coordination data into the briefing: the
+// display-ready parent label, the shared SQLite DB path (computed once per
+// run so briefing and registry seed always agree), and the launch-time
+// sibling roster built from this run's plan targets (self included).
+type TeamContext struct {
+	ParentLabel string // "#68" for issue parents, Project URLs verbatim
+	DBPath      string
+	Siblings    []TeamSibling
+}
+
 // Render produces the brief body. Live mode writes it to Path(); dry-run uses
 // len(Render()) to compute the goldened "briefing size" without touching disk.
-func Render(num int, title, body, agent, baseBranch string, s settings.Settings, codexPlanMode bool) string {
+// team is nil unless the run opted in with --team.
+func Render(num int, title, body, agent, baseBranch string, s settings.Settings, codexPlanMode bool, team *TeamContext) string {
 	if codexPlanMode {
 		return renderCodexPlanBriefing(num, title, body)
 	}
@@ -49,6 +67,9 @@ func Render(num int, title, body, agent, baseBranch string, s settings.Settings,
 	base := strings.Join(lines, "\n") + "\n"
 	if s.AutoPullRequest && s.PRVisualization {
 		base += prVisualizationSection(num, baseBranch)
+	}
+	if team != nil {
+		base += teamSection(num, team)
 	}
 	if agent == "codex" {
 		return base + codexReviewSection(s.AutoPullRequest)
@@ -171,6 +192,51 @@ Before committing your final changes, run the ` + "`/code-review`" + ` slash com
 files you've changed. /code-review is a Claude Code skill that reviews changed code
 for reuse, quality, and efficiency and fixes issues it finds. Apply its fixes,
 re-run lint/test, then commit and push as described above.
+`
+
+// teamSection renders the --team coordination block appended to the shared
+// base briefing for every agent. The roster is the launch-time snapshot of
+// this run's targets; the text points at `fanout msg peers` for the live
+// list and degrades gracefully while the msg subcommand (#70) is unmerged.
+func teamSection(num int, t *TeamContext) string {
+	var roster strings.Builder
+	for _, sibling := range t.Siblings {
+		fmt.Fprintf(&roster, "- #%d: %s", sibling.Num, sibling.Title)
+		if sibling.Num == num {
+			roster.WriteString(" (you)")
+		}
+		roster.WriteString("\n")
+	}
+	return fmt.Sprintf(teamSectionTemplate, num, t.ParentLabel, roster.String(), t.DBPath)
+}
+
+const teamSectionTemplate = `
+## Coordinating with your sibling panes
+
+You are the pane for issue #%d (parent %s), launched alongside these sibling panes:
+%s
+A shared SQLite message board for this parent lives at:
+%s
+The roster above is a launch-time snapshot; ` + "`fanout msg peers`" + ` is the live list.
+
+Cheatsheet (best-effort; skip messaging if the ` + "`fanout msg`" + ` subcommand is unavailable):
+- ` + "`fanout msg peers`" + `                 — live sibling roster
+- ` + "`fanout msg inbox [--mark-read]`" + `  — read messages addressed to you
+- ` + "`fanout msg board`" + `                 — read the shared board
+- ` + "`fanout msg send --to <N> \"<body>\"`" + ` — message sibling #N directly
+- ` + "`fanout msg post \"<body>\"`" + `        — post to the shared board
+
+Checkpoints (lightweight; never block waiting for a reply):
+1. After reading this briefing, check ` + "`fanout msg inbox`" + ` and ` + "`fanout msg board`" + ` once.
+   Siblings are registered after the whole batch has launched, so a missing DB or
+   an empty roster early in the run only means they have not joined yet — do not
+   give up on messaging; just check again at the next checkpoint.
+2. Before touching files siblings may share (configs, schemas, lockfiles), post a one-line heads-up.
+3. Check your inbox once more before opening the PR.
+
+Etiquette: keep messages short and factual — file paths, branch names, issue numbers.
+Note: this is messaging between separate panes; it is unrelated to Claude Code
+Agent Teams, which coordinates teammates inside your own single session.
 `
 
 const agentTeamsSection = `

--- a/internal/briefing/briefing_test.go
+++ b/internal/briefing/briefing_test.go
@@ -10,7 +10,7 @@ import (
 func TestPRVisualizationSectionHonorsSettings(t *testing.T) {
 	defaults := settings.Defaults()
 	for _, agent := range []string{"claude", "codex"} {
-		got := Render(123, "structured PR briefing", "Issue body", agent, "release/v1", defaults, false)
+		got := Render(123, "structured PR briefing", "Issue body", agent, "release/v1", defaults, false, nil)
 		if !strings.Contains(got, "structure the PR body") {
 			t.Fatalf("Render(..., %q) is missing structured PR body guidance", agent)
 		}
@@ -30,29 +30,85 @@ func TestPRVisualizationSectionHonorsSettings(t *testing.T) {
 
 	noVisualization := defaults
 	noVisualization.PRVisualization = false
-	got := Render(123, "structured PR briefing", "Issue body", "claude", "release/v1", noVisualization, false)
+	got := Render(123, "structured PR briefing", "Issue body", "claude", "release/v1", noVisualization, false, nil)
 	if strings.Contains(got, "structure the PR body") || strings.Contains(got, "Diagram gate") {
 		t.Fatal("PR visualization section present when PRVisualization=false")
 	}
 
 	noAutoPR := defaults
 	noAutoPR.AutoPullRequest = false
-	got = Render(123, "structured PR briefing", "Issue body", "codex", "release/v1", noAutoPR, false)
+	got = Render(123, "structured PR briefing", "Issue body", "codex", "release/v1", noAutoPR, false, nil)
 	if strings.Contains(got, "structure the PR body") || strings.Contains(got, "Diagram gate") {
 		t.Fatal("PR visualization section present when AutoPullRequest=false")
 	}
 }
 
 func TestPRVisualizationSectionQuotesBaseBranch(t *testing.T) {
-	got := Render(123, "structured PR briefing", "Issue body", "codex", "foo;bar", settings.Defaults(), false)
+	got := Render(123, "structured PR briefing", "Issue body", "codex", "foo;bar", settings.Defaults(), false, nil)
 	want := "git diff --name-only 'foo;bar'...HEAD"
 	if !strings.Contains(got, want) {
 		t.Fatalf("Render(...) missing shell-quoted base branch command %q", want)
 	}
 }
 
+func testTeamContext() *TeamContext {
+	return &TeamContext{
+		ParentLabel: "#100",
+		DBPath:      "/tmp/fanout-project_root-100.db",
+		Siblings: []TeamSibling{
+			{Num: 101, Title: "First child"},
+			{Num: 102, Title: "Second child"},
+		},
+	}
+}
+
+func TestTeamSectionAbsentWithoutTeamContext(t *testing.T) {
+	for _, agent := range []string{"claude", "codex"} {
+		got := Render(101, "First child", "Issue body", agent, "main", settings.Defaults(), false, nil)
+		if strings.Contains(got, "Coordinating with your sibling panes") {
+			t.Fatalf("Render(..., %q, team=nil) contains the team section", agent)
+		}
+	}
+}
+
+func TestTeamSectionRendersForBothAgents(t *testing.T) {
+	team := testTeamContext()
+	// The section sits in the agent-shared base string, so the full content
+	// is asserted once (claude) and codex only needs the section to appear.
+	got := Render(101, "First child", "Issue body", "claude", "main", settings.Defaults(), false, team)
+	for _, want := range []string{
+		"## Coordinating with your sibling panes",
+		"You are the pane for issue #101 (parent #100)",
+		"- #101: First child (you)",
+		"- #102: Second child",
+		"/tmp/fanout-project_root-100.db",
+		"fanout msg peers",
+		"fanout msg send --to <N>",
+		"Agent Teams, which coordinates teammates inside your own single session",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("Render(..., team) missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "- #102: Second child (you)") {
+		t.Fatal("Render(..., team) marks a non-self sibling as (you)")
+	}
+
+	codex := Render(101, "First child", "Issue body", "codex", "main", settings.Defaults(), false, team)
+	if !strings.Contains(codex, "## Coordinating with your sibling panes") {
+		t.Fatalf("Render(..., \"codex\", team) missing the team section:\n%s", codex)
+	}
+}
+
+func TestTeamSectionAbsentInCodexPlanBriefing(t *testing.T) {
+	got := Render(101, "First child", "Issue body", "codex", "main", settings.Defaults(), true, testTeamContext())
+	if strings.Contains(got, "Coordinating with your sibling panes") {
+		t.Fatalf("codex plan briefing contains the team section:\n%s", got)
+	}
+}
+
 func TestCodexPlanModeUsesPlanningBriefing(t *testing.T) {
-	got := Render(122, "Plan mode", "Issue body", "codex", "release/v1", settings.Defaults(), true)
+	got := Render(122, "Plan mode", "Issue body", "codex", "release/v1", settings.Defaults(), true, nil)
 	if !strings.Contains(got, "<proposed_plan>...</proposed_plan>") {
 		t.Fatalf("plan briefing missing proposed_plan requirement:\n%s", got)
 	}

--- a/internal/cliflags/cliflags.go
+++ b/internal/cliflags/cliflags.go
@@ -52,6 +52,7 @@ type Config struct {
 	DryRun             bool
 	Debug              bool
 	UnblockedOnly      bool
+	Team               bool
 	StatusMode         bool
 	PostDashboard      bool
 	CloseNum           int
@@ -192,6 +193,7 @@ func Parse(args []string, lg *log.Logger, stdout io.Writer) ParseResult {
 		"--debug":                   func(cfg *Config) { cfg.Debug = true },
 		"--no-refresh":              func(cfg *Config) { cfg.NoRefresh = true },
 		"--unblocked-only":          func(cfg *Config) { cfg.UnblockedOnly = true },
+		"--team":                    func(cfg *Config) { cfg.Team = true },
 		"--status":                  func(cfg *Config) { cfg.StatusMode = true },
 		"--post-dashboard":          func(cfg *Config) { cfg.PostDashboard = true },
 		"--cleanup":                 func(cfg *Config) { cfg.CleanupMode = true },
@@ -388,6 +390,8 @@ func validateParsed(cfg *Config, state parseState, lg *log.Logger) ParseResult {
 			return statusConflict(lg, boolSettingFlag("--pr-visualization", "--no-pr-visualization", cfg.PRVisualization))
 		case cfg.DashboardKeybind != nil:
 			return statusConflict(lg, boolSettingFlag("--dashboard-keybind", "--no-dashboard-keybind", cfg.DashboardKeybind))
+		case cfg.Team:
+			return statusConflict(lg, "--team")
 		case state.sleepExplicit:
 			return statusConflict(lg, "--sleep")
 		case state.popupExplicit:
@@ -449,6 +453,8 @@ func validateParsed(cfg *Config, state parseState, lg *log.Logger) ParseResult {
 			return lifecycleConflict(lg, boolSettingFlag("--pr-visualization", "--no-pr-visualization", cfg.PRVisualization))
 		case cfg.DashboardKeybind != nil:
 			return lifecycleConflict(lg, boolSettingFlag("--dashboard-keybind", "--no-dashboard-keybind", cfg.DashboardKeybind))
+		case cfg.Team:
+			return lifecycleConflict(lg, "--team")
 		case state.sleepExplicit:
 			return lifecycleConflict(lg, "--sleep")
 		case state.popupExplicit:

--- a/internal/cliflags/cliflags_test.go
+++ b/internal/cliflags/cliflags_test.go
@@ -144,6 +144,7 @@ func TestParseStatusRejectsSettingsBoolFlags(t *testing.T) {
 		{"--no-codex-plan-mode", "--status cannot be combined with --no-codex-plan-mode"},
 		{"--pr-visualization", "--status cannot be combined with --pr-visualization"},
 		{"--no-pr-visualization", "--status cannot be combined with --no-pr-visualization"},
+		{"--team", "--status cannot be combined with --team"},
 	} {
 		t.Run(tc.flag, func(t *testing.T) {
 			var stdout, stderr bytes.Buffer
@@ -155,6 +156,26 @@ func TestParseStatusRejectsSettingsBoolFlags(t *testing.T) {
 				t.Fatalf("stderr = %q, want to contain %q", got, tc.want)
 			}
 		})
+	}
+}
+
+func TestParseTeamFlag(t *testing.T) {
+	if cfg := parseOK(t, "100", "--agent", "claude"); cfg.Team {
+		t.Fatal("Team = true without --team, want false (opt-in)")
+	}
+	if cfg := parseOK(t, "100", "--agent", "claude", "--team"); !cfg.Team {
+		t.Fatal("Team = false with --team, want true")
+	}
+}
+
+func TestParseLifecycleRejectsTeam(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	res := Parse([]string{"100", "--close", "101", "--team"}, log.NewWith(&stdout, &stderr, false), io.Discard)
+	if res.Code != exitcode.Invocation {
+		t.Fatalf("Parse() code = %d, want %d", res.Code, exitcode.Invocation)
+	}
+	if got := stderr.String(); !strings.Contains(got, "--close/--merge/--cleanup cannot be combined with --team") {
+		t.Fatalf("stderr = %q, want lifecycle --team conflict message", got)
 	}
 }
 

--- a/internal/cliflags/usage.go
+++ b/internal/cliflags/usage.go
@@ -105,6 +105,12 @@ Options:
                       Register (or skip) a tmux 'prefix + D' keybinding after a
                       live fan-out so the read-only web dashboard can be opened
                       from any pane. Default: on.
+  --team              Opt in to sibling-pane messaging for this run: add a
+                      "Coordinating with your sibling panes" section (roster +
+                      shared SQLite DB path) to every child briefing and seed
+                      the created panes into the per-parent peers registry.
+                      Best-effort; registry failures never fail the fan-out.
+                      Default: off.
   --sleep <seconds>   Pause between pane-creation requests. Default 4.
   --popup-timeout <s> Deprecated compatibility flag; accepted but ignored by
                       the direct tmux path.

--- a/internal/team/registry.go
+++ b/internal/team/registry.go
@@ -1,0 +1,28 @@
+package team
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/butaosuinu/fanout/internal/state"
+)
+
+// UpsertPeer records pane p in the peers registry, replacing any existing row
+// for the same issue. A conflict means the issue was fanned out again after a
+// --close (the /tmp DB outlives .fanout/state.json), so the row is rewritten
+// as the new pane's identity: joined_at moves to now and last_seen resets to
+// NULL so a dead pane's activity never shows as recent. now is the caller's
+// timestamp (team.Now()) so tests stay deterministic.
+func UpsertPeer(db *sql.DB, p state.Pane, now string) error {
+	_, err := db.Exec(`INSERT INTO peers (issue, pane_id, slug, worktree_path, agent, display_name, joined_at)
+VALUES (?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(issue) DO UPDATE SET
+  pane_id=excluded.pane_id, slug=excluded.slug, worktree_path=excluded.worktree_path,
+  agent=excluded.agent, display_name=excluded.display_name,
+  joined_at=excluded.joined_at, last_seen=NULL`,
+		p.IssueNum, p.PaneID, p.Slug, p.WorktreePath, p.Agent, p.DisplayName, now)
+	if err != nil {
+		return fmt.Errorf("upsert peer #%d: %w", p.IssueNum, err)
+	}
+	return nil
+}

--- a/internal/team/registry_test.go
+++ b/internal/team/registry_test.go
@@ -1,0 +1,72 @@
+package team
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/butaosuinu/fanout/internal/state"
+)
+
+func TestUpsertPeerInsertsAndRewritesOnConflict(t *testing.T) {
+	db, _ := openTestDB(t)
+	if err := EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	first := state.Pane{
+		IssueNum:     71,
+		PaneID:       "%5",
+		Slug:         "team-fanout-integration-71",
+		WorktreePath: "/repo/.fanout/worktrees/team-fanout-integration-71",
+		Agent:        "claude",
+		DisplayName:  "Team integration",
+	}
+	if err := UpsertPeer(db, first, "2026-06-13T01:00:00Z"); err != nil {
+		t.Fatalf("UpsertPeer insert: %v", err)
+	}
+
+	// Simulate a live pane before the re-fanout: last_seen must not survive
+	// the conflict rewrite below.
+	if _, err := db.Exec("UPDATE peers SET last_seen = ? WHERE issue = ?", "2026-06-13T01:30:00Z", 71); err != nil {
+		t.Fatalf("seed last_seen: %v", err)
+	}
+
+	refanned := first
+	refanned.PaneID = "%9"
+	refanned.WorktreePath = "/repo/.fanout/worktrees/team-fanout-integration-71-redo"
+	refanned.Agent = "codex"
+	if err := UpsertPeer(db, refanned, "2026-06-13T02:00:00Z"); err != nil {
+		t.Fatalf("UpsertPeer conflict update: %v", err)
+	}
+
+	var count int
+	if err := db.QueryRow("SELECT COUNT(*) FROM peers").Scan(&count); err != nil {
+		t.Fatalf("count peers: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("peers rows = %d, want 1 (issue is the PK)", count)
+	}
+
+	var (
+		paneID, slug, worktree, agent, display, joinedAt string
+		lastSeen                                         sql.NullString
+	)
+	err := db.QueryRow(
+		"SELECT pane_id, slug, worktree_path, agent, display_name, joined_at, last_seen FROM peers WHERE issue = ?", 71,
+	).Scan(&paneID, &slug, &worktree, &agent, &display, &joinedAt, &lastSeen)
+	if err != nil {
+		t.Fatalf("select peer: %v", err)
+	}
+	if paneID != "%9" || worktree != refanned.WorktreePath || agent != "codex" {
+		t.Errorf("peer identity = (%q, %q, %q), want the re-fanned pane's values", paneID, worktree, agent)
+	}
+	if slug != refanned.Slug || display != refanned.DisplayName {
+		t.Errorf("peer naming = (%q, %q), want (%q, %q)", slug, display, refanned.Slug, refanned.DisplayName)
+	}
+	if joinedAt != "2026-06-13T02:00:00Z" {
+		t.Errorf("joined_at = %q, want the re-fanout timestamp", joinedAt)
+	}
+	if lastSeen.Valid {
+		t.Errorf("last_seen = %q, want NULL after the conflict rewrite", lastSeen.String)
+	}
+}

--- a/tests/bats/helpers.bash
+++ b/tests/bats/helpers.bash
@@ -64,6 +64,11 @@ setup() {
   # lifecycle operations at another test's state file.
   unset FANOUT_STATE_PATH
 
+  # `--team` honors FANOUT_DB_PATH as a registry DB override; an ambient value
+  # would also rewrite the DB path shown in --team briefings. Unset for
+  # deterministic briefing/golden assertions.
+  unset FANOUT_DB_PATH
+
   # Supply the tmux shim with a PID that's alive for the full test run.
   # Kept for compatibility with older fixture helpers; current direct-runtime
   # shims do not need tmux option liveness checks.
@@ -78,6 +83,12 @@ teardown() {
   # Tier 1 tests don't reach the briefing path, but scrub defensively so a
   # future test (or a Tier 2 leakage) doesn't confuse the next run.
   rm -f /tmp/fanout-*.md 2>/dev/null || true
+  # --team registry DBs share the same /tmp prefix (team.DBPath). Dry-run
+  # tests never create one, but scrub defensively for future live tests.
+  # Scoped to the fixture repo slug (always project_root): a bare
+  # /tmp/fanout-*.db glob would delete the live, durable message DBs of any
+  # real --team session on this machine, unlike the regenerable .md briefings.
+  rm -f /tmp/fanout-project_root-*.db /tmp/fanout-project_root-*.db-wal /tmp/fanout-project_root-*.db-shm 2>/dev/null || true
 }
 
 # Run the repo-local fanout binary under bats' `run`, folding stderr into

--- a/tests/bats/tier1_briefing.bats
+++ b/tests/bats/tier1_briefing.bats
@@ -115,6 +115,45 @@ load helpers
   grep -q "Open a pull request with \"Closes #101\"" /tmp/fanout-project_root-101.md
 }
 
+@test "--team briefing for claude contains sibling section, roster, DB path, and msg cheatsheet" {
+  skip_unless_fanout_go
+  use_fixture scenario-sub-issue-only
+  run_fanout_dry 100 --team
+  assert_success
+  local briefing="/tmp/fanout-project_root-101.md"
+  grep -q "## Coordinating with your sibling panes" "$briefing"
+  grep -q "You are the pane for issue #101 (parent #100)" "$briefing"
+  grep -q "(you)" "$briefing"
+  grep -q "#102:" "$briefing"
+  grep -q "/tmp/fanout-project_root-100.db" "$briefing"
+  grep -q "fanout msg peers" "$briefing"
+  grep -q "fanout msg send --to <N>" "$briefing"
+  grep -q "Agent Teams, which coordinates teammates inside your own single session" "$briefing"
+  # The sibling #102 briefing carries the same roster with the marker moved.
+  grep -q "## Coordinating with your sibling panes" /tmp/fanout-project_root-102.md
+  grep -q "You are the pane for issue #102" /tmp/fanout-project_root-102.md
+}
+
+@test "--team briefing for codex contains sibling section alongside the codex review gate" {
+  skip_unless_fanout_go
+  use_fixture scenario-sub-issue-only
+  run_fanout_dry 100 --team --agent codex
+  assert_success
+  local briefing="/tmp/fanout-project_root-101.md"
+  grep -q "## Coordinating with your sibling panes" "$briefing"
+  grep -q "/tmp/fanout-project_root-100.db" "$briefing"
+  grep -q "codex review --uncommitted" "$briefing"
+}
+
+@test "briefing without --team omits the sibling coordination section" {
+  use_fixture scenario-sub-issue-only
+  run_fanout_dry 100
+  assert_success
+  local briefing="/tmp/fanout-project_root-101.md"
+  ! grep -q "Coordinating with your sibling panes" "$briefing"
+  ! grep -q "fanout msg" "$briefing"
+}
+
 @test "Go settings: disabled PR review gate adds bypass notice for Claude" {
   skip_unless_fanout_go
   use_fixture scenario-sub-issue-only

--- a/tests/bats/tier1_flags.bats
+++ b/tests/bats/tier1_flags.bats
@@ -311,6 +311,18 @@ load helpers
   [[ "$output" == *"--close/--merge/--cleanup cannot be combined with --agent"* ]]
 }
 
+@test "--close conflicts with --team: exit 2" {
+  run_fanout 20 --close 4 --team
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"--close/--merge/--cleanup cannot be combined with --team"* ]]
+}
+
+@test "--status conflicts with --team: exit 2" {
+  run_fanout --status 1 --team
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"--status cannot be combined with --team"* ]]
+}
+
 @test "--only with non-integer entry: exit 1" {
   run_fanout 20 --only 4,abc
   [ "$status" -eq 1 ]

--- a/tests/bats/tier2_dry_run.bats
+++ b/tests/bats/tier2_dry_run.bats
@@ -128,6 +128,18 @@ load helpers
   assert_golden scenario-sub-issue-only-codex-plan
 }
 
+@test "--team variant of scenario-sub-issue-only: briefing grows and registry seed is printed" {
+  # Reuses the scenario-sub-issue-only fixture. --team must add the sibling
+  # coordination section to every briefing (size lines diverge from
+  # scenario-sub-issue-only.dry-run.txt) and print the would-seed line after
+  # the summary; without --team the sibling goldens stay byte-identical.
+  skip_unless_fanout_go
+  use_fixture scenario-sub-issue-only
+  run_fanout_dry 100 --team
+  assert_success
+  assert_golden scenario-sub-issue-only-team
+}
+
 @test "Go settings disabled variant of scenario-sub-issue-only: briefing size tracks toggles" {
   skip_unless_fanout_go
   use_fixture scenario-sub-issue-only

--- a/tests/golden/scenario-sub-issue-only-team.dry-run.txt
+++ b/tests/golden/scenario-sub-issue-only-team.dry-run.txt
@@ -1,0 +1,45 @@
+[info] tmux session: fanout
+[info] tmux target:  %1
+[info] project root: <REPO>/tests/fixtures/scenario-sub-issue-only/project_root
+[info] fetching sub-issues of #100
+[info] sub-issues: 2 total, 2 OPEN
+[info] will create 2 pane(s); deferred (blocked): 0; deferred (--limit): 0
+[info] #101: First child
+  briefing -> /tmp/fanout-project_root-101.md
+  slug -> first-child-101
+  worktree -> <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/first-child-101
+  branch -> fanout/first-child-101
+  base -> main
+  briefing size: 5741 bytes
+    $ git -C <REPO>/tests/fixtures/scenario-sub-issue-only/project_root fetch --quiet --no-tags origin main
+    # may fast-forward the local base before worktree creation
+    $ git -C <REPO>/tests/fixtures/scenario-sub-issue-only/project_root branch -f main refs/remotes/origin/main
+    # if the base is checked out elsewhere, fanout uses merge --ff-only in that worktree
+    $ git -C <REPO>/tests/fixtures/scenario-sub-issue-only/project_root worktree add -b fanout/first-child-101 <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/first-child-101 main
+    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/first-child-101 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout #101 of #100] first-child-101: First child. read /tmp/fanout-project_root-101.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
+    $ tmux select-pane -t <pane_id> -T first-child-101
+    $ tmux select-layout -t '%1' tiled
+    # would write .fanout/state.json with paneId <pane_id>
+    # would write .fanout/worktree-metadata.json in the child worktree
+[ ok ] #101: dry-run complete
+[info] #102: Second child
+  briefing -> /tmp/fanout-project_root-102.md
+  slug -> second-child-102
+  worktree -> <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/second-child-102
+  branch -> fanout/second-child-102
+  base -> main
+  briefing size: 5742 bytes
+    $ git -C <REPO>/tests/fixtures/scenario-sub-issue-only/project_root fetch --quiet --no-tags origin main
+    # may fast-forward the local base before worktree creation
+    $ git -C <REPO>/tests/fixtures/scenario-sub-issue-only/project_root branch -f main refs/remotes/origin/main
+    # if the base is checked out elsewhere, fanout uses merge --ff-only in that worktree
+    $ git -C <REPO>/tests/fixtures/scenario-sub-issue-only/project_root worktree add -b fanout/second-child-102 <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/second-child-102 main
+    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/second-child-102 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout #102 of #100] second-child-102: Second child. read /tmp/fanout-project_root-102.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
+    $ tmux select-pane -t <pane_id> -T second-child-102
+    $ tmux select-layout -t '%1' tiled
+    # would write .fanout/state.json with paneId <pane_id>
+    # would write .fanout/worktree-metadata.json in the child worktree
+[ ok ] #102: dry-run complete
+
+[ ok ] created: 2
+# would seed team registry: 2 peer(s) -> /tmp/fanout-project_root-100.db


### PR DESCRIPTION
## TL;DR

opt-in の `--team` フラグを追加。指定時のみ、各子 briefing に sibling roster・共有 SQLite DB パス・`fanout msg` チートシートを含む「Coordinating with your sibling panes」セクションを追記し、`executePlan` 完了後に作成済みペインを per-parent の `peers` テーブルへ best-effort で upsert する。未指定時は dry-run golden 含め byte 不変。

`Review effort: 3`

## Why

親 #68(fanout ペイン間 peer messaging)の wave2。wave1 #69(PR #239)で入った `internal/team` の SQLite 基盤を fan-out 本体に統合し、「兄弟ペインが互いを認識できる」状態を作る。issue #71 が指定する設計: `--team` は plain bool の opt-in(`boolOptions`)、roster は `Plan.Targets` から **1 回だけ**構築、registry seed は `executePlan` 完了直後の**一度きり**のフック、messaging 層の失敗は fail-fast に波及させない best-effort。チートシートが参照する `fanout msg` CLI 本体は並行 sibling issue #70 が実装する。

## Changes by file

<details><summary>Changed files</summary>

| File | What changed | Why |
| --- | --- | --- |
| `internal/cliflags/cliflags.go` | `Config.Team bool` + `--team` boolOption、`--status`/lifecycle 競合 switch に `cfg.Team` 追加 | issue 指定のフラグ追加先。既存フラグと同じ競合規律 |
| `internal/cliflags/usage.go` | `--team` の help エントリ 1 件 | フラグの最低限の発見性(README/skill docs は wave3 #73 のスコープ) |
| `internal/cliflags/cliflags_test.go` | parse 成功 + `--status`/`--close` 競合テスト | 新フラグの surface を pin |
| `internal/briefing/briefing.go` | `Render()` に第 8 引数 `team *TeamContext`(nil = off)、`teamSection`(const template + Sprintf)、`TeamSibling`/`TeamContext` 型 | Claude/Codex 共通の base 文字列側にセクションを追記(briefing.go:53-55)。nil 時は byte 不変 |
| `internal/briefing/briefing_test.go` | 既存 5 呼び出しに `nil` 追従 + team セクションの unit テスト 4 件 | 見出し/roster/(you)/DB パス/cheatsheet/Agent Teams 住み分け文を pin |
| `internal/team/registry.go` | `UpsertPeer(db, pane, now)`: `issue` PK の `ON CONFLICT DO UPDATE`(identity 書き換え + `joined_at` 更新 + `last_seen` NULL リセット) | peers seed の SQL 本体。**#70 の `register` verb はこれを再利用すること**(並行実装の衝突回避) |
| `internal/team/registry_test.go` | insert → 再 upsert で書き換え/1 行維持/last_seen NULL を検証 | conflict 意味論(--close 後の再 fan-out)を pin |
| `cmd/fanout/team.go` | `buildTeamContext`(DB パス + roster を run ごとに 1 回構築、純関数)、`teamParentLabel`(`ParentDBSlug` と同じ strconv 分類)、`seedTeamRegistry`(全エラー `lg.Warn`) | briefing と seed の DB パス一致を構造的に保証。dry-run は DB 無接触 |
| `cmd/fanout/team_test.go` | buildTeamContext / teamParentLabel / seed(欠損行 warn 継続・Open 失敗 warn)の unit テスト | best-effort 境界を pin |
| `cmd/fanout/main.go` | teamCtx 構築(main.go:204-207)→ `executePlan` へ伝搬、seed フックを summary 後・`result.Failed` 判定前に配置(main.go:223-229) | issue 指定のフック位置。fail-fast 部分成功でも作成分は seed。dry-run は `# would seed` 行のみ |
| `cmd/fanout/pane.go` | `createPaneForIssue`/`newPaneRequest` に teamCtx 伝搬、`Render` 呼び出し(pane.go:259)に渡す | briefing への配線。manual pane は Render 非経由で無関係 |
| `cmd/fanout/report.go` | `--limit` rerun ヒントに `boolFlag(" --team", ...)` 追加(report.go:106) | deferred 分の再実行が team 無しにならないように。off 時は出力不変 |
| `cmd/fanout/main_test.go` / `pane_test.go` | シグネチャ追従(`nil` 追加) | コンパイル追従のみ |
| `tests/bats/helpers.bash` | setup に `unset FANOUT_DB_PATH`、teardown に fixture スコープ(`/tmp/fanout-project_root-*.db*`)の DB scrub | 環境リーク防止。bare glob だと実機の live --team セッション DB を消すため fixture slug に限定 |
| `tests/bats/tier1_briefing.bats` | `--team`(claude/codex)+ `--team` 無しの 3 テスト | issue の受け入れ条件(見出し/roster/DB パス grep) |
| `tests/bats/tier1_flags.bats` | `--status`×`--team`、`--close`×`--team` 競合 2 テスト | 競合 surface を pin |
| `tests/bats/tier2_dry_run.bats` + `tests/golden/scenario-sub-issue-only-team.dry-run.txt` | `--team` 変種の golden テスト(新規 golden 1 ファイルのみ) | briefing サイズ増分と would-seed 行を pin。**既存 golden は無変更** |

</details>

## Risk

> [!WARNING]
> - roster は当該 run の `Plan.Targets` スナップショット(issue 指定)。already-fanned / blocked / `--limit` deferred の兄弟は載らず、registry seed もループ完了後一度きりのため、起動直後のエージェントは DB 未作成・空 roster を見うる。briefing の checkpoint 文言(「siblings はバッチ起動完了後に登録されるので諦めず次の checkpoint で再確認」)で緩和し、live 一覧は #70 の `fanout msg peers` に委譲。全子が already-fanned の再実行では seed フックに到達しない(#70 の `register` が自己修復手段)。
> - briefing のチートシートが参照する `fanout msg` は並行 #70 が実装中(本ブランチには未存在)。「コマンドが無ければ skip」のフォールバック文でマージ順依存を吸収している。
> - `--codex-plan-mode` の plan briefing には team セクションを入れない(実装しない turn のため)が、ペイン自体は seed される。
> - README / bundled skill への `--team` 記載は wave3 #73(docs & skill 連携)のスコープとして本 PR では意図的に触れていない(codex review 最終反復の残指摘もこの docs drift のみ)。

## Test plan

- `make lint`(golangci-lint v2 + shellcheck): 0 issues
- `go test ./...`: 全 pass(briefing / cliflags / team / cmd/fanout の新規 unit テスト含む)
- `make test-tier2` を **golden 更新なし**で実行 → 既存 golden 全 pass(受け入れ条件「`--team` 無し dry-run golden 不変」を確認)
- `FANOUT_GOLDEN_UPDATE=1 make test-tier2` → 新規 `scenario-sub-issue-only-team.dry-run.txt` の 1 ファイルのみ追加、既存 golden に diff なし
- `make test`(go-test + tier1 102 + tier2 30): 全 pass
- `/code-review`(7 angle マルチエージェント)→ 5 件修正適用 + codex review 3 反復(seed タイミング指摘を checkpoint 文言で解消、最終 verdict「functionally sound」)

```mermaid
flowchart LR
    A["--team\n(cliflags.Config.Team)"] --> B["buildTeamContext\ncmd/fanout/team.go"]
    B -->|"TeamContext\n(ParentLabel / DBPath / Siblings)"| C["briefing.Render → teamSection\ninternal/briefing/briefing.go"]
    C --> D["子ペイン briefing\n## Coordinating with your sibling panes"]
    E["executePlan 完了\ncmd/fanout/main.go run()"] --> F["seedTeamRegistry\n(best-effort, warn のみ)"]
    B -->|"同一 DBPath"| F
    F --> G[("peers テーブル\nteam.UpsertPeer\n/tmp/fanout-&lt;repo&gt;-&lt;parent&gt;.db")]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #71