### PR TITLE
feat(web): フィルタを GitHub PR 風ドロップダウン popover に刷新

### DIFF
--- a/web/src/components/App.tsx
+++ b/web/src/components/App.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
 import { useSnapshot } from "../hooks/useSnapshot";
 import { readToken } from "../lib/api";
-import { filterTokens, matches, parseQuery, removeToken, replaceToken } from "../lib/filter";
+import { filterTokens, matches, parseQuery, removeToken, replaceToken, stripKey } from "../lib/filter";
 import { clock, degradedMessages } from "../lib/format";
 import { deriveAgents, deriveWaves } from "../lib/options";
 import { findPane } from "../lib/pane";
@@ -88,12 +88,17 @@ export function App() {
       setSortDir(1);
     }
   };
-  const onPickToken = (key: string, value: string) => {
-    setFilter(replaceToken(filterTokens(filter), key, value).join(" "));
-  };
-  const onRemoveToken = (tok: string) => {
-    setFilter(removeToken(filterTokens(filter), tok).join(" "));
-  };
+  /* 関数 setState + useCallback で identity を安定させ、memo(FilterDropdown)
+   * が snapshot tick の再レンダーをスキップできるようにする */
+  const onPickToken = useCallback((key: string, value: string) => {
+    setFilter((f) => replaceToken(filterTokens(f), key, value).join(" "));
+  }, []);
+  const onClearKey = useCallback((key: string) => {
+    setFilter((f) => stripKey(filterTokens(f), key).join(" "));
+  }, []);
+  const onRemoveToken = useCallback((tok: string) => {
+    setFilter((f) => removeToken(filterTokens(f), tok).join(" "));
+  }, []);
   const closeDrawer = () => {
     const key = selected;
     setSelected(null);
@@ -131,6 +136,7 @@ export function App() {
               agents={deriveAgents(snap)}
               waves={deriveWaves(snap)}
               onPickToken={onPickToken}
+              onClearKey={onClearKey}
               onRemoveToken={onRemoveToken}
             />
             <main id="sessions" aria-live="polite">

--- a/web/src/components/Drawer.tsx
+++ b/web/src/components/Drawer.tsx
@@ -43,7 +43,8 @@ export function Drawer({
 }) {
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
+      // defaultPrevented = 手前のオーバーレイ(フィルタ popover 等)が消費済み
+      if (e.key === "Escape" && !e.defaultPrevented) onClose();
     };
     document.addEventListener("keydown", onKeyDown);
     return () => document.removeEventListener("keydown", onKeyDown);

--- a/web/src/components/FilterBar.tsx
+++ b/web/src/components/FilterBar.tsx
@@ -1,96 +1,96 @@
-import { type CSSProperties } from "react";
+import { useMemo, type CSSProperties } from "react";
 import { filterTokens, tokenForKey } from "../lib/filter";
 import { FilterDropdown, type Option } from "./FilterDropdown";
+
+/* 静的キーのドロップダウン定義。options をモジュール定数にすることで
+ * memo(FilterDropdown) が snapshot tick の再レンダーをスキップできる。 */
+const STATIC_DROPDOWNS: readonly { key: string; ariaLabel: string; options: readonly Option[] }[] = [
+  {
+    key: "state",
+    ariaLabel: "issue / tmux 状態で絞り込み",
+    options: [
+      ["open", "open"],
+      ["closed", "closed"],
+      ["live", "live"],
+      ["stale", "stale"],
+    ],
+  },
+  {
+    key: "run",
+    ariaLabel: "agent 実行状態で絞り込み",
+    options: [
+      ["running", "running"],
+      ["done", "done"],
+    ],
+  },
+  {
+    key: "ci",
+    ariaLabel: "CI 結果で絞り込み",
+    options: [
+      ["pass", "pass"],
+      ["fail", "fail"],
+      ["pending", "pending"],
+    ],
+  },
+  {
+    key: "dirty",
+    ariaLabel: "worktree の dirty 状態で絞り込み",
+    options: [
+      ["yes", "yes"],
+      ["no", "no"],
+    ],
+  },
+  {
+    key: "live",
+    ariaLabel: "tmux ペイン生死で絞り込み",
+    options: [
+      ["yes", "yes"],
+      ["no", "no"],
+    ],
+  },
+  {
+    key: "pr",
+    ariaLabel: "PR 状態で絞り込み",
+    options: [
+      ["merged", "merged"],
+      ["open", "open"],
+      ["closed", "closed"],
+      ["none", "none"],
+    ],
+  },
+];
 
 export function FilterBar({
   filter,
   agents,
   waves,
   onPickToken,
+  onClearKey,
   onRemoveToken,
 }: {
   filter: string;
   agents: string[];
   waves: number[];
   onPickToken: (key: string, value: string) => void;
+  onClearKey: (key: string) => void;
   onRemoveToken: (tok: string) => void;
 }) {
   const tokens = filterTokens(filter);
-  // 8 キー共通の props 束ね。placeholder は trigger 表示 = dataKey で統一。
-  const dd = (dataKey: string) => ({
-    dataKey,
-    placeholder: dataKey,
-    active: tokenForKey(tokens, dataKey),
+  const agentOptions = useMemo(() => agents.map((a): Option => [a, a]), [agents]);
+  const waveOptions = useMemo(() => waves.map((w): Option => [String(w), `w${w}`]), [waves]);
+  const dd = (key: string) => ({
+    dataKey: key,
+    active: tokenForKey(tokens, key),
     onPickToken,
-    onRemoveToken,
+    onClearKey,
   });
   return (
     <div className="filter-bar rise" style={{ "--d": ".25s" } as CSSProperties} id="filter-bar">
-      <FilterDropdown
-        {...dd("state")}
-        ariaLabel="issue / tmux 状態で絞り込み"
-        options={[
-          ["open", "open"],
-          ["closed", "closed"],
-          ["live", "live"],
-          ["stale", "stale"],
-        ]}
-      />
-      <FilterDropdown
-        {...dd("run")}
-        ariaLabel="agent 実行状態で絞り込み"
-        options={[
-          ["running", "running"],
-          ["done", "done"],
-        ]}
-      />
-      <FilterDropdown
-        {...dd("ci")}
-        ariaLabel="CI 結果で絞り込み"
-        options={[
-          ["pass", "pass"],
-          ["fail", "fail"],
-          ["pending", "pending"],
-        ]}
-      />
-      <FilterDropdown
-        {...dd("dirty")}
-        ariaLabel="worktree の dirty 状態で絞り込み"
-        options={[
-          ["yes", "yes"],
-          ["no", "no"],
-        ]}
-      />
-      <FilterDropdown
-        {...dd("live")}
-        ariaLabel="tmux ペイン生死で絞り込み"
-        options={[
-          ["yes", "yes"],
-          ["no", "no"],
-        ]}
-      />
-      <FilterDropdown
-        {...dd("pr")}
-        ariaLabel="PR 状態で絞り込み"
-        options={[
-          ["merged", "merged"],
-          ["open", "open"],
-          ["closed", "closed"],
-          ["none", "none"],
-        ]}
-      />
-      <FilterDropdown
-        {...dd("agent")}
-        ariaLabel="agent で絞り込み"
-        options={agents.map((a): Option => [a, a])}
-        searchable
-      />
-      <FilterDropdown
-        {...dd("wave")}
-        ariaLabel="wave で絞り込み"
-        options={waves.map((w): Option => [String(w), `w${w}`])}
-        searchable
-      />
+      {STATIC_DROPDOWNS.map((d) => (
+        <FilterDropdown key={d.key} {...dd(d.key)} ariaLabel={d.ariaLabel} options={d.options} />
+      ))}
+      <FilterDropdown {...dd("agent")} ariaLabel="agent で絞り込み" options={agentOptions} searchable />
+      <FilterDropdown {...dd("wave")} ariaLabel="wave で絞り込み" options={waveOptions} searchable />
       <span id="chips" role="list" aria-label="適用中のフィルタ">
         {tokens.map((t) => (
           <button

--- a/web/src/components/FilterBar.tsx
+++ b/web/src/components/FilterBar.tsx
@@ -1,79 +1,6 @@
-import { useEffect, useRef, useState, type CSSProperties } from "react";
-import { filterTokens } from "../lib/filter";
-
-type Option = readonly [value: string, label: string];
-
-function StaticSelect({
-  dataKey,
-  ariaLabel,
-  placeholder,
-  options,
-  onPick,
-}: {
-  dataKey: string;
-  ariaLabel: string;
-  placeholder: string;
-  options: Option[];
-  onPick: (key: string, value: string) => void;
-}) {
-  return (
-    <select
-      data-key={dataKey}
-      aria-label={ariaLabel}
-      value=""
-      onChange={(e) => {
-        // 選択 → トークン書込 → select はプレースホルダーに戻す(常に value="")
-        if (e.target.value) onPick(dataKey, e.target.value);
-      }}
-    >
-      <option value="">{placeholder}</option>
-      {options.map(([v, l]) => (
-        <option key={v} value={v}>
-          {l}
-        </option>
-      ))}
-    </select>
-  );
-}
-
-/* snapshot 由来の動的選択肢(agent / wave)。フォーカス中(=開いている可能性)
- * は選択肢を凍結する — 2 秒 tick がユーザーの開いたドロップダウンを閉じて
- * しまうのを防ぐ(旧 patchSelect 相当)。 */
-function DynamicSelect(props: {
-  id: string;
-  dataKey: string;
-  ariaLabel: string;
-  placeholder: string;
-  options: Option[];
-  onPick: (key: string, value: string) => void;
-}) {
-  const [focused, setFocused] = useState(false);
-  const frozen = useRef(props.options);
-  useEffect(() => {
-    if (!focused) frozen.current = props.options;
-  }, [focused, props.options]);
-  const options = focused ? frozen.current : props.options;
-  return (
-    <select
-      id={props.id}
-      data-key={props.dataKey}
-      aria-label={props.ariaLabel}
-      value=""
-      onFocus={() => setFocused(true)}
-      onBlur={() => setFocused(false)}
-      onChange={(e) => {
-        if (e.target.value) props.onPick(props.dataKey, e.target.value);
-      }}
-    >
-      <option value="">{props.placeholder}</option>
-      {options.map(([v, l]) => (
-        <option key={v} value={v}>
-          {l}
-        </option>
-      ))}
-    </select>
-  );
-}
+import { type CSSProperties } from "react";
+import { filterTokens, tokenForKey } from "../lib/filter";
+import { FilterDropdown, type Option } from "./FilterDropdown";
 
 export function FilterBar({
   filter,
@@ -89,88 +16,80 @@ export function FilterBar({
   onRemoveToken: (tok: string) => void;
 }) {
   const tokens = filterTokens(filter);
+  // 8 キー共通の props 束ね。placeholder は trigger 表示 = dataKey で統一。
+  const dd = (dataKey: string) => ({
+    dataKey,
+    placeholder: dataKey,
+    active: tokenForKey(tokens, dataKey),
+    onPickToken,
+    onRemoveToken,
+  });
   return (
     <div className="filter-bar rise" style={{ "--d": ".25s" } as CSSProperties} id="filter-bar">
-      <StaticSelect
-        dataKey="state"
+      <FilterDropdown
+        {...dd("state")}
         ariaLabel="issue / tmux 状態で絞り込み"
-        placeholder="state"
         options={[
           ["open", "open"],
           ["closed", "closed"],
           ["live", "live"],
           ["stale", "stale"],
         ]}
-        onPick={onPickToken}
       />
-      <StaticSelect
-        dataKey="run"
+      <FilterDropdown
+        {...dd("run")}
         ariaLabel="agent 実行状態で絞り込み"
-        placeholder="run"
         options={[
           ["running", "running"],
           ["done", "done"],
         ]}
-        onPick={onPickToken}
       />
-      <StaticSelect
-        dataKey="ci"
+      <FilterDropdown
+        {...dd("ci")}
         ariaLabel="CI 結果で絞り込み"
-        placeholder="ci"
         options={[
           ["pass", "pass"],
           ["fail", "fail"],
           ["pending", "pending"],
         ]}
-        onPick={onPickToken}
       />
-      <StaticSelect
-        dataKey="dirty"
+      <FilterDropdown
+        {...dd("dirty")}
         ariaLabel="worktree の dirty 状態で絞り込み"
-        placeholder="dirty"
         options={[
           ["yes", "yes"],
           ["no", "no"],
         ]}
-        onPick={onPickToken}
       />
-      <StaticSelect
-        dataKey="live"
+      <FilterDropdown
+        {...dd("live")}
         ariaLabel="tmux ペイン生死で絞り込み"
-        placeholder="live"
         options={[
           ["yes", "yes"],
           ["no", "no"],
         ]}
-        onPick={onPickToken}
       />
-      <StaticSelect
-        dataKey="pr"
+      <FilterDropdown
+        {...dd("pr")}
         ariaLabel="PR 状態で絞り込み"
-        placeholder="pr"
         options={[
           ["merged", "merged"],
           ["open", "open"],
           ["closed", "closed"],
           ["none", "none"],
         ]}
-        onPick={onPickToken}
       />
-      <DynamicSelect
-        id="f-agent"
-        dataKey="agent"
+      <FilterDropdown
+        {...dd("agent")}
         ariaLabel="agent で絞り込み"
-        placeholder="agent"
-        options={agents.map((a) => [a, a] as const)}
-        onPick={onPickToken}
+        options={agents.map((a): Option => [a, a])}
+        searchable
       />
-      <DynamicSelect
-        id="f-wave"
-        dataKey="wave"
+      <FilterDropdown
+        {...dd("wave")}
         ariaLabel="wave で絞り込み"
-        placeholder="wave"
-        options={waves.map((w) => [String(w), `w${w}`] as const)}
-        onPick={onPickToken}
+        options={waves.map((w): Option => [String(w), `w${w}`])}
+        searchable
       />
       <span id="chips" role="list" aria-label="適用中のフィルタ">
         {tokens.map((t) => (

--- a/web/src/components/FilterDropdown.tsx
+++ b/web/src/components/FilterDropdown.tsx
@@ -52,13 +52,15 @@ export const FilterDropdown = memo(function FilterDropdown({
       ? base.filter(([v, l]) => v.toLowerCase().includes(q) || l.toLowerCase().includes(q))
       : base;
 
-  const isActive = (value: string) => active === value.toLowerCase();
+  /* 手打ちトークンは label 表記の別名でも来る(wave:w2 — matches() が
+   * fmtWave 経由で受け付ける)ので、value と label の両方で照合する */
+  const isActive = ([v, l]: Option) => active === v.toLowerCase() || active === l.toLowerCase();
   const listId = `fd-list-${dataKey}`;
 
   const openPopover = () => {
     frozen.current = options; // 開く瞬間の選択肢で凍結
     setQuery("");
-    const idx = active ? options.findIndex(([v]) => isActive(v)) : -1;
+    const idx = active ? options.findIndex(isActive) : -1;
     setCursor(idx >= 0 ? idx : 0);
     setOpen(true);
   };
@@ -66,9 +68,9 @@ export const FilterDropdown = memo(function FilterDropdown({
     setOpen(false);
     if (refocus) triggerRef.current?.focus();
   };
-  const pick = (value: string) => {
-    if (isActive(value)) onClearKey(dataKey);
-    else onPickToken(dataKey, value);
+  const pick = (opt: Option) => {
+    if (isActive(opt)) onClearKey(dataKey);
+    else onPickToken(dataKey, opt[0]);
     close(true);
   };
 
@@ -142,7 +144,7 @@ export const FilterDropdown = memo(function FilterDropdown({
     if (e.nativeEvent.isComposing || e.key !== "Enter") return;
     e.preventDefault();
     const target = visible[cursor] ?? visible[0];
-    if (target) pick(target[0]);
+    if (target) pick(target);
   };
 
   /* Tab 等でフォーカスが外に出たら閉じる(外側 click は pointerdown が先に処理) */
@@ -209,12 +211,12 @@ export const FilterDropdown = memo(function FilterDropdown({
                 type="button"
                 role="option"
                 className="fd-opt"
-                aria-selected={isActive(v)}
+                aria-selected={isActive([v, l])}
                 tabIndex={i === cursor ? 0 : -1}
                 ref={(el) => {
                   optionRefs.current[i] = el;
                 }}
-                onClick={() => pick(v)}
+                onClick={() => pick([v, l])}
                 onFocus={() => setCursor(i)} // click / Tab でのフォーカス移動も roving に反映
               >
                 <svg className="fd-check" viewBox="0 0 16 16" width="12" height="12" aria-hidden="true">

--- a/web/src/components/FilterDropdown.tsx
+++ b/web/src/components/FilterDropdown.tsx
@@ -1,36 +1,39 @@
-import { useEffect, useRef, useState, type FocusEvent, type KeyboardEvent } from "react";
+import { memo, useEffect, useRef, useState, type FocusEvent, type KeyboardEvent } from "react";
 
 export type Option = readonly [value: string, label: string];
 
 /* GitHub PR 風フィルタードロップダウン(8 キー共通)。trigger ボタン +
  * role="listbox" の popover で、選択は onPickToken による key:value トークン
  * 書込のみ — 「#filter のテキストが単一の真実」という既存モデルは変えない。
- * アクティブ値の再クリックは onRemoveToken(トグルオフ)。
+ * アクティブ値の再クリックは onClearKey(同キーのトークンを全て外す
+ * トグルオフ — 手打ちの重複キーも取り残さない)。
  *
  * - 開いている間は選択肢を凍結する: 2 秒 tick の snapshot 更新で開いたメニュー
  *   がズレたり閉じたりしない(旧 DynamicSelect の focus-freeze の置き換え)。
- * - Esc は popover を閉じて trigger にフォーカスを戻し、stopPropagation で
- *   Drawer の document keydown へ漏らさない(drawer まで閉じない)。
+ * - キー処理はルート div に置く: popover が開いている間は trigger に
+ *   フォーカスが戻っていても(Shift+Tab)Esc / 矢印 / typeahead が効く。
+ *   Esc は popover を閉じて trigger にフォーカスを戻し、preventDefault +
+ *   stopPropagation で Drawer の document keydown へ漏らさない(Drawer 側も
+ *   defaultPrevented を見る)。
  * - option は flat button の roving tabindex(ArrowUp/Down で巡回、Enter で
- *   選択)。searchable(agent / wave)は検索 input から ↓ で option 列に入る。 */
-export function FilterDropdown({
+ *   選択、非 searchable は先頭文字 typeahead)。searchable(agent / wave)は
+ *   検索 input から ↓ で option 列に入る。 */
+export const FilterDropdown = memo(function FilterDropdown({
   dataKey,
   ariaLabel,
-  placeholder,
   options,
   active,
   searchable = false,
   onPickToken,
-  onRemoveToken,
+  onClearKey,
 }: {
   dataKey: string;
   ariaLabel: string;
-  placeholder: string;
-  options: Option[];
-  active: { raw: string; value: string } | null;
+  options: readonly Option[];
+  active: string | null; // 適用中トークンの値(小文字)。tokenForKey の結果
   searchable?: boolean;
   onPickToken: (key: string, value: string) => void;
-  onRemoveToken: (tok: string) => void;
+  onClearKey: (key: string) => void;
 }) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
@@ -41,17 +44,21 @@ export function FilterDropdown({
   const optionRefs = useRef<(HTMLButtonElement | null)[]>([]);
   const frozen = useRef(options);
 
-  const base = open ? frozen.current : options;
+  // 開いている間しか描画されないので、常に凍結値を読む(開く瞬間に再同期)
+  const base = frozen.current;
   const q = query.trim().toLowerCase();
   const visible =
     searchable && q
       ? base.filter(([v, l]) => v.toLowerCase().includes(q) || l.toLowerCase().includes(q))
       : base;
 
+  const isActive = (value: string) => active === value.toLowerCase();
+  const listId = `fd-list-${dataKey}`;
+
   const openPopover = () => {
     frozen.current = options; // 開く瞬間の選択肢で凍結
     setQuery("");
-    const idx = active ? options.findIndex(([v]) => v.toLowerCase() === active.value) : -1;
+    const idx = active ? options.findIndex(([v]) => isActive(v)) : -1;
     setCursor(idx >= 0 ? idx : 0);
     setOpen(true);
   };
@@ -60,7 +67,7 @@ export function FilterDropdown({
     if (refocus) triggerRef.current?.focus();
   };
   const pick = (value: string) => {
-    if (active && active.value === value.toLowerCase()) onRemoveToken(active.raw);
+    if (isActive(value)) onClearKey(dataKey);
     else onPickToken(dataKey, value);
     close(true);
   };
@@ -86,10 +93,8 @@ export function FilterDropdown({
     return () => document.removeEventListener("pointerdown", onPointerDown);
   }, [open]);
 
-  const focusOption = (idx: number) => {
-    setCursor(idx);
-    optionRefs.current[idx]?.focus();
-  };
+  // cursor は option の onFocus が単一の書き手(click / Tab / 矢印すべて経由)
+  const focusOption = (idx: number) => optionRefs.current[idx]?.focus();
   const moveCursor = (delta: 1 | -1) => {
     if (!visible.length) return;
     // 検索 input からの矢印キーは端から option 列に入る(↓=先頭 / ↑=末尾)
@@ -97,7 +102,25 @@ export function FilterDropdown({
     focusOption((from + delta + visible.length) % visible.length);
   };
 
-  const onPopoverKeyDown = (e: KeyboardEvent) => {
+  /* 非 searchable はネイティブ select 同等の先頭文字 typeahead(現在位置の
+   * 次から巡回検索)。 */
+  const typeahead = (ch: string) => {
+    const n = visible.length;
+    for (let i = 1; i <= n; i++) {
+      const idx = (cursor + i) % n;
+      if (visible[idx]?.[1].toLowerCase().startsWith(ch)) {
+        focusOption(idx);
+        return true;
+      }
+    }
+    return false;
+  };
+
+  /* ルート div のキー処理: trigger にフォーカスが戻っていても popover が
+   * 開いていれば効く(.fd-pop 限定にすると Esc が Drawer に漏れる)。 */
+  const onRootKeyDown = (e: KeyboardEvent) => {
+    if (!open || e.nativeEvent.isComposing) return; // IME 変換中のキーは奪わない
+    const inSearch = document.activeElement === searchRef.current;
     if (e.key === "Escape") {
       e.preventDefault();
       e.stopPropagation(); // Drawer の document keydown に漏らさない
@@ -105,18 +128,21 @@ export function FilterDropdown({
     } else if (e.key === "ArrowDown" || e.key === "ArrowUp") {
       e.preventDefault();
       moveCursor(e.key === "ArrowDown" ? 1 : -1);
-    } else if ((e.key === "Home" || e.key === "End") && document.activeElement !== searchRef.current) {
+    } else if ((e.key === "Home" || e.key === "End") && !inSearch) {
       e.preventDefault();
       if (visible.length) focusOption(e.key === "Home" ? 0 : visible.length - 1);
+    } else if (!searchable && e.key.length === 1 && !e.ctrlKey && !e.metaKey && !e.altKey) {
+      if (typeahead(e.key.toLowerCase())) e.preventDefault();
     }
   };
 
-  /* 検索 input の Enter は先頭の絞り込み結果を選択(GitHub 同様) */
+  /* 検索 input の Enter は roving cursor 位置(既定 = アクティブ or 先頭の
+   * 絞り込み結果)を選択。IME の変換確定 Enter は奪わない。 */
   const onSearchKeyDown = (e: KeyboardEvent) => {
-    if (e.key !== "Enter") return;
+    if (e.nativeEvent.isComposing || e.key !== "Enter") return;
     e.preventDefault();
-    const first = visible[0];
-    if (first) pick(first[0]);
+    const target = visible[cursor] ?? visible[0];
+    if (target) pick(target[0]);
   };
 
   /* Tab 等でフォーカスが外に出たら閉じる(外側 click は pointerdown が先に処理) */
@@ -124,17 +150,16 @@ export function FilterDropdown({
     if (open && e.relatedTarget && !rootRef.current?.contains(e.relatedTarget as Node)) setOpen(false);
   };
 
-  optionRefs.current.length = visible.length;
   return (
-    <div className="fd" ref={rootRef} onBlur={onBlur}>
+    <div className="fd" ref={rootRef} onBlur={onBlur} onKeyDown={onRootKeyDown}>
       <button
         ref={triggerRef}
         type="button"
         className={active ? "fd-trigger on" : "fd-trigger"}
-        data-key={dataKey}
         aria-label={ariaLabel}
         aria-haspopup="listbox"
         aria-expanded={open}
+        aria-controls={open ? listId : undefined}
         onClick={() => (open ? close(false) : openPopover())}
         onKeyDown={(e) => {
           if (!open && (e.key === "ArrowDown" || e.key === "ArrowUp")) {
@@ -143,7 +168,7 @@ export function FilterDropdown({
           }
         }}
       >
-        {placeholder}
+        {dataKey}
         <svg className="fd-caret" viewBox="0 0 16 16" width="10" height="10" aria-hidden="true">
           <path
             d="M4 6.2 8 10l4-3.8"
@@ -156,7 +181,9 @@ export function FilterDropdown({
         </svg>
       </button>
       {open && (
-        <div className="fd-pop" onKeyDown={onPopoverKeyDown}>
+        /* tabIndex=-1: popover の余白クリックでフォーカスを body に逃がさない
+         * (逃がすと root のキー処理が届かず Esc が Drawer に漏れる) */
+        <div className="fd-pop" tabIndex={-1}>
           {searchable && (
             <div className="fd-search">
               <input
@@ -164,7 +191,7 @@ export function FilterDropdown({
                 type="text"
                 value={query}
                 placeholder="絞り込み…"
-                aria-label={`${placeholder} の選択肢を検索`}
+                aria-label={`${dataKey} の選択肢を検索`}
                 autoComplete="off"
                 spellCheck={false}
                 onChange={(e) => {
@@ -175,14 +202,14 @@ export function FilterDropdown({
               />
             </div>
           )}
-          <div role="listbox" aria-label={ariaLabel} className="fd-list">
+          <div role="listbox" id={listId} aria-label={ariaLabel} className="fd-list">
             {visible.map(([v, l], i) => (
               <button
                 key={v}
                 type="button"
                 role="option"
                 className="fd-opt"
-                aria-selected={active?.value === v.toLowerCase()}
+                aria-selected={isActive(v)}
                 tabIndex={i === cursor ? 0 : -1}
                 ref={(el) => {
                   optionRefs.current[i] = el;
@@ -209,4 +236,4 @@ export function FilterDropdown({
       )}
     </div>
   );
-}
+});

--- a/web/src/components/FilterDropdown.tsx
+++ b/web/src/components/FilterDropdown.tsx
@@ -1,0 +1,212 @@
+import { useEffect, useRef, useState, type FocusEvent, type KeyboardEvent } from "react";
+
+export type Option = readonly [value: string, label: string];
+
+/* GitHub PR 風フィルタードロップダウン(8 キー共通)。trigger ボタン +
+ * role="listbox" の popover で、選択は onPickToken による key:value トークン
+ * 書込のみ — 「#filter のテキストが単一の真実」という既存モデルは変えない。
+ * アクティブ値の再クリックは onRemoveToken(トグルオフ)。
+ *
+ * - 開いている間は選択肢を凍結する: 2 秒 tick の snapshot 更新で開いたメニュー
+ *   がズレたり閉じたりしない(旧 DynamicSelect の focus-freeze の置き換え)。
+ * - Esc は popover を閉じて trigger にフォーカスを戻し、stopPropagation で
+ *   Drawer の document keydown へ漏らさない(drawer まで閉じない)。
+ * - option は flat button の roving tabindex(ArrowUp/Down で巡回、Enter で
+ *   選択)。searchable(agent / wave)は検索 input から ↓ で option 列に入る。 */
+export function FilterDropdown({
+  dataKey,
+  ariaLabel,
+  placeholder,
+  options,
+  active,
+  searchable = false,
+  onPickToken,
+  onRemoveToken,
+}: {
+  dataKey: string;
+  ariaLabel: string;
+  placeholder: string;
+  options: Option[];
+  active: { raw: string; value: string } | null;
+  searchable?: boolean;
+  onPickToken: (key: string, value: string) => void;
+  onRemoveToken: (tok: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [cursor, setCursor] = useState(0); // roving tabindex の現在位置(visible 基準)
+  const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+  const optionRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const frozen = useRef(options);
+
+  const base = open ? frozen.current : options;
+  const q = query.trim().toLowerCase();
+  const visible =
+    searchable && q
+      ? base.filter(([v, l]) => v.toLowerCase().includes(q) || l.toLowerCase().includes(q))
+      : base;
+
+  const openPopover = () => {
+    frozen.current = options; // 開く瞬間の選択肢で凍結
+    setQuery("");
+    const idx = active ? options.findIndex(([v]) => v.toLowerCase() === active.value) : -1;
+    setCursor(idx >= 0 ? idx : 0);
+    setOpen(true);
+  };
+  const close = (refocus: boolean) => {
+    setOpen(false);
+    if (refocus) triggerRef.current?.focus();
+  };
+  const pick = (value: string) => {
+    if (active && active.value === value.toLowerCase()) onRemoveToken(active.raw);
+    else onPickToken(dataKey, value);
+    close(true);
+  };
+
+  /* 開いた直後の初期フォーカス: searchable は検索 input、それ以外はアクティブ
+   * (無ければ先頭)option。cursor 変化での再フォーカスは矢印キーハンドラが
+   * 直接行うため、deps は意図的に open のみ。 */
+  useEffect(() => {
+    if (!open) return;
+    if (searchable) searchRef.current?.focus();
+    else optionRefs.current[cursor]?.focus();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  /* popover の外の pointerdown で閉じる(フォーカスは奪わない)。別ドロップ
+   * ダウンの trigger 押下も「外」なので、同時に 2 つ開くことはない。 */
+  useEffect(() => {
+    if (!open) return;
+    const onPointerDown = (e: PointerEvent) => {
+      if (e.target instanceof Node && !rootRef.current?.contains(e.target)) setOpen(false);
+    };
+    document.addEventListener("pointerdown", onPointerDown);
+    return () => document.removeEventListener("pointerdown", onPointerDown);
+  }, [open]);
+
+  const focusOption = (idx: number) => {
+    setCursor(idx);
+    optionRefs.current[idx]?.focus();
+  };
+  const moveCursor = (delta: 1 | -1) => {
+    if (!visible.length) return;
+    // 検索 input からの矢印キーは端から option 列に入る(↓=先頭 / ↑=末尾)
+    const from = document.activeElement === searchRef.current ? (delta === 1 ? -1 : 0) : cursor;
+    focusOption((from + delta + visible.length) % visible.length);
+  };
+
+  const onPopoverKeyDown = (e: KeyboardEvent) => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      e.stopPropagation(); // Drawer の document keydown に漏らさない
+      close(true);
+    } else if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+      e.preventDefault();
+      moveCursor(e.key === "ArrowDown" ? 1 : -1);
+    } else if ((e.key === "Home" || e.key === "End") && document.activeElement !== searchRef.current) {
+      e.preventDefault();
+      if (visible.length) focusOption(e.key === "Home" ? 0 : visible.length - 1);
+    }
+  };
+
+  /* 検索 input の Enter は先頭の絞り込み結果を選択(GitHub 同様) */
+  const onSearchKeyDown = (e: KeyboardEvent) => {
+    if (e.key !== "Enter") return;
+    e.preventDefault();
+    const first = visible[0];
+    if (first) pick(first[0]);
+  };
+
+  /* Tab 等でフォーカスが外に出たら閉じる(外側 click は pointerdown が先に処理) */
+  const onBlur = (e: FocusEvent) => {
+    if (open && e.relatedTarget && !rootRef.current?.contains(e.relatedTarget as Node)) setOpen(false);
+  };
+
+  optionRefs.current.length = visible.length;
+  return (
+    <div className="fd" ref={rootRef} onBlur={onBlur}>
+      <button
+        ref={triggerRef}
+        type="button"
+        className={active ? "fd-trigger on" : "fd-trigger"}
+        data-key={dataKey}
+        aria-label={ariaLabel}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        onClick={() => (open ? close(false) : openPopover())}
+        onKeyDown={(e) => {
+          if (!open && (e.key === "ArrowDown" || e.key === "ArrowUp")) {
+            e.preventDefault();
+            openPopover();
+          }
+        }}
+      >
+        {placeholder}
+        <svg className="fd-caret" viewBox="0 0 16 16" width="10" height="10" aria-hidden="true">
+          <path
+            d="M4 6.2 8 10l4-3.8"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.8"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </button>
+      {open && (
+        <div className="fd-pop" onKeyDown={onPopoverKeyDown}>
+          {searchable && (
+            <div className="fd-search">
+              <input
+                ref={searchRef}
+                type="text"
+                value={query}
+                placeholder="絞り込み…"
+                aria-label={`${placeholder} の選択肢を検索`}
+                autoComplete="off"
+                spellCheck={false}
+                onChange={(e) => {
+                  setQuery(e.target.value);
+                  setCursor(0);
+                }}
+                onKeyDown={onSearchKeyDown}
+              />
+            </div>
+          )}
+          <div role="listbox" aria-label={ariaLabel} className="fd-list">
+            {visible.map(([v, l], i) => (
+              <button
+                key={v}
+                type="button"
+                role="option"
+                className="fd-opt"
+                aria-selected={active?.value === v.toLowerCase()}
+                tabIndex={i === cursor ? 0 : -1}
+                ref={(el) => {
+                  optionRefs.current[i] = el;
+                }}
+                onClick={() => pick(v)}
+                onFocus={() => setCursor(i)} // click / Tab でのフォーカス移動も roving に反映
+              >
+                <svg className="fd-check" viewBox="0 0 16 16" width="12" height="12" aria-hidden="true">
+                  <path
+                    d="M3.2 8.6 6.6 12l6.2-7.4"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+                {l}
+              </button>
+            ))}
+            {!visible.length && <div className="fd-empty">該当なし</div>}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/lib/filter.test.ts
+++ b/web/src/lib/filter.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { makePane } from "../test/fixtures";
-import { filterTokens, matches, parseQuery, removeToken, replaceToken, tokenForKey } from "./filter";
+import { filterTokens, matches, parseQuery, removeToken, replaceToken, stripKey, tokenForKey } from "./filter";
 
 describe("parseQuery", () => {
   it("key:value トークンと自由語を区別する", () => {
@@ -116,14 +116,19 @@ describe("トークン操作", () => {
     expect(removeToken(["state:open", "state:o"], "state:open")).toEqual(["state:o"]);
   });
 
-  it("tokenForKey は指定キーのトークンを raw(原文)+ value(小文字)で返す", () => {
-    expect(tokenForKey(["claude", "state:open"], "state")).toEqual({ raw: "state:open", value: "open" });
-    // 手打ちの大文字でも raw は原文のまま — removeToken の exact-match 除去に使える
-    expect(tokenForKey(["STATE:Open"], "state")).toEqual({ raw: "STATE:Open", value: "open" });
+  it("tokenForKey は指定キーの最初のトークン値を小文字で返す", () => {
+    expect(tokenForKey(["claude", "state:open"], "state")).toBe("open");
+    // 手打ちの大文字も小文字に正規化して返す(選択肢との比較用)
+    expect(tokenForKey(["STATE:Open"], "state")).toBe("open");
   });
 
   it("tokenForKey は該当キーが無ければ null(自由語・他キー・前方一致違いは見ない)", () => {
     expect(tokenForKey([], "state")).toBeNull();
     expect(tokenForKey(["open", "agent:claude", "statex:open"], "state")).toBeNull();
+  });
+
+  it("stripKey は同キーのトークンを重複・大文字違いごと全て外す", () => {
+    expect(stripKey(["state:open", "STATE:closed", "agent:claude"], "state")).toEqual(["agent:claude"]);
+    expect(stripKey(["claude"], "state")).toEqual(["claude"]);
   });
 });

--- a/web/src/lib/filter.test.ts
+++ b/web/src/lib/filter.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { makePane } from "../test/fixtures";
-import { filterTokens, matches, parseQuery, removeToken, replaceToken } from "./filter";
+import { filterTokens, matches, parseQuery, removeToken, replaceToken, tokenForKey } from "./filter";
 
 describe("parseQuery", () => {
   it("key:value トークンと自由語を区別する", () => {
@@ -114,5 +114,16 @@ describe("トークン操作", () => {
 
   it("removeToken は完全一致のみ外す", () => {
     expect(removeToken(["state:open", "state:o"], "state:open")).toEqual(["state:o"]);
+  });
+
+  it("tokenForKey は指定キーのトークンを raw(原文)+ value(小文字)で返す", () => {
+    expect(tokenForKey(["claude", "state:open"], "state")).toEqual({ raw: "state:open", value: "open" });
+    // 手打ちの大文字でも raw は原文のまま — removeToken の exact-match 除去に使える
+    expect(tokenForKey(["STATE:Open"], "state")).toEqual({ raw: "STATE:Open", value: "open" });
+  });
+
+  it("tokenForKey は該当キーが無ければ null(自由語・他キー・前方一致違いは見ない)", () => {
+    expect(tokenForKey([], "state")).toBeNull();
+    expect(tokenForKey(["open", "agent:claude", "statex:open"], "state")).toBeNull();
   });
 });

--- a/web/src/lib/filter.ts
+++ b/web/src/lib/filter.ts
@@ -101,24 +101,36 @@ export function filterTokens(filter: string): string[] {
   return filter.trim().split(/\s+/).filter(Boolean);
 }
 
+/* key: プレフィックス一致(大文字小文字無視)。replaceToken / stripKey /
+ * tokenForKey は必ずこの 1 つの判定を共有する(判定が割れると trigger の
+ * 点灯・チェック表示・チップ行が食い違う)。 */
+function hasKey(tok: string, key: string): boolean {
+  return tok.toLowerCase().startsWith(`${key}:`);
+}
+
 /* 同キーの既存トークンを置き換えて追加(state:open → state:closed は上書き) */
 export function replaceToken(tokens: string[], key: string, value: string): string[] {
-  const prefix = `${key}:`;
-  const toks = tokens.filter((t) => !t.toLowerCase().startsWith(prefix));
-  toks.push(prefix + value);
+  const toks = stripKey(tokens, key);
+  toks.push(`${key}:${value}`);
   return toks;
+}
+
+/* 指定キーのトークンを全て除去(手打ちの重複・大文字違いも残さない)。
+ * ドロップダウンのトグルオフ用 — exact-match の removeToken だと
+ * 「state:open STATE:CLOSED」のような手打ち重複の取り残しが出る。 */
+export function stripKey(tokens: string[], key: string): string[] {
+  return tokens.filter((t) => !hasKey(t, key));
 }
 
 export function removeToken(tokens: string[], tok: string): string[] {
   return tokens.filter((t) => t !== tok);
 }
 
-/* 指定キーの key:value トークンを探す(手打ち含め最初の 1 つ)。raw は
- * removeToken での exact-match 除去用の原文、value は選択肢との小文字比較用。 */
-export function tokenForKey(tokens: string[], key: string): { raw: string; value: string } | null {
-  const prefix = `${key}:`;
+/* 指定キーの最初の key:value トークンの値(小文字)。ドロップダウンの
+ * アクティブ表示・トグルオフ判定用。該当キーが無ければ null。 */
+export function tokenForKey(tokens: string[], key: string): string | null {
   for (const t of tokens) {
-    if (t.toLowerCase().startsWith(prefix)) return { raw: t, value: t.slice(prefix.length).toLowerCase() };
+    if (hasKey(t, key)) return t.slice(key.length + 1).toLowerCase();
   }
   return null;
 }

--- a/web/src/lib/filter.ts
+++ b/web/src/lib/filter.ts
@@ -112,3 +112,13 @@ export function replaceToken(tokens: string[], key: string, value: string): stri
 export function removeToken(tokens: string[], tok: string): string[] {
   return tokens.filter((t) => t !== tok);
 }
+
+/* 指定キーの key:value トークンを探す(手打ち含め最初の 1 つ)。raw は
+ * removeToken での exact-match 除去用の原文、value は選択肢との小文字比較用。 */
+export function tokenForKey(tokens: string[], key: string): { raw: string; value: string } | null {
+  const prefix = `${key}:`;
+  for (const t of tokens) {
+    if (t.toLowerCase().startsWith(prefix)) return { raw: t, value: t.slice(prefix.length).toLowerCase() };
+  }
+  return null;
+}

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -259,17 +259,76 @@ html[data-theme="dark"] .theme-toggle .ic-moon{ display:none; }
   margin-top:10px;
   display:flex; flex-wrap:wrap; align-items:center; gap:8px;
 }
-.filter-bar select{
+/* GitHub PR 風ドロップダウン(FilterDropdown)。trigger は旧 select と同じ
+ * 砂色ピル、popover は和紙カード + fdIn の扇イージングで開く。 */
+.fd{ position:relative; }
+.fd-trigger{
+  display:inline-flex; align-items:center; gap:6px;
   font-family:var(--f-code); font-size:12px;
   color:var(--ink-60);
   background:var(--paper);
   border:1px solid var(--suna); border-radius:999px;
   padding:4px 12px;
   cursor:pointer;
-  transition:border-color .25s ease, color .25s ease;
+  transition:border-color .25s ease, color .25s ease, background-color .25s ease;
 }
-.filter-bar select:hover{ border-color:var(--asagi); color:var(--sumi); }
-.filter-bar select:focus{ outline:none; border-color:var(--asagi); color:var(--sumi); }
+.fd-trigger:hover{ border-color:var(--asagi); color:var(--sumi); }
+.fd-trigger:focus-visible{ outline:none; border-color:var(--asagi); color:var(--sumi); }
+.fd-trigger[aria-expanded="true"]{ border-color:var(--asagi); color:var(--sumi); }
+.fd-trigger .fd-caret{ color:var(--ink-40); transition:transform .25s var(--ease-fan), color .25s ease; }
+.fd-trigger:hover .fd-caret{ color:var(--asagi); }
+.fd-trigger[aria-expanded="true"] .fd-caret{ color:var(--asagi); transform:rotate(180deg); }
+/* トークン適用中の trigger はチップと同じ浅葱トーン */
+.fd-trigger.on{
+  color:var(--ai-deep);
+  border-color:color-mix(in srgb, var(--asagi) 35%, transparent);
+  background:color-mix(in srgb, var(--asagi) 8%, transparent);
+}
+@keyframes fdIn{ from{ opacity:0; transform:translateY(-5px) scale(.97); } }
+.fd-pop{
+  position:absolute; top:calc(100% + 6px); left:0; z-index:30; /* nav(40)の下 */
+  min-width:184px;
+  background:var(--paper);
+  border:1px solid var(--suna); border-radius:12px;
+  box-shadow:var(--shadow);
+  padding:6px;
+  transform-origin:top left;
+  animation:fdIn .22s var(--ease-fan) both;
+}
+.fd-search{ padding:2px 2px 7px; margin-bottom:6px; border-bottom:1px solid var(--suna-soft); }
+.fd-search input{
+  width:100%;
+  font-family:var(--f-code); font-size:12px;
+  color:var(--sumi);
+  background:var(--washi);
+  border:1px solid var(--suna); border-radius:8px;
+  padding:5px 10px;
+  transition:border-color .25s ease;
+}
+.fd-search input::placeholder{ color:var(--ink-40); }
+.fd-search input:focus{ outline:none; border-color:var(--asagi); }
+.fd-list{ display:flex; flex-direction:column; gap:1px; max-height:248px; overflow-y:auto; }
+.fd-opt{
+  display:flex; align-items:center; gap:8px;
+  width:100%; text-align:left;
+  font-family:var(--f-code); font-size:12px;
+  color:var(--ink-78);
+  background:transparent;
+  border:none; border-radius:8px;
+  padding:5px 10px;
+  cursor:pointer;
+  transition:background-color .15s ease, color .15s ease;
+}
+.fd-opt:hover{ background:var(--byakugun-bg); color:var(--sumi); }
+.fd-opt:focus-visible{ outline:none; background:var(--byakugun-bg); color:var(--sumi); }
+.fd-opt .fd-check{
+  flex:none; color:var(--asagi);
+  opacity:0; transform:scale(.6);
+  transition:opacity .15s ease, transform .2s var(--ease-fan);
+}
+.fd-opt[aria-selected="true"]{ color:var(--sumi); font-weight:500; }
+.fd-opt[aria-selected="true"] .fd-check{ opacity:1; transform:scale(1); }
+.fd-empty{ padding:5px 10px; font-family:var(--f-code); font-size:11.5px; color:var(--ink-40); }
 #chips{ display:inline-flex; flex-wrap:wrap; align-items:center; gap:6px; }
 .chip{
   display:inline-flex; align-items:center; gap:6px;

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -100,7 +100,11 @@ a:hover{ color:var(--asagi); }
 .wrap{ width:min(var(--maxw), calc(100% - 48px)); margin-inline:auto; }
 
 @keyframes riseIn{ from{ opacity:0; transform:translateY(14px); } }
-.rise{ animation:riseIn .7s var(--ease-fan) both; animation-delay:var(--d,0s); }
+/* fill は backwards: 遅延中だけ from 状態を保持し、終了後はアニメを「適用中」
+ * にしない。both だと終了後も opacity/transform が適用扱いになり、全 .rise
+ * 要素に恒久スタッキングコンテキストが残って popover 類が DOM 順で後続要素の
+ * 下に描画される(riseIn は from しか無いので見た目は both と同一)。 */
+.rise{ animation:riseIn .7s var(--ease-fan) backwards; animation-delay:var(--d,0s); }
 
 /* ============================================================ ナビ */
 .nav{
@@ -258,10 +262,10 @@ html[data-theme="dark"] .theme-toggle .ic-moon{ display:none; }
 .filter-bar{
   margin-top:10px;
   display:flex; flex-wrap:wrap; align-items:center; gap:8px;
-  /* rise の fill(both)は終了後も opacity/transform を「適用中」とみなし、
-   * .filter-bar と後続の .session 双方に恒久スタッキングコンテキストを作る。
-   * 両者 z-index:auto だと DOM 順で session が popover ごと上に描画されるため、
-   * filter-bar 全体を明示的に持ち上げる(nav の 40 より下)。 */
+  /* rise アニメ実行中(0.7s + 遅延)は .filter-bar / .session が一時的に
+   * スタッキングコンテキストになり DOM 順で後の session が上に描画されるため、
+   * popover が開く可能性のある filter-bar を明示的に持ち上げておく
+   * (恒久残留の方は .rise の fill=backwards で根本対処済み。nav の 40 より下)。 */
   position:relative; z-index:30;
 }
 /* GitHub PR 風ドロップダウン(FilterDropdown)。trigger は旧 select と同じ
@@ -291,7 +295,10 @@ html[data-theme="dark"] .theme-toggle .ic-moon{ display:none; }
 }
 @keyframes fdIn{ from{ opacity:0; transform:translateY(-5px) scale(.97); } }
 .fd-pop{
-  position:absolute; top:calc(100% + 6px); left:0; z-index:30; /* nav(40)の下 */
+  /* z-index は .filter-bar コンテキスト内の兄弟順制御のみ(nav との前後は
+   * 親 .filter-bar の z-index:30 が決める) */
+  position:absolute; top:calc(100% + 6px); left:0; z-index:1;
+  outline:none; /* tabIndex=-1 の余白クリック受け */
   min-width:184px;
   background:var(--paper);
   border:1px solid var(--suna); border-radius:12px;
@@ -325,7 +332,9 @@ html[data-theme="dark"] .theme-toggle .ic-moon{ display:none; }
   transition:background-color .15s ease, color .15s ease;
 }
 .fd-opt:hover{ background:var(--byakugun-bg); color:var(--sumi); }
-.fd-opt:focus-visible{ outline:none; background:var(--byakugun-bg); color:var(--sumi); }
+/* :focus(-visible でなく)で塗る: クリック開時のプログラムフォーカスでも
+ * roving カーソル位置が見えるように */
+.fd-opt:focus{ outline:none; background:var(--byakugun-bg); color:var(--sumi); }
 .fd-opt .fd-check{
   flex:none; color:var(--asagi);
   opacity:0; transform:scale(.6);

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -258,6 +258,11 @@ html[data-theme="dark"] .theme-toggle .ic-moon{ display:none; }
 .filter-bar{
   margin-top:10px;
   display:flex; flex-wrap:wrap; align-items:center; gap:8px;
+  /* rise の fill(both)は終了後も opacity/transform を「適用中」とみなし、
+   * .filter-bar と後続の .session 双方に恒久スタッキングコンテキストを作る。
+   * 両者 z-index:auto だと DOM 順で session が popover ごと上に描画されるため、
+   * filter-bar 全体を明示的に持ち上げる(nav の 40 より下)。 */
+  position:relative; z-index:30;
 }
 /* GitHub PR 風ドロップダウン(FilterDropdown)。trigger は旧 select と同じ
  * 砂色ピル、popover は和紙カード + fdIn の扇イージングで開く。 */

--- a/web/src/test/app.test.tsx
+++ b/web/src/test/app.test.tsx
@@ -337,6 +337,32 @@ describe("フィルタ", () => {
     await user.click(screen.getByRole("button", { name: "agent で絞り込み" }));
     expect(screen.getByRole("option", { name: "gemini" })).toBeInTheDocument();
   });
+
+  it("非 searchable は先頭文字 typeahead で option へジャンプする", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+    streamSnapshot(basicSnapshot());
+
+    await user.click(screen.getByRole("button", { name: "issue / tmux 状態で絞り込み" }));
+    await user.keyboard("c"); // open → closed へジャンプ
+    expect(screen.getByRole("option", { name: "closed" })).toHaveFocus();
+    await user.keyboard("{Enter}");
+    expect(screen.getByRole("listitem", { name: "フィルタ state:closed を外す" })).toBeInTheDocument();
+  });
+
+  it("トグルオフは手打ちの同キー重複トークンも全て外す", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+    streamSnapshot(basicSnapshot());
+
+    await user.type(screen.getByRole("searchbox"), "state:open STATE:CLOSED");
+    const trigger = screen.getByRole("button", { name: "issue / tmux 状態で絞り込み" });
+    await user.click(trigger);
+    // 最初の同キートークン(open)がアクティブ表示。クリックで同キーを一掃
+    await user.click(screen.getByRole("option", { name: "open" }));
+    expect(screen.getByRole("searchbox")).toHaveValue("");
+    expect(trigger).not.toHaveClass("on");
+  });
 });
 
 describe("ソート", () => {

--- a/web/src/test/app.test.tsx
+++ b/web/src/test/app.test.tsx
@@ -350,6 +350,22 @@ describe("フィルタ", () => {
     expect(screen.getByRole("listitem", { name: "フィルタ state:closed を外す" })).toBeInTheDocument();
   });
 
+  it("label 表記の別名トークン(wave:w2)もアクティブ表示・トグルオフできる", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+    streamSnapshot(basicSnapshot());
+
+    await user.type(screen.getByRole("searchbox"), "wave:w2");
+    const trigger = screen.getByRole("button", { name: "wave で絞り込み" });
+    expect(trigger).toHaveClass("on");
+    await user.click(trigger);
+    const opt = screen.getByRole("option", { name: "w2" });
+    expect(opt).toHaveAttribute("aria-selected", "true");
+    await user.click(opt);
+    expect(screen.getByRole("searchbox")).toHaveValue("");
+    expect(trigger).not.toHaveClass("on");
+  });
+
   it("トグルオフは手打ちの同キー重複トークンも全て外す", async () => {
     const user = userEvent.setup();
     render(<App />);

--- a/web/src/test/app.test.tsx
+++ b/web/src/test/app.test.tsx
@@ -181,29 +181,161 @@ describe("フィルタ", () => {
     expect(screen.getByText("フィルタに一致するペインがありません")).toBeInTheDocument();
   });
 
-  it("select はトークンを書き込み、同キーは上書き、選択後はプレースホルダーに戻る", async () => {
+  it("trigger クリックで popover が開き、option 選択でトークン書込・閉じて trigger に復帰、同キーは上書き", async () => {
     const user = userEvent.setup();
     render(<App />);
     streamSnapshot(basicSnapshot());
 
-    const stateSel = screen.getByRole("combobox", { name: "issue / tmux 状態で絞り込み" });
-    await user.selectOptions(stateSel, "open");
-    expect(screen.getByRole("listitem", { name: "フィルタ state:open を外す" })).toBeInTheDocument();
-    expect(stateSel).toHaveValue("");
+    const trigger = screen.getByRole("button", { name: "issue / tmux 状態で絞り込み" });
+    expect(trigger).toHaveAttribute("aria-haspopup", "listbox");
+    expect(trigger).toHaveAttribute("aria-expanded", "false");
 
-    await user.selectOptions(stateSel, "closed");
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute("aria-expanded", "true");
+    const listbox = screen.getByRole("listbox", { name: "issue / tmux 状態で絞り込み" });
+    await user.click(within(listbox).getByRole("option", { name: "open" }));
+
+    expect(screen.getByRole("listitem", { name: "フィルタ state:open を外す" })).toBeInTheDocument();
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument(); // 選択で閉じる
+    expect(trigger).toHaveFocus();
+
+    await user.click(trigger);
+    await user.click(screen.getByRole("option", { name: "closed" }));
     expect(screen.queryByRole("listitem", { name: "フィルタ state:open を外す" })).not.toBeInTheDocument();
     expect(screen.getByRole("listitem", { name: "フィルタ state:closed を外す" })).toBeInTheDocument();
   });
 
-  it("agent / wave の動的 select は snapshot 由来の選択肢を持つ", () => {
+  it("アクティブ option は aria-selected で示し、再クリックでトグルオフする", async () => {
+    const user = userEvent.setup();
     render(<App />);
     streamSnapshot(basicSnapshot());
-    const agentSel = screen.getByRole("combobox", { name: "agent で絞り込み" });
-    expect(within(agentSel).getByRole("option", { name: "claude" })).toBeInTheDocument();
-    expect(within(agentSel).getByRole("option", { name: "codex" })).toBeInTheDocument();
-    const waveSel = screen.getByRole("combobox", { name: "wave で絞り込み" });
-    expect(within(waveSel).getByRole("option", { name: "w2" })).toBeInTheDocument();
+
+    const trigger = screen.getByRole("button", { name: "issue / tmux 状態で絞り込み" });
+    await user.click(trigger);
+    await user.click(screen.getByRole("option", { name: "open" }));
+    expect(trigger).toHaveClass("on"); // 適用中スタイル
+
+    await user.click(trigger);
+    const opt = screen.getByRole("option", { name: "open" });
+    expect(opt).toHaveAttribute("aria-selected", "true");
+    expect(screen.getByRole("option", { name: "closed" })).toHaveAttribute("aria-selected", "false");
+
+    await user.click(opt);
+    expect(screen.queryByRole("listitem", { name: "フィルタ state:open を外す" })).not.toBeInTheDocument();
+    expect(screen.getByRole("searchbox")).toHaveValue("");
+    expect(trigger).not.toHaveClass("on");
+  });
+
+  it("popover 外の pointerdown で閉じる(トークンは書かない)", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+    streamSnapshot(basicSnapshot());
+
+    await user.click(screen.getByRole("button", { name: "issue / tmux 状態で絞り込み" }));
+    expect(screen.getByRole("listbox")).toBeInTheDocument();
+
+    await user.click(screen.getByText("Fix login"));
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    expect(screen.getByRole("searchbox")).toHaveValue("");
+  });
+
+  it("Esc は popover だけ閉じて trigger に復帰し、Drawer の document keydown へ漏らさない", async () => {
+    server.use(peekHandler(() => "boot ok"));
+    const user = userEvent.setup();
+    render(<App />);
+    streamSnapshot(basicSnapshot());
+
+    await user.click(screen.getByText("Fix login"));
+    await screen.findByRole("complementary", { name: "ペイン詳細" });
+
+    const trigger = screen.getByRole("button", { name: "issue / tmux 状態で絞り込み" });
+    await user.click(trigger);
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    expect(trigger).toHaveFocus();
+    expect(screen.getByRole("complementary", { name: "ペイン詳細" })).toBeInTheDocument(); // drawer 残存
+
+    await user.keyboard("{Escape}"); // popover が閉じた後の Esc は drawer に届く
+    expect(screen.queryByRole("complementary", { name: "ペイン詳細" })).not.toBeInTheDocument();
+  });
+
+  it("キーボード操作: ArrowDown/Up の roving tabindex で巡回し、Enter で選択する", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+    streamSnapshot(basicSnapshot());
+
+    const trigger = screen.getByRole("button", { name: "issue / tmux 状態で絞り込み" });
+    act(() => trigger.focus());
+    await user.keyboard("{ArrowDown}"); // trigger 上の ↓ で開く
+    const opts = within(screen.getByRole("listbox")).getAllByRole("option");
+    expect(opts.map((o) => o.textContent)).toEqual(["open", "closed", "live", "stale"]);
+    expect(opts[0]).toHaveFocus();
+    expect(opts[0]).toHaveAttribute("tabindex", "0");
+    expect(opts[1]).toHaveAttribute("tabindex", "-1");
+
+    await user.keyboard("{ArrowDown}");
+    expect(opts[1]).toHaveFocus();
+    expect(opts[1]).toHaveAttribute("tabindex", "0");
+    expect(opts[0]).toHaveAttribute("tabindex", "-1");
+
+    await user.keyboard("{ArrowUp}{ArrowUp}"); // 先頭から上へはラップして末尾
+    expect(opts[3]).toHaveFocus();
+
+    await user.keyboard("{Enter}");
+    expect(screen.getByRole("listitem", { name: "フィルタ state:stale を外す" })).toBeInTheDocument();
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+    expect(trigger).toHaveFocus();
+  });
+
+  it("agent / wave は snapshot 由来の選択肢を検索 input で絞り込め、Enter で先頭を選択する", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+    streamSnapshot(basicSnapshot());
+
+    await user.click(screen.getByRole("button", { name: "agent で絞り込み" }));
+    const listbox = screen.getByRole("listbox", { name: "agent で絞り込み" });
+    expect(within(listbox).getByRole("option", { name: "claude" })).toBeInTheDocument();
+    expect(within(listbox).getByRole("option", { name: "codex" })).toBeInTheDocument();
+
+    const search = screen.getByRole("textbox", { name: "agent の選択肢を検索" });
+    expect(search).toHaveFocus(); // searchable は開いた直後に検索へフォーカス
+    await user.keyboard("cod");
+    expect(within(listbox).queryByRole("option", { name: "claude" })).not.toBeInTheDocument();
+    await user.keyboard("{Enter}");
+    expect(screen.getByRole("listitem", { name: "フィルタ agent:codex を外す" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "wave で絞り込み" }));
+    await user.click(screen.getByRole("option", { name: "w2" }));
+    expect(screen.getByRole("listitem", { name: "フィルタ wave:2 を外す" })).toBeInTheDocument();
+  });
+
+  it("開いている popover の選択肢は freeze され、閉じて開き直すと新 option が反映される", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+    streamSnapshot(basicSnapshot());
+
+    await user.click(screen.getByRole("button", { name: "agent で絞り込み" }));
+    const listbox = screen.getByRole("listbox", { name: "agent で絞り込み" });
+    expect(within(listbox).getAllByRole("option")).toHaveLength(2);
+
+    // 開いたまま snapshot 更新(gemini の pane 追加)— 閉じず・選択肢も不変
+    act(() => {
+      FakeEventSource.latest().emitSnapshot(
+        makeSnapshot([
+          makeSession("142", [
+            makePane({ issueNum: 101, agent: "claude" }),
+            makePane({ issueNum: 102, agent: "codex" }),
+            makePane({ issueNum: 103, agent: "gemini" }),
+          ]),
+        ]),
+      );
+    });
+    expect(within(listbox).getAllByRole("option")).toHaveLength(2);
+    expect(within(listbox).queryByRole("option", { name: "gemini" })).not.toBeInTheDocument();
+
+    await user.keyboard("{Escape}");
+    await user.click(screen.getByRole("button", { name: "agent で絞り込み" }));
+    expect(screen.getByRole("option", { name: "gemini" })).toBeInTheDocument();
   });
 });
 


### PR DESCRIPTION
## 概要

Web ダッシュボードのフィルタ UI を、ネイティブ `<select>` から GitHub の PR フィルタバー風の popover ドロップダウンに置き換えます(ダッシュボード改善 6 連 PR の 1 つ)。

- 新規 `FilterDropdown`(8 キー共通・依存ライブラリなし): trigger ボタン + `role="listbox"` popover、roving tabindex(↑↓ / Home / End / Enter)、非 searchable キーは先頭文字 typeahead、agent / wave は検索 input 付き
- トークン/チップの既存モデルは不変(popover は `onPickToken` で書き、アクティブ値の再クリックは同キー一掃のトグルオフ)
- 開いている popover は選択肢を凍結(2 秒 tick の snapshot 更新でズレない / 閉じない)
- IME 変換中のキーは奪わない(変換確定 Enter で誤選択しない)
- Esc は popover だけ閉じて trigger に復帰。Drawer 側も `defaultPrevented` を見る明示的契約に
- PAPER BREEZE トークン準拠(和紙カード + `--ease-fan` の開閉アニメ、浅葱のチェック / アクティブ trigger)

## ブラウザ実動確認で見つけて直したバグ

- **`.rise` の `animation-fill-mode: both` が恒久スタッキングコンテキストを残し、popover が後続の `.session` の下に描画されてクリック不能**(jsdom では再現不可、Playwright で発見)。fill を `backwards` に変更して根本対処 + `.filter-bar` に防御的 z-index
- Shift+Tab で trigger にフォーカスが戻った状態 / popover 余白クリック後の Esc が Drawer に漏れて Drawer が閉じる → キー処理を root div へ移動 + `.fd-pop` に `tabIndex={-1}`

## 検証

- `make lint-web` / `make test-web`(60 tests)green
- Playwright で実動確認 22 チェック PASS(開閉・選択→chip・トグルオフ・キーボード巡回・検索・Esc 隔離・freeze・右端はみ出しなし)
- /post-work-review 実施済み(code-review 9 angle → 修正 → codex:review 2 反復で approve)

## 既知の制限

- `agent:cla` のような部分一致トークン(`matches()` のファジー仕様)はチェック表示されない(`wave:w2` の label 別名は対応済み)
- popover の dismiss クリックは下の要素にクリックスルーする(テストで意図として明文化)

## マージ順

6 連 PR は独立に main へ。`chore/web-oxlint-oxfmt` だけ**最後**にマージしてください(全体 reformat を含むため)。本 PR は `feat/web-drawer-resize` / `feat/dashboard-queued-children` と style.css / app.test.tsx で軽微なコンフリクトの可能性あり(後着が rebase)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)