### PR TITLE
feat(web): ダッシュボードのリスト幅を 1.2 倍に拡大

### DIFF
--- a/web/src/style.css
+++ b/web/src/style.css
@@ -38,7 +38,7 @@
   --f-code: "M PLUS 1 Code",ui-monospace,"SFMono-Regular",Menlo,monospace;
 
   --ease-fan: cubic-bezier(.22,1,.36,1);
-  --maxw: 1180px;
+  --maxw: 1416px;
   --nav-h: 60px;
 }
 html[data-theme="dark"]{
@@ -111,7 +111,7 @@ a:hover{ color:var(--asagi); }
   border-bottom:1px solid var(--suna);
 }
 .nav-inner{
-  width:min(1280px, calc(100% - 40px)); margin-inline:auto;
+  width:min(calc(var(--maxw) + 100px), calc(100% - 40px)); margin-inline:auto;
   display:flex; align-items:center; gap:14px;
   height:var(--nav-h);
 }
@@ -357,9 +357,9 @@ tbody tr.selected td:first-child{ box-shadow:inset 2px 0 0 var(--asagi); }
 td.c-issue{ color:var(--ai); font-weight:500; }
 td.c-name{
   font-family:var(--f-body); color:var(--sumi);
-  max-width:240px; overflow:hidden; text-overflow:ellipsis;
+  max-width:288px; overflow:hidden; text-overflow:ellipsis;
 }
-td.c-branch{ color:var(--ink-60); max-width:200px; overflow:hidden; text-overflow:ellipsis; }
+td.c-branch{ color:var(--ink-60); max-width:240px; overflow:hidden; text-overflow:ellipsis; }
 td.c-diff .add{ color:var(--ok); }
 td.c-diff .del{ color:var(--err); }
 td.c-diff.fault{ color:var(--err); }

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -111,6 +111,7 @@ a:hover{ color:var(--asagi); }
   border-bottom:1px solid var(--suna);
 }
 .nav-inner{
+  /* +100px は意図的な nav のオーバーハング(nav > コンテンツの関係を維持) */
   width:min(calc(var(--maxw) + 100px), calc(100% - 40px)); margin-inline:auto;
   display:flex; align-items:center; gap:14px;
   height:var(--nav-h);
@@ -355,6 +356,8 @@ tbody tr.selected td{
 }
 tbody tr.selected td:first-child{ box-shadow:inset 2px 0 0 var(--asagi); }
 td.c-issue{ color:var(--ai); font-weight:500; }
+/* c-name / c-branch の上限は --maxw と連動して手動スケール(1416/1180 = 1.2x)。
+   --maxw を変えるときはここも見直すこと。 */
 td.c-name{
   font-family:var(--f-body); color:var(--sumi);
   max-width:288px; overflow:hidden; text-overflow:ellipsis;


### PR DESCRIPTION
## 概要

リストの横幅がやや狭く見づらいため、コンテンツ幅を 1.2 倍に広げます(ダッシュボード改善 6 連 PR の 1 つ)。CSS のみの最小変更です。

- `--maxw`: 1180px → **1416px**(ちょうど 1.2 倍)
- `.nav-inner`: ハードコード 1280px → `min(calc(var(--maxw) + 100px), calc(100% - 40px))`(nav > コンテンツの関係を維持しつつ将来の drift を防止)
- `td.c-name` 240→288px / `td.c-branch` 200→240px(セル上限も 1.2 倍 — 広げた幅が省略されていた列に届くように)
- セル上限と `--maxw` の連動・nav の +100px オーバーハングが設計判断であることをコメントで記録

## 検証

- `make lint-web` / `make test-web`(49 tests)green
- Playwright で実動確認 6 チェック PASS(1600px で .wrap=1416 / nav=1516 / セル上限 / 1280px では従来どおり `calc(100% - 48px)` にフォールバック)。両テーマで目視確認
- /post-work-review 実施済み(code-review → コメント追記 → codex:review 1 反復で approve)

## 補足

- 1100/820/640px のブレークポイントは未変更(1416px 未満のビューポートでは従来と同一挙動)
- ワイド画面で drawer を開いた際のリフロー幅は大きくなる(`feat/web-drawer-resize` のドラッグリサイズで利用者が調整可能)

## マージ順

6 連 PR は独立に main へ。`chore/web-oxlint-oxfmt` だけ最後にマージしてください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)