### PR TITLE
feat(web): Session 詳細 Drawer を初期幅 2 倍 + ドラッグリサイズ対応に

### DIFF
--- a/web/src/components/Drawer.tsx
+++ b/web/src/components/Drawer.tsx
@@ -1,4 +1,9 @@
-import { Fragment, useEffect } from "react";
+import { Fragment, useEffect, type CSSProperties } from "react";
+import {
+  DRAWER_MAX_WIDTH,
+  DRAWER_MIN_WIDTH,
+  useDrawerWidth,
+} from "../hooks/useDrawerWidth";
 import { usePeek } from "../hooks/usePeek";
 import { usePlan } from "../hooks/usePlan";
 import { fmtCreated } from "../lib/format";
@@ -62,6 +67,8 @@ export function Drawer({
   token: string;
   onClose: () => void;
 }) {
+  const { width, gripProps } = useDrawerWidth();
+
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
       // defaultPrevented = 手前のオーバーレイ(フィルタ popover 等)が消費済み
@@ -71,8 +78,25 @@ export function Drawer({
     return () => document.removeEventListener("keydown", onKeyDown);
   }, [onClose]);
 
+  /* 幅は CSS 変数 --drawer-w 経由でのみ反映する(inline width にすると
+   * ≤820px の bottom sheet など media query が cascade で勝てなくなる)。 */
   return (
-    <aside id="drawer" aria-label="ペイン詳細">
+    <aside
+      id="drawer"
+      aria-label="ペイン詳細"
+      style={{ "--drawer-w": `${width}px` } as CSSProperties}
+    >
+      <div
+        className="drawer-grip"
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="詳細パネルの幅を変更"
+        aria-valuenow={width}
+        aria-valuemin={DRAWER_MIN_WIDTH}
+        aria-valuemax={DRAWER_MAX_WIDTH}
+        tabIndex={0}
+        {...gripProps}
+      />
       <header className="drawer-head">
         <h3>
           <span className="d-issue" id="d-issue">

--- a/web/src/components/Drawer.tsx
+++ b/web/src/components/Drawer.tsx
@@ -1,9 +1,5 @@
 import { Fragment, useEffect, type CSSProperties } from "react";
-import {
-  DRAWER_MAX_WIDTH,
-  DRAWER_MIN_WIDTH,
-  useDrawerWidth,
-} from "../hooks/useDrawerWidth";
+import { useDrawerWidth } from "../hooks/useDrawerWidth";
 import { usePeek } from "../hooks/usePeek";
 import { usePlan } from "../hooks/usePlan";
 import { fmtCreated } from "../lib/format";
@@ -86,17 +82,9 @@ export function Drawer({
       aria-label="ペイン詳細"
       style={{ "--drawer-w": `${width}px` } as CSSProperties}
     >
-      <div
-        className="drawer-grip"
-        role="separator"
-        aria-orientation="vertical"
-        aria-label="詳細パネルの幅を変更"
-        aria-valuenow={width}
-        aria-valuemin={DRAWER_MIN_WIDTH}
-        aria-valuemax={DRAWER_MAX_WIDTH}
-        tabIndex={0}
-        {...gripProps}
-      />
+      {/* role / aria / tabIndex は hook が幅と一体で提供する(スプレッド漏れで
+          セパレータ意味論だけ落ちる事故を防ぐ) */}
+      <div className="drawer-grip" {...gripProps} />
       <header className="drawer-head">
         <h3>
           <span className="d-issue" id="d-issue">

--- a/web/src/hooks/useDrawerWidth.test.tsx
+++ b/web/src/hooks/useDrawerWidth.test.tsx
@@ -184,6 +184,40 @@ describe("useDrawerWidth", () => {
     fireEvent.pointerUp(grip(), { pointerId: 2, clientX: 820 });
   });
 
+  it("描画上限に張り付いた状態の拡大ドラッグは大きい intent(保存値)を縮めない", () => {
+    localStorage.setItem("fanout.drawerWidth", "1300");
+    setInnerWidth(1200); // viewport 上限 840
+    render(<Probe />);
+    expect(width()).toBe(840); // 1300 は cap されて 840 描画
+
+    // 拡大方向(左 20px)に引いても描画は 840 のまま、intent 1300 は維持
+    fireEvent.pointerDown(grip(), { button: 0, pointerId: 1, clientX: 800, isPrimary: true });
+    fireEvent.pointerMove(grip(), { pointerId: 1, clientX: 780, buttons: 1 });
+    expect(width()).toBe(840);
+    fireEvent.pointerUp(grip(), { pointerId: 1, clientX: 780 });
+
+    // 広い画面に戻すと設定した 1300 が復元する(860 に縮んでいない)
+    setInnerWidth(2000);
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+    });
+    expect(width()).toBe(1300);
+  });
+
+  it("描画上限に張り付いた状態でも縮小ドラッグは見えている幅から追従する", () => {
+    localStorage.setItem("fanout.drawerWidth", "1300");
+    setInnerWidth(1200); // viewport 上限 840
+    render(<Probe />);
+    expect(width()).toBe(840);
+
+    // 縮小方向(右 40px)→ 見えている 840 から 800 へ
+    fireEvent.pointerDown(grip(), { button: 0, pointerId: 1, clientX: 800, isPrimary: true });
+    fireEvent.pointerMove(grip(), { pointerId: 1, clientX: 840, buttons: 1 });
+    expect(width()).toBe(800);
+    fireEvent.pointerUp(grip(), { pointerId: 1, clientX: 840 });
+    expect(localStorage.getItem("fanout.drawerWidth")).toBe("800");
+  });
+
   it("bottom sheet 相当の縮小を経ても intent を失わず、広げれば設定幅へ復元する", () => {
     localStorage.setItem("fanout.drawerWidth", "1300");
     render(<Probe />);

--- a/web/src/hooks/useDrawerWidth.test.tsx
+++ b/web/src/hooks/useDrawerWidth.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it } from "vitest";
 import { useDrawerWidth } from "./useDrawerWidth";
 
@@ -160,6 +160,27 @@ describe("useDrawerWidth", () => {
     localStorage.setItem("fanout.drawerWidth", "1600");
     render(<Probe />);
     expect(width()).toBe(900);
+  });
+
+  it("ビューポート縮小の resize で内部 width を再 clamp(stale startWidth を防ぐ)", () => {
+    render(<Probe />);
+    fireEvent.pointerDown(grip(), { button: 0, pointerId: 1, clientX: 800, isPrimary: true });
+    fireEvent.pointerMove(grip(), { pointerId: 1, clientX: -2000, buttons: 1 });
+    expect(width()).toBe(1600); // 2000px なので上限 1600
+    fireEvent.pointerUp(grip(), { pointerId: 1, clientX: -2000 });
+
+    // ウィンドウを 1200px に縮小 → 上限 840。resize で内部 width も追従する
+    setInnerWidth(1200);
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+    });
+    expect(width()).toBe(840);
+
+    // 次のドラッグは clamp 済みの 840 から始まる(デッドゾーンなし)
+    fireEvent.pointerDown(grip(), { button: 0, pointerId: 2, clientX: 800, isPrimary: true });
+    fireEvent.pointerMove(grip(), { pointerId: 2, clientX: 820, buttons: 1 }); // 右 20px = 縮小
+    expect(width()).toBe(820);
+    fireEvent.pointerUp(grip(), { pointerId: 2, clientX: 820 });
   });
 
   it("無移動クリックでは永続化しない(保存値なし = デフォルト追従を保つ)", () => {

--- a/web/src/hooks/useDrawerWidth.test.tsx
+++ b/web/src/hooks/useDrawerWidth.test.tsx
@@ -10,7 +10,7 @@ function Probe() {
   const { width, gripProps } = useDrawerWidth();
   return (
     <div>
-      <div data-testid="grip" tabIndex={0} {...gripProps} />
+      <div data-testid="grip" {...gripProps} />
       <output data-testid="width">{width}</output>
     </div>
   );
@@ -19,9 +19,16 @@ function Probe() {
 const width = () => Number(screen.getByTestId("width").textContent);
 const grip = () => screen.getByTestId("grip");
 
+/* hook はビューポート上限(innerWidth - 360 / ≤1100px は 90vw)でも clamp する。
+ * jsdom の既定 innerWidth(1024)だと上限 921px になり値が読みにくいので、
+ * 既定は広い画面に固定し、ビューポート clamp 自体は専用ケースで検証する。 */
+const setInnerWidth = (w: number) =>
+  Object.defineProperty(window, "innerWidth", { value: w, configurable: true, writable: true });
+
 beforeEach(() => {
   localStorage.clear();
   document.documentElement.classList.remove("drawer-resizing");
+  setInnerWidth(2000); // 上限 = min(1600, 2000 - 360) = 1600
 });
 
 describe("useDrawerWidth", () => {
@@ -54,14 +61,14 @@ describe("useDrawerWidth", () => {
 
   it("左ドラッグで拡大・右ドラッグで縮小し、pointerup でのみ永続化する", () => {
     render(<Probe />);
-    fireEvent.pointerDown(grip(), { button: 0, pointerId: 1, clientX: 800 });
+    fireEvent.pointerDown(grip(), { button: 0, pointerId: 1, clientX: 800, isPrimary: true });
     expect(document.documentElement).toHaveClass("drawer-resizing");
 
-    fireEvent.pointerMove(grip(), { pointerId: 1, clientX: 700 });
+    fireEvent.pointerMove(grip(), { pointerId: 1, clientX: 700, buttons: 1 });
     expect(width()).toBe(940); // 840 + (800 - 700)
     expect(localStorage.getItem("fanout.drawerWidth")).toBeNull(); // ドラッグ中は未保存
 
-    fireEvent.pointerMove(grip(), { pointerId: 1, clientX: 860 });
+    fireEvent.pointerMove(grip(), { pointerId: 1, clientX: 860, buttons: 1 });
     expect(width()).toBe(780); // 840 + (800 - 860)
 
     fireEvent.pointerUp(grip(), { pointerId: 1, clientX: 860 });
@@ -71,10 +78,10 @@ describe("useDrawerWidth", () => {
 
   it("ドラッグ中の幅も 320–1600px に clamp する", () => {
     render(<Probe />);
-    fireEvent.pointerDown(grip(), { button: 0, pointerId: 1, clientX: 800 });
-    fireEvent.pointerMove(grip(), { pointerId: 1, clientX: -2000 });
+    fireEvent.pointerDown(grip(), { button: 0, pointerId: 1, clientX: 800, isPrimary: true });
+    fireEvent.pointerMove(grip(), { pointerId: 1, clientX: -2000, buttons: 1 });
     expect(width()).toBe(1600);
-    fireEvent.pointerMove(grip(), { pointerId: 1, clientX: 3000 });
+    fireEvent.pointerMove(grip(), { pointerId: 1, clientX: 3000, buttons: 1 });
     expect(width()).toBe(320);
     fireEvent.pointerUp(grip(), { pointerId: 1, clientX: 3000 });
     expect(localStorage.getItem("fanout.drawerWidth")).toBe("320");
@@ -82,19 +89,19 @@ describe("useDrawerWidth", () => {
 
   it("ドラッグ外の pointermove・別 pointerId の move は無視する", () => {
     render(<Probe />);
-    fireEvent.pointerMove(grip(), { pointerId: 1, clientX: 100 });
+    fireEvent.pointerMove(grip(), { pointerId: 1, clientX: 100, buttons: 1 });
     expect(width()).toBe(840);
 
-    fireEvent.pointerDown(grip(), { button: 0, pointerId: 1, clientX: 800 });
-    fireEvent.pointerMove(grip(), { pointerId: 2, clientX: 100 });
+    fireEvent.pointerDown(grip(), { button: 0, pointerId: 1, clientX: 800, isPrimary: true });
+    fireEvent.pointerMove(grip(), { pointerId: 2, clientX: 100, buttons: 1 });
     expect(width()).toBe(840);
     fireEvent.pointerUp(grip(), { pointerId: 1, clientX: 800 });
   });
 
   it("pointercancel はドラッグを終了するが永続化しない", () => {
     render(<Probe />);
-    fireEvent.pointerDown(grip(), { button: 0, pointerId: 1, clientX: 800 });
-    fireEvent.pointerMove(grip(), { pointerId: 1, clientX: 700 });
+    fireEvent.pointerDown(grip(), { button: 0, pointerId: 1, clientX: 800, isPrimary: true });
+    fireEvent.pointerMove(grip(), { pointerId: 1, clientX: 700, buttons: 1 });
     fireEvent.pointerCancel(grip(), { pointerId: 1 });
     expect(document.documentElement).not.toHaveClass("drawer-resizing");
     expect(localStorage.getItem("fanout.drawerWidth")).toBeNull();
@@ -102,7 +109,7 @@ describe("useDrawerWidth", () => {
 
   it("ドラッグ中の unmount で html.drawer-resizing を残さない", () => {
     const probe = render(<Probe />);
-    fireEvent.pointerDown(grip(), { button: 0, pointerId: 1, clientX: 800 });
+    fireEvent.pointerDown(grip(), { button: 0, pointerId: 1, clientX: 800, isPrimary: true });
     expect(document.documentElement).toHaveClass("drawer-resizing");
     probe.unmount();
     expect(document.documentElement).not.toHaveClass("drawer-resizing");
@@ -127,5 +134,61 @@ describe("useDrawerWidth", () => {
     fireEvent.keyDown(grip(), { key: "ArrowRight" });
     expect(width()).toBe(816);
     expect(localStorage.getItem("fanout.drawerWidth")).toBe("816");
+  });
+
+  it("修飾キー付きの矢印(Alt+← = 履歴等)は奪わない", () => {
+    render(<Probe />);
+    fireEvent.keyDown(grip(), { key: "ArrowLeft", altKey: true });
+    fireEvent.keyDown(grip(), { key: "ArrowLeft", metaKey: true });
+    fireEvent.keyDown(grip(), { key: "ArrowLeft", ctrlKey: true });
+    expect(width()).toBe(840);
+    expect(localStorage.getItem("fanout.drawerWidth")).toBeNull();
+  });
+
+  it("操作値・保存値もビューポート上限(innerWidth - 360)で clamp する", () => {
+    setInnerWidth(1440); // 上限 1080
+    render(<Probe />);
+    fireEvent.pointerDown(grip(), { button: 0, pointerId: 1, clientX: 800, isPrimary: true });
+    fireEvent.pointerMove(grip(), { pointerId: 1, clientX: -2000, buttons: 1 });
+    expect(width()).toBe(1080); // 1600 ではなく実描画上限まで
+    fireEvent.pointerUp(grip(), { pointerId: 1, clientX: -2000 });
+    expect(localStorage.getItem("fanout.drawerWidth")).toBe("1080");
+  });
+
+  it("≤1100px のオーバーレイでは上限 90vw、保存値の読込も同様に clamp する", () => {
+    setInnerWidth(1000); // 上限 900
+    localStorage.setItem("fanout.drawerWidth", "1600");
+    render(<Probe />);
+    expect(width()).toBe(900);
+  });
+
+  it("無移動クリックでは永続化しない(保存値なし = デフォルト追従を保つ)", () => {
+    render(<Probe />);
+    fireEvent.pointerDown(grip(), { button: 0, pointerId: 1, clientX: 800, isPrimary: true });
+    fireEvent.pointerUp(grip(), { pointerId: 1, clientX: 800 });
+    expect(localStorage.getItem("fanout.drawerWidth")).toBeNull();
+  });
+
+  it("微調整ドラッグ直後の dblclick はリセットとして扱わない", () => {
+    render(<Probe />);
+    fireEvent.pointerDown(grip(), { button: 0, pointerId: 1, clientX: 800, isPrimary: true });
+    fireEvent.pointerMove(grip(), { pointerId: 1, clientX: 760, buttons: 1 }); // 40px 移動
+    fireEvent.pointerUp(grip(), { pointerId: 1, clientX: 760 });
+    expect(width()).toBe(880);
+    fireEvent.doubleClick(grip()); // 直前ドラッグの誤爆 → 無視
+    expect(width()).toBe(880);
+    expect(localStorage.getItem("fanout.drawerWidth")).toBe("880");
+  });
+
+  it("ボタン解放を取り逃しても buttons=0 の move でドラッグを終了する", () => {
+    render(<Probe />);
+    fireEvent.pointerDown(grip(), { button: 0, pointerId: 1, clientX: 800, isPrimary: true });
+    fireEvent.pointerMove(grip(), { pointerId: 1, clientX: 700, buttons: 1 });
+    expect(width()).toBe(940);
+    // capture が効かない環境: pointerup が grip 外で起き、buttons=0 の move だけ届く
+    fireEvent.pointerMove(grip(), { pointerId: 1, clientX: 600, buttons: 0 });
+    expect(document.documentElement).not.toHaveClass("drawer-resizing");
+    expect(width()).toBe(940); // 取り逃し後の hover では動かない
+    expect(localStorage.getItem("fanout.drawerWidth")).toBe("940");
   });
 });

--- a/web/src/hooks/useDrawerWidth.test.tsx
+++ b/web/src/hooks/useDrawerWidth.test.tsx
@@ -204,6 +204,34 @@ describe("useDrawerWidth", () => {
     expect(width()).toBe(1300);
   });
 
+  it("描画上限に張り付いた状態のキーボード拡大は大きい intent を縮めない", () => {
+    localStorage.setItem("fanout.drawerWidth", "1300");
+    setInnerWidth(1200); // viewport 上限 840
+    render(<Probe />);
+    expect(width()).toBe(840);
+
+    fireEvent.keyDown(grip(), { key: "ArrowLeft" }); // 拡大 → 描画変えられず no-op
+    expect(width()).toBe(840);
+    expect(localStorage.getItem("fanout.drawerWidth")).toBe("1300"); // 864 に縮んでいない
+
+    setInnerWidth(2000);
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+    });
+    expect(width()).toBe(1300);
+  });
+
+  it("描画上限に張り付いた状態でもキーボード縮小は見えている幅から追従する", () => {
+    localStorage.setItem("fanout.drawerWidth", "1300");
+    setInnerWidth(1200); // viewport 上限 840
+    render(<Probe />);
+    expect(width()).toBe(840);
+
+    fireEvent.keyDown(grip(), { key: "ArrowRight" }); // 縮小 → 816
+    expect(width()).toBe(816);
+    expect(localStorage.getItem("fanout.drawerWidth")).toBe("816");
+  });
+
   it("描画上限に張り付いた状態でも縮小ドラッグは見えている幅から追従する", () => {
     localStorage.setItem("fanout.drawerWidth", "1300");
     setInnerWidth(1200); // viewport 上限 840

--- a/web/src/hooks/useDrawerWidth.test.tsx
+++ b/web/src/hooks/useDrawerWidth.test.tsx
@@ -1,0 +1,131 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useDrawerWidth } from "./useDrawerWidth";
+
+/* hook 単体のテスト。jsdom には pointer capture が無いので grip 要素へ直接
+ * pointer イベントを発火する(実ブラウザでは setPointerCapture が grip 外の
+ * move/up も同じ要素へ配送することを保証する)。 */
+
+function Probe() {
+  const { width, gripProps } = useDrawerWidth();
+  return (
+    <div>
+      <div data-testid="grip" tabIndex={0} {...gripProps} />
+      <output data-testid="width">{width}</output>
+    </div>
+  );
+}
+
+const width = () => Number(screen.getByTestId("width").textContent);
+const grip = () => screen.getByTestId("grip");
+
+beforeEach(() => {
+  localStorage.clear();
+  document.documentElement.classList.remove("drawer-resizing");
+});
+
+describe("useDrawerWidth", () => {
+  it("保存値が無ければデフォルト 840px", () => {
+    render(<Probe />);
+    expect(width()).toBe(840);
+  });
+
+  it("localStorage の保存値から同期初期化する", () => {
+    localStorage.setItem("fanout.drawerWidth", "560");
+    render(<Probe />);
+    expect(width()).toBe(560);
+  });
+
+  it("保存値は 320–1600px に clamp し、不正値はデフォルトへ落とす", () => {
+    localStorage.setItem("fanout.drawerWidth", "100");
+    const small = render(<Probe />);
+    expect(width()).toBe(320);
+    small.unmount();
+
+    localStorage.setItem("fanout.drawerWidth", "99999");
+    const large = render(<Probe />);
+    expect(width()).toBe(1600);
+    large.unmount();
+
+    localStorage.setItem("fanout.drawerWidth", "abc");
+    render(<Probe />);
+    expect(width()).toBe(840);
+  });
+
+  it("左ドラッグで拡大・右ドラッグで縮小し、pointerup でのみ永続化する", () => {
+    render(<Probe />);
+    fireEvent.pointerDown(grip(), { button: 0, pointerId: 1, clientX: 800 });
+    expect(document.documentElement).toHaveClass("drawer-resizing");
+
+    fireEvent.pointerMove(grip(), { pointerId: 1, clientX: 700 });
+    expect(width()).toBe(940); // 840 + (800 - 700)
+    expect(localStorage.getItem("fanout.drawerWidth")).toBeNull(); // ドラッグ中は未保存
+
+    fireEvent.pointerMove(grip(), { pointerId: 1, clientX: 860 });
+    expect(width()).toBe(780); // 840 + (800 - 860)
+
+    fireEvent.pointerUp(grip(), { pointerId: 1, clientX: 860 });
+    expect(document.documentElement).not.toHaveClass("drawer-resizing");
+    expect(localStorage.getItem("fanout.drawerWidth")).toBe("780");
+  });
+
+  it("ドラッグ中の幅も 320–1600px に clamp する", () => {
+    render(<Probe />);
+    fireEvent.pointerDown(grip(), { button: 0, pointerId: 1, clientX: 800 });
+    fireEvent.pointerMove(grip(), { pointerId: 1, clientX: -2000 });
+    expect(width()).toBe(1600);
+    fireEvent.pointerMove(grip(), { pointerId: 1, clientX: 3000 });
+    expect(width()).toBe(320);
+    fireEvent.pointerUp(grip(), { pointerId: 1, clientX: 3000 });
+    expect(localStorage.getItem("fanout.drawerWidth")).toBe("320");
+  });
+
+  it("ドラッグ外の pointermove・別 pointerId の move は無視する", () => {
+    render(<Probe />);
+    fireEvent.pointerMove(grip(), { pointerId: 1, clientX: 100 });
+    expect(width()).toBe(840);
+
+    fireEvent.pointerDown(grip(), { button: 0, pointerId: 1, clientX: 800 });
+    fireEvent.pointerMove(grip(), { pointerId: 2, clientX: 100 });
+    expect(width()).toBe(840);
+    fireEvent.pointerUp(grip(), { pointerId: 1, clientX: 800 });
+  });
+
+  it("pointercancel はドラッグを終了するが永続化しない", () => {
+    render(<Probe />);
+    fireEvent.pointerDown(grip(), { button: 0, pointerId: 1, clientX: 800 });
+    fireEvent.pointerMove(grip(), { pointerId: 1, clientX: 700 });
+    fireEvent.pointerCancel(grip(), { pointerId: 1 });
+    expect(document.documentElement).not.toHaveClass("drawer-resizing");
+    expect(localStorage.getItem("fanout.drawerWidth")).toBeNull();
+  });
+
+  it("ドラッグ中の unmount で html.drawer-resizing を残さない", () => {
+    const probe = render(<Probe />);
+    fireEvent.pointerDown(grip(), { button: 0, pointerId: 1, clientX: 800 });
+    expect(document.documentElement).toHaveClass("drawer-resizing");
+    probe.unmount();
+    expect(document.documentElement).not.toHaveClass("drawer-resizing");
+  });
+
+  it("ダブルクリックでデフォルトに戻し、保存値を消す", () => {
+    localStorage.setItem("fanout.drawerWidth", "560");
+    render(<Probe />);
+    expect(width()).toBe(560);
+    fireEvent.doubleClick(grip());
+    expect(width()).toBe(840);
+    expect(localStorage.getItem("fanout.drawerWidth")).toBeNull();
+  });
+
+  it("ArrowLeft で +24px / ArrowRight で -24px、即永続化する", () => {
+    render(<Probe />);
+    fireEvent.keyDown(grip(), { key: "ArrowLeft" });
+    expect(width()).toBe(864);
+    expect(localStorage.getItem("fanout.drawerWidth")).toBe("864");
+
+    fireEvent.keyDown(grip(), { key: "ArrowRight" });
+    fireEvent.keyDown(grip(), { key: "ArrowRight" });
+    expect(width()).toBe(816);
+    expect(localStorage.getItem("fanout.drawerWidth")).toBe("816");
+  });
+});

--- a/web/src/hooks/useDrawerWidth.test.tsx
+++ b/web/src/hooks/useDrawerWidth.test.tsx
@@ -28,7 +28,7 @@ const setInnerWidth = (w: number) =>
 beforeEach(() => {
   localStorage.clear();
   document.documentElement.classList.remove("drawer-resizing");
-  setInnerWidth(2000); // 上限 = min(1600, 2000 - 360) = 1600
+  setInnerWidth(2000); // 上限 = min(1416, 2000 - 360) = 1416(コンテンツ幅 cap)
 });
 
 describe("useDrawerWidth", () => {
@@ -43,7 +43,7 @@ describe("useDrawerWidth", () => {
     expect(width()).toBe(560);
   });
 
-  it("保存値は 320–1600px に clamp し、不正値はデフォルトへ落とす", () => {
+  it("保存値は 320–1416px に clamp し、不正値はデフォルトへ落とす", () => {
     localStorage.setItem("fanout.drawerWidth", "100");
     const small = render(<Probe />);
     expect(width()).toBe(320);
@@ -51,7 +51,7 @@ describe("useDrawerWidth", () => {
 
     localStorage.setItem("fanout.drawerWidth", "99999");
     const large = render(<Probe />);
-    expect(width()).toBe(1600);
+    expect(width()).toBe(1416);
     large.unmount();
 
     localStorage.setItem("fanout.drawerWidth", "abc");
@@ -76,11 +76,11 @@ describe("useDrawerWidth", () => {
     expect(localStorage.getItem("fanout.drawerWidth")).toBe("780");
   });
 
-  it("ドラッグ中の幅も 320–1600px に clamp する", () => {
+  it("ドラッグ中の幅も 320–1416px に clamp する", () => {
     render(<Probe />);
     fireEvent.pointerDown(grip(), { button: 0, pointerId: 1, clientX: 800, isPrimary: true });
     fireEvent.pointerMove(grip(), { pointerId: 1, clientX: -2000, buttons: 1 });
-    expect(width()).toBe(1600);
+    expect(width()).toBe(1416);
     fireEvent.pointerMove(grip(), { pointerId: 1, clientX: 3000, buttons: 1 });
     expect(width()).toBe(320);
     fireEvent.pointerUp(grip(), { pointerId: 1, clientX: 3000 });
@@ -145,14 +145,15 @@ describe("useDrawerWidth", () => {
     expect(localStorage.getItem("fanout.drawerWidth")).toBeNull();
   });
 
-  it("操作値・保存値もビューポート上限(innerWidth - 360)で clamp する", () => {
-    setInnerWidth(1440); // 上限 1080
+  it("狭い画面では描画を viewport 上限に抑え、intent(保存値)は静的上限まで伸ばす", () => {
+    setInnerWidth(1440); // viewport 上限 1080、静的上限 1416
     render(<Probe />);
     fireEvent.pointerDown(grip(), { button: 0, pointerId: 1, clientX: 800, isPrimary: true });
     fireEvent.pointerMove(grip(), { pointerId: 1, clientX: -2000, buttons: 1 });
-    expect(width()).toBe(1080); // 1600 ではなく実描画上限まで
+    expect(width()).toBe(1080); // 描画はビューポート上限で頭打ち
     fireEvent.pointerUp(grip(), { pointerId: 1, clientX: -2000 });
-    expect(localStorage.getItem("fanout.drawerWidth")).toBe("1080");
+    // intent は静的上限まで伸びる(広い画面に移れば 1416 で描画される)
+    expect(localStorage.getItem("fanout.drawerWidth")).toBe("1416");
   });
 
   it("≤1100px のオーバーレイでは上限 90vw、保存値の読込も同様に clamp する", () => {
@@ -162,25 +163,45 @@ describe("useDrawerWidth", () => {
     expect(width()).toBe(900);
   });
 
-  it("ビューポート縮小の resize で内部 width を再 clamp(stale startWidth を防ぐ)", () => {
+  it("ビューポート縮小では描画だけ追従し、次ドラッグは見えている幅起点(デッドゾーンなし)", () => {
     render(<Probe />);
     fireEvent.pointerDown(grip(), { button: 0, pointerId: 1, clientX: 800, isPrimary: true });
     fireEvent.pointerMove(grip(), { pointerId: 1, clientX: -2000, buttons: 1 });
-    expect(width()).toBe(1600); // 2000px なので上限 1600
+    expect(width()).toBe(1416); // 2000px の上限(コンテンツ幅 cap)
     fireEvent.pointerUp(grip(), { pointerId: 1, clientX: -2000 });
 
-    // ウィンドウを 1200px に縮小 → 上限 840。resize で内部 width も追従する
+    // ウィンドウを 1200px に縮小 → 描画は min(1416, 1200-360)=840 へ追従
     setInnerWidth(1200);
     act(() => {
       window.dispatchEvent(new Event("resize"));
     });
     expect(width()).toBe(840);
 
-    // 次のドラッグは clamp 済みの 840 から始まる(デッドゾーンなし)
+    // 次のドラッグは見えている 840 から始まる(stale な 1416 起点にならない)
     fireEvent.pointerDown(grip(), { button: 0, pointerId: 2, clientX: 800, isPrimary: true });
     fireEvent.pointerMove(grip(), { pointerId: 2, clientX: 820, buttons: 1 }); // 右 20px = 縮小
     expect(width()).toBe(820);
     fireEvent.pointerUp(grip(), { pointerId: 2, clientX: 820 });
+  });
+
+  it("bottom sheet 相当の縮小を経ても intent を失わず、広げれば設定幅へ復元する", () => {
+    localStorage.setItem("fanout.drawerWidth", "1300");
+    render(<Probe />);
+    expect(width()).toBe(1300); // 2000px: min(1300, 1416)
+
+    // 800px(bottom sheet 帯)へ縮小 → 描画は 720(800*0.9)だが intent は保持
+    setInnerWidth(800);
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+    });
+    expect(width()).toBe(720);
+
+    // 2000px に戻すと設定した 1300 に復元(下方向 clamp で失わない)
+    setInnerWidth(2000);
+    act(() => {
+      window.dispatchEvent(new Event("resize"));
+    });
+    expect(width()).toBe(1300);
   });
 
   it("無移動クリックでは永続化しない(保存値なし = デフォルト追従を保つ)", () => {

--- a/web/src/hooks/useDrawerWidth.ts
+++ b/web/src/hooks/useDrawerWidth.ts
@@ -96,6 +96,22 @@ export function useDrawerWidth(): { width: number; gripProps: DrawerGripProps } 
     [],
   );
 
+  /* ビューポート縮小で CSS が描画幅を clamp したら、内部値・aria-valuenow・
+   * 永続対象も同じ上限へ追従させる。追従しないと widthRef.current が古い
+   * ワイド値のまま残り、次ドラッグの startWidth が実描画より大きくなって
+   * デッドゾーン(右へ大きく動かすまで縮まらない)を生み、aria も実幅と
+   * 乖離する。 */
+  useEffect(() => {
+    const onResize = () => {
+      const clamped = clampWidth(widthRef.current);
+      if (clamped !== widthRef.current) setWidth(clamped);
+    };
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+    // setWidth / widthRef は安定参照。マウント中ずっと同じリスナーでよい。
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   const endDrag = (e: PointerEvent<HTMLElement>): boolean => {
     const drag = dragRef.current;
     if (!drag || e.pointerId !== drag.pointerId) return false;
@@ -122,7 +138,10 @@ export function useDrawerWidth(): { width: number; gripProps: DrawerGripProps } 
     tabIndex: 0,
     onPointerDown: (e) => {
       if (e.button !== 0 || !e.isPrimary || dragRef.current) return;
-      dragRef.current = { pointerId: e.pointerId, startX: e.clientX, startWidth: widthRef.current };
+      // resize イベントを取り逃していても現在ビューポートの上限から開始する
+      const startWidth = clampWidth(widthRef.current);
+      if (startWidth !== widthRef.current) setWidth(startWidth);
+      dragRef.current = { pointerId: e.pointerId, startX: e.clientX, startWidth };
       movedRef.current = false;
       e.currentTarget.setPointerCapture?.(e.pointerId);
       document.documentElement.classList.add(RESIZING_CLASS);

--- a/web/src/hooks/useDrawerWidth.ts
+++ b/web/src/hooks/useDrawerWidth.ts
@@ -1,0 +1,120 @@
+import { useEffect, useRef, useState } from "react";
+import type { KeyboardEvent, PointerEvent } from "react";
+
+export const DRAWER_DEFAULT_WIDTH = 840;
+export const DRAWER_MIN_WIDTH = 320;
+export const DRAWER_MAX_WIDTH = 1600;
+
+const STORAGE_KEY = "fanout.drawerWidth";
+const RESIZING_CLASS = "drawer-resizing";
+const KEY_STEP = 24;
+
+function clampWidth(w: number): number {
+  return Math.min(DRAWER_MAX_WIDTH, Math.max(DRAWER_MIN_WIDTH, Math.round(w)));
+}
+
+/* 初期値は localStorage から同期 read(Drawer は key={selected} で remount される
+ * ため、保存値さえ読めれば state は Drawer 内で完結する)。localStorage は
+ * private mode で例外を投げるので try/catch で握りつぶす(useTheme と同じ)。
+ * 不正値はデフォルトへ、範囲外は clamp。 */
+function initialWidth(): number {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const n = Number(raw);
+      if (Number.isFinite(n) && n > 0) return clampWidth(n);
+    }
+  } catch {
+    /* private mode */
+  }
+  return DRAWER_DEFAULT_WIDTH;
+}
+
+function persist(w: number) {
+  try {
+    localStorage.setItem(STORAGE_KEY, String(w));
+  } catch {
+    /* private mode */
+  }
+}
+
+export interface DrawerGripProps {
+  onPointerDown: (e: PointerEvent<HTMLElement>) => void;
+  onPointerMove: (e: PointerEvent<HTMLElement>) => void;
+  onPointerUp: (e: PointerEvent<HTMLElement>) => void;
+  onPointerCancel: (e: PointerEvent<HTMLElement>) => void;
+  onDoubleClick: () => void;
+  onKeyDown: (e: KeyboardEvent<HTMLElement>) => void;
+}
+
+/* ドロワー幅(px)の管理。値は CSS 変数 --drawer-w としてだけ反映し、ビューポート
+ * 上限(calc(100vw - 360px) / 90vw / bottom sheet)のクランプは CSS 側の仕事 —
+ * ここでは保存値・操作値の静的な健全範囲(320–1600px)だけを守る。
+ * ドロワーは右アンカーなので左ドラッグで拡大。setPointerCapture は jsdom に
+ * 存在しないため optional chain で呼ぶ(pointerup での解放は implicit release に
+ * 任せる)。永続化は pointerup / ダブルクリック / キー操作時のみ。 */
+export function useDrawerWidth(): { width: number; gripProps: DrawerGripProps } {
+  const [width, setWidthState] = useState<number>(initialWidth);
+  const widthRef = useRef(width);
+  const dragRef = useRef<{ pointerId: number; startX: number; startWidth: number } | null>(null);
+
+  const setWidth = (w: number) => {
+    widthRef.current = w;
+    setWidthState(w);
+  };
+
+  /* ドラッグ中に unmount(pane 切替の remount)しても html に状態を残さない */
+  useEffect(
+    () => () => {
+      document.documentElement.classList.remove(RESIZING_CLASS);
+    },
+    [],
+  );
+
+  const endDrag = (e: PointerEvent<HTMLElement>): boolean => {
+    const drag = dragRef.current;
+    if (!drag || e.pointerId !== drag.pointerId) return false;
+    dragRef.current = null;
+    document.documentElement.classList.remove(RESIZING_CLASS);
+    return true;
+  };
+
+  const gripProps: DrawerGripProps = {
+    onPointerDown: (e) => {
+      if (e.button !== 0) return;
+      dragRef.current = { pointerId: e.pointerId, startX: e.clientX, startWidth: widthRef.current };
+      e.currentTarget.setPointerCapture?.(e.pointerId);
+      document.documentElement.classList.add(RESIZING_CLASS);
+    },
+    onPointerMove: (e) => {
+      const drag = dragRef.current;
+      if (!drag || e.pointerId !== drag.pointerId) return;
+      setWidth(clampWidth(drag.startWidth + (drag.startX - e.clientX)));
+    },
+    onPointerUp: (e) => {
+      if (endDrag(e)) persist(widthRef.current);
+    },
+    onPointerCancel: (e) => {
+      endDrag(e); // OS 都合の中断は永続化しない(次回 remount は直前の保存値)
+    },
+    onDoubleClick: () => {
+      setWidth(DRAWER_DEFAULT_WIDTH);
+      try {
+        localStorage.removeItem(STORAGE_KEY);
+      } catch {
+        /* private mode */
+      }
+    },
+    onKeyDown: (e) => {
+      // 右アンカーなので ArrowLeft = セパレータを左へ = 拡大
+      const delta = e.key === "ArrowLeft" ? KEY_STEP : e.key === "ArrowRight" ? -KEY_STEP : 0;
+      if (!delta) return;
+      e.preventDefault();
+      const next = clampWidth(widthRef.current + delta);
+      setWidth(next);
+      persist(next);
+    },
+  };
+
+  return { width, gripProps };
+}

--- a/web/src/hooks/useDrawerWidth.ts
+++ b/web/src/hooks/useDrawerWidth.ts
@@ -1,46 +1,58 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useReducer, useRef, useState } from "react";
 import type { KeyboardEvent, PointerEvent } from "react";
 
 export const DRAWER_DEFAULT_WIDTH = 840;
 export const DRAWER_MIN_WIDTH = 320;
-export const DRAWER_MAX_WIDTH = 1600;
+// ドロワーはコンテンツ領域(style.css の --maxw)より広げない。これより広い
+// グリッドコンテナはそもそも無く、main 列を不当に潰すだけなので静的上限を
+// コンテンツ幅に合わせる。--maxw を変えたらここも合わせること。
+export const DRAWER_MAX_WIDTH = 1416;
 
+// main 列に最低限残す幅(デスクトップ grid 時)。CSS の calc(100vw - 360px) と同期。
+const MAIN_MIN = 360;
 const STORAGE_KEY = "fanout.drawerWidth";
 const RESIZING_CLASS = "drawer-resizing";
 const KEY_STEP = 24;
-// この移動量(px)を超えたドラッグ直後の dblclick はリセットとして扱わない
-// (微調整ドラッグ 2 連発が dblclick に化けて幅を吹き飛ばすのを防ぐ)
+// この移動量(px)を超えたドラッグだけ「リサイズ操作」とみなす(無移動クリックや
+// 微調整 2 連発の dblclick 誤爆で intent を書き換えないため)。
 const CLICK_SLOP = 4;
 
-/* CSS 側のビューポート上限(calc(100vw - 360px) / ≤1100px は 90vw)と同じ値。
- * 描画は CSS の clamp が常に守るが、操作値・保存値・aria-valuenow も実描画を
- * 超えないようここでも同じ上限でクランプする(超えると逆ドラッグにデッド
- * ゾーンができ、aria が実幅と乖離する)。 */
+// intent(ユーザーが設定した幅)の静的な健全範囲だけを守る。ビューポート由来の
+// 上限は描画時に別途かける(rendered)。
+function clampIntent(w: number): number {
+  return Math.min(DRAWER_MAX_WIDTH, Math.max(DRAWER_MIN_WIDTH, Math.round(w)));
+}
+
+/* 現在のビューポート/レイアウトで実際に描画できる最大幅。CSS の clamp と必ず
+ * 一致させる: ≤1100px は overlay(グリッド外)なので 90vw、それ以上は grid 内
+ * なので main 列に MAIN_MIN を残しつつコンテンツ幅(DRAWER_MAX_WIDTH)も超えない。 */
 function viewportMax(): number {
   const vw = window.innerWidth;
-  const cssMax = vw <= 1100 ? vw * 0.9 : vw - 360;
-  return Math.min(DRAWER_MAX_WIDTH, Math.max(DRAWER_MIN_WIDTH, Math.floor(cssMax)));
+  const cap = vw <= 1100 ? vw * 0.9 : Math.min(vw - MAIN_MIN, DRAWER_MAX_WIDTH);
+  return Math.max(DRAWER_MIN_WIDTH, Math.floor(cap));
 }
 
-function clampWidth(w: number): number {
-  return Math.min(viewportMax(), Math.max(DRAWER_MIN_WIDTH, Math.round(w)));
+/* intent を「いま描画できる幅」に落とした値。--drawer-w と aria-valuenow に使う。
+ * intent 自体は保持したまま、狭い画面では描画だけ縮める(広げれば intent に戻る)。 */
+function renderedWidth(intent: number): number {
+  return Math.min(intent, viewportMax());
 }
 
-/* 初期値は localStorage から同期 read(Drawer は key={selected} で remount される
- * ため、保存値さえ読めれば state は Drawer 内で完結する)。localStorage は
+/* 初期 intent は localStorage から同期 read(Drawer は key={selected} で remount
+ * されるため、保存値さえ読めれば state は Drawer 内で完結する)。localStorage は
  * private mode で例外を投げるので try/catch で握りつぶす(useTheme と同じ)。
- * 不正値はデフォルトへ、範囲外は clamp。 */
-function initialWidth(): number {
+ * 不正値はデフォルトへ、範囲外は intent の静的範囲へ clamp。 */
+function initialIntent(): number {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (raw) {
       const n = Number(raw);
-      if (Number.isFinite(n) && n > 0) return clampWidth(n);
+      if (Number.isFinite(n) && n > 0) return clampIntent(n);
     }
   } catch {
     /* private mode */
   }
-  return Math.min(DRAWER_DEFAULT_WIDTH, viewportMax());
+  return DRAWER_DEFAULT_WIDTH;
 }
 
 function persist(w: number) {
@@ -68,24 +80,27 @@ export interface DrawerGripProps {
   onKeyDown: (e: KeyboardEvent<HTMLElement>) => void;
 }
 
-/* ドロワー幅(px)の管理。値は CSS 変数 --drawer-w としてだけ反映する。
- * 描画上のクランプは CSS の clamp が一次防衛で、ここでは操作値も同じ
- * ビューポート上限(viewportMax)に揃えて aria と保存値の正直さを保つ。
- * ドロワーは右アンカーなので左ドラッグで拡大。setPointerCapture は jsdom に
- * 存在しないため optional chain で呼ぶ(pointerup での解放は implicit release に
- * 任せる)。永続化は「幅が実際に変わった」pointerup / キー操作時のみ —
- * 無移動クリックで保存すると、保存値なし(=将来のデフォルト変更に追従)の
- * ユーザーを暗黙にオプトアウトさせてしまう。 */
+/* ドロワー幅の管理。intent(ユーザー設定値、静的 320–1416px・保存対象)と
+ * rendered(intent を現在ビューポートで clamp した描画値)を分離する:
+ * - 描画 (--drawer-w) と aria-valuenow は rendered。CSS の clamp と一致する。
+ * - intent はビューポートが狭くなっても保持されるので、bottom sheet を経由
+ *   したり画面を縮めて戻したりしても、設定した幅を失わず復元できる。
+ * - ドラッグは「いま見えている幅(rendered)」を起点にするのでデッドゾーンが
+ *   出ない。右アンカーなので左ドラッグで拡大。
+ * setPointerCapture は jsdom に無いため optional chain で呼ぶ(解放は implicit
+ * release に任せる)。永続化は実際に動いた pointerup / キー操作時のみ。 */
 export function useDrawerWidth(): { width: number; gripProps: DrawerGripProps } {
-  const [width, setWidthState] = useState<number>(initialWidth);
-  const widthRef = useRef(width);
+  const [intent, setIntentState] = useState<number>(initialIntent);
+  const intentRef = useRef(intent);
   const dragRef = useRef<{ pointerId: number; startX: number; startWidth: number } | null>(null);
-  // 直前のドラッグが CLICK_SLOP を超えて動いたか(dblclick リセット抑制用)
+  // 直前のドラッグが CLICK_SLOP を超えて動いたか(保存 / dblclick リセット判定)
   const movedRef = useRef(false);
+  // ビューポート変化で rendered を再計算するための再描画トリガー(intent は不変)
+  const [, bumpRender] = useReducer((c: number) => c + 1, 0);
 
-  const setWidth = (w: number) => {
-    widthRef.current = w;
-    setWidthState(w);
+  const setIntent = (w: number) => {
+    intentRef.current = w;
+    setIntentState(w);
   };
 
   /* ドラッグ中に unmount(pane 切替の remount)しても html に状態を残さない */
@@ -96,21 +111,16 @@ export function useDrawerWidth(): { width: number; gripProps: DrawerGripProps } 
     [],
   );
 
-  /* ビューポート縮小で CSS が描画幅を clamp したら、内部値・aria-valuenow・
-   * 永続対象も同じ上限へ追従させる。追従しないと widthRef.current が古い
-   * ワイド値のまま残り、次ドラッグの startWidth が実描画より大きくなって
-   * デッドゾーン(右へ大きく動かすまで縮まらない)を生み、aria も実幅と
-   * 乖離する。 */
+  /* ビューポートが変わったら rendered を再計算する(intent は触らない)。これに
+   * より bottom sheet(≤820px で CSS が width:100%)を経由しても intent を縮め
+   * ず、画面を広げれば設定値に戻る。 */
   useEffect(() => {
-    const onResize = () => {
-      const clamped = clampWidth(widthRef.current);
-      if (clamped !== widthRef.current) setWidth(clamped);
-    };
+    const onResize = () => bumpRender();
     window.addEventListener("resize", onResize);
     return () => window.removeEventListener("resize", onResize);
-    // setWidth / widthRef は安定参照。マウント中ずっと同じリスナーでよい。
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  const rendered = renderedWidth(intent);
 
   const endDrag = (e: PointerEvent<HTMLElement>): boolean => {
     const drag = dragRef.current;
@@ -120,28 +130,24 @@ export function useDrawerWidth(): { width: number; gripProps: DrawerGripProps } 
     return true;
   };
 
-  // 幅が変わったドラッグだけ保存する(終了理由を問わず共通)
+  // 実際に動いたドラッグだけ intent を保存する(終了理由を問わず共通)
   const finishDrag = (e: PointerEvent<HTMLElement>) => {
-    const drag = dragRef.current;
-    if (!drag) return;
-    const changed = widthRef.current !== drag.startWidth;
-    if (endDrag(e) && changed) persist(widthRef.current);
+    if (!dragRef.current) return;
+    if (endDrag(e) && movedRef.current) persist(intentRef.current);
   };
 
   const gripProps: DrawerGripProps = {
     role: "separator",
     "aria-orientation": "vertical",
     "aria-label": "詳細パネルの幅を変更",
-    "aria-valuenow": width,
+    "aria-valuenow": rendered,
     "aria-valuemin": DRAWER_MIN_WIDTH,
-    "aria-valuemax": DRAWER_MAX_WIDTH,
+    "aria-valuemax": viewportMax(),
     tabIndex: 0,
     onPointerDown: (e) => {
       if (e.button !== 0 || !e.isPrimary || dragRef.current) return;
-      // resize イベントを取り逃していても現在ビューポートの上限から開始する
-      const startWidth = clampWidth(widthRef.current);
-      if (startWidth !== widthRef.current) setWidth(startWidth);
-      dragRef.current = { pointerId: e.pointerId, startX: e.clientX, startWidth };
+      // 起点は「いま見えている幅」= rendered。これで縮小後でもデッドゾーンなし。
+      dragRef.current = { pointerId: e.pointerId, startX: e.clientX, startWidth: rendered };
       movedRef.current = false;
       e.currentTarget.setPointerCapture?.(e.pointerId);
       document.documentElement.classList.add(RESIZING_CLASS);
@@ -155,8 +161,9 @@ export function useDrawerWidth(): { width: number; gripProps: DrawerGripProps } 
         return;
       }
       const dx = drag.startX - e.clientX;
+      if (dx === 0) return; // 無移動では intent を触らない(rendered への巻き戻り防止)
       if (Math.abs(dx) > CLICK_SLOP) movedRef.current = true;
-      setWidth(clampWidth(drag.startWidth + dx));
+      setIntent(clampIntent(drag.startWidth + dx));
     },
     onPointerUp: finishDrag,
     onPointerCancel: (e) => {
@@ -167,7 +174,7 @@ export function useDrawerWidth(): { width: number; gripProps: DrawerGripProps } 
     onLostPointerCapture: finishDrag,
     onDoubleClick: () => {
       if (movedRef.current) return; // 微調整ドラッグ 2 連発の誤爆を抑制
-      setWidth(Math.min(DRAWER_DEFAULT_WIDTH, viewportMax()));
+      setIntent(DRAWER_DEFAULT_WIDTH);
       try {
         localStorage.removeItem(STORAGE_KEY);
       } catch {
@@ -176,16 +183,17 @@ export function useDrawerWidth(): { width: number; gripProps: DrawerGripProps } 
     },
     onKeyDown: (e) => {
       if (e.altKey || e.metaKey || e.ctrlKey) return; // Alt+← は履歴等に譲る
-      // 右アンカーなので ArrowLeft = セパレータを左へ = 拡大
+      // 右アンカーなので ArrowLeft = セパレータを左へ = 拡大。キーボードは
+      // 「いま見えている幅」起点で調整するので rendered を基準にする。
       const delta = e.key === "ArrowLeft" ? KEY_STEP : e.key === "ArrowRight" ? -KEY_STEP : 0;
       if (!delta) return;
       e.preventDefault();
-      const next = clampWidth(widthRef.current + delta);
-      if (next === widthRef.current) return;
-      setWidth(next);
+      const next = clampIntent(rendered + delta);
+      if (next === intentRef.current) return;
+      setIntent(next);
       persist(next);
     },
   };
 
-  return { width, gripProps };
+  return { width: rendered, gripProps };
 }

--- a/web/src/hooks/useDrawerWidth.ts
+++ b/web/src/hooks/useDrawerWidth.ts
@@ -198,6 +198,10 @@ export function useDrawerWidth(): { width: number; gripProps: DrawerGripProps } 
       if (!delta) return;
       e.preventDefault();
       const next = clampIntent(rendered + delta);
+      // 描画上限に張り付いた状態の拡大はドラッグと同じく no-op にする。capped
+      // な rendered から intent を再計算すると、広い画面で見えるはずの大きい
+      // 保存値を縮めてしまうため。
+      if (next >= rendered && intentRef.current > rendered) return;
       if (next === intentRef.current) return;
       setIntent(next);
       persist(next);

--- a/web/src/hooks/useDrawerWidth.ts
+++ b/web/src/hooks/useDrawerWidth.ts
@@ -8,9 +8,22 @@ export const DRAWER_MAX_WIDTH = 1600;
 const STORAGE_KEY = "fanout.drawerWidth";
 const RESIZING_CLASS = "drawer-resizing";
 const KEY_STEP = 24;
+// この移動量(px)を超えたドラッグ直後の dblclick はリセットとして扱わない
+// (微調整ドラッグ 2 連発が dblclick に化けて幅を吹き飛ばすのを防ぐ)
+const CLICK_SLOP = 4;
+
+/* CSS 側のビューポート上限(calc(100vw - 360px) / ≤1100px は 90vw)と同じ値。
+ * 描画は CSS の clamp が常に守るが、操作値・保存値・aria-valuenow も実描画を
+ * 超えないようここでも同じ上限でクランプする(超えると逆ドラッグにデッド
+ * ゾーンができ、aria が実幅と乖離する)。 */
+function viewportMax(): number {
+  const vw = window.innerWidth;
+  const cssMax = vw <= 1100 ? vw * 0.9 : vw - 360;
+  return Math.min(DRAWER_MAX_WIDTH, Math.max(DRAWER_MIN_WIDTH, Math.floor(cssMax)));
+}
 
 function clampWidth(w: number): number {
-  return Math.min(DRAWER_MAX_WIDTH, Math.max(DRAWER_MIN_WIDTH, Math.round(w)));
+  return Math.min(viewportMax(), Math.max(DRAWER_MIN_WIDTH, Math.round(w)));
 }
 
 /* 初期値は localStorage から同期 read(Drawer は key={selected} で remount される
@@ -27,7 +40,7 @@ function initialWidth(): number {
   } catch {
     /* private mode */
   }
-  return DRAWER_DEFAULT_WIDTH;
+  return Math.min(DRAWER_DEFAULT_WIDTH, viewportMax());
 }
 
 function persist(w: number) {
@@ -39,24 +52,36 @@ function persist(w: number) {
 }
 
 export interface DrawerGripProps {
+  role: "separator";
+  "aria-orientation": "vertical";
+  "aria-label": string;
+  "aria-valuenow": number;
+  "aria-valuemin": number;
+  "aria-valuemax": number;
+  tabIndex: 0;
   onPointerDown: (e: PointerEvent<HTMLElement>) => void;
   onPointerMove: (e: PointerEvent<HTMLElement>) => void;
   onPointerUp: (e: PointerEvent<HTMLElement>) => void;
   onPointerCancel: (e: PointerEvent<HTMLElement>) => void;
+  onLostPointerCapture: (e: PointerEvent<HTMLElement>) => void;
   onDoubleClick: () => void;
   onKeyDown: (e: KeyboardEvent<HTMLElement>) => void;
 }
 
-/* ドロワー幅(px)の管理。値は CSS 変数 --drawer-w としてだけ反映し、ビューポート
- * 上限(calc(100vw - 360px) / 90vw / bottom sheet)のクランプは CSS 側の仕事 —
- * ここでは保存値・操作値の静的な健全範囲(320–1600px)だけを守る。
+/* ドロワー幅(px)の管理。値は CSS 変数 --drawer-w としてだけ反映する。
+ * 描画上のクランプは CSS の clamp が一次防衛で、ここでは操作値も同じ
+ * ビューポート上限(viewportMax)に揃えて aria と保存値の正直さを保つ。
  * ドロワーは右アンカーなので左ドラッグで拡大。setPointerCapture は jsdom に
  * 存在しないため optional chain で呼ぶ(pointerup での解放は implicit release に
- * 任せる)。永続化は pointerup / ダブルクリック / キー操作時のみ。 */
+ * 任せる)。永続化は「幅が実際に変わった」pointerup / キー操作時のみ —
+ * 無移動クリックで保存すると、保存値なし(=将来のデフォルト変更に追従)の
+ * ユーザーを暗黙にオプトアウトさせてしまう。 */
 export function useDrawerWidth(): { width: number; gripProps: DrawerGripProps } {
   const [width, setWidthState] = useState<number>(initialWidth);
   const widthRef = useRef(width);
   const dragRef = useRef<{ pointerId: number; startX: number; startWidth: number } | null>(null);
+  // 直前のドラッグが CLICK_SLOP を超えて動いたか(dblclick リセット抑制用)
+  const movedRef = useRef(false);
 
   const setWidth = (w: number) => {
     widthRef.current = w;
@@ -79,26 +104,51 @@ export function useDrawerWidth(): { width: number; gripProps: DrawerGripProps } 
     return true;
   };
 
+  // 幅が変わったドラッグだけ保存する(終了理由を問わず共通)
+  const finishDrag = (e: PointerEvent<HTMLElement>) => {
+    const drag = dragRef.current;
+    if (!drag) return;
+    const changed = widthRef.current !== drag.startWidth;
+    if (endDrag(e) && changed) persist(widthRef.current);
+  };
+
   const gripProps: DrawerGripProps = {
+    role: "separator",
+    "aria-orientation": "vertical",
+    "aria-label": "詳細パネルの幅を変更",
+    "aria-valuenow": width,
+    "aria-valuemin": DRAWER_MIN_WIDTH,
+    "aria-valuemax": DRAWER_MAX_WIDTH,
+    tabIndex: 0,
     onPointerDown: (e) => {
-      if (e.button !== 0) return;
+      if (e.button !== 0 || !e.isPrimary || dragRef.current) return;
       dragRef.current = { pointerId: e.pointerId, startX: e.clientX, startWidth: widthRef.current };
+      movedRef.current = false;
       e.currentTarget.setPointerCapture?.(e.pointerId);
       document.documentElement.classList.add(RESIZING_CLASS);
     },
     onPointerMove: (e) => {
       const drag = dragRef.current;
       if (!drag || e.pointerId !== drag.pointerId) return;
-      setWidth(clampWidth(drag.startWidth + (drag.startX - e.clientX)));
+      // capture が効かない環境でボタン解放を取り逃した場合の保険
+      if (e.buttons === 0) {
+        finishDrag(e);
+        return;
+      }
+      const dx = drag.startX - e.clientX;
+      if (Math.abs(dx) > CLICK_SLOP) movedRef.current = true;
+      setWidth(clampWidth(drag.startWidth + dx));
     },
-    onPointerUp: (e) => {
-      if (endDrag(e)) persist(widthRef.current);
-    },
+    onPointerUp: finishDrag,
     onPointerCancel: (e) => {
       endDrag(e); // OS 都合の中断は永続化しない(次回 remount は直前の保存値)
     },
+    // capture 喪失(≤820px への resize で grip が display:none になる等)でも
+    // ドラッグ状態と html クラスを残さない
+    onLostPointerCapture: finishDrag,
     onDoubleClick: () => {
-      setWidth(DRAWER_DEFAULT_WIDTH);
+      if (movedRef.current) return; // 微調整ドラッグ 2 連発の誤爆を抑制
+      setWidth(Math.min(DRAWER_DEFAULT_WIDTH, viewportMax()));
       try {
         localStorage.removeItem(STORAGE_KEY);
       } catch {
@@ -106,11 +156,13 @@ export function useDrawerWidth(): { width: number; gripProps: DrawerGripProps } 
       }
     },
     onKeyDown: (e) => {
+      if (e.altKey || e.metaKey || e.ctrlKey) return; // Alt+← は履歴等に譲る
       // 右アンカーなので ArrowLeft = セパレータを左へ = 拡大
       const delta = e.key === "ArrowLeft" ? KEY_STEP : e.key === "ArrowRight" ? -KEY_STEP : 0;
       if (!delta) return;
       e.preventDefault();
       const next = clampWidth(widthRef.current + delta);
+      if (next === widthRef.current) return;
       setWidth(next);
       persist(next);
     },

--- a/web/src/hooks/useDrawerWidth.ts
+++ b/web/src/hooks/useDrawerWidth.ts
@@ -162,8 +162,17 @@ export function useDrawerWidth(): { width: number; gripProps: DrawerGripProps } 
       }
       const dx = drag.startX - e.clientX;
       if (dx === 0) return; // 無移動では intent を触らない(rendered への巻き戻り防止)
+      const candidate = clampIntent(drag.startWidth + dx);
+      // 描画上限に張り付いた状態(intent が見えている startWidth より大きい)で
+      // さらに拡大方向へ引いても描画は変わらない。ここで intent を startWidth
+      // ベースに縮めると、広い画面で見えるはずの大きい保存値を失う。拡大方向は
+      // intent を維持し、見えている幅より縮めたときだけ追従する。
+      if (candidate >= drag.startWidth && intentRef.current > drag.startWidth) {
+        movedRef.current = true; // ジェスチャーはあったので click 扱いにしない
+        return;
+      }
       if (Math.abs(dx) > CLICK_SLOP) movedRef.current = true;
-      setIntent(clampIntent(drag.startWidth + dx));
+      setIntent(candidate);
     },
     onPointerUp: finishDrag,
     onPointerCancel: (e) => {

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -494,8 +494,10 @@ a.gh-pill:hover .tag{ border-color:var(--asagi); color:var(--asagi); }
 /* ============================================================ 詳細ドロワー */
 #drawer{
   /* 幅は CSS 変数 --drawer-w のみで制御(inline width 禁止 — media query が
-   * cascade で上書きできるように)。上限はリスト側に最低 360px を保証する。 */
-  width:clamp(320px, var(--drawer-w, 840px), calc(100vw - 360px));
+   * cascade で上書きできるように)。上限はリスト側に最低 360px を残し、かつ
+   * グリッドコンテナのコンテンツ幅(--maxw)も超えない(超えると main 列が
+   * 不当に潰れる)。hook の viewportMax と一致させること。 */
+  width:clamp(320px, var(--drawer-w, 840px), min(calc(100vw - 360px), var(--maxw)));
   position:sticky; top:var(--nav-h);
   height:calc(100vh - var(--nav-h));
   display:flex; flex-direction:column;

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -522,8 +522,8 @@ a.gh-pill:hover .tag{ border-color:var(--asagi); color:var(--asagi); }
 html.drawer-resizing .drawer-grip::after{ opacity:1; }
 .drawer-grip:focus-visible{ outline:none; }
 html.drawer-resizing{ user-select:none; cursor:col-resize; }
+/* ヘッダ常時表示は flex column(#drawer)+ .drawer-body のスクロールが担う */
 .drawer-head{
-  position:sticky; top:0; z-index:2;
   display:flex; align-items:center; gap:10px;
   padding:16px 20px 13px;
   background:var(--paper);

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -189,7 +189,8 @@ html[data-theme="dark"] .theme-toggle .ic-moon{ display:none; }
 /* ============================================================ HUD */
 .hud{
   margin-top:30px;
-  display:grid; grid-template-columns:repeat(5, minmax(110px,1fr)); gap:14px;
+  /* auto-fit — ドロワー拡大で main col が狭まっても overflow せず折り返す */
+  display:grid; grid-template-columns:repeat(auto-fit, minmax(110px,1fr)); gap:14px;
 }
 .stat{
   background:var(--paper);
@@ -492,14 +493,35 @@ a.gh-pill:hover .tag{ border-color:var(--asagi); color:var(--asagi); }
 
 /* ============================================================ 詳細ドロワー */
 #drawer{
-  width:min(420px, 100vw);
+  /* 幅は CSS 変数 --drawer-w のみで制御(inline width 禁止 — media query が
+   * cascade で上書きできるように)。上限はリスト側に最低 360px を保証する。 */
+  width:clamp(320px, var(--drawer-w, 840px), calc(100vw - 360px));
   position:sticky; top:var(--nav-h);
   height:calc(100vh - var(--nav-h));
-  overflow-y:auto;
+  display:flex; flex-direction:column;
+  overflow:hidden;
   background:var(--paper);
   border-left:1px solid var(--suna);
 }
 #drawer[hidden]{ display:none; }
+/* リサイズグリップ — 左端 6px のヒットエリア。hover / focus / ドラッグ中に
+ * 浅葱 2px のラインを出す(focus の可視化はライン側で行う)。 */
+.drawer-grip{
+  position:absolute; inset:0 auto 0 0; width:6px;
+  z-index:3;
+  cursor:col-resize;
+  touch-action:none;
+}
+.drawer-grip::after{
+  content:""; position:absolute; inset:0 auto 0 0; width:2px;
+  background:var(--asagi);
+  opacity:0; transition:opacity .25s ease;
+}
+.drawer-grip:hover::after,
+.drawer-grip:focus-visible::after,
+html.drawer-resizing .drawer-grip::after{ opacity:1; }
+.drawer-grip:focus-visible{ outline:none; }
+html.drawer-resizing{ user-select:none; cursor:col-resize; }
 .drawer-head{
   position:sticky; top:0; z-index:2;
   display:flex; align-items:center; gap:10px;
@@ -524,7 +546,8 @@ a.gh-pill:hover .tag{ border-color:var(--asagi); color:var(--asagi); }
   transition:border-color .25s ease, color .25s ease;
 }
 #drawer-close:hover{ border-color:var(--asagi); color:var(--asagi); }
-.drawer-body{ padding:18px 20px 28px; }
+/* スクロールは body 側 — グリップ(absolute)をドロワーの可視高に固定するため */
+.drawer-body{ flex:1; min-height:0; overflow-y:auto; padding:18px 20px 28px; }
 .d-sec{ margin-top:20px; }
 .d-sec:first-child{ margin-top:0; }
 .d-sec h4{
@@ -631,6 +654,7 @@ html[data-theme="dark"] .terminal{ border-color:var(--suna); }
 @media (max-width:1100px){
   #drawer{
     position:fixed; top:auto; right:0; bottom:0; left:auto;
+    width:clamp(320px, var(--drawer-w, 840px), 90vw); /* overlay でもドラッグ有効 */
     height:calc(100vh - var(--nav-h));
     z-index:50;
     box-shadow:-12px 0 36px -18px rgba(0,0,0,.35);
@@ -642,6 +666,7 @@ html[data-theme="dark"] .terminal{ border-color:var(--suna); }
     border-left:none; border-top:1px solid var(--suna);
     border-radius:14px 14px 0 0;
   }
+  .drawer-grip{ display:none; } /* bottom sheet は横リサイズしない */
   .hud{ grid-template-columns:repeat(auto-fit, minmax(104px,1fr)); }
   #repo{ display:none; }
 }

--- a/web/src/test/app.test.tsx
+++ b/web/src/test/app.test.tsx
@@ -622,6 +622,55 @@ describe("plan(Codex Plan Mode)", () => {
   });
 });
 
+describe("drawer リサイズ", () => {
+  const openDrawer = async (user: ReturnType<typeof userEvent.setup>, name: string) => {
+    await user.click(screen.getByText(name));
+    return await screen.findByRole("complementary", { name: "ペイン詳細" });
+  };
+  const drawerWidthVar = (drawer: HTMLElement) => drawer.style.getPropertyValue("--drawer-w");
+
+  it("localStorage の保存値が --drawer-w と grip の aria-valuenow に反映される", async () => {
+    server.use(peekHandler(() => "boot ok"));
+    localStorage.setItem("fanout.drawerWidth", "560");
+    const user = userEvent.setup();
+    render(<App />);
+    streamSnapshot(basicSnapshot());
+
+    const drawer = await openDrawer(user, "Fix login");
+    expect(drawerWidthVar(drawer)).toBe("560px");
+    const grip = within(drawer).getByRole("separator", { name: "詳細パネルの幅を変更" });
+    expect(grip).toHaveAttribute("aria-orientation", "vertical");
+    expect(grip).toHaveAttribute("aria-valuenow", "560");
+  });
+
+  it("グリップのドラッグで広がり、pane を切り替えても幅を維持する", async () => {
+    server.use(peekHandler(() => "boot ok"));
+    const user = userEvent.setup();
+    render(<App />);
+    streamSnapshot(basicSnapshot());
+
+    const drawer = await openDrawer(user, "Fix login");
+    expect(drawerWidthVar(drawer)).toBe("840px"); // 初期幅 = 従来 420px の 2 倍
+
+    const grip = within(drawer).getByRole("separator", { name: "詳細パネルの幅を変更" });
+    fireEvent.pointerDown(grip, { button: 0, pointerId: 1, clientX: 800 });
+    expect(document.documentElement).toHaveClass("drawer-resizing");
+    fireEvent.pointerMove(grip, { pointerId: 1, clientX: 680 });
+    expect(drawerWidthVar(drawer)).toBe("960px"); // 右アンカー: 左ドラッグで拡大
+    fireEvent.pointerUp(grip, { pointerId: 1, clientX: 680 });
+    expect(document.documentElement).not.toHaveClass("drawer-resizing");
+    expect(localStorage.getItem("fanout.drawerWidth")).toBe("960");
+
+    // Drawer は pane ごとに remount されるが、保存値からの同期初期化で幅は維持
+    const drawer2 = await openDrawer(user, "Add docs");
+    expect(within(drawer2).getByText("fanout/add-docs")).toBeInTheDocument();
+    expect(drawerWidthVar(drawer2)).toBe("960px");
+    expect(
+      within(drawer2).getByRole("separator", { name: "詳細パネルの幅を変更" }),
+    ).toHaveAttribute("aria-valuenow", "960");
+  });
+});
+
 describe("transport フォールバック", () => {
   it("SSE 断でポーリングに移行し、更新が継続する", async () => {
     const polled = makeSnapshot([

--- a/web/src/test/app.test.tsx
+++ b/web/src/test/app.test.tsx
@@ -623,6 +623,11 @@ describe("plan(Codex Plan Mode)", () => {
 });
 
 describe("drawer リサイズ", () => {
+  beforeEach(() => {
+    // hook はビューポート上限(innerWidth - 360)でも clamp する。jsdom 既定の
+    // 1024px だと上限 921px になりドラッグ値が読みにくいので広い画面に固定。
+    Object.defineProperty(window, "innerWidth", { value: 2000, configurable: true, writable: true });
+  });
   const openDrawer = async (user: ReturnType<typeof userEvent.setup>, name: string) => {
     await user.click(screen.getByText(name));
     return await screen.findByRole("complementary", { name: "ペイン詳細" });
@@ -653,9 +658,9 @@ describe("drawer リサイズ", () => {
     expect(drawerWidthVar(drawer)).toBe("840px"); // 初期幅 = 従来 420px の 2 倍
 
     const grip = within(drawer).getByRole("separator", { name: "詳細パネルの幅を変更" });
-    fireEvent.pointerDown(grip, { button: 0, pointerId: 1, clientX: 800 });
+    fireEvent.pointerDown(grip, { button: 0, pointerId: 1, clientX: 800, isPrimary: true });
     expect(document.documentElement).toHaveClass("drawer-resizing");
-    fireEvent.pointerMove(grip, { pointerId: 1, clientX: 680 });
+    fireEvent.pointerMove(grip, { pointerId: 1, clientX: 680, buttons: 1 });
     expect(drawerWidthVar(drawer)).toBe("960px"); // 右アンカー: 左ドラッグで拡大
     fireEvent.pointerUp(grip, { pointerId: 1, clientX: 680 });
     expect(document.documentElement).not.toHaveClass("drawer-resizing");


### PR DESCRIPTION
## 概要

Session 詳細表示(Drawer)の横幅を初期で 2 倍(420px → **840px**)にし、左端の grip をマウスドラッグ / キーボードで自由にリサイズできるようにします(ダッシュボード改善 6 連 PR の 1 つ)。

- 幅は CSS 変数 `--drawer-w` 経由でのみ反映(inline width を使わないので media query が cascade で勝てる)。描画は `clamp(320px, var(--drawer-w, 840px), calc(100vw - 360px))` でリストに最低幅を保証
- 新規 `useDrawerWidth` hook(useTheme 踏襲): `localStorage("fanout.drawerWidth")` に永続化、`key={selected}` の remount でも同期初期化で幅維持
- grip は `role="separator"` + `aria-valuenow` + キーボード(←/→ ±24px)対応、ダブルクリックでリセット(保存値削除 = 将来のデフォルト変更に追従)
- ≤1100px overlay でもドラッグ可(上限 90vw)、≤820px bottom sheet では grip 非表示
- 付随修正: `.hud` を `auto-fit` 化(狭い main col で折返し)、flex column 化で dead になった `.drawer-head` の sticky を除去

## レビューで直した edge case

- **hook の clamp がビューポート非依存**で、内部値が描画上限を超えて逆ドラッグにデッドゾーン・aria/保存値の乖離が出る → CSS と同じ `innerWidth - 360` / `90vw` 上限で操作値も clamp
- capture 喪失時のドラッグ固着(`buttons=0` move での終了 + `onLostPointerCapture`)、ドラッグ中の二重 pointerdown / 非 primary pointer ガード
- 微調整ドラッグ 2 連発が dblclick 判定されて幅が吹き飛ぶ誤爆を抑制(移動量 slop)
- 無移動クリックで現在幅が永続化され「デフォルト追従」が暗黙に外れる問題
- Alt/Cmd/Ctrl+矢印(ブラウザ履歴等)を奪わない

## 検証

- `make lint-web` / `make test-web`(67 tests、hook 単体 16 ケース含む)green
- Playwright 実動確認 15 チェック PASS(初期 840px・ドラッグ±・リロード/ペイン切替で幅維持・dblclick リセット・1240px clamp・bottom sheet で grip 非表示)
- /post-work-review 実施済み(code-review 5 angle → 修正 → codex:review 1 反復で approve)

## 既知のニット

- `100vw` は古典スクロールバー幅を含むため、Windows/Linux ではリスト最低幅が実質 ~345px(`.hud` auto-fit と table の overflow-x で吸収)

## マージ順

6 連 PR は独立に main へ。`chore/web-oxlint-oxfmt` だけ最後にマージしてください。`feat/web-filter-popovers` / `feat/dashboard-*` と style.css / app.test.tsx / Drawer.tsx で軽微なコンフリクトの可能性あり(後着が rebase)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)