### PR TITLE
feat(team): fanout msg CLI surface（read/write + dry-run + JSON + tests）[wave2]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,10 +123,10 @@ check-bats:
 test: go-test test-tier1 test-tier2
 
 test-tier1: build-go check-bats
-	FANOUT_BIN="$(CURDIR)/$(GO_BIN)" $(BATS) tests/bats/tier1_flags.bats tests/bats/tier1_briefing.bats
+	FANOUT_BIN="$(CURDIR)/$(GO_BIN)" $(BATS) tests/bats/tier1_flags.bats tests/bats/tier1_briefing.bats tests/bats/tier1_msg.bats
 
 test-tier2: build-go check-bats
-	FANOUT_BIN="$(CURDIR)/$(GO_BIN)" $(BATS) tests/bats/tier2_dry_run.bats tests/bats/tier2_status.bats
+	FANOUT_BIN="$(CURDIR)/$(GO_BIN)" $(BATS) tests/bats/tier2_dry_run.bats tests/bats/tier2_status.bats tests/bats/tier2_msg.bats
 
 go-test:
 	GOCACHE="$(GOCACHE)" $(GO) test ./...

--- a/cmd/fanout/main.go
+++ b/cmd/fanout/main.go
@@ -52,6 +52,9 @@ func main() {
 	if isDashboardRequest(os.Args[1:]) {
 		os.Exit(int(cmdDashboard(os.Args[2:], lg)))
 	}
+	if isMsgRequest(os.Args[1:]) {
+		os.Exit(int(cmdMsg(os.Args[2:], lg)))
+	}
 
 	pr := cliflags.Parse(os.Args[1:], lg, os.Stdout)
 	if pr.Code != exitcode.OK || pr.Config == nil {

--- a/cmd/fanout/msg.go
+++ b/cmd/fanout/msg.go
@@ -1,0 +1,658 @@
+package main
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/butaosuinu/fanout/internal/exitcode"
+	"github.com/butaosuinu/fanout/internal/log"
+	"github.com/butaosuinu/fanout/internal/msgstore"
+	"github.com/butaosuinu/fanout/internal/team"
+)
+
+const msgUsage = `Usage: fanout msg <verb> [options] [body...]
+
+Peer messaging between fanout panes (per-parent SQLite DB, see FANOUT_DB_PATH).
+
+Read verbs:
+  peers                          List registered peers.
+  inbox [--all] [--mark-read]    Unread 1:1 messages + unread board posts.
+  board [--all]                  Unread board posts (cursor-based).
+
+Write verbs:
+  send --to <N> [--kind K] <body...>   Send a 1:1 message (body words are joined).
+  post [--kind K] <body...>            Post to the shared board.
+  mark-read [--id N ... | --all]       Mark 1:1 messages read (--all also advances the board cursor).
+  register                             Upsert this pane into the peers table.
+
+Options:
+  --json           Emit JSON instead of the human-readable view.
+  --self <N>       Act as child issue N (overrides pane detection).
+  --parent <ref>   Parent issue number or Projects URL (overrides pane detection).
+  --dry-run        Write verbs only: print what would be written, touch nothing.
+  --to <N>         send: recipient child issue number.
+  --kind <K>       send/post: message kind (default: note).
+  --id <N>         mark-read: message id (repeatable).
+  --all            inbox/board: include read messages; mark-read: mark everything.
+  --mark-read      inbox: mark the displayed messages read.
+  -h, --help       Show this help.
+
+Exit codes: 0 success, 2 invalid invocation, 4 backend (SQLite) failure.
+`
+
+// detectIdentity is swapped by tests to avoid depending on the developer's
+// live tmux/state environment (same pattern as sleepBetweenIssues).
+var detectIdentity = team.Detect
+
+type msgFlags struct {
+	verb     string
+	json     bool
+	dryRun   bool
+	self     int // 0 = not given; --self only accepts positive integers
+	parent   string
+	to       int // 0 = not given; --to only accepts positive integers
+	kind     string
+	ids      []int64
+	all      bool
+	markRead bool
+	body     string
+}
+
+// msgVerbFlags is the per-verb flag allowlist. msgUniversalFlags are accepted
+// by every verb; --dry-run is write-verb only per the #70 contract. The known
+// flag set is derived from these two tables (msgFlagKnown), so adding a flag
+// here is the single registration point for parsing.
+var msgVerbFlags = map[string]map[string]bool{
+	"peers":     {},
+	"inbox":     {"--all": true, "--mark-read": true},
+	"board":     {"--all": true},
+	"send":      {"--dry-run": true, "--to": true, "--kind": true},
+	"post":      {"--dry-run": true, "--kind": true},
+	"mark-read": {"--dry-run": true, "--id": true, "--all": true},
+	"register":  {"--dry-run": true},
+}
+
+var msgUniversalFlags = map[string]bool{"--json": true, "--self": true, "--parent": true}
+
+func msgFlagKnown(flag string) bool {
+	if msgUniversalFlags[flag] {
+		return true
+	}
+	for _, allowed := range msgVerbFlags {
+		if allowed[flag] {
+			return true
+		}
+	}
+	return false
+}
+
+// msgBodyVerbs are the verbs whose trailing positionals form the message body.
+var msgBodyVerbs = map[string]bool{"send": true, "post": true}
+
+// isMsgRequest detects the `fanout msg ...` subcommand, dispatched before
+// cliflags.Parse (which requires an integer/Project-URL <parent> positional).
+func isMsgRequest(args []string) bool {
+	return len(args) > 0 && args[0] == "msg"
+}
+
+func cmdMsg(args []string, lg *log.Logger) exitcode.Code {
+	flags, code := parseMsgFlags(args, lg)
+	if flags == nil {
+		return code // help (OK) or a parse error; either way the message is out
+	}
+	self, parent, pane, code := resolveMsgIdentity(flags, lg)
+	if code != exitcode.OK {
+		return code
+	}
+
+	if flags.dryRun {
+		return printMsgDryRun(flags, self, parent, pane, lg)
+	}
+
+	db, code := openMsgDB(flags.verb, parent, lg)
+	if code != exitcode.OK {
+		return code
+	}
+	defer func() { _ = db.Close() }()
+	return runMsgVerb(flags, msgstore.New(db, parent), self, parent, pane, lg)
+}
+
+// parseMsgFlags parses `msg` argv. A nil msgFlags means "stop with this
+// code": exitcode.OK after printing help, exitcode.Invocation on any error.
+func parseMsgFlags(args []string, lg *log.Logger) (*msgFlags, exitcode.Code) {
+	if len(args) == 0 {
+		fmt.Fprint(lg.Stderr(), msgUsage)
+		return nil, exitcode.Invocation
+	}
+	if args[0] == "-h" || args[0] == "--help" {
+		fmt.Fprint(lg.Stdout(), msgUsage)
+		return nil, exitcode.OK
+	}
+	f := &msgFlags{verb: args[0], kind: "note"}
+	allowed, ok := msgVerbFlags[f.verb]
+	if !ok {
+		lg.Err("msg: unknown verb: %s", f.verb)
+		fmt.Fprint(lg.Stderr(), msgUsage)
+		return nil, exitcode.Invocation
+	}
+	var body []string
+	terminated := false // a `--` ends flag parsing so bodies can carry --words
+	for i := 1; i < len(args); i++ {
+		a := args[i]
+		if !terminated {
+			if a == "--" {
+				terminated = true
+				continue
+			}
+			// Help wins only while no body word has been seen; `send --to 71
+			// try -h here` must send the message, not print usage and exit 0.
+			if a == "--help" || (a == "-h" && len(body) == 0) {
+				fmt.Fprint(lg.Stdout(), msgUsage)
+				return nil, exitcode.OK
+			}
+		}
+		if terminated || !strings.HasPrefix(a, "--") {
+			if !msgBodyVerbs[f.verb] {
+				lg.Err("msg %s: unexpected argument: %s", f.verb, a)
+				return nil, exitcode.Invocation
+			}
+			body = append(body, a)
+			continue
+		}
+		consumed, code := parseMsgFlag(f, allowed, args, i, lg)
+		if code != exitcode.OK {
+			return nil, code
+		}
+		i += consumed
+	}
+	f.body = strings.TrimSpace(strings.Join(body, " "))
+	if code := validateMsgFlags(f, lg); code != exitcode.OK {
+		return nil, code
+	}
+	return f, exitcode.OK
+}
+
+// parseMsgFlag consumes args[i] (and a value argument when the flag takes
+// one), returning how many extra args were consumed.
+func parseMsgFlag(f *msgFlags, allowed map[string]bool, args []string, i int, lg *log.Logger) (int, exitcode.Code) {
+	a := args[i]
+	name, inlineValue, hasInline := strings.Cut(a, "=")
+	if hasInline {
+		a = name
+	}
+	if !msgFlagKnown(a) {
+		lg.Err("msg %s: unknown option: %s", f.verb, name)
+		fmt.Fprint(lg.Stderr(), msgUsage)
+		return 0, exitcode.Invocation
+	}
+	if !msgUniversalFlags[a] && !allowed[a] {
+		lg.Err("msg %s: %s is not supported", f.verb, a)
+		return 0, exitcode.Invocation
+	}
+
+	switch a {
+	case "--json":
+		f.json = true
+	case "--dry-run":
+		f.dryRun = true
+	case "--all":
+		f.all = true
+	case "--mark-read":
+		f.markRead = true
+	default:
+		value := inlineValue
+		consumed := 0
+		if !hasInline {
+			if i+1 >= len(args) {
+				lg.Err("msg %s: %s requires an argument", f.verb, a)
+				return 0, exitcode.Invocation
+			}
+			value = args[i+1]
+			consumed = 1
+		}
+		if code := setMsgFlagValue(f, a, value, lg); code != exitcode.OK {
+			return 0, code
+		}
+		return consumed, exitcode.OK
+	}
+	if hasInline {
+		lg.Err("msg %s: %s does not take a value", f.verb, name)
+		return 0, exitcode.Invocation
+	}
+	return 0, exitcode.OK
+}
+
+func setMsgFlagValue(f *msgFlags, flag, value string, lg *log.Logger) exitcode.Code {
+	switch flag {
+	case "--self":
+		n, err := strconv.Atoi(value)
+		if err != nil || n <= 0 {
+			lg.Err("msg %s: --self must be a positive issue number, got: %s", f.verb, value)
+			return exitcode.Invocation
+		}
+		f.self = n
+	case "--parent":
+		if strings.TrimSpace(value) == "" {
+			lg.Err("msg %s: --parent must not be empty", f.verb)
+			return exitcode.Invocation
+		}
+		f.parent = value
+	case "--to":
+		n, err := strconv.Atoi(value)
+		if err != nil || n <= 0 {
+			lg.Err("msg %s: --to must be a positive issue number, got: %s", f.verb, value)
+			return exitcode.Invocation
+		}
+		f.to = n
+	case "--kind":
+		if strings.TrimSpace(value) == "" {
+			lg.Err("msg %s: --kind must not be empty", f.verb)
+			return exitcode.Invocation
+		}
+		f.kind = value
+	case "--id":
+		n, err := strconv.ParseInt(value, 10, 64)
+		if err != nil || n <= 0 {
+			lg.Err("msg %s: --id must be a positive message id, got: %s", f.verb, value)
+			return exitcode.Invocation
+		}
+		f.ids = append(f.ids, n)
+	}
+	return exitcode.OK
+}
+
+func validateMsgFlags(f *msgFlags, lg *log.Logger) exitcode.Code {
+	switch f.verb {
+	case "send":
+		if f.to == 0 {
+			lg.Err("msg send: --to <issue> is required")
+			return exitcode.Invocation
+		}
+		fallthrough
+	case "post":
+		if f.body == "" {
+			lg.Err("msg %s: message body is required", f.verb)
+			return exitcode.Invocation
+		}
+	case "mark-read":
+		if f.all == (len(f.ids) > 0) {
+			lg.Err("msg mark-read: pass either --id <n> (repeatable) or --all")
+			return exitcode.Invocation
+		}
+	}
+	return exitcode.OK
+}
+
+// resolveMsgIdentity resolves who is speaking (self) and which team DB to use
+// (parent). Explicit --self/--parent win per field; missing fields fall back
+// to pane detection. peers needs only parent.
+func resolveMsgIdentity(f *msgFlags, lg *log.Logger) (int, string, msgstore.Peer, exitcode.Code) {
+	self, parent := f.self, f.parent
+	pane := msgstore.Peer{Issue: self}
+	needSelf := f.verb != "peers"
+	if (needSelf && self == 0) || parent == "" {
+		id, err := detectIdentity()
+		if err != nil {
+			lg.Err("msg %s: could not detect this pane (%v); pass %s", f.verb, err, msgMissingIdentityFlags(needSelf && self == 0, parent == ""))
+			return 0, "", msgstore.Peer{}, exitcode.Invocation
+		}
+		if self == 0 {
+			self = id.Issue
+			pane = msgstore.Peer{
+				Issue:        id.Issue,
+				PaneID:       id.Pane.PaneID,
+				Slug:         id.Pane.Slug,
+				WorktreePath: id.Pane.WorktreePath,
+				Agent:        id.Pane.Agent,
+				DisplayName:  id.Pane.DisplayName,
+			}
+		}
+		if parent == "" {
+			parent = id.Parent
+		}
+	}
+	if parent == "" {
+		lg.Err("msg %s: parent is unknown; pass --parent <ref>", f.verb)
+		return 0, "", msgstore.Peer{}, exitcode.Invocation
+	}
+	if needSelf && self <= 0 {
+		lg.Err("msg %s: self issue is unknown; pass --self <issue>", f.verb)
+		return 0, "", msgstore.Peer{}, exitcode.Invocation
+	}
+	return self, parent, pane, exitcode.OK
+}
+
+// msgMissingIdentityFlags names only the flags the user actually still owes,
+// so `--self 70` without --parent is told about --parent alone.
+func msgMissingIdentityFlags(needSelf, needParent bool) string {
+	switch {
+	case needSelf && needParent:
+		return "--self <issue> and --parent <ref>"
+	case needSelf:
+		return "--self <issue>"
+	default:
+		return "--parent <ref>"
+	}
+}
+
+// openMsgDB resolves the team DB path and opens it with the schema ensured.
+// FANOUT_DB_PATH bypasses git entirely so orchestrators outside a checkout
+// can still join; otherwise the owning project root names the DB.
+func openMsgDB(verb, parent string, lg *log.Logger) (*sql.DB, exitcode.Code) {
+	root := ""
+	if os.Getenv(team.DBPathEnv) == "" {
+		var err error
+		root, err = team.OwnerProjectRoot()
+		if err != nil {
+			lg.Err("msg %s: %v; set %s or run inside the repository", verb, err, team.DBPathEnv)
+			return nil, exitcode.Invocation
+		}
+	}
+	path := team.DBPath(root, parent)
+	db, err := team.Open(path)
+	if err != nil {
+		lg.Err("msg %s: %v", verb, err)
+		return nil, exitcode.Backend
+	}
+	if err := team.EnsureSchema(db); err != nil {
+		_ = db.Close()
+		lg.Err("msg %s: %v", verb, err)
+		return nil, exitcode.Backend
+	}
+	return db, exitcode.OK
+}
+
+func runMsgVerb(f *msgFlags, store *msgstore.Store, self int, parent string, pane msgstore.Peer, lg *log.Logger) exitcode.Code {
+	now := team.Now()
+	switch f.verb {
+	case "peers":
+		return runMsgPeers(f, store, parent, lg)
+	case "inbox":
+		msgs, marked, err := store.Inbox(self, f.all, f.markRead, now)
+		if err != nil {
+			return msgBackendErr(f.verb, err, lg)
+		}
+		return writeMsgMessages(f, self, parent, msgs, marked, lg)
+	case "board":
+		msgs, err := store.Board(self, f.all)
+		if err != nil {
+			return msgBackendErr(f.verb, err, lg)
+		}
+		return writeMsgMessages(f, self, parent, msgs, nil, lg)
+	case "send":
+		msg, err := store.Send(self, f.to, f.kind, f.body, now)
+		if err != nil {
+			return msgBackendErr(f.verb, err, lg)
+		}
+		return writeMsgResult(f, msg, fmt.Sprintf("sent #%d to #%d", msg.ID, f.to), lg)
+	case "post":
+		msg, err := store.Post(self, f.kind, f.body, now)
+		if err != nil {
+			return msgBackendErr(f.verb, err, lg)
+		}
+		return writeMsgResult(f, msg, fmt.Sprintf("posted #%d to the board", msg.ID), lg)
+	case "mark-read":
+		return runMsgMarkRead(f, store, self, now, lg)
+	case "register":
+		peer, err := store.Register(pane, now)
+		if err != nil {
+			return msgBackendErr(f.verb, err, lg)
+		}
+		return writeMsgResult(f, msgRegisterReport{Peer: peer}, fmt.Sprintf("registered peer #%d", peer.Issue), lg)
+	}
+	// Unreachable while msgVerbFlags and this switch stay in sync; fail loud
+	// instead of silently exiting so a half-added verb is caught immediately.
+	lg.Err("msg: internal error: verb %s parsed but not implemented", f.verb)
+	return exitcode.Invocation
+}
+
+type msgMessagesReport struct {
+	Self       int                  `json:"self"`
+	Parent     string               `json:"parent"`
+	All        bool                 `json:"all"`
+	Messages   []msgstore.Message   `json:"messages"`
+	MarkedRead *msgstore.MarkResult `json:"marked_read,omitempty"`
+}
+
+type msgPeersReport struct {
+	Parent string          `json:"parent"`
+	Peers  []msgstore.Peer `json:"peers"`
+}
+
+type msgMarkReadReport struct {
+	Self        int     `json:"self"`
+	MarkedIDs   []int64 `json:"marked_ids"`
+	BoardCursor *int64  `json:"board_cursor,omitempty"`
+}
+
+type msgRegisterReport struct {
+	Peer msgstore.Peer `json:"peer"`
+}
+
+func runMsgPeers(f *msgFlags, store *msgstore.Store, parent string, lg *log.Logger) exitcode.Code {
+	peers, err := store.Peers()
+	if err != nil {
+		return msgBackendErr(f.verb, err, lg)
+	}
+	if f.json {
+		return writeMsgJSON(msgPeersReport{Parent: parent, Peers: peers}, lg)
+	}
+	writeMsgPeersTable(peers, lg)
+	return exitcode.OK
+}
+
+// writeMsgMessages is the shared renderer for the inbox and board views.
+// marked is non-nil only for `inbox --mark-read`.
+func writeMsgMessages(f *msgFlags, self int, parent string, msgs []msgstore.Message, marked *msgstore.MarkResult, lg *log.Logger) exitcode.Code {
+	if f.json {
+		return writeMsgJSON(msgMessagesReport{Self: self, Parent: parent, All: f.all, Messages: msgs, MarkedRead: marked}, lg)
+	}
+	writeMsgMessagesTable(msgs, f.all, lg)
+	if marked != nil {
+		lg.Ok("marked %d message(s) read, board cursor at %d", len(marked.MessageIDs), marked.BoardCursor)
+	}
+	return exitcode.OK
+}
+
+func runMsgMarkRead(f *msgFlags, store *msgstore.Store, self int, now string, lg *log.Logger) exitcode.Code {
+	report := msgMarkReadReport{Self: self}
+	if f.all {
+		marked, cursor, err := store.MarkReadAll(self, now)
+		if err != nil {
+			return msgBackendErr(f.verb, err, lg)
+		}
+		report.MarkedIDs = marked
+		report.BoardCursor = &cursor
+	} else {
+		marked, err := store.MarkReadIDs(self, f.ids, now)
+		if err != nil {
+			return msgBackendErr(f.verb, err, lg)
+		}
+		report.MarkedIDs = marked
+	}
+	summary := fmt.Sprintf("marked %d message(s) read", len(report.MarkedIDs))
+	if report.BoardCursor != nil {
+		summary += fmt.Sprintf(", board cursor at %d", *report.BoardCursor)
+	}
+	return writeMsgResult(f, report, summary, lg)
+}
+
+func writeMsgResult(f *msgFlags, report any, summary string, lg *log.Logger) exitcode.Code {
+	if f.json {
+		return writeMsgJSON(report, lg)
+	}
+	lg.Ok("%s", summary)
+	return exitcode.OK
+}
+
+func writeMsgJSON(report any, lg *log.Logger) exitcode.Code {
+	out, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		lg.Err("msg: failed to encode report: %v", err)
+		return exitcode.Backend
+	}
+	fmt.Fprintln(lg.Stdout(), string(out))
+	return exitcode.OK
+}
+
+func writeMsgMessagesTable(msgs []msgstore.Message, all bool, lg *log.Logger) {
+	out := lg.Stdout()
+	if len(msgs) == 0 {
+		if all {
+			fmt.Fprintln(out, "no messages")
+		} else {
+			fmt.Fprintln(out, "no unread messages")
+		}
+		return
+	}
+	headers := []string{"ID", "FROM", "TO", "KIND", "CREATED", "BODY"}
+	rows := make([][]string, 0, len(msgs))
+	for _, m := range msgs {
+		to := "board"
+		if m.To != nil {
+			to = "#" + strconv.Itoa(*m.To)
+		}
+		rows = append(rows, []string{
+			strconv.FormatInt(m.ID, 10),
+			"#" + strconv.Itoa(m.From),
+			to,
+			m.Kind,
+			m.CreatedAt,
+			msgTableBody(m.Body),
+		})
+	}
+	colors := lg.Colors()
+	dims := make([]bool, len(msgs))
+	for i, m := range msgs {
+		dims[i] = m.ReadAt != nil
+	}
+	writeMsgTable(out, headers, rows, dims, colors)
+}
+
+func writeMsgPeersTable(peers []msgstore.Peer, lg *log.Logger) {
+	out := lg.Stdout()
+	if len(peers) == 0 {
+		fmt.Fprintln(out, "no peers registered")
+		return
+	}
+	headers := []string{"ISSUE", "SLUG", "AGENT", "DISPLAY_NAME", "PANE", "LAST_SEEN"}
+	rows := make([][]string, 0, len(peers))
+	for _, p := range peers {
+		rows = append(rows, []string{
+			"#" + strconv.Itoa(p.Issue),
+			dashIfEmpty(p.Slug),
+			dashIfEmpty(p.Agent),
+			dashIfEmpty(p.DisplayName),
+			dashIfEmpty(p.PaneID),
+			dashIfEmpty(p.LastSeen),
+		})
+	}
+	writeMsgTable(out, headers, rows, make([]bool, len(peers)), lg.Colors())
+}
+
+// writeMsgTable renders the shared header/separator/rows layout via the
+// status table primitives. dims[i] dims row i (read messages in --all views).
+func writeMsgTable(out io.Writer, headers []string, rows [][]string, dims []bool, colors log.Palette) {
+	widths := make([]int, len(headers))
+	for i, h := range headers {
+		widths[i] = len(h)
+	}
+	for _, row := range rows {
+		for i, col := range row {
+			widths[i] = max(widths[i], len(col))
+		}
+	}
+	fmt.Fprintln(out, statusTableLine(headers, widths))
+	separators := make([]string, len(headers))
+	for i := range headers {
+		separators[i] = strings.Repeat("-", widths[i])
+	}
+	fmt.Fprintln(out, statusTableLine(separators, widths))
+	for i, row := range rows {
+		line := statusTableLine(row, widths)
+		if dims[i] {
+			line = colorWrap(colors.Dim, colors.Reset, line)
+		}
+		fmt.Fprintln(out, line)
+	}
+}
+
+// msgTableBody flattens a message body to one table cell.
+func msgTableBody(s string) string {
+	s = strings.ReplaceAll(s, "\r", " ")
+	s = strings.ReplaceAll(s, "\n", " ")
+	return s
+}
+
+// --- dry-run -----------------------------------------------------------
+
+// printMsgDryRun prints the would-be writes without opening the DB, in the
+// pane.go printPaneDryRun "# would ..." idiom. Ids and cursor positions are
+// unknown by design (no DB access), so --all renders a symbolic MAX().
+func printMsgDryRun(f *msgFlags, self int, parent string, pane msgstore.Peer, lg *log.Logger) exitcode.Code {
+	lines := msgDryRunLines(f, self, parent, pane, team.Now())
+	if len(lines) == 0 {
+		// Unreachable while msgVerbFlags' --dry-run set and msgDryRunLines
+		// stay in sync; fail loud so a half-added verb can't fake success.
+		lg.Err("msg: internal error: no dry-run rendering for verb %s", f.verb)
+		return exitcode.Invocation
+	}
+	for _, line := range lines {
+		lg.Dim("%s", line)
+	}
+	return exitcode.OK
+}
+
+func msgDryRunLines(f *msgFlags, self int, parent string, pane msgstore.Peer, now string) []string {
+	switch f.verb {
+	case "send":
+		return []string{fmt.Sprintf(
+			"# would INSERT INTO messages(parent, from_issue, to_issue, kind, body, created_at) VALUES (%s, %d, %d, %s, %s, %s)",
+			sqlLiteral(parent), self, f.to, sqlLiteral(f.kind), sqlLiteral(f.body), sqlLiteral(now))}
+	case "post":
+		return []string{fmt.Sprintf(
+			"# would INSERT INTO messages(parent, from_issue, to_issue, kind, body, created_at) VALUES (%s, %d, NULL, %s, %s, %s)",
+			sqlLiteral(parent), self, sqlLiteral(f.kind), sqlLiteral(f.body), sqlLiteral(now))}
+	case "mark-read":
+		if f.all {
+			return []string{
+				fmt.Sprintf("# would UPDATE messages SET read_at = %s WHERE parent = %s AND to_issue = %d AND read_at IS NULL",
+					sqlLiteral(now), sqlLiteral(parent), self),
+				fmt.Sprintf("# would UPSERT board_cursors(issue=%d, last_read_id=MAX(id) of board posts)", self),
+			}
+		}
+		ids := make([]string, len(f.ids))
+		for i, id := range f.ids {
+			ids[i] = strconv.FormatInt(id, 10)
+		}
+		return []string{fmt.Sprintf(
+			"# would UPDATE messages SET read_at = %s WHERE parent = %s AND to_issue = %d AND id IN (%s) AND read_at IS NULL",
+			sqlLiteral(now), sqlLiteral(parent), self, strings.Join(ids, ", "))}
+	case "register":
+		return []string{fmt.Sprintf(
+			"# would UPSERT INTO peers(issue, pane_id, slug, worktree_path, agent, display_name, joined_at, last_seen) VALUES (%d, %s, %s, %s, %s, %s, %s, %s)",
+			self, sqlLiteral(pane.PaneID), sqlLiteral(pane.Slug), sqlLiteral(pane.WorktreePath),
+			sqlLiteral(pane.Agent), sqlLiteral(pane.DisplayName), sqlLiteral(now), sqlLiteral(now))}
+	}
+	return nil
+}
+
+// sqlLiteral renders s as a single-quoted SQL string literal for dry-run
+// display only — real statements always bind placeholders. Newlines become
+// \n so a dry-run line stays a single golden-friendly line.
+func sqlLiteral(s string) string {
+	s = strings.ReplaceAll(s, "'", "''")
+	s = strings.ReplaceAll(s, "\r", `\r`)
+	s = strings.ReplaceAll(s, "\n", `\n`)
+	return "'" + s + "'"
+}
+
+func msgBackendErr(verb string, err error, lg *log.Logger) exitcode.Code {
+	lg.Err("msg %s: %v", verb, err)
+	return exitcode.Backend
+}

--- a/cmd/fanout/msg.go
+++ b/cmd/fanout/msg.go
@@ -35,7 +35,8 @@ Options:
   --json           Emit JSON instead of the human-readable view.
   --self <N>       Act as child issue N (overrides pane detection).
   --parent <ref>   Parent issue number or Projects URL (overrides pane detection).
-  --dry-run        Write verbs only: print what would be written, touch nothing.
+  --dry-run        Write verbs only: print '# would ...' lines describing the
+                   writes, touch nothing. Not combinable with --json.
   --to <N>         send: recipient child issue number.
   --kind <K>       send/post: message kind (default: note).
   --id <N>         mark-read: message id (repeatable).
@@ -273,6 +274,12 @@ func setMsgFlagValue(f *msgFlags, flag, value string, lg *log.Logger) exitcode.C
 }
 
 func validateMsgFlags(f *msgFlags, lg *log.Logger) exitcode.Code {
+	// Dry-run output is the "# would ..." line contract, not JSON; reject the
+	// combination instead of silently handing automation non-JSON output.
+	if f.dryRun && f.json {
+		lg.Err("msg %s: --dry-run cannot be combined with --json (dry-run prints '# would ...' lines)", f.verb)
+		return exitcode.Invocation
+	}
 	switch f.verb {
 	case "send":
 		if f.to == 0 {

--- a/cmd/fanout/msg.go
+++ b/cmd/fanout/msg.go
@@ -121,7 +121,12 @@ func cmdMsg(args []string, lg *log.Logger) exitcode.Code {
 		return code
 	}
 	defer func() { _ = db.Close() }()
-	return runMsgVerb(flags, msgstore.New(db, parent), self, parent, pane, lg)
+	store, err := msgstore.New(db, parent)
+	if err != nil {
+		lg.Err("msg %s: %v", flags.verb, err)
+		return exitcode.Backend
+	}
+	return runMsgVerb(flags, store, self, parent, pane, lg)
 }
 
 // parseMsgFlags parses `msg` argv. A nil msgFlags means "stop with this
@@ -234,9 +239,12 @@ func parseMsgFlag(f *msgFlags, allowed map[string]bool, args []string, i int, lg
 func setMsgFlagValue(f *msgFlags, flag, value string, lg *log.Logger) exitcode.Code {
 	switch flag {
 	case "--self":
+		// Zero is the "not given" sentinel; negative numbers are valid — TUI
+		// manual panes record synthetic issue numbers -1, -2, ... (pane.go
+		// nextSyntheticPaneNumber) and team.Detect returns them verbatim.
 		n, err := strconv.Atoi(value)
-		if err != nil || n <= 0 {
-			lg.Err("msg %s: --self must be a positive issue number, got: %s", f.verb, value)
+		if err != nil || n == 0 {
+			lg.Err("msg %s: --self must be a non-zero issue number (manual panes use negative synthetic numbers), got: %s", f.verb, value)
 			return exitcode.Invocation
 		}
 		f.self = n
@@ -251,8 +259,8 @@ func setMsgFlagValue(f *msgFlags, flag, value string, lg *log.Logger) exitcode.C
 		f.parent = ref
 	case "--to":
 		n, err := strconv.Atoi(value)
-		if err != nil || n <= 0 {
-			lg.Err("msg %s: --to must be a positive issue number, got: %s", f.verb, value)
+		if err != nil || n == 0 {
+			lg.Err("msg %s: --to must be a non-zero issue number (manual panes use negative synthetic numbers), got: %s", f.verb, value)
 			return exitcode.Invocation
 		}
 		f.to = n
@@ -333,7 +341,9 @@ func resolveMsgIdentity(f *msgFlags, lg *log.Logger) (int, string, msgstore.Peer
 		lg.Err("msg %s: parent is unknown; pass --parent <ref>", f.verb)
 		return 0, "", msgstore.Peer{}, exitcode.Invocation
 	}
-	if needSelf && self <= 0 {
+	// Negative self is legitimate: manual panes carry synthetic numbers
+	// (-1, -2, ...) under the @manual parent. Only zero means unknown.
+	if needSelf && self == 0 {
 		lg.Err("msg %s: self issue is unknown; pass --self <issue>", f.verb)
 		return 0, "", msgstore.Peer{}, exitcode.Invocation
 	}

--- a/cmd/fanout/msg.go
+++ b/cmd/fanout/msg.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/butaosuinu/fanout/internal/cliflags"
 	"github.com/butaosuinu/fanout/internal/exitcode"
 	"github.com/butaosuinu/fanout/internal/log"
 	"github.com/butaosuinu/fanout/internal/msgstore"
@@ -237,11 +238,14 @@ func setMsgFlagValue(f *msgFlags, flag, value string, lg *log.Logger) exitcode.C
 		}
 		f.self = n
 	case "--parent":
-		if strings.TrimSpace(value) == "" {
-			lg.Err("msg %s: --parent must not be empty", f.verb)
+		// Canonicalize so an explicit ref matches the parent recorded at
+		// pane-launch time: "0068" and "68" must scope the same messages.
+		ref, ok := cliflags.NormalizeParentRef(value)
+		if !ok {
+			lg.Err("msg %s: --parent must be an issue number or a GitHub Projects v2 URL, got: %s", f.verb, value)
 			return exitcode.Invocation
 		}
-		f.parent = value
+		f.parent = ref
 	case "--to":
 		n, err := strconv.Atoi(value)
 		if err != nil || n <= 0 {

--- a/cmd/fanout/msg.go
+++ b/cmd/fanout/msg.go
@@ -151,8 +151,10 @@ func parseMsgFlags(args []string, lg *log.Logger) (*msgFlags, exitcode.Code) {
 				continue
 			}
 			// Help wins only while no body word has been seen; `send --to 71
-			// try -h here` must send the message, not print usage and exit 0.
-			if a == "--help" || (a == "-h" && len(body) == 0) {
+			// ask about --help` must not silently print usage and exit 0
+			// instead of sending. (A post-body --help still fails loudly as
+			// an unknown option — use `--` to put flag-like words in a body.)
+			if (a == "--help" || a == "-h") && len(body) == 0 {
 				fmt.Fprint(lg.Stdout(), msgUsage)
 				return nil, exitcode.OK
 			}

--- a/cmd/fanout/msg_test.go
+++ b/cmd/fanout/msg_test.go
@@ -94,6 +94,7 @@ func TestParseMsgFlags(t *testing.T) {
 				t.Errorf("body = %q, want %q", f.body, "try -h now")
 			}
 		}},
+		{name: "long help after body word fails loudly, never silent usage", args: []string{"send", "--to", "71", "ask", "about", "--help"}, code: exitcode.Invocation},
 		{name: "terminator lets the body carry flag-like words", args: []string{"send", "--to", "71", "--", "--kind", "is part of the body"}, code: exitcode.OK, want: func(t *testing.T, f *msgFlags) {
 			t.Helper()
 			if f.body != "--kind is part of the body" || f.kind != "note" {

--- a/cmd/fanout/msg_test.go
+++ b/cmd/fanout/msg_test.go
@@ -59,6 +59,7 @@ func TestParseMsgFlags(t *testing.T) {
 		}},
 		{name: "inbox rejects positional", args: []string{"inbox", "hello"}, code: exitcode.Invocation},
 		{name: "inbox rejects dry-run", args: []string{"inbox", "--dry-run"}, code: exitcode.Invocation},
+		{name: "dry-run rejects json", args: []string{"send", "--dry-run", "--json", "--to", "71", "--self", "70", "--parent", "68", "hi"}, code: exitcode.Invocation},
 		{name: "board rejects mark-read", args: []string{"board", "--mark-read"}, code: exitcode.Invocation},
 		{name: "peers rejects --to", args: []string{"peers", "--to", "5"}, code: exitcode.Invocation},
 		{name: "unknown option", args: []string{"peers", "--bogus"}, code: exitcode.Invocation},

--- a/cmd/fanout/msg_test.go
+++ b/cmd/fanout/msg_test.go
@@ -1,0 +1,302 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/butaosuinu/fanout/internal/exitcode"
+	"github.com/butaosuinu/fanout/internal/log"
+	"github.com/butaosuinu/fanout/internal/msgstore"
+	"github.com/butaosuinu/fanout/internal/state"
+	"github.com/butaosuinu/fanout/internal/team"
+)
+
+func msgTestLogger() *log.Logger {
+	return log.NewWith(&strings.Builder{}, &strings.Builder{}, false)
+}
+
+func TestParseMsgFlags(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+		code exitcode.Code
+		want func(*testing.T, *msgFlags)
+	}{
+		{name: "no verb", args: nil, code: exitcode.Invocation},
+		{name: "unknown verb", args: []string{"bogus"}, code: exitcode.Invocation},
+		{name: "send happy path", args: []string{"send", "--to", "71", "--self", "70", "--parent", "68", "hello", "world"}, code: exitcode.OK, want: func(t *testing.T, f *msgFlags) {
+			t.Helper()
+			if f.to != 71 || f.self != 70 || f.parent != "68" || f.body != "hello world" || f.kind != "note" {
+				t.Errorf("parsed = %+v", f)
+			}
+		}},
+		{name: "send missing --to", args: []string{"send", "--self", "70", "--parent", "68", "hi"}, code: exitcode.Invocation},
+		{name: "send non-integer --to", args: []string{"send", "--to", "abc", "--self", "70", "--parent", "68", "hi"}, code: exitcode.Invocation},
+		{name: "send empty body", args: []string{"send", "--to", "71", "--self", "70", "--parent", "68"}, code: exitcode.Invocation},
+		{name: "send whitespace body", args: []string{"send", "--to", "71", "--self", "70", "--parent", "68", " "}, code: exitcode.Invocation},
+		{name: "post custom kind", args: []string{"post", "--kind", "blocker", "watch", "out"}, code: exitcode.OK, want: func(t *testing.T, f *msgFlags) {
+			t.Helper()
+			if f.kind != "blocker" || f.body != "watch out" {
+				t.Errorf("parsed = %+v", f)
+			}
+		}},
+		{name: "post empty kind", args: []string{"post", "--kind", "", "hi"}, code: exitcode.Invocation},
+		{name: "mark-read ids", args: []string{"mark-read", "--id", "3", "--id", "5"}, code: exitcode.OK, want: func(t *testing.T, f *msgFlags) {
+			t.Helper()
+			if len(f.ids) != 2 || f.ids[0] != 3 || f.ids[1] != 5 {
+				t.Errorf("ids = %v", f.ids)
+			}
+		}},
+		{name: "mark-read no mode", args: []string{"mark-read"}, code: exitcode.Invocation},
+		{name: "mark-read both modes", args: []string{"mark-read", "--id", "3", "--all"}, code: exitcode.Invocation},
+		{name: "mark-read bad id", args: []string{"mark-read", "--id", "0"}, code: exitcode.Invocation},
+		{name: "inbox flags", args: []string{"inbox", "--all", "--mark-read", "--json"}, code: exitcode.OK, want: func(t *testing.T, f *msgFlags) {
+			t.Helper()
+			if !f.all || !f.markRead || !f.json {
+				t.Errorf("parsed = %+v", f)
+			}
+		}},
+		{name: "inbox rejects positional", args: []string{"inbox", "hello"}, code: exitcode.Invocation},
+		{name: "inbox rejects dry-run", args: []string{"inbox", "--dry-run"}, code: exitcode.Invocation},
+		{name: "board rejects mark-read", args: []string{"board", "--mark-read"}, code: exitcode.Invocation},
+		{name: "peers rejects --to", args: []string{"peers", "--to", "5"}, code: exitcode.Invocation},
+		{name: "unknown option", args: []string{"peers", "--bogus"}, code: exitcode.Invocation},
+		{name: "missing value", args: []string{"send", "--to"}, code: exitcode.Invocation},
+		{name: "inline value", args: []string{"send", "--to=71", "--self=70", "--parent=68", "hi"}, code: exitcode.OK, want: func(t *testing.T, f *msgFlags) {
+			t.Helper()
+			if f.to != 71 || f.self != 70 || f.parent != "68" {
+				t.Errorf("parsed = %+v", f)
+			}
+		}},
+		{name: "inline value on boolean flag", args: []string{"inbox", "--all=1"}, code: exitcode.Invocation},
+		{name: "self must be positive", args: []string{"inbox", "--self", "-3"}, code: exitcode.Invocation},
+		{name: "empty parent", args: []string{"inbox", "--parent", ""}, code: exitcode.Invocation},
+		{name: "register dry-run", args: []string{"register", "--dry-run", "--self", "70", "--parent", "68"}, code: exitcode.OK, want: func(t *testing.T, f *msgFlags) {
+			t.Helper()
+			if !f.dryRun {
+				t.Errorf("parsed = %+v", f)
+			}
+		}},
+		{name: "help as verb", args: []string{"-h"}, code: exitcode.OK},
+		{name: "long help flag mid-args", args: []string{"inbox", "--help"}, code: exitcode.OK},
+		{name: "short help before body", args: []string{"send", "-h"}, code: exitcode.OK},
+		{name: "short help after body word stays in the body", args: []string{"send", "--to", "71", "try", "-h", "now"}, code: exitcode.OK, want: func(t *testing.T, f *msgFlags) {
+			t.Helper()
+			if f.body != "try -h now" {
+				t.Errorf("body = %q, want %q", f.body, "try -h now")
+			}
+		}},
+		{name: "terminator lets the body carry flag-like words", args: []string{"send", "--to", "71", "--", "--kind", "is part of the body"}, code: exitcode.OK, want: func(t *testing.T, f *msgFlags) {
+			t.Helper()
+			if f.body != "--kind is part of the body" || f.kind != "note" {
+				t.Errorf("body, kind = %q, %q", f.body, f.kind)
+			}
+		}},
+		{name: "terminator on a read verb still rejects positionals", args: []string{"inbox", "--", "x"}, code: exitcode.Invocation},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f, code := parseMsgFlags(tc.args, msgTestLogger())
+			if code != tc.code {
+				t.Fatalf("parseMsgFlags(%v) code = %d, want %d", tc.args, code, tc.code)
+			}
+			if tc.want != nil {
+				tc.want(t, f)
+			}
+		})
+	}
+}
+
+func TestResolveMsgIdentity(t *testing.T) {
+	detected := team.Identity{
+		Issue:  70,
+		Parent: "68",
+		Pane: state.Pane{
+			IssueNum: 70, Parent: "68", PaneID: "%1", Slug: "msg-cli-surface-70",
+			Agent: "claude", DisplayName: "msg cli", WorktreePath: "/tmp/wt",
+		},
+	}
+	for _, tc := range []struct {
+		name       string
+		flags      msgFlags
+		detect     func() (team.Identity, error)
+		code       exitcode.Code
+		wantSelf   int
+		wantParent string
+		wantPane   string // expected pane_id, "" when identity is explicit
+	}{
+		{
+			name:  "both explicit skips detection",
+			flags: msgFlags{verb: "send", self: 70, parent: "68"},
+			detect: func() (team.Identity, error) {
+				t.Error("detect called despite explicit --self/--parent")
+				return team.Identity{}, nil
+			},
+			code: exitcode.OK, wantSelf: 70, wantParent: "68",
+		},
+		{
+			name:   "detection fills both",
+			flags:  msgFlags{verb: "inbox"},
+			detect: func() (team.Identity, error) { return detected, nil },
+			code:   exitcode.OK, wantSelf: 70, wantParent: "68", wantPane: "%1",
+		},
+		{
+			name:   "explicit self keeps detected parent",
+			flags:  msgFlags{verb: "send", self: 99},
+			detect: func() (team.Identity, error) { return detected, nil },
+			code:   exitcode.OK, wantSelf: 99, wantParent: "68",
+		},
+		{
+			name:   "explicit parent keeps detected self",
+			flags:  msgFlags{verb: "send", parent: "77"},
+			detect: func() (team.Identity, error) { return detected, nil },
+			code:   exitcode.OK, wantSelf: 70, wantParent: "77", wantPane: "%1",
+		},
+		{
+			name:   "detection failure",
+			flags:  msgFlags{verb: "send"},
+			detect: func() (team.Identity, error) { return team.Identity{}, team.ErrPaneNotFound },
+			code:   exitcode.Invocation,
+		},
+		{
+			name:   "peers needs only parent",
+			flags:  msgFlags{verb: "peers", parent: "68"},
+			detect: func() (team.Identity, error) { return team.Identity{}, errors.New("must not be called") },
+			code:   exitcode.OK, wantSelf: 0, wantParent: "68",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			orig := detectIdentity
+			detectIdentity = tc.detect
+			defer func() { detectIdentity = orig }()
+
+			self, parent, pane, code := resolveMsgIdentity(&tc.flags, msgTestLogger())
+			if code != tc.code {
+				t.Fatalf("code = %d, want %d", code, tc.code)
+			}
+			if code != exitcode.OK {
+				return
+			}
+			if self != tc.wantSelf || parent != tc.wantParent {
+				t.Errorf("self, parent = %d, %q, want %d, %q", self, parent, tc.wantSelf, tc.wantParent)
+			}
+			if pane.PaneID != tc.wantPane {
+				t.Errorf("pane.PaneID = %q, want %q", pane.PaneID, tc.wantPane)
+			}
+		})
+	}
+}
+
+func TestMsgDryRunLines(t *testing.T) {
+	const now = "2026-06-13T00:00:00Z"
+	for _, tc := range []struct {
+		name  string
+		flags msgFlags
+		pane  msgstore.Peer
+		want  []string
+	}{
+		{
+			name:  "send",
+			flags: msgFlags{verb: "send", to: 71, kind: "note", body: "hello world"},
+			want: []string{
+				"# would INSERT INTO messages(parent, from_issue, to_issue, kind, body, created_at) VALUES ('68', 70, 71, 'note', 'hello world', '2026-06-13T00:00:00Z')",
+			},
+		},
+		{
+			name:  "post escapes quotes and newlines",
+			flags: msgFlags{verb: "post", kind: "blocker", body: "it's\nbroken"},
+			want: []string{
+				`# would INSERT INTO messages(parent, from_issue, to_issue, kind, body, created_at) VALUES ('68', 70, NULL, 'blocker', 'it''s\nbroken', '2026-06-13T00:00:00Z')`,
+			},
+		},
+		{
+			name:  "mark-read ids",
+			flags: msgFlags{verb: "mark-read", ids: []int64{3, 5}},
+			want: []string{
+				"# would UPDATE messages SET read_at = '2026-06-13T00:00:00Z' WHERE parent = '68' AND to_issue = 70 AND id IN (3, 5) AND read_at IS NULL",
+			},
+		},
+		{
+			name:  "mark-read all",
+			flags: msgFlags{verb: "mark-read", all: true},
+			want: []string{
+				"# would UPDATE messages SET read_at = '2026-06-13T00:00:00Z' WHERE parent = '68' AND to_issue = 70 AND read_at IS NULL",
+				"# would UPSERT board_cursors(issue=70, last_read_id=MAX(id) of board posts)",
+			},
+		},
+		{
+			name:  "register with pane",
+			flags: msgFlags{verb: "register"},
+			pane:  msgstore.Peer{Issue: 70, PaneID: "%1", Slug: "s-70", WorktreePath: "/tmp/wt", Agent: "claude", DisplayName: "name"},
+			want: []string{
+				"# would UPSERT INTO peers(issue, pane_id, slug, worktree_path, agent, display_name, joined_at, last_seen) VALUES (70, '%1', 's-70', '/tmp/wt', 'claude', 'name', '2026-06-13T00:00:00Z', '2026-06-13T00:00:00Z')",
+			},
+		},
+		{
+			name:  "register without pane",
+			flags: msgFlags{verb: "register"},
+			want: []string{
+				"# would UPSERT INTO peers(issue, pane_id, slug, worktree_path, agent, display_name, joined_at, last_seen) VALUES (70, '', '', '', '', '', '2026-06-13T00:00:00Z', '2026-06-13T00:00:00Z')",
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := msgDryRunLines(&tc.flags, 70, "68", tc.pane, now)
+			if len(got) != len(tc.want) {
+				t.Fatalf("lines = %q, want %q", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("line %d = %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestWriteMsgMessagesTable(t *testing.T) {
+	to := 70
+	read := "2026-06-13T00:00:00Z"
+	msgs := []msgstore.Message{
+		{ID: 1, From: 71, To: &to, Kind: "note", Body: "multi\nline", CreatedAt: "2026-06-13T00:00:00Z", ReadAt: &read},
+		{ID: 3, From: 71, Board: true, Kind: "note", Body: "board post", CreatedAt: "2026-06-13T00:00:00Z"},
+	}
+	var out strings.Builder
+	lg := log.NewWith(&out, &strings.Builder{}, false)
+	writeMsgMessagesTable(msgs, true, lg)
+	got := out.String()
+	for _, want := range []string{
+		"ID  FROM  TO     KIND  CREATED               BODY",
+		"1   #71   #70    note  2026-06-13T00:00:00Z  multi line",
+		"3   #71   board  note  2026-06-13T00:00:00Z  board post",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("table missing %q in:\n%s", want, got)
+		}
+	}
+
+	out.Reset()
+	writeMsgMessagesTable(nil, false, lg)
+	if got := out.String(); got != "no unread messages\n" {
+		t.Errorf("empty unread table = %q", got)
+	}
+	out.Reset()
+	writeMsgMessagesTable(nil, true, lg)
+	if got := out.String(); got != "no messages\n" {
+		t.Errorf("empty all table = %q", got)
+	}
+}
+
+func TestSQLLiteral(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"plain", "'plain'"},
+		{"it's", "'it''s'"},
+		{"a\nb", `'a\nb'`},
+		{"a\r\nb", `'a\r\nb'`},
+		{"", "''"},
+	} {
+		if got := sqlLiteral(tc.in); got != tc.want {
+			t.Errorf("sqlLiteral(%q) = %s, want %s", tc.in, got, tc.want)
+		}
+	}
+}

--- a/cmd/fanout/msg_test.go
+++ b/cmd/fanout/msg_test.go
@@ -71,7 +71,19 @@ func TestParseMsgFlags(t *testing.T) {
 			}
 		}},
 		{name: "inline value on boolean flag", args: []string{"inbox", "--all=1"}, code: exitcode.Invocation},
-		{name: "self must be positive", args: []string{"inbox", "--self", "-3"}, code: exitcode.Invocation},
+		{name: "zero self is rejected", args: []string{"inbox", "--self", "0"}, code: exitcode.Invocation},
+		{name: "negative self is a manual-pane synthetic number", args: []string{"inbox", "--self", "-3", "--parent", "68"}, code: exitcode.OK, want: func(t *testing.T, f *msgFlags) {
+			t.Helper()
+			if f.self != -3 {
+				t.Errorf("self = %d, want -3", f.self)
+			}
+		}},
+		{name: "negative to targets a manual pane", args: []string{"send", "--to", "-2", "--self", "-1", "--parent", "68", "hi"}, code: exitcode.OK, want: func(t *testing.T, f *msgFlags) {
+			t.Helper()
+			if f.to != -2 || f.self != -1 {
+				t.Errorf("to, self = %d, %d, want -2, -1", f.to, f.self)
+			}
+		}},
 		{name: "empty parent", args: []string{"inbox", "--parent", ""}, code: exitcode.Invocation},
 		{name: "prose parent", args: []string{"inbox", "--parent", "not-a-ref"}, code: exitcode.Invocation},
 		{name: "parent is canonicalized", args: []string{"inbox", "--self", "70", "--parent", "0068"}, code: exitcode.OK, want: func(t *testing.T, f *msgFlags) {
@@ -160,6 +172,18 @@ func TestResolveMsgIdentity(t *testing.T) {
 			flags:  msgFlags{verb: "send", parent: "77"},
 			detect: func() (team.Identity, error) { return detected, nil },
 			code:   exitcode.OK, wantSelf: 70, wantParent: "77", wantPane: "%1",
+		},
+		{
+			name:  "manual pane negative synthetic issue is accepted",
+			flags: msgFlags{verb: "inbox"},
+			detect: func() (team.Identity, error) {
+				return team.Identity{
+					Issue:  -1,
+					Parent: "@manual",
+					Pane:   state.Pane{IssueNum: -1, Parent: "@manual", PaneID: "%9"},
+				}, nil
+			},
+			code: exitcode.OK, wantSelf: -1, wantParent: "@manual", wantPane: "%9",
 		},
 		{
 			name:   "detection failure",

--- a/cmd/fanout/msg_test.go
+++ b/cmd/fanout/msg_test.go
@@ -72,6 +72,13 @@ func TestParseMsgFlags(t *testing.T) {
 		{name: "inline value on boolean flag", args: []string{"inbox", "--all=1"}, code: exitcode.Invocation},
 		{name: "self must be positive", args: []string{"inbox", "--self", "-3"}, code: exitcode.Invocation},
 		{name: "empty parent", args: []string{"inbox", "--parent", ""}, code: exitcode.Invocation},
+		{name: "prose parent", args: []string{"inbox", "--parent", "not-a-ref"}, code: exitcode.Invocation},
+		{name: "parent is canonicalized", args: []string{"inbox", "--self", "70", "--parent", "0068"}, code: exitcode.OK, want: func(t *testing.T, f *msgFlags) {
+			t.Helper()
+			if f.parent != "68" {
+				t.Errorf("parent = %q, want %q (leading zeros must collapse)", f.parent, "68")
+			}
+		}},
 		{name: "register dry-run", args: []string{"register", "--dry-run", "--self", "70", "--parent", "68"}, code: exitcode.OK, want: func(t *testing.T, f *msgFlags) {
 			t.Helper()
 			if !f.dryRun {

--- a/internal/cliflags/cliflags_test.go
+++ b/internal/cliflags/cliflags_test.go
@@ -177,3 +177,28 @@ func assertBoolPtr(t *testing.T, name string, got *bool, want bool) {
 		t.Fatalf("%s = %v, want %v", name, *got, want)
 	}
 }
+
+func TestNormalizeParentRef(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		raw    string
+		want   string
+		wantOK bool
+	}{
+		{name: "issue number", raw: "68", want: "68", wantOK: true},
+		{name: "leading zeros collapse", raw: "0068", want: "68", wantOK: true},
+		{name: "surrounding whitespace", raw: " 68 ", want: "68", wantOK: true},
+		{name: "project URL", raw: "https://github.com/users/butaosuinu/projects/3", want: "https://github.com/users/butaosuinu/projects/3", wantOK: true},
+		{name: "project URL drops views suffix", raw: "https://github.com/orgs/acme/projects/12/views/1?query=x", want: "https://github.com/orgs/acme/projects/12", wantOK: true},
+		{name: "empty", raw: "", wantOK: false},
+		{name: "prose", raw: "not-a-ref", wantOK: false},
+		{name: "non-project URL", raw: "https://github.com/butaosuinu/fanout/issues/68", wantOK: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := NormalizeParentRef(tc.raw)
+			if ok != tc.wantOK || got != tc.want {
+				t.Fatalf("NormalizeParentRef(%q) = (%q, %t), want (%q, %t)", tc.raw, got, ok, tc.want, tc.wantOK)
+			}
+		})
+	}
+}

--- a/internal/cliflags/usage.go
+++ b/internal/cliflags/usage.go
@@ -3,6 +3,8 @@ package cliflags
 import (
 	"fmt"
 	"io"
+	"strconv"
+	"strings"
 )
 
 const usageText = `Usage: fanout
@@ -183,4 +185,29 @@ Exit codes (update):
 // Usage writes the help text to w.
 func Usage(w io.Writer) {
 	fmt.Fprint(w, usageText)
+}
+
+// NormalizeParentRef canonicalizes a parent reference exactly the way Parse
+// records it in Config.ParentRef: integer refs lose leading zeros, Projects
+// v2 URLs drop any trailing path/query. ok is false when raw is neither.
+// Consumers that persist or compare parent refs (fanout msg scopes every
+// messages row by this string) must normalize through here so an explicit
+// --parent matches the refs recorded at pane-launch time.
+func NormalizeParentRef(raw string) (ref string, ok bool) {
+	raw = strings.TrimSpace(raw)
+	if reAllDigits.MatchString(raw) {
+		n, err := strconv.Atoi(raw)
+		if err != nil {
+			return "", false
+		}
+		return strconv.Itoa(n), true
+	}
+	if m := reProjectURL.FindStringSubmatch(raw); len(m) == 5 {
+		n, err := strconv.Atoi(m[3])
+		if err != nil {
+			return "", false
+		}
+		return fmt.Sprintf("https://github.com/%s/%s/projects/%d", m[1], m[2], n), true
+	}
+	return "", false
 }

--- a/internal/cliflags/usage.go
+++ b/internal/cliflags/usage.go
@@ -139,6 +139,9 @@ Options:
                       live — pane liveness, issue state, PR merge status.
                       127.0.0.1-bound, GET-only, token-gated. See
                       'fanout dashboard --help'.
+  msg                 Subcommand. Peer messaging between fanout panes over a
+                      per-parent SQLite DB: send/post/mark-read/register plus
+                      peers/inbox/board read views. See 'fanout msg --help'.
   update              Subcommand. Replace this binary and bundled Claude/Codex
                       integrations through install.sh immediately. Supports
                       --version <tag> and --no-skills.

--- a/internal/exitcode/exitcode.go
+++ b/internal/exitcode/exitcode.go
@@ -1,5 +1,7 @@
-// Package exitcode centralizes the three CLI exit codes fanout uses.
+// Package exitcode centralizes the CLI exit codes fanout uses.
 // Behavior locked in by tests/bats/tier1_flags.bats; see fanout:113-117.
+// Backend is the `fanout msg` contract (tests/bats/tier1_msg.bats): the
+// team SQLite DB could not be opened, migrated, or queried.
 package exitcode
 
 type Code int
@@ -9,4 +11,5 @@ const (
 	Env        Code = 1
 	Invocation Code = 2
 	GitHub     Code = 3
+	Backend    Code = 4
 )

--- a/internal/msgstore/store.go
+++ b/internal/msgstore/store.go
@@ -1,0 +1,430 @@
+// Package msgstore implements the message/peer queries behind `fanout msg`
+// (#70) on top of the internal/team v1 schema. internal/team owns the DB
+// path convention, the connection helper, and the DDL; this package owns
+// every SELECT/INSERT/UPDATE so the CLI surface (cmd/fanout/msg.go) stays a
+// thin parse-and-print layer. All statements bind parameters via
+// placeholders — never interpolate caller input into SQL.
+package msgstore
+
+import (
+	"database/sql"
+	"fmt"
+	"strings"
+)
+
+// Message is one messages row. To is nil for board posts (to_issue IS NULL);
+// Board mirrors that so JSON consumers don't have to test null. The struct
+// doubles as the canonical `fanout msg --json` message encoding.
+type Message struct {
+	ID        int64   `json:"id"`
+	From      int     `json:"from"`
+	To        *int    `json:"to"`
+	Board     bool    `json:"board"`
+	Kind      string  `json:"kind"`
+	Body      string  `json:"body"`
+	CreatedAt string  `json:"created_at"`
+	ReadAt    *string `json:"read_at"`
+	ReplyTo   *int64  `json:"reply_to"`
+}
+
+// Peer is one peers row, also the canonical JSON encoding. Nullable text
+// columns scan to "" — register writes "" rather than NULL for unknown
+// fields, so the distinction carries no information.
+type Peer struct {
+	Issue        int    `json:"issue"`
+	PaneID       string `json:"pane_id"`
+	Slug         string `json:"slug"`
+	WorktreePath string `json:"worktree_path"`
+	Agent        string `json:"agent"`
+	DisplayName  string `json:"display_name"`
+	JoinedAt     string `json:"joined_at"`
+	LastSeen     string `json:"last_seen"`
+}
+
+// MarkResult reports what `inbox --mark-read` actually marked: the 1:1
+// message ids whose read_at was set, and the board cursor position after
+// advancing (0 when no board post was displayed and no cursor existed).
+type MarkResult struct {
+	MessageIDs  []int64 `json:"message_ids"`
+	BoardCursor int64   `json:"board_cursor"`
+}
+
+// Store wraps an open team DB scoped to one parent ref. The parent scopes
+// every messages query; peers and board_cursors are per-DB (the DB itself is
+// per-parent, see team.DBPath).
+type Store struct {
+	db     *sql.DB
+	parent string
+}
+
+func New(db *sql.DB, parent string) *Store {
+	return &Store{db: db, parent: parent}
+}
+
+const messageColumns = "id, from_issue, to_issue, kind, body, created_at, read_at, reply_to"
+
+// boardUnreadCond selects unread board posts: beyond self's cursor, excluding
+// self's own posts so `post` followed by `inbox`/`board` doesn't surface the
+// poster's own words as unread. Placeholder order: self, self.
+const boardUnreadCond = `(to_issue IS NULL AND from_issue != ?
+       AND id > COALESCE((SELECT last_read_id FROM board_cursors WHERE issue = ?), 0))`
+
+// unreadCond is the inbox union: unread 1:1 messages plus unread board posts.
+// Placeholder order: self, self, self.
+const unreadCond = `(to_issue = ? AND read_at IS NULL)
+   OR ` + boardUnreadCond
+
+// Send inserts a 1:1 message and returns the stored row.
+func (s *Store) Send(from, to int, kind, body, now string) (Message, error) {
+	return s.insertMessage(from, &to, kind, body, now)
+}
+
+// Post inserts a board post (to_issue IS NULL) and returns the stored row.
+func (s *Store) Post(from int, kind, body, now string) (Message, error) {
+	return s.insertMessage(from, nil, kind, body, now)
+}
+
+func (s *Store) insertMessage(from int, to *int, kind, body, now string) (Message, error) {
+	res, err := s.db.Exec(
+		"INSERT INTO messages(parent, from_issue, to_issue, kind, body, created_at) VALUES (?, ?, ?, ?, ?, ?)",
+		s.parent, from, to, kind, body, now,
+	)
+	if err != nil {
+		return Message{}, fmt.Errorf("insert message: %w", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return Message{}, fmt.Errorf("insert message: %w", err)
+	}
+	msg := Message{ID: id, From: from, To: to, Board: to == nil, Kind: kind, Body: body, CreatedAt: now}
+	return msg, nil
+}
+
+// Inbox returns self's messages ordered by id: the unread union by default,
+// or every 1:1/board message addressed to (or visible by) self with all set.
+// With markRead, the displayed rows are marked read in one transaction —
+// read_at only on the ids actually returned, the board cursor only up to the
+// highest returned board id — so messages that arrive between the SELECT and
+// the UPDATE stay unread for the next call.
+func (s *Store) Inbox(self int, all, markRead bool, now string) ([]Message, *MarkResult, error) {
+	if !markRead {
+		msgs, err := s.queryMessages(inboxQuery(all), inboxArgs(s.parent, self, all)...)
+		return msgs, nil, err
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return nil, nil, fmt.Errorf("inbox: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	msgs, err := queryMessagesIn(tx, inboxQuery(all), inboxArgs(s.parent, self, all)...)
+	if err != nil {
+		return nil, nil, err
+	}
+	marked, err := s.markDisplayed(tx, self, msgs, now)
+	if err != nil {
+		return nil, nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, nil, fmt.Errorf("inbox: %w", err)
+	}
+	return msgs, marked, nil
+}
+
+func inboxQuery(all bool) string {
+	cond := unreadCond
+	if all {
+		cond = "(to_issue = ? OR to_issue IS NULL)"
+	}
+	return "SELECT " + messageColumns + " FROM messages WHERE parent = ? AND (" + cond + ") ORDER BY id"
+}
+
+func inboxArgs(parent string, self int, all bool) []any {
+	if all {
+		return []any{parent, self}
+	}
+	return []any{parent, self, self, self}
+}
+
+// markDisplayed sets read_at on the displayed 1:1 rows and advances the board
+// cursor to the highest displayed board id. Cursor updates never regress
+// (MAX) so a stale --all view cannot rewind another invocation's progress.
+func (s *Store) markDisplayed(tx *sql.Tx, self int, msgs []Message, now string) (*MarkResult, error) {
+	marked := &MarkResult{MessageIDs: []int64{}}
+	var maxBoardID int64
+	for _, m := range msgs {
+		if m.Board {
+			maxBoardID = max(maxBoardID, m.ID)
+			continue
+		}
+		if m.To != nil && *m.To == self && m.ReadAt == nil {
+			marked.MessageIDs = append(marked.MessageIDs, m.ID)
+		}
+	}
+	if err := s.markRead(tx, self, marked.MessageIDs, now); err != nil {
+		return nil, err
+	}
+	if maxBoardID > 0 {
+		if err := advanceCursor(tx, self, maxBoardID); err != nil {
+			return nil, err
+		}
+	}
+	cursor, err := readBoardCursor(tx, self)
+	if err != nil {
+		return nil, err
+	}
+	marked.BoardCursor = cursor
+	return marked, nil
+}
+
+// markRead flips read_at on the given 1:1 ids, scoped to this Store's parent
+// like every other messages statement. No-op on an empty id list.
+func (s *Store) markRead(tx *sql.Tx, self int, ids []int64, now string) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	query := "UPDATE messages SET read_at = ? WHERE parent = ? AND to_issue = ? AND id IN (" +
+		placeholders(len(ids)) + ") AND read_at IS NULL"
+	if _, err := tx.Exec(query, append([]any{now, s.parent, self}, int64sToAny(ids)...)...); err != nil {
+		return fmt.Errorf("mark read: %w", err)
+	}
+	return nil
+}
+
+func readBoardCursor(tx *sql.Tx, self int) (int64, error) {
+	var cursor int64
+	if err := tx.QueryRow(
+		"SELECT COALESCE((SELECT last_read_id FROM board_cursors WHERE issue = ?), 0)", self,
+	).Scan(&cursor); err != nil {
+		return 0, fmt.Errorf("read board cursor: %w", err)
+	}
+	return cursor, nil
+}
+
+// Board returns board posts ordered by id: unread beyond self's cursor by
+// default (own posts excluded), or every post with all set. The cursor is
+// never advanced — that is `inbox --mark-read` / `mark-read --all` territory.
+func (s *Store) Board(self int, all bool) ([]Message, error) {
+	if all {
+		return s.queryMessages(
+			"SELECT "+messageColumns+" FROM messages WHERE parent = ? AND to_issue IS NULL ORDER BY id",
+			s.parent,
+		)
+	}
+	return s.queryMessages(
+		"SELECT "+messageColumns+" FROM messages WHERE parent = ? AND "+boardUnreadCond+" ORDER BY id",
+		s.parent, self, self,
+	)
+}
+
+// MarkReadIDs marks the given 1:1 message ids read and returns the ids it
+// actually updated. Ids that are board posts, addressed to someone else,
+// under another parent, already read, or absent are silently skipped —
+// callers retry idempotently.
+func (s *Store) MarkReadIDs(self int, ids []int64, now string) ([]int64, error) {
+	if len(ids) == 0 {
+		return []int64{}, nil
+	}
+	tx, err := s.db.Begin()
+	if err != nil {
+		return nil, fmt.Errorf("mark-read: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	// SELECT before UPDATE so the returned ids are exactly the rows flipped.
+	query := "SELECT id FROM messages WHERE parent = ? AND to_issue = ? AND id IN (" +
+		placeholders(len(ids)) + ") AND read_at IS NULL ORDER BY id"
+	rows, err := tx.Query(query, append([]any{s.parent, self}, int64sToAny(ids)...)...)
+	if err != nil {
+		return nil, fmt.Errorf("mark-read: %w", err)
+	}
+	markable, err := scanIDs(rows)
+	if err != nil {
+		return nil, fmt.Errorf("mark-read: %w", err)
+	}
+	if err := s.markRead(tx, self, markable, now); err != nil {
+		return nil, err
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("mark-read: %w", err)
+	}
+	return markable, nil
+}
+
+// MarkReadAll marks every unread 1:1 message to self read and advances the
+// board cursor to the current highest board id, returning the marked ids and
+// the cursor position.
+func (s *Store) MarkReadAll(self int, now string) ([]int64, int64, error) {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return nil, 0, fmt.Errorf("mark-read: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	rows, err := tx.Query(
+		"SELECT id FROM messages WHERE parent = ? AND to_issue = ? AND read_at IS NULL ORDER BY id",
+		s.parent, self,
+	)
+	if err != nil {
+		return nil, 0, fmt.Errorf("mark-read: %w", err)
+	}
+	markable, err := scanIDs(rows)
+	if err != nil {
+		return nil, 0, fmt.Errorf("mark-read: %w", err)
+	}
+	if err = s.markRead(tx, self, markable, now); err != nil {
+		return nil, 0, err
+	}
+
+	var maxBoardID int64
+	if err = tx.QueryRow(
+		"SELECT COALESCE(MAX(id), 0) FROM messages WHERE parent = ? AND to_issue IS NULL", s.parent,
+	).Scan(&maxBoardID); err != nil {
+		return nil, 0, fmt.Errorf("mark-read: %w", err)
+	}
+	if maxBoardID > 0 {
+		if err = advanceCursor(tx, self, maxBoardID); err != nil {
+			return nil, 0, err
+		}
+	}
+	cursor, err := readBoardCursor(tx, self)
+	if err != nil {
+		return nil, 0, err
+	}
+	if err = tx.Commit(); err != nil {
+		return nil, 0, fmt.Errorf("mark-read: %w", err)
+	}
+	return markable, cursor, nil
+}
+
+// Register upserts a peer row. joined_at is set on first insert only;
+// last_seen is refreshed on every call.
+func (s *Store) Register(p Peer, now string) (Peer, error) {
+	_, err := s.db.Exec(
+		`INSERT INTO peers(issue, pane_id, slug, worktree_path, agent, display_name, joined_at, last_seen)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(issue) DO UPDATE SET
+  pane_id=excluded.pane_id, slug=excluded.slug, worktree_path=excluded.worktree_path,
+  agent=excluded.agent, display_name=excluded.display_name, last_seen=excluded.last_seen`,
+		p.Issue, p.PaneID, p.Slug, p.WorktreePath, p.Agent, p.DisplayName, now, now,
+	)
+	if err != nil {
+		return Peer{}, fmt.Errorf("register peer: %w", err)
+	}
+	row := s.db.QueryRow(
+		"SELECT issue, pane_id, slug, worktree_path, agent, display_name, joined_at, last_seen FROM peers WHERE issue = ?",
+		p.Issue,
+	)
+	stored, err := scanPeer(row)
+	if err != nil {
+		return Peer{}, fmt.Errorf("register peer: %w", err)
+	}
+	return stored, nil
+}
+
+// Peers returns every registered peer ordered by issue.
+func (s *Store) Peers() ([]Peer, error) {
+	rows, err := s.db.Query(
+		"SELECT issue, pane_id, slug, worktree_path, agent, display_name, joined_at, last_seen FROM peers ORDER BY issue",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("list peers: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	peers := []Peer{}
+	for rows.Next() {
+		p, err := scanPeer(rows)
+		if err != nil {
+			return nil, fmt.Errorf("list peers: %w", err)
+		}
+		peers = append(peers, p)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("list peers: %w", err)
+	}
+	return peers, nil
+}
+
+type querier interface {
+	Query(query string, args ...any) (*sql.Rows, error)
+}
+
+func (s *Store) queryMessages(query string, args ...any) ([]Message, error) {
+	return queryMessagesIn(s.db, query, args...)
+}
+
+func queryMessagesIn(q querier, query string, args ...any) ([]Message, error) {
+	rows, err := q.Query(query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("query messages: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+	msgs := []Message{}
+	for rows.Next() {
+		var m Message
+		if err := rows.Scan(&m.ID, &m.From, &m.To, &m.Kind, &m.Body, &m.CreatedAt, &m.ReadAt, &m.ReplyTo); err != nil {
+			return nil, fmt.Errorf("scan message: %w", err)
+		}
+		m.Board = m.To == nil
+		msgs = append(msgs, m)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("query messages: %w", err)
+	}
+	return msgs, nil
+}
+
+type rowScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanPeer(row rowScanner) (Peer, error) {
+	var p Peer
+	var paneID, slug, worktree, agent, display, lastSeen sql.NullString
+	if err := row.Scan(&p.Issue, &paneID, &slug, &worktree, &agent, &display, &p.JoinedAt, &lastSeen); err != nil {
+		return Peer{}, err
+	}
+	p.PaneID = paneID.String
+	p.Slug = slug.String
+	p.WorktreePath = worktree.String
+	p.Agent = agent.String
+	p.DisplayName = display.String
+	p.LastSeen = lastSeen.String
+	return p, nil
+}
+
+func scanIDs(rows *sql.Rows) ([]int64, error) {
+	defer func() { _ = rows.Close() }()
+	ids := []int64{}
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
+func advanceCursor(tx *sql.Tx, self int, id int64) error {
+	if _, err := tx.Exec(
+		`INSERT INTO board_cursors(issue, last_read_id) VALUES (?, ?)
+ON CONFLICT(issue) DO UPDATE SET last_read_id = MAX(last_read_id, excluded.last_read_id)`,
+		self, id,
+	); err != nil {
+		return fmt.Errorf("advance board cursor: %w", err)
+	}
+	return nil
+}
+
+func placeholders(n int) string {
+	return strings.TrimSuffix(strings.Repeat("?, ", n), ", ")
+}
+
+func int64sToAny(ids []int64) []any {
+	out := make([]any, len(ids))
+	for i, id := range ids {
+		out[i] = id
+	}
+	return out
+}

--- a/internal/msgstore/store.go
+++ b/internal/msgstore/store.go
@@ -50,8 +50,13 @@ type MarkResult struct {
 }
 
 // Store wraps an open team DB scoped to one parent ref. The parent scopes
-// every messages query; peers and board_cursors are per-DB (the DB itself is
-// per-parent, see team.DBPath).
+// every messages query; peers and board_cursors are per-DB because the v1
+// schema (internal/team) keys them by issue alone — sound under the default
+// one-DB-per-parent convention (team.DBPath). Pointing FANOUT_DB_PATH at one
+// shared file for SEVERAL parents keeps messages correctly isolated, but
+// board cursors and peer rows are then shared across those parents (a cursor
+// advanced under one parent hides older board posts under another). Keep one
+// DB per parent; per-parent cursors need a v2 schema migration.
 type Store struct {
 	db     *sql.DB
 	parent string

--- a/internal/msgstore/store.go
+++ b/internal/msgstore/store.go
@@ -59,17 +59,33 @@ type Store struct {
 	parent string
 }
 
-// New wraps db scoped to parent. It rejects a DB that already holds another
-// parent's messages: peers and board_cursors are keyed by issue alone in the
-// v1 schema, so sharing one DB file across parents would leak cursors and
-// peer rows across team boundaries even though messages are parent-scoped.
-// Per-parent cursors/peers need a v2 schema migration in internal/team.
+// New wraps db scoped to parent. It enforces the single-parent invariant by
+// persisting ownership: the first parent to open the DB claims it in the
+// msg_db_owner singleton (this store's own bookkeeping table, separate from
+// the internal/team v1 schema), and every later open must present the same
+// parent. Evidence-based checks (inspecting messages rows) are not enough —
+// a register-only DB has peer rows but no message row revealing its parent.
+// peers and board_cursors are keyed by issue alone in the v1 schema, so a
+// shared DB would leak cursors and peer rows across team boundaries; the
+// claim makes that unrepresentable. Per-parent cursors/peers need a v2
+// schema migration in internal/team, at which point this table can go.
 func New(db *sql.DB, parent string) (*Store, error) {
+	owner, err := claimDBOwner(db, parent)
+	if err != nil {
+		return nil, err
+	}
+	if owner != parent {
+		return nil, fmt.Errorf(
+			"team db is owned by parent %s; one team DB serves one parent (use a separate FANOUT_DB_PATH per parent)",
+			owner)
+	}
+	// Defense in depth for DBs whose owner row was removed by hand: foreign
+	// message rows still reveal a conflicting tenant.
 	var other string
-	err := db.QueryRow("SELECT parent FROM messages WHERE parent != ? LIMIT 1", parent).Scan(&other)
+	err = db.QueryRow("SELECT parent FROM messages WHERE parent != ? LIMIT 1", parent).Scan(&other)
 	switch {
 	case errors.Is(err, sql.ErrNoRows):
-		// parent is the DB's sole tenant — the v1 single-parent invariant holds.
+		// parent is the DB's sole tenant — the single-parent invariant holds.
 	case err != nil:
 		return nil, fmt.Errorf("check team db parent: %w", err)
 	default:
@@ -78,6 +94,28 @@ func New(db *sql.DB, parent string) (*Store, error) {
 			other)
 	}
 	return &Store{db: db, parent: parent}, nil
+}
+
+// claimDBOwner records parent as the DB's owner when no owner exists yet and
+// returns the owner on record. The CHECK(id = 1) singleton plus the no-op
+// conflict clause make concurrent first opens race-safe: exactly one parent
+// wins the claim and the loser reads the winner's row.
+func claimDBOwner(db *sql.DB, parent string) (string, error) {
+	if _, err := db.Exec(
+		"CREATE TABLE IF NOT EXISTS msg_db_owner (id INTEGER PRIMARY KEY CHECK (id = 1), parent TEXT NOT NULL)",
+	); err != nil {
+		return "", fmt.Errorf("ensure team db owner table: %w", err)
+	}
+	if _, err := db.Exec(
+		"INSERT INTO msg_db_owner(id, parent) VALUES (1, ?) ON CONFLICT(id) DO NOTHING", parent,
+	); err != nil {
+		return "", fmt.Errorf("claim team db owner: %w", err)
+	}
+	var owner string
+	if err := db.QueryRow("SELECT parent FROM msg_db_owner WHERE id = 1").Scan(&owner); err != nil {
+		return "", fmt.Errorf("read team db owner: %w", err)
+	}
+	return owner, nil
 }
 
 const messageColumns = "id, from_issue, to_issue, kind, body, created_at, read_at, reply_to"

--- a/internal/msgstore/store.go
+++ b/internal/msgstore/store.go
@@ -8,6 +8,7 @@ package msgstore
 
 import (
 	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 )
@@ -51,19 +52,32 @@ type MarkResult struct {
 
 // Store wraps an open team DB scoped to one parent ref. The parent scopes
 // every messages query; peers and board_cursors are per-DB because the v1
-// schema (internal/team) keys them by issue alone — sound under the default
-// one-DB-per-parent convention (team.DBPath). Pointing FANOUT_DB_PATH at one
-// shared file for SEVERAL parents keeps messages correctly isolated, but
-// board cursors and peer rows are then shared across those parents (a cursor
-// advanced under one parent hides older board posts under another). Keep one
-// DB per parent; per-parent cursors need a v2 schema migration.
+// schema (internal/team) keys them by issue alone. That is sound only under
+// the one-DB-per-parent convention (team.DBPath), so New enforces it.
 type Store struct {
 	db     *sql.DB
 	parent string
 }
 
-func New(db *sql.DB, parent string) *Store {
-	return &Store{db: db, parent: parent}
+// New wraps db scoped to parent. It rejects a DB that already holds another
+// parent's messages: peers and board_cursors are keyed by issue alone in the
+// v1 schema, so sharing one DB file across parents would leak cursors and
+// peer rows across team boundaries even though messages are parent-scoped.
+// Per-parent cursors/peers need a v2 schema migration in internal/team.
+func New(db *sql.DB, parent string) (*Store, error) {
+	var other string
+	err := db.QueryRow("SELECT parent FROM messages WHERE parent != ? LIMIT 1", parent).Scan(&other)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		// parent is the DB's sole tenant — the v1 single-parent invariant holds.
+	case err != nil:
+		return nil, fmt.Errorf("check team db parent: %w", err)
+	default:
+		return nil, fmt.Errorf(
+			"team db already holds messages for parent %s; one team DB serves one parent (use a separate FANOUT_DB_PATH per parent)",
+			other)
+	}
+	return &Store{db: db, parent: parent}, nil
 }
 
 const messageColumns = "id, from_issue, to_issue, kind, body, created_at, read_at, reply_to"

--- a/internal/msgstore/store.go
+++ b/internal/msgstore/store.go
@@ -96,18 +96,32 @@ func New(db *sql.DB, parent string) (*Store, error) {
 	return &Store{db: db, parent: parent}, nil
 }
 
-// claimDBOwner records parent as the DB's owner when no owner exists yet and
-// returns the owner on record. The CHECK(id = 1) singleton plus the no-op
-// conflict clause make concurrent first opens race-safe: exactly one parent
-// wins the claim and the loser reads the winner's row.
+// claimDBOwner records the DB's owner when no owner row exists yet and
+// returns the owner on record. A DB predating msg_db_owner may already hold
+// message rows; their parent — not the requested one — seeds the claim, so a
+// wrong first opener cannot hijack ownership of an existing team DB and lock
+// the resident parent out. The CHECK(id = 1) singleton plus the no-op
+// conflict clause make concurrent first opens race-safe: exactly one claim
+// wins and the loser reads the winner's row.
 func claimDBOwner(db *sql.DB, parent string) (string, error) {
 	if _, err := db.Exec(
 		"CREATE TABLE IF NOT EXISTS msg_db_owner (id INTEGER PRIMARY KEY CHECK (id = 1), parent TEXT NOT NULL)",
 	); err != nil {
 		return "", fmt.Errorf("ensure team db owner table: %w", err)
 	}
+	resident := parent
+	var found string
+	err := db.QueryRow("SELECT parent FROM messages ORDER BY id LIMIT 1").Scan(&found)
+	switch {
+	case errors.Is(err, sql.ErrNoRows):
+		// No messages yet: the requested parent may claim the DB.
+	case err != nil:
+		return "", fmt.Errorf("discover team db resident parent: %w", err)
+	default:
+		resident = found
+	}
 	if _, err := db.Exec(
-		"INSERT INTO msg_db_owner(id, parent) VALUES (1, ?) ON CONFLICT(id) DO NOTHING", parent,
+		"INSERT INTO msg_db_owner(id, parent) VALUES (1, ?) ON CONFLICT(id) DO NOTHING", resident,
 	); err != nil {
 		return "", fmt.Errorf("claim team db owner: %w", err)
 	}

--- a/internal/msgstore/store_test.go
+++ b/internal/msgstore/store_test.go
@@ -3,6 +3,7 @@ package msgstore
 import (
 	"path/filepath"
 	"slices"
+	"strings"
 	"testing"
 
 	"github.com/butaosuinu/fanout/internal/team"
@@ -18,14 +19,18 @@ func openTestStore(t *testing.T) *Store {
 		t.Fatalf("team.Open(%q): %v", path, err)
 	}
 	t.Cleanup(func() {
-		if err := db.Close(); err != nil {
-			t.Errorf("close db: %v", err)
+		if closeErr := db.Close(); closeErr != nil {
+			t.Errorf("close db: %v", closeErr)
 		}
 	})
-	if err := team.EnsureSchema(db); err != nil {
-		t.Fatalf("team.EnsureSchema: %v", err)
+	if schemaErr := team.EnsureSchema(db); schemaErr != nil {
+		t.Fatalf("team.EnsureSchema: %v", schemaErr)
 	}
-	return New(db, "68")
+	s, err := New(db, "68")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return s
 }
 
 func mustSend(t *testing.T, s *Store, from, to int, kind, body string) Message {
@@ -236,10 +241,27 @@ func TestMarkReadAllAdvancesCursorAndNeverRegresses(t *testing.T) {
 	}
 }
 
+func TestNewRejectsForeignParent(t *testing.T) {
+	s := openTestStore(t)
+	seedStore(t, s)
+
+	// The v1 schema keys peers/board_cursors by issue alone, so one DB file
+	// must serve one parent; opening it for another parent must fail loudly.
+	if _, err := New(s.db, "99"); err == nil || !strings.Contains(err.Error(), "one team DB serves one parent") {
+		t.Fatalf("New for foreign parent = %v, want single-parent rejection", err)
+	}
+	if _, err := New(s.db, "68"); err != nil {
+		t.Fatalf("New for the resident parent: %v", err)
+	}
+}
+
+// Defense in depth: even if a mixed DB exists (constructed here by bypassing
+// New), every messages statement stays parent-scoped so cross-parent reads
+// and mark-read --id (user-supplied ids) cannot touch another team's rows.
 func TestParentScopesMessages(t *testing.T) {
 	s := openTestStore(t)
 	seedStore(t, s)
-	other := New(s.db, "99")
+	other := &Store{db: s.db, parent: "99"}
 
 	msgs, _, err := other.Inbox(70, false, false, testNow)
 	if err != nil {
@@ -249,8 +271,6 @@ func TestParentScopesMessages(t *testing.T) {
 		t.Errorf("other parent inbox = %v, want empty", messageIDs(msgs))
 	}
 
-	// mark-read is parent-scoped too: a shared FANOUT_DB_PATH DB must not let
-	// one parent's mark-read flip another parent's rows (ids are user input).
 	marked, err := other.MarkReadIDs(70, []int64{1, 2}, testNow)
 	if err != nil {
 		t.Fatalf("MarkReadIDs other parent: %v", err)

--- a/internal/msgstore/store_test.go
+++ b/internal/msgstore/store_test.go
@@ -255,6 +255,25 @@ func TestNewRejectsForeignParent(t *testing.T) {
 	}
 }
 
+func TestNewSeedsLegacyOwnerFromMessages(t *testing.T) {
+	s := openTestStore(t)
+	seedStore(t, s)
+	// Simulate a DB created before msg_db_owner existed.
+	if _, err := s.db.Exec("DROP TABLE msg_db_owner"); err != nil {
+		t.Fatalf("drop owner table: %v", err)
+	}
+
+	// A wrong first opener must not hijack ownership of the legacy DB: the
+	// claim seeds from the resident parent found in messages, so the open is
+	// rejected AND the recorded owner stays the resident.
+	if _, err := New(s.db, "99"); err == nil || !strings.Contains(err.Error(), "owned by parent 68") {
+		t.Fatalf("New(99) on a legacy DB = %v, want rejection naming resident 68", err)
+	}
+	if _, err := New(s.db, "68"); err != nil {
+		t.Fatalf("New(68) after the failed hijack: %v", err)
+	}
+}
+
 func TestNewOwnershipSurvivesRegisterOnlyDB(t *testing.T) {
 	s := openTestStore(t)
 	// Register a peer but write no message: the messages table alone cannot

--- a/internal/msgstore/store_test.go
+++ b/internal/msgstore/store_test.go
@@ -255,6 +255,22 @@ func TestNewRejectsForeignParent(t *testing.T) {
 	}
 }
 
+func TestNewOwnershipSurvivesRegisterOnlyDB(t *testing.T) {
+	s := openTestStore(t)
+	// Register a peer but write no message: the messages table alone cannot
+	// reveal the resident parent, so ownership must come from the claim.
+	if _, err := s.Register(Peer{Issue: 70}, testNow); err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+
+	if _, err := New(s.db, "99"); err == nil || !strings.Contains(err.Error(), "owned by parent 68") {
+		t.Fatalf("New on a register-only DB for a foreign parent = %v, want ownership rejection", err)
+	}
+	if _, err := New(s.db, "68"); err != nil {
+		t.Fatalf("reopening for the owner: %v", err)
+	}
+}
+
 // Defense in depth: even if a mixed DB exists (constructed here by bypassing
 // New), every messages statement stays parent-scoped so cross-parent reads
 // and mark-read --id (user-supplied ids) cannot touch another team's rows.

--- a/internal/msgstore/store_test.go
+++ b/internal/msgstore/store_test.go
@@ -1,0 +1,335 @@
+package msgstore
+
+import (
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/butaosuinu/fanout/internal/team"
+)
+
+const testNow = "2026-06-13T00:00:00Z"
+
+func openTestStore(t *testing.T) *Store {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "team.db")
+	db, err := team.Open(path)
+	if err != nil {
+		t.Fatalf("team.Open(%q): %v", path, err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Errorf("close db: %v", err)
+		}
+	})
+	if err := team.EnsureSchema(db); err != nil {
+		t.Fatalf("team.EnsureSchema: %v", err)
+	}
+	return New(db, "68")
+}
+
+func mustSend(t *testing.T, s *Store, from, to int, kind, body string) Message {
+	t.Helper()
+	m, err := s.Send(from, to, kind, body, testNow)
+	if err != nil {
+		t.Fatalf("Send(%d->%d, %q): %v", from, to, body, err)
+	}
+	return m
+}
+
+func mustPost(t *testing.T, s *Store, from int, kind, body string) Message {
+	t.Helper()
+	m, err := s.Post(from, kind, body, testNow)
+	if err != nil {
+		t.Fatalf("Post(%d, %q): %v", from, body, err)
+	}
+	return m
+}
+
+// seedStore loads the canonical fixture: two 1:1 messages to 70, one board
+// post by 71, one board post by 70 (self), and one 1:1 to 71 (not ours).
+func seedStore(t *testing.T, s *Store) {
+	t.Helper()
+	mustSend(t, s, 71, 70, "note", "first to 70")     // id 1
+	mustSend(t, s, 71, 70, "blocker", "second to 70") // id 2
+	mustPost(t, s, 71, "note", "board by 71")         // id 3
+	mustPost(t, s, 70, "note", "board by 70")         // id 4
+	mustSend(t, s, 70, 71, "note", "to 71, not ours") // id 5
+}
+
+func messageIDs(msgs []Message) []int64 {
+	ids := make([]int64, len(msgs))
+	for i, m := range msgs {
+		ids[i] = m.ID
+	}
+	return ids
+}
+
+func TestSendAndPostAssignSequentialIDs(t *testing.T) {
+	s := openTestStore(t)
+	sent, err := s.Send(70, 71, "note", "hello", testNow)
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+	posted, err := s.Post(70, "note", "to the board", testNow)
+	if err != nil {
+		t.Fatalf("Post: %v", err)
+	}
+	if sent.ID != 1 || posted.ID != 2 {
+		t.Errorf("ids = %d, %d, want 1, 2", sent.ID, posted.ID)
+	}
+	if sent.Board || posted.To != nil || !posted.Board {
+		t.Errorf("board flags wrong: sent=%+v posted=%+v", sent, posted)
+	}
+}
+
+func TestInboxUnreadUnion(t *testing.T) {
+	s := openTestStore(t)
+	seedStore(t, s)
+
+	msgs, marked, err := s.Inbox(70, false, false, testNow)
+	if err != nil {
+		t.Fatalf("Inbox: %v", err)
+	}
+	if marked != nil {
+		t.Errorf("marked = %+v, want nil without markRead", marked)
+	}
+	// Unread for 70: 1:1 ids 1-2 plus board id 3. Own board post (4) and the
+	// message to 71 (5) are excluded.
+	if got, want := messageIDs(msgs), []int64{1, 2, 3}; !slices.Equal(got, want) {
+		t.Errorf("inbox ids = %v, want %v", got, want)
+	}
+}
+
+func TestInboxAllIncludesReadAndOwnBoardPosts(t *testing.T) {
+	s := openTestStore(t)
+	seedStore(t, s)
+	if _, err := s.MarkReadIDs(70, []int64{1}, testNow); err != nil {
+		t.Fatalf("MarkReadIDs: %v", err)
+	}
+
+	msgs, _, err := s.Inbox(70, true, false, testNow)
+	if err != nil {
+		t.Fatalf("Inbox --all: %v", err)
+	}
+	if got, want := messageIDs(msgs), []int64{1, 2, 3, 4}; !slices.Equal(got, want) {
+		t.Errorf("inbox --all ids = %v, want %v", got, want)
+	}
+	if msgs[0].ReadAt == nil || *msgs[0].ReadAt != testNow {
+		t.Errorf("id 1 read_at = %v, want %q", msgs[0].ReadAt, testNow)
+	}
+}
+
+func TestInboxMarkReadDrainsAndIsScopedToDisplayedRows(t *testing.T) {
+	s := openTestStore(t)
+	seedStore(t, s)
+
+	msgs, marked, err := s.Inbox(70, false, true, testNow)
+	if err != nil {
+		t.Fatalf("Inbox --mark-read: %v", err)
+	}
+	if got, want := messageIDs(msgs), []int64{1, 2, 3}; !slices.Equal(got, want) {
+		t.Errorf("displayed ids = %v, want %v", got, want)
+	}
+	if got, want := marked.MessageIDs, []int64{1, 2}; !slices.Equal(got, want) {
+		t.Errorf("marked ids = %v, want %v", got, want)
+	}
+	if marked.BoardCursor != 3 {
+		t.Errorf("board cursor = %d, want 3", marked.BoardCursor)
+	}
+
+	again, _, err := s.Inbox(70, false, false, testNow)
+	if err != nil {
+		t.Fatalf("second Inbox: %v", err)
+	}
+	if len(again) != 0 {
+		t.Errorf("second inbox = %v, want empty", messageIDs(again))
+	}
+
+	// id 4 (own board post, beyond the cursor only via --all) and id 5
+	// (addressed to 71) must be untouched.
+	other, _, err := s.Inbox(71, false, false, testNow)
+	if err != nil {
+		t.Fatalf("Inbox for 71: %v", err)
+	}
+	if got, want := messageIDs(other), []int64{4, 5}; !slices.Equal(got, want) {
+		t.Errorf("inbox for 71 = %v, want %v", got, want)
+	}
+}
+
+func TestBoardCursorAndAll(t *testing.T) {
+	s := openTestStore(t)
+	seedStore(t, s)
+
+	unread, err := s.Board(70, false)
+	if err != nil {
+		t.Fatalf("Board: %v", err)
+	}
+	if got, want := messageIDs(unread), []int64{3}; !slices.Equal(got, want) {
+		t.Errorf("board unread = %v, want %v (own post excluded)", got, want)
+	}
+
+	all, err := s.Board(70, true)
+	if err != nil {
+		t.Fatalf("Board --all: %v", err)
+	}
+	if got, want := messageIDs(all), []int64{3, 4}; !slices.Equal(got, want) {
+		t.Errorf("board --all = %v, want %v", got, want)
+	}
+
+	// Board never advances the cursor.
+	again, err := s.Board(70, false)
+	if err != nil {
+		t.Fatalf("second Board: %v", err)
+	}
+	if got, want := messageIDs(again), []int64{3}; !slices.Equal(got, want) {
+		t.Errorf("board after read = %v, want %v", got, want)
+	}
+}
+
+func TestMarkReadIDsSkipsForeignBoardAndMissing(t *testing.T) {
+	s := openTestStore(t)
+	seedStore(t, s)
+
+	// 1 is ours; 3 is a board post, 5 is addressed to 71, 99 does not exist.
+	marked, err := s.MarkReadIDs(70, []int64{1, 3, 5, 99}, testNow)
+	if err != nil {
+		t.Fatalf("MarkReadIDs: %v", err)
+	}
+	if got, want := marked, []int64{1}; !slices.Equal(got, want) {
+		t.Errorf("marked = %v, want %v", got, want)
+	}
+
+	// Idempotent: a second run finds nothing left to mark.
+	marked, err = s.MarkReadIDs(70, []int64{1}, testNow)
+	if err != nil {
+		t.Fatalf("second MarkReadIDs: %v", err)
+	}
+	if len(marked) != 0 {
+		t.Errorf("second marked = %v, want empty", marked)
+	}
+}
+
+func TestMarkReadAllAdvancesCursorAndNeverRegresses(t *testing.T) {
+	s := openTestStore(t)
+	seedStore(t, s)
+
+	marked, cursor, err := s.MarkReadAll(70, testNow)
+	if err != nil {
+		t.Fatalf("MarkReadAll: %v", err)
+	}
+	if got, want := marked, []int64{1, 2}; !slices.Equal(got, want) {
+		t.Errorf("marked = %v, want %v", got, want)
+	}
+	if cursor != 4 {
+		t.Errorf("cursor = %d, want 4 (max board id)", cursor)
+	}
+
+	// A later partial inbox --mark-read sees nothing unread and must not
+	// rewind the cursor below 4.
+	_, res, err := s.Inbox(70, false, true, testNow)
+	if err != nil {
+		t.Fatalf("Inbox --mark-read after MarkReadAll: %v", err)
+	}
+	if res.BoardCursor != 4 {
+		t.Errorf("cursor after empty mark = %d, want 4", res.BoardCursor)
+	}
+}
+
+func TestParentScopesMessages(t *testing.T) {
+	s := openTestStore(t)
+	seedStore(t, s)
+	other := New(s.db, "99")
+
+	msgs, _, err := other.Inbox(70, false, false, testNow)
+	if err != nil {
+		t.Fatalf("Inbox other parent: %v", err)
+	}
+	if len(msgs) != 0 {
+		t.Errorf("other parent inbox = %v, want empty", messageIDs(msgs))
+	}
+
+	// mark-read is parent-scoped too: a shared FANOUT_DB_PATH DB must not let
+	// one parent's mark-read flip another parent's rows (ids are user input).
+	marked, err := other.MarkReadIDs(70, []int64{1, 2}, testNow)
+	if err != nil {
+		t.Fatalf("MarkReadIDs other parent: %v", err)
+	}
+	if len(marked) != 0 {
+		t.Errorf("other parent marked = %v, want empty", marked)
+	}
+	still, _, err := s.Inbox(70, false, false, testNow)
+	if err != nil {
+		t.Fatalf("Inbox after cross-parent attempt: %v", err)
+	}
+	if got, want := messageIDs(still), []int64{1, 2, 3}; !slices.Equal(got, want) {
+		t.Errorf("inbox after cross-parent mark = %v, want %v (untouched)", got, want)
+	}
+}
+
+func TestMarkReadIDsEmptyListIsANoOp(t *testing.T) {
+	s := openTestStore(t)
+	seedStore(t, s)
+	marked, err := s.MarkReadIDs(70, nil, testNow)
+	if err != nil {
+		t.Fatalf("MarkReadIDs(nil): %v", err)
+	}
+	if len(marked) != 0 {
+		t.Errorf("marked = %v, want empty", marked)
+	}
+}
+
+func TestRegisterUpsertPreservesJoinedAt(t *testing.T) {
+	s := openTestStore(t)
+	first, err := s.Register(Peer{
+		Issue: 70, PaneID: "%1", Slug: "msg-cli-surface-70", Agent: "claude", DisplayName: "msg cli",
+	}, "2026-06-13T00:00:00Z")
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if first.JoinedAt != "2026-06-13T00:00:00Z" || first.LastSeen != "2026-06-13T00:00:00Z" {
+		t.Errorf("first register = %+v", first)
+	}
+
+	second, err := s.Register(Peer{Issue: 70, PaneID: "%2", Agent: "codex"}, "2026-06-13T01:00:00Z")
+	if err != nil {
+		t.Fatalf("second Register: %v", err)
+	}
+	if second.JoinedAt != "2026-06-13T00:00:00Z" {
+		t.Errorf("joined_at = %q, want preserved %q", second.JoinedAt, "2026-06-13T00:00:00Z")
+	}
+	if second.LastSeen != "2026-06-13T01:00:00Z" || second.PaneID != "%2" || second.Agent != "codex" {
+		t.Errorf("second register = %+v", second)
+	}
+	if second.Slug != "" {
+		t.Errorf("slug = %q, want overwritten to empty", second.Slug)
+	}
+
+	peers, err := s.Peers()
+	if err != nil {
+		t.Fatalf("Peers: %v", err)
+	}
+	if len(peers) != 1 || peers[0].Issue != 70 {
+		t.Errorf("peers = %+v, want one row for 70", peers)
+	}
+}
+
+func TestPeersOrderedByIssue(t *testing.T) {
+	s := openTestStore(t)
+	for _, issue := range []int{71, 69, 70} {
+		if _, err := s.Register(Peer{Issue: issue}, testNow); err != nil {
+			t.Fatalf("Register(%d): %v", issue, err)
+		}
+	}
+	peers, err := s.Peers()
+	if err != nil {
+		t.Fatalf("Peers: %v", err)
+	}
+	got := make([]int, len(peers))
+	for i, p := range peers {
+		got[i] = p.Issue
+	}
+	if want := []int{69, 70, 71}; !slices.Equal(got, want) {
+		t.Errorf("peer order = %v, want %v", got, want)
+	}
+}

--- a/tests/bats/helpers.bash
+++ b/tests/bats/helpers.bash
@@ -77,6 +77,12 @@ teardown() {
   # Briefings are written to /tmp with a hardcoded prefix (fanout:791).
   # Tier 1 tests don't reach the briefing path, but scrub defensively so a
   # future test (or a Tier 2 leakage) doesn't confuse the next run.
+  #
+  # Do NOT add a /tmp/fanout-*.db scrub here: that pattern is the LIVE
+  # `fanout msg` team DB location (internal/team DBPath) for every fanout
+  # session on this machine, and deleting a WAL-mode SQLite DB out from under
+  # open connections destroys real peer messages. msg tests must instead pin
+  # FANOUT_DB_PATH into BATS_TEST_TMPDIR (see tier1_msg.bats msg_env).
   rm -f /tmp/fanout-*.md 2>/dev/null || true
 }
 

--- a/tests/bats/tier1_msg.bats
+++ b/tests/bats/tier1_msg.bats
@@ -1,0 +1,159 @@
+#!/usr/bin/env bats
+# Tier 1 surface tests for the `fanout msg` subcommand (#70): usage, verb and
+# flag validation, the 0/2/4 exit-code contract, and identity-detection
+# failure guidance. No goldens here — exact output lives in tier2_msg.bats.
+
+load helpers
+
+# Isolate every msg test from the developer's live environment. helpers'
+# setup() exports TMUX_PANE=%1, so without an explicit FANOUT_STATE_PATH the
+# pane detection in `fanout msg` could match a real .fanout/state.json row on
+# a dev machine; pointing it at a nonexistent file makes detection fail
+# deterministically. FANOUT_DB_PATH keeps the SQLite DB (and its WAL/SHM
+# sidecars) inside bats' auto-cleaned tmpdir instead of /tmp.
+msg_env() {
+  export FANOUT_DB_PATH="$BATS_TEST_TMPDIR/team.db"
+  export FANOUT_STATE_PATH="$BATS_TEST_TMPDIR/no-state.json"
+}
+
+@test "msg without a verb prints usage and exits 2" {
+  msg_env
+  run_fanout msg
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"Usage: fanout msg"* ]]
+}
+
+@test "msg --help prints usage and exits 0" {
+  msg_env
+  run_fanout msg --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: fanout msg"* ]]
+}
+
+@test "msg -h before a verb prints usage and exits 0" {
+  msg_env
+  run_fanout msg inbox -h
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage: fanout msg"* ]]
+}
+
+@test "msg with an unknown verb exits 2" {
+  msg_env
+  run_fanout msg bogus
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unknown verb: bogus"* ]]
+}
+
+@test "msg send without detectable pane asks for --self/--parent: exit 2" {
+  msg_env
+  run_fanout msg send --to 71 hello
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"pass --self <issue> and --parent <ref>"* ]]
+}
+
+@test "msg send without --to exits 2" {
+  msg_env
+  run_fanout msg send --self 70 --parent 68 hello
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"--to <issue> is required"* ]]
+}
+
+@test "msg send with a non-integer --to exits 2" {
+  msg_env
+  run_fanout msg send --to abc --self 70 --parent 68 hello
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"--to must be a positive issue number"* ]]
+}
+
+@test "msg send without a body exits 2" {
+  msg_env
+  run_fanout msg send --to 71 --self 70 --parent 68
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"message body is required"* ]]
+}
+
+@test "msg mark-read without --id or --all exits 2" {
+  msg_env
+  run_fanout msg mark-read --self 70 --parent 68
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"pass either --id <n> (repeatable) or --all"* ]]
+}
+
+@test "msg mark-read with both --id and --all exits 2" {
+  msg_env
+  run_fanout msg mark-read --id 1 --all --self 70 --parent 68
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"pass either --id <n> (repeatable) or --all"* ]]
+}
+
+@test "msg inbox rejects --dry-run (read verb): exit 2" {
+  msg_env
+  run_fanout msg inbox --dry-run --self 70 --parent 68
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"--dry-run is not supported"* ]]
+}
+
+@test "msg peers rejects a verb-foreign flag: exit 2" {
+  msg_env
+  run_fanout msg peers --to 5 --parent 68
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"--to is not supported"* ]]
+}
+
+@test "msg with an unknown option exits 2" {
+  msg_env
+  run_fanout msg peers --bogus --parent 68
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unknown option: --bogus"* ]]
+}
+
+@test "msg with a value-flag missing its value exits 2" {
+  msg_env
+  run_fanout msg send --self 70 --parent 68 hello --to
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"--to requires an argument"* ]]
+}
+
+@test "msg read verb rejects a stray positional argument: exit 2" {
+  msg_env
+  run_fanout msg inbox hello --self 70 --parent 68
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"unexpected argument: hello"* ]]
+}
+
+@test "msg exits 4 when the team DB path is unusable (backend)" {
+  msg_env
+  export FANOUT_DB_PATH="$BATS_TEST_TMPDIR"
+  run_fanout msg peers --parent 68
+  [ "$status" -eq 4 ]
+}
+
+@test "msg send happy path writes the isolated DB and exits 0" {
+  msg_env
+  run_fanout msg send --to 71 --self 70 --parent 68 hello over there
+  assert_success
+  [[ "$output" == *"sent #1 to #71"* ]]
+  [ -f "$BATS_TEST_TMPDIR/team.db" ]
+}
+
+@test "msg dry-run touches no DB file" {
+  msg_env
+  run_fanout msg send --dry-run --to 71 --self 70 --parent 68 hello
+  assert_success
+  [[ "$output" == *"# would INSERT INTO messages"* ]]
+  [ ! -e "$BATS_TEST_TMPDIR/team.db" ]
+}
+
+@test "msg send body may contain -h after the first body word (no silent help)" {
+  msg_env
+  run_fanout msg send --to 71 --self 70 --parent 68 try -h on the new flag
+  assert_success
+  [[ "$output" == *"sent #1 to #71"* ]]
+}
+
+@test "msg send -- terminator lets the body carry flag-like words" {
+  msg_env
+  run_fanout msg send --to 71 --self 70 --parent 68 -- --kind is body text
+  assert_success
+  [[ "$output" == *"sent #1 to #71"* ]]
+}

--- a/tests/bats/tier1_msg.bats
+++ b/tests/bats/tier1_msg.bats
@@ -93,6 +93,13 @@ msg_env() {
   [[ "$output" == *"--dry-run is not supported"* ]]
 }
 
+@test "msg send rejects --dry-run with --json: exit 2" {
+  msg_env
+  run_fanout msg send --dry-run --json --to 71 --self 70 --parent 68 hello
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"--dry-run cannot be combined with --json"* ]]
+}
+
 @test "msg peers rejects a verb-foreign flag: exit 2" {
   msg_env
   run_fanout msg peers --to 5 --parent 68

--- a/tests/bats/tier1_msg.bats
+++ b/tests/bats/tier1_msg.bats
@@ -184,3 +184,12 @@ msg_env() {
   [ "$status" -eq 4 ]
   [[ "$output" == *"one team DB serves one parent"* ]]
 }
+
+@test "msg ownership claim covers register-only DBs (no message rows): exit 4" {
+  msg_env
+  run_fanout msg register --self 70 --parent 68
+  assert_success
+  run_fanout msg peers --parent 99
+  [ "$status" -eq 4 ]
+  [[ "$output" == *"owned by parent 68"* ]]
+}

--- a/tests/bats/tier1_msg.bats
+++ b/tests/bats/tier1_msg.bats
@@ -62,7 +62,7 @@ msg_env() {
   msg_env
   run_fanout msg send --to abc --self 70 --parent 68 hello
   [ "$status" -eq 2 ]
-  [[ "$output" == *"--to must be a positive issue number"* ]]
+  [[ "$output" == *"--to must be a non-zero issue number"* ]]
 }
 
 @test "msg send without a body exits 2" {
@@ -163,4 +163,24 @@ msg_env() {
   run_fanout msg send --to 71 --self 70 --parent 68 -- --kind is body text
   assert_success
   [[ "$output" == *"sent #1 to #71"* ]]
+}
+
+@test "msg detects a manual pane (negative synthetic issue under @manual)" {
+  msg_env
+  printf '%s\n' '{"schemaVersion":1,"panes":[{"parent":"@manual","issueNum":-1,"slug":"manual-1-scratch","branchName":"","paneId":"%1","agent":"claude","displayName":"scratch","worktreePath":"","prompt":"scratch work","createdAt":"2026-06-13T00:00:00Z"}]}' \
+    > "$BATS_TEST_TMPDIR/state.json"
+  export FANOUT_STATE_PATH="$BATS_TEST_TMPDIR/state.json"
+  run_fanout msg inbox --json
+  assert_success
+  [[ "$output" == *'"self": -1'* ]]
+  [[ "$output" == *'"parent": "@manual"'* ]]
+}
+
+@test "msg rejects a DB already holding another parent's messages: exit 4" {
+  msg_env
+  run_fanout msg send --to 71 --self 70 --parent 68 hello
+  assert_success
+  run_fanout msg send --to 71 --self 70 --parent 99 hello again
+  [ "$status" -eq 4 ]
+  [[ "$output" == *"one team DB serves one parent"* ]]
 }

--- a/tests/bats/tier2_msg.bats
+++ b/tests/bats/tier2_msg.bats
@@ -1,0 +1,150 @@
+#!/usr/bin/env bats
+# Tier 2 goldens for `fanout msg` (#70): exact dry-run output for the write
+# verbs, and the read-path JSON/table views against a real SQLite DB. The DB
+# fixture is self-hosting — seeded through fanout's own write verbs instead
+# of a sqlite3 CLI (which is deliberately not a test dependency) — so the
+# write path is exercised by every read-path golden. FANOUT_FAKE_NOW freezes
+# created_at/read_at; ids are deterministic because each test starts from a
+# fresh DB (AUTOINCREMENT yields 1, 2, 3, ...).
+
+load helpers
+
+# Same isolation rationale as tier1_msg.bats: detection must never see a dev
+# machine's live state.json, and the DB must live in bats' tmpdir.
+msg_env() {
+  export FANOUT_DB_PATH="$BATS_TEST_TMPDIR/team.db"
+  export FANOUT_STATE_PATH="$BATS_TEST_TMPDIR/no-state.json"
+  export FANOUT_FAKE_NOW="2026-06-13T00:00:00Z"
+}
+
+# Canonical conversation: peers 70/71 registered, two 1:1 messages 71->70,
+# one board post by 71, one board post by 70 (own posts must not show up as
+# unread for 70), one 1:1 message 70->71 (must not show up in 70's inbox).
+seed_msg_db() {
+  run_fanout msg register --self 70 --parent 68
+  assert_success
+  run_fanout msg register --self 71 --parent 68
+  assert_success
+  run_fanout msg send --to 70 --self 71 --parent 68 first note to 70
+  assert_success
+  run_fanout msg send --to 70 --self 71 --parent 68 --kind blocker waiting on your schema
+  assert_success
+  run_fanout msg post --self 71 --parent 68 board update from 71
+  assert_success
+  run_fanout msg post --self 70 --parent 68 board update from 70
+  assert_success
+  run_fanout msg send --to 71 --self 70 --parent 68 reply meant for 71
+  assert_success
+}
+
+@test "msg send --dry-run golden" {
+  msg_env
+  run_fanout msg send --dry-run --to 71 --self 70 --parent 68 hello world
+  assert_success
+  assert_golden msg-send
+}
+
+@test "msg post --dry-run --kind golden" {
+  msg_env
+  run_fanout msg post --dry-run --kind blocker --self 70 --parent 68 schema is not ready
+  assert_success
+  assert_golden msg-post-kind
+}
+
+@test "msg mark-read --dry-run --id golden" {
+  msg_env
+  run_fanout msg mark-read --dry-run --id 3 --id 5 --self 70 --parent 68
+  assert_success
+  assert_golden msg-mark-read-ids
+}
+
+@test "msg mark-read --dry-run --all golden" {
+  msg_env
+  run_fanout msg mark-read --dry-run --all --self 70 --parent 68
+  assert_success
+  assert_golden msg-mark-read-all
+}
+
+@test "msg register --dry-run with explicit identity golden (no pane fields)" {
+  msg_env
+  run_fanout msg register --dry-run --self 70 --parent 68
+  assert_success
+  assert_golden msg-register-bare
+}
+
+@test "msg inbox --json golden: unread 1:1 + board union" {
+  msg_env
+  seed_msg_db
+  run_fanout msg inbox --self 70 --parent 68 --json
+  assert_success
+  assert_golden msg-inbox json
+}
+
+@test "msg inbox --mark-read --json golden, then a drained second read" {
+  msg_env
+  seed_msg_db
+  run_fanout msg inbox --mark-read --self 70 --parent 68 --json
+  assert_success
+  assert_golden msg-inbox-mark-read json
+
+  run_fanout msg inbox --self 70 --parent 68 --json
+  assert_success
+  assert_golden msg-inbox-drained json
+}
+
+@test "msg board --json golden: own posts excluded from unread" {
+  msg_env
+  seed_msg_db
+  run_fanout msg board --self 71 --parent 68 --json
+  assert_success
+  assert_golden msg-board-own-excluded json
+}
+
+@test "msg board --all --json golden" {
+  msg_env
+  seed_msg_db
+  run_fanout msg board --all --self 71 --parent 68 --json
+  assert_success
+  assert_golden msg-board-all json
+}
+
+@test "msg peers --json golden" {
+  msg_env
+  seed_msg_db
+  run_fanout msg peers --parent 68 --json
+  assert_success
+  assert_golden msg-peers json
+}
+
+@test "msg inbox human table golden (TERM=dumb, no color)" {
+  msg_env
+  seed_msg_db
+  run_fanout msg inbox --self 70 --parent 68
+  assert_success
+  assert_golden msg-inbox-table table
+}
+
+@test "msg send --json golden: inserted message echo" {
+  msg_env
+  seed_msg_db
+  run_fanout msg send --to 71 --self 70 --parent 68 --json one more for 71
+  assert_success
+  assert_golden msg-send-echo json
+}
+
+@test "msg with zero identity flags detects the pane from state.json" {
+  msg_env
+  # worktreePath stays "" on purpose: IdentifyPane skips rows whose recorded
+  # worktree conflicts with the live one, and the bats cwd varies by machine.
+  printf '%s\n' '{"schemaVersion":1,"panes":[{"parent":"68","issueNum":70,"slug":"msg-cli-surface-70","branchName":"fanout/msg-cli-surface-70","paneId":"%1","agent":"claude","displayName":"msg cli surface","worktreePath":"","prompt":"[fanout #70 of #68] msg-cli-surface-70: msg CLI.","createdAt":"2026-06-13T00:00:00Z"}]}' \
+    > "$BATS_TEST_TMPDIR/state.json"
+  export FANOUT_STATE_PATH="$BATS_TEST_TMPDIR/state.json"
+
+  run_fanout msg register --json
+  assert_success
+  assert_golden msg-register-detected json
+
+  run_fanout msg inbox --json
+  assert_success
+  assert_golden msg-inbox-detected json
+}

--- a/tests/golden/msg-board-all.json.txt
+++ b/tests/golden/msg-board-all.json.txt
@@ -1,0 +1,29 @@
+{
+  "self": 71,
+  "parent": "68",
+  "all": true,
+  "messages": [
+    {
+      "id": 3,
+      "from": 71,
+      "to": null,
+      "board": true,
+      "kind": "note",
+      "body": "board update from 71",
+      "created_at": "2026-06-13T00:00:00Z",
+      "read_at": null,
+      "reply_to": null
+    },
+    {
+      "id": 4,
+      "from": 70,
+      "to": null,
+      "board": true,
+      "kind": "note",
+      "body": "board update from 70",
+      "created_at": "2026-06-13T00:00:00Z",
+      "read_at": null,
+      "reply_to": null
+    }
+  ]
+}

--- a/tests/golden/msg-board-own-excluded.json.txt
+++ b/tests/golden/msg-board-own-excluded.json.txt
@@ -1,0 +1,18 @@
+{
+  "self": 71,
+  "parent": "68",
+  "all": false,
+  "messages": [
+    {
+      "id": 4,
+      "from": 70,
+      "to": null,
+      "board": true,
+      "kind": "note",
+      "body": "board update from 70",
+      "created_at": "2026-06-13T00:00:00Z",
+      "read_at": null,
+      "reply_to": null
+    }
+  ]
+}

--- a/tests/golden/msg-inbox-detected.json.txt
+++ b/tests/golden/msg-inbox-detected.json.txt
@@ -1,0 +1,6 @@
+{
+  "self": 70,
+  "parent": "68",
+  "all": false,
+  "messages": []
+}

--- a/tests/golden/msg-inbox-drained.json.txt
+++ b/tests/golden/msg-inbox-drained.json.txt
@@ -1,0 +1,6 @@
+{
+  "self": 70,
+  "parent": "68",
+  "all": false,
+  "messages": []
+}

--- a/tests/golden/msg-inbox-mark-read.json.txt
+++ b/tests/golden/msg-inbox-mark-read.json.txt
@@ -1,0 +1,47 @@
+{
+  "self": 70,
+  "parent": "68",
+  "all": false,
+  "messages": [
+    {
+      "id": 1,
+      "from": 71,
+      "to": 70,
+      "board": false,
+      "kind": "note",
+      "body": "first note to 70",
+      "created_at": "2026-06-13T00:00:00Z",
+      "read_at": null,
+      "reply_to": null
+    },
+    {
+      "id": 2,
+      "from": 71,
+      "to": 70,
+      "board": false,
+      "kind": "blocker",
+      "body": "waiting on your schema",
+      "created_at": "2026-06-13T00:00:00Z",
+      "read_at": null,
+      "reply_to": null
+    },
+    {
+      "id": 3,
+      "from": 71,
+      "to": null,
+      "board": true,
+      "kind": "note",
+      "body": "board update from 71",
+      "created_at": "2026-06-13T00:00:00Z",
+      "read_at": null,
+      "reply_to": null
+    }
+  ],
+  "marked_read": {
+    "message_ids": [
+      1,
+      2
+    ],
+    "board_cursor": 3
+  }
+}

--- a/tests/golden/msg-inbox-table.table.txt
+++ b/tests/golden/msg-inbox-table.table.txt
@@ -1,0 +1,5 @@
+ID  FROM  TO     KIND     CREATED               BODY
+--  ----  -----  -------  --------------------  ----------------------
+1   #71   #70    note     2026-06-13T00:00:00Z  first note to 70
+2   #71   #70    blocker  2026-06-13T00:00:00Z  waiting on your schema
+3   #71   board  note     2026-06-13T00:00:00Z  board update from 71

--- a/tests/golden/msg-inbox.json.txt
+++ b/tests/golden/msg-inbox.json.txt
@@ -1,0 +1,40 @@
+{
+  "self": 70,
+  "parent": "68",
+  "all": false,
+  "messages": [
+    {
+      "id": 1,
+      "from": 71,
+      "to": 70,
+      "board": false,
+      "kind": "note",
+      "body": "first note to 70",
+      "created_at": "2026-06-13T00:00:00Z",
+      "read_at": null,
+      "reply_to": null
+    },
+    {
+      "id": 2,
+      "from": 71,
+      "to": 70,
+      "board": false,
+      "kind": "blocker",
+      "body": "waiting on your schema",
+      "created_at": "2026-06-13T00:00:00Z",
+      "read_at": null,
+      "reply_to": null
+    },
+    {
+      "id": 3,
+      "from": 71,
+      "to": null,
+      "board": true,
+      "kind": "note",
+      "body": "board update from 71",
+      "created_at": "2026-06-13T00:00:00Z",
+      "read_at": null,
+      "reply_to": null
+    }
+  ]
+}

--- a/tests/golden/msg-mark-read-all.dry-run.txt
+++ b/tests/golden/msg-mark-read-all.dry-run.txt
@@ -1,0 +1,2 @@
+# would UPDATE messages SET read_at = '2026-06-13T00:00:00Z' WHERE parent = '68' AND to_issue = 70 AND read_at IS NULL
+# would UPSERT board_cursors(issue=70, last_read_id=MAX(id) of board posts)

--- a/tests/golden/msg-mark-read-ids.dry-run.txt
+++ b/tests/golden/msg-mark-read-ids.dry-run.txt
@@ -1,0 +1,1 @@
+# would UPDATE messages SET read_at = '2026-06-13T00:00:00Z' WHERE parent = '68' AND to_issue = 70 AND id IN (3, 5) AND read_at IS NULL

--- a/tests/golden/msg-peers.json.txt
+++ b/tests/golden/msg-peers.json.txt
@@ -1,0 +1,25 @@
+{
+  "parent": "68",
+  "peers": [
+    {
+      "issue": 70,
+      "pane_id": "",
+      "slug": "",
+      "worktree_path": "",
+      "agent": "",
+      "display_name": "",
+      "joined_at": "2026-06-13T00:00:00Z",
+      "last_seen": "2026-06-13T00:00:00Z"
+    },
+    {
+      "issue": 71,
+      "pane_id": "",
+      "slug": "",
+      "worktree_path": "",
+      "agent": "",
+      "display_name": "",
+      "joined_at": "2026-06-13T00:00:00Z",
+      "last_seen": "2026-06-13T00:00:00Z"
+    }
+  ]
+}

--- a/tests/golden/msg-post-kind.dry-run.txt
+++ b/tests/golden/msg-post-kind.dry-run.txt
@@ -1,0 +1,1 @@
+# would INSERT INTO messages(parent, from_issue, to_issue, kind, body, created_at) VALUES ('68', 70, NULL, 'blocker', 'schema is not ready', '2026-06-13T00:00:00Z')

--- a/tests/golden/msg-register-bare.dry-run.txt
+++ b/tests/golden/msg-register-bare.dry-run.txt
@@ -1,0 +1,1 @@
+# would UPSERT INTO peers(issue, pane_id, slug, worktree_path, agent, display_name, joined_at, last_seen) VALUES (70, '', '', '', '', '', '2026-06-13T00:00:00Z', '2026-06-13T00:00:00Z')

--- a/tests/golden/msg-register-detected.json.txt
+++ b/tests/golden/msg-register-detected.json.txt
@@ -1,0 +1,12 @@
+{
+  "peer": {
+    "issue": 70,
+    "pane_id": "%1",
+    "slug": "msg-cli-surface-70",
+    "worktree_path": "",
+    "agent": "claude",
+    "display_name": "msg cli surface",
+    "joined_at": "2026-06-13T00:00:00Z",
+    "last_seen": "2026-06-13T00:00:00Z"
+  }
+}

--- a/tests/golden/msg-send-echo.json.txt
+++ b/tests/golden/msg-send-echo.json.txt
@@ -1,0 +1,11 @@
+{
+  "id": 6,
+  "from": 70,
+  "to": 71,
+  "board": false,
+  "kind": "note",
+  "body": "one more for 71",
+  "created_at": "2026-06-13T00:00:00Z",
+  "read_at": null,
+  "reply_to": null
+}

--- a/tests/golden/msg-send.dry-run.txt
+++ b/tests/golden/msg-send.dry-run.txt
@@ -1,0 +1,1 @@
+# would INSERT INTO messages(parent, from_issue, to_issue, kind, body, created_at) VALUES ('68', 70, 71, 'note', 'hello world', '2026-06-13T00:00:00Z')


### PR DESCRIPTION
## TL;DR

`fanout msg <verb>` サブコマンドを新設し、ペイン内の Claude/Codex エージェントが per-parent SQLite DB（#69 の `internal/team` 基盤）越しに 1:1 メッセージと掲示板を読み書きできるようにする。read（peers/inbox/board）+ write（send/post/mark-read/register）+ `--json` + `--dry-run` + exit code 4、tier1/tier2 bats と unit tests 付き。

Review effort: 3

## Why

issue #70（wave2、blocked by #69 → マージ済み）の実装。#69 がスキーマ・DB パス規約・`Detect()` までを提供したのに対し、本 PR はその上の CLI surface を `cmd/fanout/status.go` と同型の「閉じた island」として追加する。`msg` は整数でも Project URL でもないため、`cliflags.Parse` より前の早期ディスパッチ（`dashboard` と同型、`cmd/fanout/main.go:55-57`）で分岐する。SQLite アクセスは #69 で確定した案B（pure-Go `modernc.org/sqlite`）に乗り、sqlite3 CLI / jq 依存は持ち込まない。

## Changes by file

<details><summary>Changed files</summary>

| File | What changed | Why |
| --- | --- | --- |
| `cmd/fanout/msg.go` | 新規。usage / 手書きフラグパース（verb 別 allowlist、`--` ターミネータ、body 開始前のみの `-h`/`--help`）/ identity 解決 / dry-run レンダラ / JSON・テーブル出力 / verb ディスパッチ | CLI surface 本体（issue 指定の island 分割） |
| `internal/msgstore/store.go` | 新規。全 SQL（プレースホルダ束縛・parent スコープ）、未読 union、board カーソル（MAX で非後退）、tx で「表示した行だけ既読化」 | SQL/純ロジックを CLI から分離し unit test 可能に |
| `cmd/fanout/main.go` | `isMsgRequest` → `cmdMsg` の早期ディスパッチ 1 分岐追加 | `resolveRuntime` の parent 整数検証で死ぬのを回避 |
| `internal/exitcode/exitcode.go` | `Backend Code = 4` 追加 | DB open/スキーマ/クエリ失敗の専用 exit code（issue 受け入れ条件） |
| `internal/cliflags/usage.go` | usage に `msg` の 3 行を追加 + `NormalizeParentRef()` を公開（`Parse` と同じ正規化規則） | 明示 `--parent 0068` と検出由来の `68` が別スコープに割れる split-brain を防止（codex review 指摘） |
| `internal/cliflags/cliflags_test.go` | `NormalizeParentRef` の table-driven test 追加 | 正規化規則の固定 |
| `Makefile` | tier1/tier2 の bats 列挙に msg ファイルを追加 | bats は明示列挙方式のため |
| `tests/bats/helpers.bash` | teardown に「`/tmp/fanout-*.db` を消してはならない」旨の警告コメントを追加 | その glob は本番 msg DB の実パス。レビューで誤追加を検出し撤回、再発防止のコメント化 |
| `cmd/fanout/msg_test.go` | 新規。パース・identity 優先順位（`detectIdentity` 差し替え）・dry-run 行・テーブル整形の table-driven tests | 純ロジックの固定 |
| `internal/msgstore/store_test.go` | 新規。実 SQLite（`t.TempDir()`）で union / カーソル / 冪等性 / parent 越境防止 / upsert を検証 | read/write セマンティクスの固定 |
| `tests/bats/tier1_msg.bats` | 新規。surface 21 件（usage / exit 0・2・4 / 検出失敗誘導 / body 内 `-h` / `--` / `--dry-run --json` 拒否） | exit code 契約の black-box 固定 |
| `tests/bats/tier2_msg.bats` | 新規。dry-run golden + 実 DB read-path golden 13 件。fixture は write verbs 自身で seed（sqlite3 CLI 不要）、`FANOUT_FAKE_NOW` で凍結 | issue 指定の golden 方式。write 経路も毎回検証される |
| `tests/golden/msg-*.txt`（16 件） | 新規 golden | tier2 比較対象 |

</details>

## 動作フロー

```mermaid
flowchart LR
  A["fanout msg &lt;verb&gt;"] --> B["main.go isMsgRequest<br/>(cliflags.Parse の前)"]
  B --> C["msg.go parseMsgFlags /<br/>resolveMsgIdentity"]
  C -->|"--self/--parent 欠落時"| D["team.Detect()<br/>TMUX_PANE / worktree → state.json"]
  C -->|"--dry-run (write verbs)"| E["msgDryRunLines<br/># would INSERT ...（DB を開かない）"]
  C -->|live| F["openMsgDB<br/>team.DBPath / Open / EnsureSchema"]
  F --> G["msgstore.Store<br/>Send / Post / Inbox / Board /<br/>MarkReadIDs / MarkReadAll / Register / Peers"]
  G --> H[("SQLite<br/>messages / peers / board_cursors")]
```

> [!WARNING]
> - `board_cursors` は v1 スキーマ（`internal/team` 所有、本 PR では変更しない）で issue 単独キーのため、`FANOUT_DB_PATH` を複数 parent で共有するとカーソルが parent を跨いで共有される（messages は全クエリ parent スコープ済みで安全）。既定の per-parent DB 規約では問題なし。per-parent カーソル化はスキーマ v2 のフォローアップ（`internal/msgstore/store.go` の Store doc に明記）。
> - #71（PR #240）が `internal/team` に peers upsert を追加する場合、本 PR の `msgstore.Register` と重複する。後からマージされる側で `register` を team 側ヘルパに乗せ換えるのが筋（現時点の origin/main には未マージのため本 PR では未対応）。

## Test plan

- `make test` — Go unit tests（`cmd/fanout`, `internal/msgstore`, `internal/cliflags` 含む全パッケージ）+ bats tier1 + tier2、計 183 ok / 0 fail
- `make lint` — golangci-lint v2: 0 issues、shellcheck: pass
- golden は `FANOUT_GOLDEN_UPDATE=1 make test-tier2` で生成し全 16 件を目視レビュー（未読 union での自分の board post 除外、mark-read のカーソル前進、検出経由 register の pane フィールドまで確認）
- /post-work-review 完了: Pass 1 = code-review プラグイン（7 angle、確認指摘 4 件 + cleanup 8 件を修正）、Pass 2 = codex review 5 反復（parent 正規化 → `--help` silent drop → board cursor 文書化 → `--dry-run --json` 拒否 → approve/指摘なし）

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)