### PR TITLE
feat(dashboard): 未開始の子 issue を synthetic 行として Web ダッシュボードに表示

### DIFF
--- a/internal/dashboard/poller.go
+++ b/internal/dashboard/poller.go
@@ -313,10 +313,11 @@ func (p *poller) refreshGH() {
 
 // refreshChildPRs fetches PR state for a parent's not-started children (those
 // outside the recorded set), as part of the wave pass — i.e. at the wave
-// cadence, not the 20s PR tick. CLOSED children that already have a successful
-// cache entry are skipped: their PR set still matters (a merged PR keeps the
-// ghost row green) but can no longer change; a reopen flips child.State on a
-// later wave pass and re-enters the child here.
+// cadence, not the 20s PR tick. A child is skipped only when BOTH the graph
+// and the PR cache agree it is CLOSED: that state is terminal (the PR set can
+// no longer change), and Build prefers the cached state, so skipping on the
+// graph state alone would freeze a stale OPEN cache entry forever after an
+// OPEN→CLOSED transition. A reopen flips child.State and re-enters here.
 func (p *poller) refreshChildPRs(gh GHProvider, graph sessionview.WaveGraph, recorded []int) {
 	rec := make(map[int]bool, len(recorded))
 	for _, n := range recorded {
@@ -327,7 +328,7 @@ func (p *poller) refreshChildPRs(gh GHProvider, graph sessionview.WaveGraph, rec
 		if child.Number <= 0 || rec[child.Number] {
 			continue
 		}
-		if strings.EqualFold(child.State, "CLOSED") && p.hasFreshPRCache(child.Number) {
+		if strings.EqualFold(child.State, "CLOSED") && p.cachedPRStateClosed(child.Number) {
 			continue
 		}
 		nums = append(nums, child.Number)
@@ -336,12 +337,13 @@ func (p *poller) refreshChildPRs(gh GHProvider, graph sessionview.WaveGraph, rec
 	p.refreshIssuePRs(gh, nums)
 }
 
-// hasFreshPRCache reports whether num has a successful PR cache entry.
-func (p *poller) hasFreshPRCache(num int) bool {
+// cachedPRStateClosed reports whether num has a successful PR cache entry that
+// already recorded the issue as CLOSED.
+func (p *poller) cachedPRStateClosed(num int) bool {
 	p.cacheMu.Lock()
 	defer p.cacheMu.Unlock()
 	e, ok := p.cache[num]
-	return ok && e.err == nil
+	return ok && e.err == nil && strings.EqualFold(e.state, "CLOSED")
 }
 
 // pruneWaveCache drops wave entries whose parent no longer has state rows.

--- a/internal/dashboard/poller.go
+++ b/internal/dashboard/poller.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"maps"
 	"slices"
-	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -223,7 +223,7 @@ func (p *poller) wavesFromCache(parent string) (sessionview.WaveGraph, error) {
 	}
 	p.cacheMu.Lock()
 	defer p.cacheMu.Unlock()
-	e, ok := p.waveCache[normalizeParent(parent)]
+	e, ok := p.waveCache[sessionview.NormalizeParent(parent)]
 	if !ok {
 		return sessionview.WaveGraph{}, nil // cache miss: unknown, not degraded
 	}
@@ -239,11 +239,13 @@ func (p *poller) refreshGH() {
 	if err != nil {
 		return
 	}
-	// Phase 1: per-issue PR state. The fetch set is the recorded issue numbers
-	// UNION the children the wave cache already discovered — not-started
-	// children have no state row, but their synthetic rows still surface
-	// issue/PR/CI state.
-	p.refreshIssuePRs(gh, unionNums(distinctIssueNums(store), p.cachedChildNums()))
+	// Phase 1: per-issue PR state for RECORDED issues only. Not-started
+	// children get their PR state inside the wave pass below, at the slower
+	// wave cadence — unioning them here would scale the 20s tick with the
+	// total child count instead of the launched pane count and exhaust the
+	// hourly GitHub API budget (the exact failure the wave throttle exists
+	// to prevent).
+	p.refreshIssuePRs(gh, distinctIssueNums(store))
 	// Phase 2: one wave-graph fetch per distinct normalized parent. The recorded
 	// issue numbers seed FetchWaveGraph's child set for @manual/Project parents
 	// and backfill unlinked children for numeric ones.
@@ -264,6 +266,10 @@ func (p *poller) refreshGH() {
 		p.lastWaveRefresh = time.Now()
 	}
 	numsByParent := recordedNumsByParent(store)
+	// state から消えた親(--cleanup 済み等)の wave エントリは捨てる: その
+	// session はもう build されないのに、子の PR fetch だけを永遠に駆動して
+	// しまう(stale エントリは wave パスの対象外なので自然回復もしない)。
+	p.pruneWaveCache(numsByParent)
 	for _, parent := range slices.Sorted(maps.Keys(numsByParent)) {
 		nums := numsByParent[parent]
 		if !due {
@@ -293,14 +299,60 @@ func (p *poller) refreshGH() {
 			// until the next clean pass.
 			graph = mergeDegradedWaveGraph(p.waveCache[parent].graph, graph)
 		}
+		p.cacheMu.Unlock()
+		// Fetch the children's PR state BEFORE publishing the graph: the 2s
+		// cheap ticker rebuilds concurrently, and publishing first would
+		// broadcast torn frames (synthetic rows without PR/CI data) for every
+		// child until the fetch loop catches up.
+		p.refreshChildPRs(gh, graph, nums)
+		p.cacheMu.Lock()
 		p.waveCache[parent] = waveCacheEntry{graph: graph, err: err, attempted: attempted}
 		p.cacheMu.Unlock()
 	}
-	// The child set only becomes known after a wave pass. Fetch the PR state of
-	// freshly discovered children right away so their synthetic rows do not sit
-	// at UNKNOWN until the next gh tick; already-known children were covered by
-	// phase 1 (and will be again next tick).
-	p.refreshIssuePRs(gh, p.uncachedIssueNums(p.cachedChildNums()))
+}
+
+// refreshChildPRs fetches PR state for a parent's not-started children (those
+// outside the recorded set), as part of the wave pass — i.e. at the wave
+// cadence, not the 20s PR tick. CLOSED children that already have a successful
+// cache entry are skipped: their PR set still matters (a merged PR keeps the
+// ghost row green) but can no longer change; a reopen flips child.State on a
+// later wave pass and re-enters the child here.
+func (p *poller) refreshChildPRs(gh GHProvider, graph sessionview.WaveGraph, recorded []int) {
+	rec := make(map[int]bool, len(recorded))
+	for _, n := range recorded {
+		rec[n] = true
+	}
+	var nums []int
+	for _, child := range graph.Children {
+		if child.Number <= 0 || rec[child.Number] {
+			continue
+		}
+		if strings.EqualFold(child.State, "CLOSED") && p.hasFreshPRCache(child.Number) {
+			continue
+		}
+		nums = append(nums, child.Number)
+	}
+	slices.Sort(nums)
+	p.refreshIssuePRs(gh, nums)
+}
+
+// hasFreshPRCache reports whether num has a successful PR cache entry.
+func (p *poller) hasFreshPRCache(num int) bool {
+	p.cacheMu.Lock()
+	defer p.cacheMu.Unlock()
+	e, ok := p.cache[num]
+	return ok && e.err == nil
+}
+
+// pruneWaveCache drops wave entries whose parent no longer has state rows.
+func (p *poller) pruneWaveCache(numsByParent map[string][]int) {
+	p.cacheMu.Lock()
+	defer p.cacheMu.Unlock()
+	for parent := range p.waveCache {
+		if _, ok := numsByParent[parent]; !ok {
+			delete(p.waveCache, parent)
+		}
+	}
 }
 
 // refreshIssuePRs fetches issue/PR state for each num and stores the result
@@ -312,54 +364,6 @@ func (p *poller) refreshIssuePRs(gh GHProvider, nums []int) {
 		p.cache[num] = ghCacheEntry{state: st, prs: prs, err: err}
 		p.cacheMu.Unlock()
 	}
-}
-
-// cachedChildNums returns the distinct positive child issue numbers the wave
-// cache knows across all parents, sorted ascending. These are the synthetic
-// not-started row candidates, so their PR state is refreshed alongside the
-// recorded issues.
-func (p *poller) cachedChildNums() []int {
-	p.cacheMu.Lock()
-	defer p.cacheMu.Unlock()
-	seen := map[int]bool{}
-	var nums []int
-	for _, e := range p.waveCache {
-		for _, child := range e.graph.Children {
-			if child.Number > 0 && !seen[child.Number] {
-				seen[child.Number] = true
-				nums = append(nums, child.Number)
-			}
-		}
-	}
-	slices.Sort(nums)
-	return nums
-}
-
-// uncachedIssueNums filters nums down to those without a PR cache entry yet.
-func (p *poller) uncachedIssueNums(nums []int) []int {
-	p.cacheMu.Lock()
-	defer p.cacheMu.Unlock()
-	var out []int
-	for _, num := range nums {
-		if _, ok := p.cache[num]; !ok {
-			out = append(out, num)
-		}
-	}
-	return out
-}
-
-// unionNums merges two ascending distinct slices into one, distinct and sorted.
-func unionNums(a, b []int) []int {
-	seen := make(map[int]bool, len(a)+len(b))
-	out := make([]int, 0, len(a)+len(b))
-	for _, n := range slices.Concat(a, b) {
-		if !seen[n] {
-			seen[n] = true
-			out = append(out, n)
-		}
-	}
-	slices.Sort(out)
-	return out
 }
 
 // mergeDegradedWaveGraph overlays a degraded wave fetch onto the previous
@@ -484,17 +488,6 @@ func distinctIssueNums(store state.Store) []int {
 	return nums
 }
 
-// normalizeParent canonicalizes numeric parents via an Atoi round-trip so
-// "0100" and "100" share one wave-cache entry, mirroring how state's
-// parentMatches treats them as the same parent. Non-numeric parents
-// (@manual, Project URLs) pass through unchanged.
-func normalizeParent(parent string) string {
-	if n, err := strconv.Atoi(parent); err == nil {
-		return strconv.Itoa(n)
-	}
-	return parent
-}
-
 // recordedNumsByParent groups each distinct normalized parent in state to the
 // sorted positive issue numbers recorded under it. Synthetic pane numbers
 // (IssueNum <= 0, e.g. @manual rows) stay out — FetchWaveGraph skips them
@@ -503,7 +496,7 @@ func normalizeParent(parent string) string {
 func recordedNumsByParent(store state.Store) map[string][]int {
 	grouped := map[string]map[int]bool{}
 	for _, p := range store.Panes {
-		key := normalizeParent(p.Parent)
+		key := sessionview.NormalizeParent(p.Parent)
 		if grouped[key] == nil {
 			grouped[key] = map[int]bool{}
 		}

--- a/internal/dashboard/poller.go
+++ b/internal/dashboard/poller.go
@@ -2,6 +2,7 @@ package dashboard
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"encoding/json"
 	"maps"
@@ -27,11 +28,12 @@ const (
 )
 
 // GHProvider is the GitHub fetch surface the poller throttles and caches:
-// per-issue PR state plus the per-parent wave/blocker graph.
+// per-issue PR state plus the per-parent wave/blocker graph (child set
+// included, so not-started children can render as synthetic rows).
 // sessionview.GH satisfies it; tests inject a fake.
 type GHProvider interface {
 	IssuePRs(num int) (string, []ghissue.PRRef, error)
-	Waves(parent string, recordedNums []int) (map[int]sessionview.WaveInfo, error)
+	Waves(parent string, recordedNums []int) (sessionview.WaveGraph, error)
 }
 
 type ghCacheEntry struct {
@@ -46,7 +48,7 @@ type ghCacheEntry struct {
 // the throttle bypass fires once per newly recorded issue without retrying
 // permanently failing lookups every tick.
 type waveCacheEntry struct {
-	info      map[int]sessionview.WaveInfo
+	graph     sessionview.WaveGraph
 	err       error
 	attempted map[int]bool
 }
@@ -212,20 +214,20 @@ func (p *poller) issuePRsFromCache(num int) (string, []ghissue.PRRef, error) {
 }
 
 // wavesFromCache mirrors issuePRsFromCache for the per-parent wave graph: a
-// sticky GitHub failure short-circuits to (nil, err), and a cache miss is
-// (nil, nil) — "not fetched yet", which Build renders as zero-valued wave
-// fields without marking GitHub degraded.
-func (p *poller) wavesFromCache(parent string) (map[int]sessionview.WaveInfo, error) {
+// sticky GitHub failure short-circuits to (zero, err), and a cache miss is
+// (zero, nil) — "not fetched yet", which Build renders as zero-valued wave
+// fields (and no synthetic rows) without marking GitHub degraded.
+func (p *poller) wavesFromCache(parent string) (sessionview.WaveGraph, error) {
 	if _, _, ghErr := p.ghIdentity(); ghErr != nil {
-		return nil, ghErr
+		return sessionview.WaveGraph{}, ghErr
 	}
 	p.cacheMu.Lock()
 	defer p.cacheMu.Unlock()
 	e, ok := p.waveCache[normalizeParent(parent)]
 	if !ok {
-		return nil, nil // cache miss: unknown, not degraded
+		return sessionview.WaveGraph{}, nil // cache miss: unknown, not degraded
 	}
-	return e.info, e.err
+	return e.graph, e.err
 }
 
 func (p *poller) refreshGH() {
@@ -237,12 +239,11 @@ func (p *poller) refreshGH() {
 	if err != nil {
 		return
 	}
-	for _, num := range distinctIssueNums(store) {
-		st, prs, err := gh.IssuePRs(num)
-		p.cacheMu.Lock()
-		p.cache[num] = ghCacheEntry{state: st, prs: prs, err: err}
-		p.cacheMu.Unlock()
-	}
+	// Phase 1: per-issue PR state. The fetch set is the recorded issue numbers
+	// UNION the children the wave cache already discovered — not-started
+	// children have no state row, but their synthetic rows still surface
+	// issue/PR/CI state.
+	p.refreshIssuePRs(gh, unionNums(distinctIssueNums(store), p.cachedChildNums()))
 	// Phase 2: one wave-graph fetch per distinct normalized parent. The recorded
 	// issue numbers seed FetchWaveGraph's child set for @manual/Project parents
 	// and backfill unlinked children for numeric ones.
@@ -280,7 +281,7 @@ func (p *poller) refreshGH() {
 				continue
 			}
 		}
-		info, err := gh.Waves(parent, nums)
+		graph, err := gh.Waves(parent, nums)
 		attempted := make(map[int]bool, len(nums))
 		for _, num := range nums {
 			attempted[num] = true
@@ -288,12 +289,110 @@ func (p *poller) refreshGH() {
 		p.cacheMu.Lock()
 		if err != nil {
 			// Partial failure: keep last-known rows instead of dropping
-			// previously confirmed blockers until the next clean pass.
-			info = mergeDegradedWaveInfos(p.waveCache[parent].info, info)
+			// previously confirmed blockers (or already-discovered children)
+			// until the next clean pass.
+			graph = mergeDegradedWaveGraph(p.waveCache[parent].graph, graph)
 		}
-		p.waveCache[parent] = waveCacheEntry{info: info, err: err, attempted: attempted}
+		p.waveCache[parent] = waveCacheEntry{graph: graph, err: err, attempted: attempted}
 		p.cacheMu.Unlock()
 	}
+	// The child set only becomes known after a wave pass. Fetch the PR state of
+	// freshly discovered children right away so their synthetic rows do not sit
+	// at UNKNOWN until the next gh tick; already-known children were covered by
+	// phase 1 (and will be again next tick).
+	p.refreshIssuePRs(gh, p.uncachedIssueNums(p.cachedChildNums()))
+}
+
+// refreshIssuePRs fetches issue/PR state for each num and stores the result
+// (success or failure) in the PR cache.
+func (p *poller) refreshIssuePRs(gh GHProvider, nums []int) {
+	for _, num := range nums {
+		st, prs, err := gh.IssuePRs(num)
+		p.cacheMu.Lock()
+		p.cache[num] = ghCacheEntry{state: st, prs: prs, err: err}
+		p.cacheMu.Unlock()
+	}
+}
+
+// cachedChildNums returns the distinct positive child issue numbers the wave
+// cache knows across all parents, sorted ascending. These are the synthetic
+// not-started row candidates, so their PR state is refreshed alongside the
+// recorded issues.
+func (p *poller) cachedChildNums() []int {
+	p.cacheMu.Lock()
+	defer p.cacheMu.Unlock()
+	seen := map[int]bool{}
+	var nums []int
+	for _, e := range p.waveCache {
+		for _, child := range e.graph.Children {
+			if child.Number > 0 && !seen[child.Number] {
+				seen[child.Number] = true
+				nums = append(nums, child.Number)
+			}
+		}
+	}
+	slices.Sort(nums)
+	return nums
+}
+
+// uncachedIssueNums filters nums down to those without a PR cache entry yet.
+func (p *poller) uncachedIssueNums(nums []int) []int {
+	p.cacheMu.Lock()
+	defer p.cacheMu.Unlock()
+	var out []int
+	for _, num := range nums {
+		if _, ok := p.cache[num]; !ok {
+			out = append(out, num)
+		}
+	}
+	return out
+}
+
+// unionNums merges two ascending distinct slices into one, distinct and sorted.
+func unionNums(a, b []int) []int {
+	seen := make(map[int]bool, len(a)+len(b))
+	out := make([]int, 0, len(a)+len(b))
+	for _, n := range slices.Concat(a, b) {
+		if !seen[n] {
+			seen[n] = true
+			out = append(out, n)
+		}
+	}
+	slices.Sort(out)
+	return out
+}
+
+// mergeDegradedWaveGraph overlays a degraded wave fetch onto the previous
+// cache entry: the per-child info merges via mergeDegradedWaveInfos and the
+// child sets union by issue number, so previously discovered not-started
+// children do not flicker out of the dashboard during a partial failure.
+// Fresh data always wins, so the merge self-heals on the next clean refresh.
+func mergeDegradedWaveGraph(previous, current sessionview.WaveGraph) sessionview.WaveGraph {
+	return sessionview.WaveGraph{
+		Children: mergeWaveChildren(previous.Children, current.Children),
+		Info:     mergeDegradedWaveInfos(previous.Info, current.Info),
+	}
+}
+
+// mergeWaveChildren unions two child sets by issue number: children dropped by
+// the partial fetch are restored from the previous set, same-number children
+// keep the fresh data. The result is sorted ascending for determinism.
+func mergeWaveChildren(previous, current []ghissue.Issue) []ghissue.Issue {
+	if len(previous) == 0 {
+		return current
+	}
+	seen := make(map[int]bool, len(current))
+	for _, child := range current {
+		seen[child.Number] = true
+	}
+	out := slices.Clone(current)
+	for _, child := range previous {
+		if !seen[child.Number] {
+			out = append(out, child)
+		}
+	}
+	slices.SortFunc(out, func(a, b ghissue.Issue) int { return cmp.Compare(a.Number, b.Number) })
+	return out
 }
 
 // mergeDegradedWaveInfos overlays a degraded wave fetch onto the previous

--- a/internal/dashboard/poller_test.go
+++ b/internal/dashboard/poller_test.go
@@ -437,6 +437,31 @@ func TestRefreshGHPrunesWaveCacheForRemovedParents(t *testing.T) {
 	}
 }
 
+// OPEN 時代の古いキャッシュが残っていても、CLOSED へ遷移した子は再 fetch
+// される(キャッシュ側も CLOSED のときだけスキップ)。
+func TestRefreshChildPRsRefetchesOnOpenToClosedTransition(t *testing.T) {
+	root := t.TempDir()
+	writeState(t, root, `{"schemaVersion":1,"panes":[
+	  {"parent":"100","issueNum":101,"slug":"a","paneId":"%1"}
+	]}`)
+	gh := &countingGH{waves: map[string]sessionview.WaveGraph{
+		"100": {
+			Children: []ghissue.Issue{{Number: 103, Title: "closing child", State: "CLOSED"}},
+			Info:     map[int]sessionview.WaveInfo{},
+		},
+	}}
+	p := newPoller("o/n", root, gh, nil, newHub())
+	p.waveInterval = 0
+	// OPEN 時代のキャッシュを偽装(graph は既に CLOSED を報告している)
+	p.cacheMu.Lock()
+	p.cache[103] = ghCacheEntry{state: "OPEN"}
+	p.cacheMu.Unlock()
+	p.refreshGH()
+	if gh.calls[103] != 1 {
+		t.Fatalf("IssuePRs(103) calls = %d, want 1 (stale OPEN cache must refetch)", gh.calls[103])
+	}
+}
+
 // CLOSED で PR キャッシュ済みの子は wave パスでも再 fetch しない(終端状態)。
 func TestRefreshChildPRsSkipsClosedCachedChildren(t *testing.T) {
 	root := t.TempDir()

--- a/internal/dashboard/poller_test.go
+++ b/internal/dashboard/poller_test.go
@@ -20,7 +20,7 @@ type countingGH struct {
 	calls     map[int]int
 	waveCalls map[string]int
 	waveNums  map[string][]int // recordedNums passed per parent (last call)
-	waves     map[string]map[int]sessionview.WaveInfo
+	waves     map[string]sessionview.WaveGraph
 	wavesErr  error
 }
 
@@ -34,7 +34,7 @@ func (g *countingGH) IssuePRs(num int) (string, []ghissue.PRRef, error) {
 	return "CLOSED", []ghissue.PRRef{{Number: 900 + num, State: "MERGED"}}, nil
 }
 
-func (g *countingGH) Waves(parent string, recordedNums []int) (map[int]sessionview.WaveInfo, error) {
+func (g *countingGH) Waves(parent string, recordedNums []int) (sessionview.WaveGraph, error) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 	if g.waveCalls == nil {
@@ -44,7 +44,7 @@ func (g *countingGH) Waves(parent string, recordedNums []int) (map[int]sessionvi
 	g.waveCalls[parent]++
 	g.waveNums[parent] = slices.Clone(recordedNums)
 	if g.wavesErr != nil {
-		return nil, g.wavesErr
+		return sessionview.WaveGraph{}, g.wavesErr
 	}
 	return g.waves[parent], nil
 }
@@ -66,11 +66,11 @@ func TestPollerRefreshGHPopulatesCacheAndBuildReadsIt(t *testing.T) {
 	  {"parent":"100","issueNum":102,"slug":"b","paneId":"%2","agent":"codex"}
 	]}`)
 
-	gh := &countingGH{waves: map[string]map[int]sessionview.WaveInfo{
-		"100": {
+	gh := &countingGH{waves: map[string]sessionview.WaveGraph{
+		"100": {Info: map[int]sessionview.WaveInfo{
 			101: {Wave: 1, Blockers: []blockers.Status{}},
 			102: {Wave: 2, WaveLabel: "wave 2", Blocked: true, Blockers: []blockers.Status{{Num: 101, State: "OPEN"}}},
-		},
+		}},
 	}}
 	p := newPoller("o/n", root, gh, nil, newHub())
 	p.refreshGH()
@@ -376,6 +376,81 @@ func TestMergeDegradedWaveInfos(t *testing.T) {
 				t.Fatalf("mergeDegradedWaveInfos = %#v, want %#v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestMergeDegradedWaveGraphUnionsChildren(t *testing.T) {
+	t.Parallel()
+
+	previous := sessionview.WaveGraph{
+		Children: []ghissue.Issue{{Number: 103, Title: "old three"}, {Number: 101, Title: "one"}},
+		Info:     map[int]sessionview.WaveInfo{101: {Wave: 1}},
+	}
+	current := sessionview.WaveGraph{
+		Children: []ghissue.Issue{{Number: 103, Title: "new three"}},
+		Info:     map[int]sessionview.WaveInfo{103: {Wave: 2}},
+	}
+
+	got := mergeDegradedWaveGraph(previous, current)
+	// Children: dropped #101 is restored, #103 keeps the fresh title, sorted.
+	wantChildren := []ghissue.Issue{{Number: 101, Title: "one"}, {Number: 103, Title: "new three"}}
+	if !reflect.DeepEqual(got.Children, wantChildren) {
+		t.Fatalf("merged children = %#v, want %#v", got.Children, wantChildren)
+	}
+	// Info: same last-known-data semantics as mergeDegradedWaveInfos.
+	if got.Info[101].Wave != 1 || got.Info[103].Wave != 2 {
+		t.Fatalf("merged info = %#v", got.Info)
+	}
+}
+
+func TestRefreshGHFetchesPRsForWaveChildren(t *testing.T) {
+	root := t.TempDir()
+	writeState(t, root, `{"schemaVersion":1,"panes":[
+	  {"parent":"100","issueNum":101,"slug":"a","paneId":"%1"}
+	]}`)
+
+	// The wave graph knows a child (#103) with no recorded pane. Its PR state
+	// must be fetched in the same refresh the child is discovered in — not a
+	// full gh tick later — so the synthetic row paints with real data.
+	gh := &countingGH{waves: map[string]sessionview.WaveGraph{
+		"100": {
+			Children: []ghissue.Issue{
+				{Number: 101, Title: "recorded", State: "OPEN"},
+				{Number: 103, Title: "queued child", State: "OPEN"},
+			},
+			Info: map[int]sessionview.WaveInfo{101: {Wave: 1}, 103: {Wave: 2}},
+		},
+	}}
+	p := newPoller("o/n", root, gh, nil, newHub())
+	p.waveInterval = time.Hour
+	p.refreshGH()
+	if gh.calls[103] != 1 {
+		t.Fatalf("IssuePRs(103) calls after first refresh = %d, want 1 (post-wave fetch)", gh.calls[103])
+	}
+
+	// Once cached, the child joins the phase-1 fetch set on every tick even
+	// while the wave phase stays throttled.
+	p.refreshGH()
+	if gh.calls[103] != 2 {
+		t.Fatalf("IssuePRs(103) calls after second refresh = %d, want 2 (phase-1 union)", gh.calls[103])
+	}
+	if gh.waveCalls["100"] != 1 {
+		t.Fatalf("Waves(100) calls = %d, want 1 (throttled)", gh.waveCalls["100"])
+	}
+
+	// The built snapshot renders the child as a synthetic not-started row with
+	// the cached PR state (countingGH reports a merged PR for every issue).
+	snap := p.build()
+	panes := snap.Sessions[0].Panes
+	if len(panes) != 2 {
+		t.Fatalf("want recorded+synthetic panes, got %+v", panes)
+	}
+	queued := panes[1]
+	if queued.IssueNum != 103 || !queued.NotStarted || !queued.HasMergedPR {
+		t.Fatalf("synthetic pane = %+v", queued)
+	}
+	if snap.Rollup.NotStarted != 1 || snap.Rollup.Total != 2 {
+		t.Fatalf("rollup = %+v, want notStarted=1 total=2", snap.Rollup)
 	}
 }
 

--- a/internal/dashboard/poller_test.go
+++ b/internal/dashboard/poller_test.go
@@ -403,6 +403,64 @@ func TestMergeDegradedWaveGraphUnionsChildren(t *testing.T) {
 	}
 }
 
+// state から消えた親の wave エントリは prune され、その子の PR fetch も止まる。
+func TestRefreshGHPrunesWaveCacheForRemovedParents(t *testing.T) {
+	root := t.TempDir()
+	writeState(t, root, `{"schemaVersion":1,"panes":[
+	  {"parent":"100","issueNum":101,"slug":"a","paneId":"%1"}
+	]}`)
+	gh := &countingGH{waves: map[string]sessionview.WaveGraph{
+		"100": {
+			Children: []ghissue.Issue{{Number: 103, Title: "child", State: "OPEN"}},
+			Info:     map[int]sessionview.WaveInfo{},
+		},
+	}}
+	p := newPoller("o/n", root, gh, nil, newHub())
+	p.waveInterval = 0 // 常に wave パスを走らせる
+	p.refreshGH()
+	if gh.calls[103] != 1 {
+		t.Fatalf("IssuePRs(103) calls = %d, want 1", gh.calls[103])
+	}
+
+	// 親 100 の state 行が消える(--cleanup 相当)
+	writeState(t, root, `{"schemaVersion":1,"panes":[]}`)
+	p.refreshGH()
+	p.refreshGH()
+	if gh.calls[103] != 1 {
+		t.Fatalf("IssuePRs(103) calls after cleanup = %d, want 1 (pruned)", gh.calls[103])
+	}
+	p.cacheMu.Lock()
+	_, cached := p.waveCache["100"]
+	p.cacheMu.Unlock()
+	if cached {
+		t.Fatalf("waveCache entry for removed parent must be pruned")
+	}
+}
+
+// CLOSED で PR キャッシュ済みの子は wave パスでも再 fetch しない(終端状態)。
+func TestRefreshChildPRsSkipsClosedCachedChildren(t *testing.T) {
+	root := t.TempDir()
+	writeState(t, root, `{"schemaVersion":1,"panes":[
+	  {"parent":"100","issueNum":101,"slug":"a","paneId":"%1"}
+	]}`)
+	gh := &countingGH{waves: map[string]sessionview.WaveGraph{
+		"100": {
+			Children: []ghissue.Issue{{Number: 103, Title: "closed child", State: "CLOSED"}},
+			Info:     map[int]sessionview.WaveInfo{},
+		},
+	}}
+	p := newPoller("o/n", root, gh, nil, newHub())
+	p.waveInterval = 0
+	p.refreshGH()
+	if gh.calls[103] != 1 {
+		t.Fatalf("IssuePRs(103) calls = %d, want 1 (first fetch)", gh.calls[103])
+	}
+	p.refreshGH()
+	if gh.calls[103] != 1 {
+		t.Fatalf("IssuePRs(103) calls = %d, want 1 (closed+cached skipped)", gh.calls[103])
+	}
+}
+
 func TestRefreshGHFetchesPRsForWaveChildren(t *testing.T) {
 	root := t.TempDir()
 	writeState(t, root, `{"schemaVersion":1,"panes":[
@@ -428,14 +486,19 @@ func TestRefreshGHFetchesPRsForWaveChildren(t *testing.T) {
 		t.Fatalf("IssuePRs(103) calls after first refresh = %d, want 1 (post-wave fetch)", gh.calls[103])
 	}
 
-	// Once cached, the child joins the phase-1 fetch set on every tick even
-	// while the wave phase stays throttled.
+	// 子の PR fetch は wave cadence に閉じる: wave パスが throttle されている
+	// tick では子を再 fetch しない(20 秒 tick のコストは記録 pane 数に比例
+	// させ、全子 issue 数に比例させない — gh API 予算の防衛線)。
 	p.refreshGH()
-	if gh.calls[103] != 2 {
-		t.Fatalf("IssuePRs(103) calls after second refresh = %d, want 2 (phase-1 union)", gh.calls[103])
+	if gh.calls[103] != 1 {
+		t.Fatalf("IssuePRs(103) calls after throttled refresh = %d, want 1 (wave cadence only)", gh.calls[103])
 	}
 	if gh.waveCalls["100"] != 1 {
 		t.Fatalf("Waves(100) calls = %d, want 1 (throttled)", gh.waveCalls["100"])
+	}
+	// 記録 pane の方は毎 tick fetch される
+	if gh.calls[101] != 2 {
+		t.Fatalf("IssuePRs(101) calls = %d, want 2 (every tick)", gh.calls[101])
 	}
 
 	// The built snapshot renders the child as a synthetic not-started row with
@@ -449,8 +512,10 @@ func TestRefreshGHFetchesPRsForWaveChildren(t *testing.T) {
 	if queued.IssueNum != 103 || !queued.NotStarted || !queued.HasMergedPR {
 		t.Fatalf("synthetic pane = %+v", queued)
 	}
-	if snap.Rollup.NotStarted != 1 || snap.Rollup.Total != 2 {
-		t.Fatalf("rollup = %+v, want notStarted=1 total=2", snap.Rollup)
+	// countingGH は全 issue に CLOSED+merged を返すので、synthetic 子は
+	// 「pane なしで完了」として Total/Merged に入り NotStarted には数えない
+	if snap.Rollup.NotStarted != 0 || snap.Rollup.Total != 2 || !snap.Rollup.AllMerged {
+		t.Fatalf("rollup = %+v, want total=2 allMerged", snap.Rollup)
 	}
 }
 

--- a/internal/dashboard/server_test.go
+++ b/internal/dashboard/server_test.go
@@ -17,8 +17,8 @@ type fakeGH struct{}
 
 func (fakeGH) IssuePRs(num int) (string, []ghissue.PRRef, error) { return "OPEN", nil, nil }
 
-func (fakeGH) Waves(parent string, recordedNums []int) (map[int]sessionview.WaveInfo, error) {
-	return nil, nil
+func (fakeGH) Waves(parent string, recordedNums []int) (sessionview.WaveGraph, error) {
+	return sessionview.WaveGraph{}, nil
 }
 
 // newTestServer binds an ephemeral server in a temp project root with no state

--- a/internal/sessionview/aggregate.go
+++ b/internal/sessionview/aggregate.go
@@ -233,28 +233,32 @@ func Build(repo, projectRoot string, c Collectors) Snapshot {
 					continue
 				}
 				issueState, prs := fetch(child.Number)
+				closeUnconfirmed := false
 				if issueState == IssueStateUnknown && child.State != "" {
 					// PR キャッシュ未取得でも wave graph は issue 状態を知って
 					// いる(Sub-issues API / IssueDetail が state を返す)ので
-					// fallback する。
+					// fallback する。ただし PR 状態は未確認なので、CLOSED に
+					// fallback した行は rollup から落とさない(下記 countsInRollup)。
 					issueState = child.State
+					closeUnconfirmed = strings.EqualFold(issueState, "CLOSED")
 				}
 				wi := graph.Info[child.Number]
 				pv := PaneView{
-					IssueNum:    child.Number,
-					DisplayName: issueDisplayName(child),
-					IssueState:  issueState,
-					PRs:         prs,
-					HasMergedPR: hasMergedPR(prs),
-					DiffSummary: "-",
-					DirtyState:  "-",
-					TmuxState:   SyntheticTmuxState(issueState, wi.Blocked),
-					CIStatus:    strings.ToLower(strings.TrimSpace(ghissue.SummarizeCI(prs))),
-					Wave:        wi.Wave,
-					WaveLabel:   wi.WaveLabel,
-					Blockers:    normalizeBlockers(wi.Blockers),
-					Blocked:     wi.Blocked,
-					NotStarted:  true,
+					IssueNum:         child.Number,
+					DisplayName:      issueDisplayName(child),
+					IssueState:       issueState,
+					PRs:              prs,
+					HasMergedPR:      hasMergedPR(prs),
+					DiffSummary:      "-",
+					DirtyState:       "-",
+					TmuxState:        SyntheticTmuxState(issueState, wi.Blocked),
+					CIStatus:         strings.ToLower(strings.TrimSpace(ghissue.SummarizeCI(prs))),
+					Wave:             wi.Wave,
+					WaveLabel:        wi.WaveLabel,
+					Blockers:         normalizeBlockers(wi.Blockers),
+					Blocked:          wi.Blocked,
+					NotStarted:       true,
+					closeUnconfirmed: closeUnconfirmed,
 				}
 				session.Panes = append(session.Panes, pv)
 				if countsInRollup(pv) {
@@ -490,7 +494,14 @@ func countsInRollup(pv PaneView) bool {
 	if !pv.NotStarted {
 		return true
 	}
-	return !strings.EqualFold(pv.IssueState, "CLOSED") || pv.HasMergedPR
+	if !strings.EqualFold(pv.IssueState, "CLOSED") || pv.HasMergedPR {
+		return true
+	}
+	// CLOSED かつ merged PR なし: PR lookup で「merged なし」を確認できたとき
+	// だけ rollup から落とす(not-planned 等の確定 close)。PR 状態が未確認
+	// (キャッシュ miss/失敗で wave graph 状態へ fallback)なら算入し、一時的な
+	// gh 失敗で session が 100%/AllMerged に見えるのを防ぐ。
+	return pv.closeUnconfirmed
 }
 
 func accumulate(r *Rollup, pv PaneView) {

--- a/internal/sessionview/aggregate.go
+++ b/internal/sessionview/aggregate.go
@@ -50,13 +50,16 @@ type Collectors struct {
 	// Waves follows the same three-outcome cache contract as IssuePRs, keyed by
 	// parent instead of issue number (the caller closes over the recorded issue
 	// numbers it passes to FetchWaveGraph):
-	//   - (info, nil)  → known wave/blocker graph for the parent's children.
-	//   - (nil, nil)   → not fetched yet (cache miss); panes show zero-valued
-	//     wave fields but this does NOT mark GitHub as degraded.
-	//   - (info, err)  → a real failure; Degraded.GitHub is set and any partial
-	//     info is still applied (FetchWaveGraph keeps partial results).
+	//   - (graph, nil) with non-nil Info → known wave/blocker graph; the child
+	//     set (graph.Children) also seeds synthetic not-started rows for
+	//     children without a recorded pane.
+	//   - (zero WaveGraph, nil) → not fetched yet (cache miss); panes show
+	//     zero-valued wave fields and no synthetic rows appear, but this does
+	//     NOT mark GitHub as degraded.
+	//   - (graph, err) → a real failure; Degraded.GitHub is set and any partial
+	//     graph is still applied (FetchWaveGraph keeps partial results).
 	// A nil collector means the GitHub tier is disabled, like a nil IssuePRs.
-	Waves        func(parent string) (map[int]WaveInfo, error)
+	Waves        func(parent string) (WaveGraph, error)
 	WorktreeStat func(path, baseRef string) (WorktreeStat, error)
 	Now          func() time.Time
 }
@@ -122,12 +125,12 @@ func Build(repo, projectRoot string, c Collectors) Snapshot {
 		return st, prs
 	}
 	// One waves read per distinct parent, cached across the Build call.
-	waveCache := map[string]map[int]WaveInfo{}
-	fetchWaves := func(parent string) map[int]WaveInfo {
+	waveCache := map[string]WaveGraph{}
+	fetchWaves := func(parent string) WaveGraph {
 		if got, ok := waveCache[parent]; ok {
 			return got
 		}
-		var info map[int]WaveInfo
+		var graph WaveGraph
 		if c.Waves == nil {
 			snap.Degraded.GitHub = true
 		} else {
@@ -136,10 +139,10 @@ func Build(repo, projectRoot string, c Collectors) Snapshot {
 				snap.Degraded.GitHub = true
 				snap.Degraded.Reason = appendReason(snap.Degraded.Reason, "github: "+err.Error())
 			}
-			info = got // a (nil, nil) cache miss leaves zero-valued wave fields
+			graph = got // a zero-valued cache miss leaves zero wave fields and no synthetic rows
 		}
-		waveCache[parent] = info
-		return info
+		waveCache[parent] = graph
+		return graph
 	}
 	worktreeCache := map[string]struct {
 		stat WorktreeStat
@@ -164,17 +167,19 @@ func Build(repo, projectRoot string, c Collectors) Snapshot {
 	}
 
 	grouped := groupByParent(store.Panes)
+	recordedByParent := recordedNumsByNormalizedParent(store.Panes)
+	syntheticEmitted := map[string]bool{}
 	for _, parent := range sortedParents(grouped) {
 		panes := grouped[parent]
 		slices.SortFunc(panes, func(a, b state.Pane) int { return cmp.Compare(a.IssueNum, b.IssueNum) })
 
 		session := Session{Parent: parent, Panes: make([]PaneView, 0, len(panes))}
-		waveInfo := fetchWaves(parent)
+		graph := fetchWaves(parent)
 		for _, p := range panes {
 			issueState, prs := fetch(p.IssueNum)
 			worktreeStat, worktreeErr := fetchWorktree(p.WorktreePath, p.BaseBranch)
 			alive := paneAlive(live, p.PaneID, p.WorktreePath)
-			wi := waveInfo[p.IssueNum]
+			wi := graph.Info[p.IssueNum]
 			pv := PaneView{
 				IssueNum:     p.IssueNum,
 				Slug:         p.Slug,
@@ -213,6 +218,47 @@ func Build(repo, projectRoot string, c Collectors) Snapshot {
 			}
 			session.Panes = append(session.Panes, pv)
 			accumulate(&session.Rollup, pv)
+		}
+		// 記録 pane の無い wave graph 上の子 issue を「未開始」の synthetic 行
+		// として追加する(TUI の synthetic 行の web 移植)。rowKey は
+		// (parent, issueNum) なので、pane が起動した次の snapshot ではこの行が
+		// そのまま実 row に置き換わる。"0100"/"100" のようなエイリアス親は同じ
+		// wave graph を共有するため、normalize したキーごとに一度だけ emit し、
+		// 未記録判定もエイリアス session 横断で行う。
+		if normKey := normalizeParentKey(parent); !syntheticEmitted[normKey] {
+			syntheticEmitted[normKey] = true
+			recorded := recordedByParent[normKey]
+			for _, child := range childrenByNumber(graph.Children) {
+				if child.Number <= 0 || recorded[child.Number] {
+					continue
+				}
+				issueState, prs := fetch(child.Number)
+				if issueState == IssueStateUnknown && child.State != "" {
+					// PR キャッシュ未取得でも wave graph は issue 状態を知って
+					// いる(Sub-issues API / IssueDetail が state を返す)ので
+					// fallback する。
+					issueState = child.State
+				}
+				wi := graph.Info[child.Number]
+				pv := PaneView{
+					IssueNum:    child.Number,
+					DisplayName: issueDisplayName(child),
+					IssueState:  issueState,
+					PRs:         prs,
+					HasMergedPR: hasMergedPR(prs),
+					DiffSummary: "-",
+					DirtyState:  "-",
+					TmuxState:   syntheticTmuxState(issueState, wi.Blocked),
+					CIStatus:    strings.ToLower(strings.TrimSpace(ghissue.SummarizeCI(prs))),
+					Wave:        wi.Wave,
+					WaveLabel:   wi.WaveLabel,
+					Blockers:    normalizeBlockers(wi.Blockers),
+					Blocked:     wi.Blocked,
+					NotStarted:  true,
+				}
+				session.Panes = append(session.Panes, pv)
+				accumulate(&session.Rollup, pv)
+			}
 		}
 		finalize(&session.Rollup)
 		snap.Sessions = append(snap.Sessions, session)
@@ -276,6 +322,68 @@ func sortedParents(grouped map[string][]state.Pane) []string {
 		}
 	})
 	return keys
+}
+
+// normalizeParentKey は数値親を Atoi 往復で正規化する("0100" と "100" を同一
+// 親として扱う)。dashboard poller の normalizeParent / state の parentMatches
+// と同じ規則。
+func normalizeParentKey(parent string) string {
+	if n, err := strconv.Atoi(parent); err == nil {
+		return strconv.Itoa(n)
+	}
+	return parent
+}
+
+// recordedNumsByNormalizedParent は normalize した親キーごとの記録済み issue
+// 番号集合。synthetic 行の「未記録」判定はエイリアス session 横断で行う —
+// "0100" 配下に記録済みの子を "100" session が synthetic として二重 emit して
+// はならない。
+func recordedNumsByNormalizedParent(panes []state.Pane) map[string]map[int]bool {
+	out := map[string]map[int]bool{}
+	for _, p := range panes {
+		key := normalizeParentKey(p.Parent)
+		if out[key] == nil {
+			out[key] = map[int]bool{}
+		}
+		if p.IssueNum > 0 {
+			out[key][p.IssueNum] = true
+		}
+	}
+	return out
+}
+
+// childrenByNumber は wave graph の子集合を issue 番号昇順のクローンで返し、
+// synthetic 行の出力順を決定的にする(FetchWaveGraph の子順はソース由来)。
+func childrenByNumber(children []ghissue.Issue) []ghissue.Issue {
+	out := slices.Clone(children)
+	slices.SortFunc(out, func(a, b ghissue.Issue) int { return cmp.Compare(a.Number, b.Number) })
+	return out
+}
+
+// issueDisplayName は synthetic 行の表示名: issue タイトル、無ければ "#<num>"
+// (TUI の issueTitle と同じ規則)。
+func issueDisplayName(child ghissue.Issue) string {
+	if strings.TrimSpace(child.Title) != "" {
+		return child.Title
+	}
+	return "#" + strconv.Itoa(child.Number)
+}
+
+// syntheticTmuxState は未開始子 issue の tmux 列値。internal/tui の
+// syntheticTmuxState と完全一致させる(`state:queued` 等のフィルタが TUI と
+// web で同じ意味を持つ): closed → deferred → queued の優先順で判定し、issue
+// 状態が取れないものは unknown。
+func syntheticTmuxState(issueState string, blocked bool) string {
+	switch {
+	case strings.EqualFold(issueState, "CLOSED"):
+		return "closed"
+	case blocked:
+		return "deferred"
+	case strings.EqualFold(issueState, "OPEN"):
+		return "queued"
+	default:
+		return "unknown"
+	}
 }
 
 // paneAlive reports whether a recorded pane is live: a tmux pane with its id
@@ -375,6 +483,9 @@ func accumulate(r *Rollup, pv PaneView) {
 	}
 	if pv.Blocked {
 		r.Blocked++
+	}
+	if pv.NotStarted {
+		r.NotStarted++
 	}
 }
 

--- a/internal/sessionview/aggregate.go
+++ b/internal/sessionview/aggregate.go
@@ -225,7 +225,7 @@ func Build(repo, projectRoot string, c Collectors) Snapshot {
 		// そのまま実 row に置き換わる。"0100"/"100" のようなエイリアス親は同じ
 		// wave graph を共有するため、normalize したキーごとに一度だけ emit し、
 		// 未記録判定もエイリアス session 横断で行う。
-		if normKey := normalizeParentKey(parent); !syntheticEmitted[normKey] {
+		if normKey := NormalizeParent(parent); !syntheticEmitted[normKey] {
 			syntheticEmitted[normKey] = true
 			recorded := recordedByParent[normKey]
 			for _, child := range childrenByNumber(graph.Children) {
@@ -248,7 +248,7 @@ func Build(repo, projectRoot string, c Collectors) Snapshot {
 					HasMergedPR: hasMergedPR(prs),
 					DiffSummary: "-",
 					DirtyState:  "-",
-					TmuxState:   syntheticTmuxState(issueState, wi.Blocked),
+					TmuxState:   SyntheticTmuxState(issueState, wi.Blocked),
 					CIStatus:    strings.ToLower(strings.TrimSpace(ghissue.SummarizeCI(prs))),
 					Wave:        wi.Wave,
 					WaveLabel:   wi.WaveLabel,
@@ -257,14 +257,18 @@ func Build(repo, projectRoot string, c Collectors) Snapshot {
 					NotStarted:  true,
 				}
 				session.Panes = append(session.Panes, pv)
-				accumulate(&session.Rollup, pv)
+				if countsInRollup(pv) {
+					accumulate(&session.Rollup, pv)
+				}
 			}
 		}
 		finalize(&session.Rollup)
 		snap.Sessions = append(snap.Sessions, session)
 
 		for _, pv := range session.Panes {
-			accumulate(&snap.Rollup, pv)
+			if countsInRollup(pv) {
+				accumulate(&snap.Rollup, pv)
+			}
 		}
 	}
 	finalize(&snap.Rollup)
@@ -312,7 +316,13 @@ func sortedParents(grouped map[string][]state.Pane) []string {
 		nb, eb := strconv.Atoi(b)
 		switch {
 		case ea == nil && eb == nil:
-			return cmp.Compare(na, nb)
+			if c := cmp.Compare(na, nb); c != 0 {
+				return c
+			}
+			// エイリアス親("0100"/"100")は数値比較で等しい。raw 文字列で
+			// タイブレークしないと map 順で session 順序と synthetic 行の
+			// 帰属先が build ごとに揺れ、SSE が毎 tick 発火する。
+			return strings.Compare(a, b)
 		case ea == nil:
 			return -1 // numeric before non-numeric
 		case eb == nil:
@@ -324,10 +334,11 @@ func sortedParents(grouped map[string][]state.Pane) []string {
 	return keys
 }
 
-// normalizeParentKey は数値親を Atoi 往復で正規化する("0100" と "100" を同一
-// 親として扱う)。dashboard poller の normalizeParent / state の parentMatches
-// と同じ規則。
-func normalizeParentKey(parent string) string {
+// NormalizeParent は数値親を Atoi 往復で正規化する("0100" と "100" を同一
+// 親として扱う)。state の parentMatches と同じ規則で、dashboard poller の
+// wave cache キーもこれを使う(規則が割れるとエイリアス親の synthetic 行が
+// 二重 emit / 消失する)。
+func NormalizeParent(parent string) string {
 	if n, err := strconv.Atoi(parent); err == nil {
 		return strconv.Itoa(n)
 	}
@@ -341,7 +352,7 @@ func normalizeParentKey(parent string) string {
 func recordedNumsByNormalizedParent(panes []state.Pane) map[string]map[int]bool {
 	out := map[string]map[int]bool{}
 	for _, p := range panes {
-		key := normalizeParentKey(p.Parent)
+		key := NormalizeParent(p.Parent)
 		if out[key] == nil {
 			out[key] = map[int]bool{}
 		}
@@ -369,11 +380,11 @@ func issueDisplayName(child ghissue.Issue) string {
 	return "#" + strconv.Itoa(child.Number)
 }
 
-// syntheticTmuxState は未開始子 issue の tmux 列値。internal/tui の
-// syntheticTmuxState と完全一致させる(`state:queued` 等のフィルタが TUI と
+// SyntheticTmuxState は未開始子 issue の tmux 列値。internal/tui の synthetic
+// 行もこれを呼ぶ単一実装(`state:queued` 等のフィルタが TUI と
 // web で同じ意味を持つ): closed → deferred → queued の優先順で判定し、issue
 // 状態が取れないものは unknown。
-func syntheticTmuxState(issueState string, blocked bool) string {
+func SyntheticTmuxState(issueState string, blocked bool) string {
 	switch {
 	case strings.EqualFold(issueState, "CLOSED"):
 		return "closed"
@@ -470,6 +481,18 @@ func hasMergedPR(prs []ghissue.PRRef) bool {
 	return false
 }
 
+// countsInRollup は rollup に算入する行かどうか。PR が merge されないまま
+// CLOSED になった synthetic 子(not-planned 等)は除外する(行としては表示
+// する): 算入すると Pending に永久に残り、セッション進捗が 100% / AllMerged
+// に到達できなくなるため。merged PR を持つ CLOSED 子は「pane なしで完了した
+// 作業」として Total / Merged に算入する。記録 pane は従来どおり常に算入。
+func countsInRollup(pv PaneView) bool {
+	if !pv.NotStarted {
+		return true
+	}
+	return !strings.EqualFold(pv.IssueState, "CLOSED") || pv.HasMergedPR
+}
+
 func accumulate(r *Rollup, pv PaneView) {
 	r.Total++
 	if pv.HasMergedPR {
@@ -484,7 +507,9 @@ func accumulate(r *Rollup, pv PaneView) {
 	if pv.Blocked {
 		r.Blocked++
 	}
-	if pv.NotStarted {
+	if pv.NotStarted && pv.TmuxState != "closed" {
+		// NotStarted は「まだ起動しうる作業」のカウンタ: merged 済みで閉じた
+		// synthetic 子は Total/Merged には入るがここには数えない。
 		r.NotStarted++
 	}
 }

--- a/internal/sessionview/aggregate_test.go
+++ b/internal/sessionview/aggregate_test.go
@@ -676,13 +676,48 @@ func TestBuildAppendsSyntheticPanesForUnrecordedChildren(t *testing.T) {
 	if blocked.TmuxState != "deferred" || !blocked.Blocked || len(blocked.Blockers) != 1 {
 		t.Fatalf("blocked synthetic pane = %+v", blocked)
 	}
-	// rollup: synthetic 行も Total/Merged/Pending/Blocked に入り、NotStarted を数える
+	// rollup: OPEN/不明の synthetic 行は Total/Pending/Blocked と NotStarted に
+	// 入る。merged PR 持ちで CLOSED の #103 は Total/Merged に入る(pane なしで
+	// 完了した作業)が NotStarted には数えない。
 	r := snap.Sessions[0].Rollup
-	if r.Total != 4 || r.NotStarted != 3 || r.Merged != 1 || r.Pending != 3 || r.Blocked != 1 {
+	if r.Total != 4 || r.NotStarted != 2 || r.Merged != 1 || r.Pending != 3 || r.Blocked != 1 {
 		t.Fatalf("session rollup = %+v", r)
 	}
-	if snap.Rollup.NotStarted != 3 || snap.Rollup.Total != 4 {
+	if snap.Rollup.NotStarted != 2 || snap.Rollup.Total != 4 {
 		t.Fatalf("snapshot rollup = %+v", snap.Rollup)
+	}
+}
+
+// CLOSED のまま起動されなかった synthetic 子が rollup から除外され、全 merge
+// 済みセッションの AllMerged を妨げないことを単体で固定する。
+func TestBuildClosedSyntheticChildDoesNotBlockAllMerged(t *testing.T) {
+	graph := WaveGraph{
+		Children: []ghissue.Issue{
+			{Number: 101, Title: "merged", State: "CLOSED"},
+			{Number: 103, Title: "not planned", State: "CLOSED"},
+		},
+		Info: map[int]WaveInfo{},
+	}
+	c := Collectors{
+		Now:       fixedNow,
+		LoadState: storeOf(pane("100", 101, "%1")),
+		LivePanes: livePanesAt(),
+		IssuePRs: func(num int) (string, []ghissue.PRRef, error) {
+			if num == 101 {
+				return "CLOSED", mergedPR(501), nil
+			}
+			return "CLOSED", nil, nil // PR なしで閉じられた子
+		},
+		Waves: wavesGraphOf(graph, nil),
+	}
+	snap := Build("o/n", "/root", c)
+	panes := snap.Sessions[0].Panes
+	if len(panes) != 2 || panes[1].TmuxState != "closed" {
+		t.Fatalf("closed synthetic row must still render: %+v", panes)
+	}
+	r := snap.Sessions[0].Rollup
+	if r.Total != 1 || !r.AllMerged || r.Pending != 0 || r.NotStarted != 0 {
+		t.Fatalf("closed synthetic child must not block AllMerged: %+v", r)
 	}
 }
 
@@ -762,8 +797,8 @@ func TestSyntheticTmuxStateMatchesTUIStrings(t *testing.T) {
 		{"", false, "unknown"},
 	}
 	for _, tc := range cases {
-		if got := syntheticTmuxState(tc.issueState, tc.blocked); got != tc.want {
-			t.Errorf("syntheticTmuxState(%q, %v) = %q, want %q", tc.issueState, tc.blocked, got, tc.want)
+		if got := SyntheticTmuxState(tc.issueState, tc.blocked); got != tc.want {
+			t.Errorf("SyntheticTmuxState(%q, %v) = %q, want %q", tc.issueState, tc.blocked, got, tc.want)
 		}
 	}
 }

--- a/internal/sessionview/aggregate_test.go
+++ b/internal/sessionview/aggregate_test.go
@@ -48,18 +48,25 @@ func livePanesWith(m map[string]LivePaneInfo) func() (map[string]LivePaneInfo, e
 
 // wavesNone is a Waves collector that always reports a cache miss (not fetched
 // yet) — the non-degraded GitHub baseline for tests not exercising waves.
-func wavesNone(parent string) (map[int]WaveInfo, error) {
-	return nil, nil
+func wavesNone(parent string) (WaveGraph, error) {
+	return WaveGraph{}, nil
 }
 
-// wavesOf builds a Waves collector serving the same WaveInfo map for any
-// parent and counting calls through calls (when non-nil).
-func wavesOf(info map[int]WaveInfo, calls *int) func(string) (map[int]WaveInfo, error) {
-	return func(parent string) (map[int]WaveInfo, error) {
+// wavesOf builds a Waves collector serving the same WaveInfo map (no child
+// set, so no synthetic rows) for any parent and counting calls through calls
+// (when non-nil).
+func wavesOf(info map[int]WaveInfo, calls *int) func(string) (WaveGraph, error) {
+	return wavesGraphOf(WaveGraph{Info: info}, calls)
+}
+
+// wavesGraphOf builds a Waves collector serving the same full WaveGraph for
+// any parent.
+func wavesGraphOf(graph WaveGraph, calls *int) func(string) (WaveGraph, error) {
+	return func(parent string) (WaveGraph, error) {
 		if calls != nil {
 			*calls++
 		}
-		return info, nil
+		return graph, nil
 	}
 }
 
@@ -520,7 +527,7 @@ func TestBuildWavesErrorDegradesGitHub(t *testing.T) {
 		LoadState: storeOf(pane("1", 2, "%1")),
 		LivePanes: livePanesAt(),
 		IssuePRs:  func(num int) (string, []ghissue.PRRef, error) { return "OPEN", nil, nil },
-		Waves:     func(parent string) (map[int]WaveInfo, error) { return nil, errors.New("gh graph down") },
+		Waves:     func(parent string) (WaveGraph, error) { return WaveGraph{}, errors.New("gh graph down") },
 	}
 	snap := Build("o/n", "/root", c)
 	if !snap.Degraded.GitHub {
@@ -595,6 +602,169 @@ func TestBuildWaveLabelStateRowWinsOverGraph(t *testing.T) {
 	}
 	if panes[1].WaveLabel != "graph-label" {
 		t.Fatalf("WaveLabel = %q; the graph label must fill in when the row has none", panes[1].WaveLabel)
+	}
+}
+
+func TestBuildAppendsSyntheticPanesForUnrecordedChildren(t *testing.T) {
+	graph := WaveGraph{
+		Children: []ghissue.Issue{
+			{Number: 104, State: "OPEN"}, // タイトル無し → "#104" fallback
+			{Number: 101, Title: "Recorded", State: "OPEN"},
+			{Number: 103, Title: "Queued child", State: "OPEN"},
+			{Number: 105, Title: "Blocked child", State: "OPEN"},
+		},
+		Info: map[int]WaveInfo{
+			101: {Wave: 1},
+			103: {Wave: 2, WaveLabel: "wave2", Blockers: []blockers.Status{}},
+			104: {Wave: 2},
+			105: {Wave: 3, Blockers: []blockers.Status{{Num: 103, State: "OPEN"}}, Blocked: true},
+		},
+	}
+	c := Collectors{
+		Now:       fixedNow,
+		LoadState: storeOf(pane("100", 101, "%1")),
+		LivePanes: livePanesAt("%1"),
+		IssuePRs: func(num int) (string, []ghissue.PRRef, error) {
+			switch num {
+			case 103:
+				return "CLOSED", mergedPR(503), nil // PR キャッシュが状態と PR を知っている
+			case 104:
+				return "", nil, nil // キャッシュ未取得 → graph の State へ fallback
+			default:
+				return "OPEN", nil, nil
+			}
+		},
+		Waves: wavesGraphOf(graph, nil),
+	}
+	snap := Build("o/n", "/root", c)
+	panes := snap.Sessions[0].Panes
+	if len(panes) != 4 {
+		t.Fatalf("want 1 recorded + 3 synthetic panes, got %+v", panes)
+	}
+	if panes[0].IssueNum != 101 || panes[0].NotStarted {
+		t.Fatalf("recorded pane must come first and not be synthetic: %+v", panes[0])
+	}
+	// synthetic 行は記録行の後に issue 番号昇順で並ぶ
+	if panes[1].IssueNum != 103 || panes[2].IssueNum != 104 || panes[3].IssueNum != 105 {
+		t.Fatalf("synthetic order = %d,%d,%d want 103,104,105",
+			panes[1].IssueNum, panes[2].IssueNum, panes[3].IssueNum)
+	}
+	queued := panes[1]
+	if !queued.NotStarted || queued.Alive || queued.PaneID != "" || queued.Agent != "" || queued.BranchName != "" {
+		t.Fatalf("synthetic pane must carry zero pane fields: %+v", queued)
+	}
+	if queued.DisplayName != "Queued child" {
+		t.Fatalf("DisplayName = %q want the issue title", queued.DisplayName)
+	}
+	if queued.IssueState != "CLOSED" || !queued.HasMergedPR || queued.TmuxState != "closed" {
+		t.Fatalf("PR-cache-backed synthetic pane = %+v", queued)
+	}
+	if queued.DiffSummary != "-" || queued.DirtyState != "-" {
+		t.Fatalf("synthetic diff/dirty = %q/%q want -/-", queued.DiffSummary, queued.DirtyState)
+	}
+	if queued.Wave != 2 || queued.WaveLabel != "wave2" {
+		t.Fatalf("synthetic wave fields = %+v", queued)
+	}
+	noTitle := panes[2]
+	if noTitle.DisplayName != "#104" {
+		t.Fatalf("DisplayName = %q want #104 fallback", noTitle.DisplayName)
+	}
+	if noTitle.IssueState != "OPEN" || noTitle.TmuxState != "queued" {
+		t.Fatalf("PR cache miss must fall back to the graph issue state: %+v", noTitle)
+	}
+	blocked := panes[3]
+	if blocked.TmuxState != "deferred" || !blocked.Blocked || len(blocked.Blockers) != 1 {
+		t.Fatalf("blocked synthetic pane = %+v", blocked)
+	}
+	// rollup: synthetic 行も Total/Merged/Pending/Blocked に入り、NotStarted を数える
+	r := snap.Sessions[0].Rollup
+	if r.Total != 4 || r.NotStarted != 3 || r.Merged != 1 || r.Pending != 3 || r.Blocked != 1 {
+		t.Fatalf("session rollup = %+v", r)
+	}
+	if snap.Rollup.NotStarted != 3 || snap.Rollup.Total != 4 {
+		t.Fatalf("snapshot rollup = %+v", snap.Rollup)
+	}
+}
+
+func TestBuildWaveCacheMissEmitsNoSyntheticRows(t *testing.T) {
+	c := Collectors{
+		Now:       fixedNow,
+		LoadState: storeOf(pane("100", 101, "%1")),
+		LivePanes: livePanesAt(),
+		IssuePRs:  func(num int) (string, []ghissue.PRRef, error) { return "OPEN", nil, nil },
+		Waves:     wavesNone,
+	}
+	snap := Build("o/n", "/root", c)
+	if len(snap.Sessions[0].Panes) != 1 {
+		t.Fatalf("a wave cache miss must not invent synthetic rows: %+v", snap.Sessions[0].Panes)
+	}
+	if snap.Rollup.NotStarted != 0 {
+		t.Fatalf("Rollup.NotStarted = %d want 0", snap.Rollup.NotStarted)
+	}
+}
+
+func TestBuildSyntheticEmittedOncePerAliasedParent(t *testing.T) {
+	// "0100" と "100" は normalize すると同一親で、同じ wave graph を共有する。
+	// 未記録の #103 はどちらか一方の session にだけ現れ、記録済みの #101/#102
+	// はエイリアス横断で「記録済み」と判定されて synthetic にならない。
+	graph := WaveGraph{
+		Children: []ghissue.Issue{
+			{Number: 101, State: "OPEN"},
+			{Number: 102, State: "OPEN"},
+			{Number: 103, Title: "Queued", State: "OPEN"},
+		},
+		Info: map[int]WaveInfo{101: {Wave: 1}, 102: {Wave: 1}, 103: {Wave: 2}},
+	}
+	c := Collectors{
+		Now:       fixedNow,
+		LoadState: storeOf(pane("0100", 101, "%1"), pane("100", 102, "%2")),
+		LivePanes: livePanesAt(),
+		IssuePRs:  func(num int) (string, []ghissue.PRRef, error) { return "OPEN", nil, nil },
+		Waves:     wavesGraphOf(graph, nil),
+	}
+	snap := Build("o/n", "/root", c)
+	if len(snap.Sessions) != 2 {
+		t.Fatalf("want 2 alias sessions, got %d", len(snap.Sessions))
+	}
+	total := 0
+	var synthetic []int
+	for _, sess := range snap.Sessions {
+		total += len(sess.Panes)
+		for _, pv := range sess.Panes {
+			if pv.NotStarted {
+				synthetic = append(synthetic, pv.IssueNum)
+			}
+		}
+	}
+	if total != 3 {
+		t.Fatalf("total panes = %d want 3 (2 recorded + 1 synthetic)", total)
+	}
+	if len(synthetic) != 1 || synthetic[0] != 103 {
+		t.Fatalf("synthetic nums = %v want [103] emitted exactly once", synthetic)
+	}
+	if snap.Rollup.NotStarted != 1 {
+		t.Fatalf("Rollup.NotStarted = %d want 1", snap.Rollup.NotStarted)
+	}
+}
+
+func TestSyntheticTmuxStateMatchesTUIStrings(t *testing.T) {
+	cases := []struct {
+		issueState string
+		blocked    bool
+		want       string
+	}{
+		{"CLOSED", false, "closed"},
+		{"closed", true, "closed"}, // closed は blocked より優先(TUI と同順)
+		{"OPEN", true, "deferred"},
+		{"OPEN", false, "queued"},
+		{"open", false, "queued"},
+		{IssueStateUnknown, false, "unknown"},
+		{"", false, "unknown"},
+	}
+	for _, tc := range cases {
+		if got := syntheticTmuxState(tc.issueState, tc.blocked); got != tc.want {
+			t.Errorf("syntheticTmuxState(%q, %v) = %q, want %q", tc.issueState, tc.blocked, got, tc.want)
+		}
 	}
 }
 

--- a/internal/sessionview/aggregate_test.go
+++ b/internal/sessionview/aggregate_test.go
@@ -721,6 +721,43 @@ func TestBuildClosedSyntheticChildDoesNotBlockAllMerged(t *testing.T) {
 	}
 }
 
+// PR lookup が失敗(IssuePRs エラー)した CLOSED 子は PR 状態が未確認なので
+// rollup に算入し、一時的な gh 失敗で session が誤って AllMerged に見えるのを
+// 防ぐ。
+func TestBuildUnconfirmedClosedSyntheticChildStaysInRollup(t *testing.T) {
+	graph := WaveGraph{
+		Children: []ghissue.Issue{
+			{Number: 101, Title: "merged", State: "CLOSED"},
+			{Number: 103, Title: "closed but PR unknown", State: "CLOSED"},
+		},
+		Info: map[int]WaveInfo{},
+	}
+	c := Collectors{
+		Now:       fixedNow,
+		LoadState: storeOf(pane("100", 101, "%1")),
+		LivePanes: livePanesAt(),
+		IssuePRs: func(num int) (string, []ghissue.PRRef, error) {
+			if num == 101 {
+				return "CLOSED", mergedPR(501), nil
+			}
+			// #103 は PR lookup 失敗(レート制限等)。状態は wave graph の
+			// CLOSED に fallback するが、merged PR の有無は未確認。
+			return "", nil, errors.New("rate limited")
+		},
+		Waves: wavesGraphOf(graph, nil),
+	}
+	snap := Build("o/n", "/root", c)
+	panes := snap.Sessions[0].Panes
+	if len(panes) != 2 || panes[1].IssueState != "CLOSED" {
+		t.Fatalf("unconfirmed closed row must still render as CLOSED: %+v", panes)
+	}
+	r := snap.Sessions[0].Rollup
+	// #103 は算入される → Total 2 / Pending 1 / AllMerged false(完了扱いしない)
+	if r.Total != 2 || r.AllMerged || r.Pending != 1 {
+		t.Fatalf("unconfirmed closed child must stay in rollup: %+v", r)
+	}
+}
+
 func TestBuildWaveCacheMissEmitsNoSyntheticRows(t *testing.T) {
 	c := Collectors{
 		Now:       fixedNow,

--- a/internal/sessionview/collect.go
+++ b/internal/sessionview/collect.go
@@ -96,12 +96,12 @@ func (g GH) IssuePRs(num int) (string, []ghissue.PRRef, error) {
 	return g.runner.IssueWithPRs(g.owner, g.repo, num)
 }
 
-// Waves fetches one parent's wave/blocker graph keyed by child issue number.
-// The Collectors.Waves field takes only the parent — the poller closes over
-// the recorded issue numbers it observed in state and wraps this method.
-// Partial results are returned alongside a non-nil error (FetchWaveGraph joins
-// per-issue failures), so callers can cache the partial graph and degrade.
-func (g GH) Waves(parent string, recordedNums []int) (map[int]WaveInfo, error) {
-	graph, err := FetchWaveGraph(g.runner, parent, recordedNums)
-	return graph.Info, err
+// Waves fetches one parent's wave/blocker graph: the resolved child set plus
+// per-child wave/blocker info keyed by issue number. The Collectors.Waves
+// field takes only the parent — the poller closes over the recorded issue
+// numbers it observed in state and wraps this method. Partial results are
+// returned alongside a non-nil error (FetchWaveGraph joins per-issue
+// failures), so callers can cache the partial graph and degrade.
+func (g GH) Waves(parent string, recordedNums []int) (WaveGraph, error) {
+	return FetchWaveGraph(g.runner, parent, recordedNums)
 }

--- a/internal/sessionview/model.go
+++ b/internal/sessionview/model.go
@@ -77,17 +77,24 @@ type PaneView struct {
 	WaveLabel string            `json:"waveLabel,omitempty"` // state row wave label, else parent-body heading
 	Blockers  []blockers.Status `json:"blockers"`            // always non-nil; serializes as []
 	Blocked   bool              `json:"blocked"`             // at least one blocker still OPEN
+	// NotStarted は state.json に記録 pane が無い「未開始」の子 issue を表す
+	// synthetic 行(TUI の synthetic 行の web 移植)。PaneID/Agent/Branch 等の
+	// pane 由来フィールドは zero、TmuxState は closed/deferred/queued/unknown。
+	NotStarted bool `json:"notStarted,omitempty"`
 }
 
 // Rollup is an aggregate count band, mirroring --status's summary plus liveness.
+// Total/Merged/Pending/Blocked count synthetic not-started rows too, so the
+// progress band reflects session completion, not just launched panes.
 type Rollup struct {
-	Total     int  `json:"total"`
-	Merged    int  `json:"merged"`  // panes with at least one MERGED PR
-	Pending   int  `json:"pending"` // total - merged
-	Live      int  `json:"live"`    // panes whose tmux pane is alive
-	Running   int  `json:"running"` // agent が実行中(AgentState=="running")のペイン数
-	Blocked   int  `json:"blocked"` // panes whose blockers still have an OPEN issue
-	AllMerged bool `json:"allMerged"`
+	Total      int  `json:"total"`
+	Merged     int  `json:"merged"`     // panes with at least one MERGED PR
+	Pending    int  `json:"pending"`    // total - merged
+	Live       int  `json:"live"`       // panes whose tmux pane is alive
+	Running    int  `json:"running"`    // agent が実行中(AgentState=="running")のペイン数
+	Blocked    int  `json:"blocked"`    // panes whose blockers still have an OPEN issue
+	NotStarted int  `json:"notStarted"` // 未開始子 issue(synthetic 行)の数
+	AllMerged  bool `json:"allMerged"`
 }
 
 // Degraded records which collectors failed so the UI can show a banner instead

--- a/internal/sessionview/model.go
+++ b/internal/sessionview/model.go
@@ -81,6 +81,11 @@ type PaneView struct {
 	// synthetic 行(TUI の synthetic 行の web 移植)。PaneID/Agent/Branch 等の
 	// pane 由来フィールドは zero、TmuxState は closed/deferred/queued/unknown。
 	NotStarted bool `json:"notStarted,omitempty"`
+	// closeUnconfirmed は synthetic な CLOSED 行のうち PR 状態を確認できなかった
+	// もの(IssuePRs が miss/失敗し wave graph の状態へ fallback)を示す内部
+	// フラグ。一時的な gh 失敗で session が 100%/AllMerged に見えないよう、
+	// こうした行は rollup に残す。JSON には出さない(非エクスポート)。
+	closeUnconfirmed bool
 }
 
 // Rollup is an aggregate count band, mirroring --status's summary plus liveness.

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1491,16 +1491,9 @@ func sortPaneViews(panes []paneView) {
 }
 
 func syntheticTmuxState(status issueStatus) string {
-	switch {
-	case strings.EqualFold(status.State, "CLOSED"):
-		return "closed"
-	case status.HasOpenBlockers:
-		return "deferred"
-	case strings.EqualFold(status.State, "OPEN"):
-		return "queued"
-	default:
-		return "unknown"
-	}
+	// web ダッシュボードの synthetic 行と同一文字列を保証する単一実装に委譲
+	// (`state:queued` 等のフィルタ語彙が TUI / web で割れないように)。
+	return sessionview.SyntheticTmuxState(status.State, status.HasOpenBlockers)
 }
 
 func (p paneView) tableRow() table.Row {

--- a/web/src/components/Drawer.tsx
+++ b/web/src/components/Drawer.tsx
@@ -28,6 +28,79 @@ function PlanPanel({ pane, token }: { pane: PaneView; token: string }) {
   );
 }
 
+/* 未開始(synthetic)行の状態説明。tmuxState は Go 側 syntheticTmuxState の
+ * closed / deferred / queued / unknown と 1:1。 */
+const NOT_STARTED_NOTES: Record<string, string> = {
+  queued: "未開始 — この子 issue の pane はまだ起動していません。",
+  deferred: "未開始 — open な blocker があるため待機中です。",
+  closed: "pane が起動しないまま issue は close されました。",
+  unknown: "未開始 — issue 状態を取得できていません。",
+};
+
+function WaveSection({ pane, repo }: { pane: PaneView; repo: string }) {
+  return (
+    <section className="d-sec">
+      <h4>wave / blockers</h4>
+      <dl className="d-kv">
+        <dt>wave</dt>
+        <dd id="d-wave">{fmtWave(pane) || "—"}</dd>
+        <dt>blockers</dt>
+        <dd id="d-blockers">
+          {pane.blockers && pane.blockers.length
+            ? pane.blockers.map((b, i) => (
+                <Fragment key={b.num}>
+                  {i > 0 && ", "}
+                  {blockerLabel(b)} <GhLink url={issueUrl(repo, b.num)}>#{b.num}</GhLink>
+                </Fragment>
+              ))
+            : "-"}
+        </dd>
+      </dl>
+    </section>
+  );
+}
+
+function PrsSection({ pane, repo }: { pane: PaneView; repo: string }) {
+  return (
+    <section className="d-sec">
+      <h4>pull requests</h4>
+      <ul className="d-prs" id="d-prs">
+        {pane.prs && pane.prs.length ? (
+          pane.prs.map((pr) => (
+            <li key={pr.number}>
+              <PrPill repo={repo} pr={pr} />
+              {pr.ci === "pass" ? (
+                <>
+                  {" "}
+                  <Tag cls="t-ok">ci pass</Tag>
+                </>
+              ) : pr.ci === "fail" ? (
+                <>
+                  {" "}
+                  <Tag cls="t-err">ci fail</Tag>
+                </>
+              ) : pr.ci ? (
+                <>
+                  {" "}
+                  <Tag cls="t-warn">ci pending</Tag>
+                </>
+              ) : null}
+              {pr.reviewDecision && (
+                <>
+                  {" "}
+                  <Tag>{pr.reviewDecision.toLowerCase().replace(/_/g, " ")}</Tag>
+                </>
+              )}
+            </li>
+          ))
+        ) : (
+          <li className="muted">—</li>
+        )}
+      </ul>
+    </section>
+  );
+}
+
 function PeekPanel({ pane, token }: { pane: PaneView; token: string }) {
   const peek = usePeek({ paneId: pane.paneId, alive: pane.alive }, token);
   return (
@@ -96,114 +169,85 @@ export function Drawer({
           ✕
         </button>
       </header>
-      <div className="drawer-body">
-        <section className="d-sec">
-          <h4>pane</h4>
-          <dl className="d-kv">
-            <dt>agent</dt>
-            <dd id="d-agent">{pane.agent || "—"}</dd>
-            <dt>pane</dt>
-            <dd id="d-pane">{pane.paneId || "—"}</dd>
-            <dt>tmux</dt>
-            <dd id="d-tmux">{pane.alive ? "live" : pane.tmuxState || "stale"}</dd>
-            <dt>run</dt>
-            <dd id="d-run">
-              {pane.agentState === "running" || pane.agentState === "done" ? (
-                <AgentStateTag state={pane.agentState} />
-              ) : (
-                <span className="muted">—</span>
-              )}
-            </dd>
-            <dt>title</dt>
-            <dd id="d-title">{pane.tmuxTitle || "—"}</dd>
-            <dt>created</dt>
-            <dd id="d-created">{fmtCreated(pane.createdAt)}</dd>
-            <dt>issue</dt>
-            <dd id="d-state">
-              <IssueStateTag state={pane.issueState} unknownLabel="UNKNOWN" />
-            </dd>
-          </dl>
-        </section>
-        <section className="d-sec">
-          <h4>wave / blockers</h4>
-          <dl className="d-kv">
-            <dt>wave</dt>
-            <dd id="d-wave">{fmtWave(pane) || "—"}</dd>
-            <dt>blockers</dt>
-            <dd id="d-blockers">
-              {pane.blockers && pane.blockers.length
-                ? pane.blockers.map((b, i) => (
-                    <Fragment key={b.num}>
-                      {i > 0 && ", "}
-                      {blockerLabel(b)} <GhLink url={issueUrl(repo, b.num)}>#{b.num}</GhLink>
-                    </Fragment>
-                  ))
-                : "-"}
-            </dd>
-          </dl>
-        </section>
-        <section className="d-sec">
-          <h4>worktree</h4>
-          <dl className="d-kv">
-            <dt>path</dt>
-            <dd id="d-path">
-              {(pane.worktreePath || "—") + (pane.worktreeErr ? ` (${pane.worktreeErr})` : "")}
-            </dd>
-            <dt>branch</dt>
-            <dd id="d-branch">{pane.branchName || "—"}</dd>
-            <dt>diff</dt>
-            <dd id="d-diff">{pane.diffSummary || "—"}</dd>
-            <dt>state</dt>
-            <dd id="d-dirty">
-              <DirtyTag state={pane.dirtyState} unknownLabel="unknown" />
-            </dd>
-          </dl>
-        </section>
-        <section className="d-sec">
-          <h4>pull requests</h4>
-          <ul className="d-prs" id="d-prs">
-            {pane.prs && pane.prs.length ? (
-              pane.prs.map((pr) => (
-                <li key={pr.number}>
-                  <PrPill repo={repo} pr={pr} />
-                  {pr.ci === "pass" ? (
-                    <>
-                      {" "}
-                      <Tag cls="t-ok">ci pass</Tag>
-                    </>
-                  ) : pr.ci === "fail" ? (
-                    <>
-                      {" "}
-                      <Tag cls="t-err">ci fail</Tag>
-                    </>
-                  ) : pr.ci ? (
-                    <>
-                      {" "}
-                      <Tag cls="t-warn">ci pending</Tag>
-                    </>
-                  ) : null}
-                  {pr.reviewDecision && (
-                    <>
-                      {" "}
-                      <Tag>{pr.reviewDecision.toLowerCase().replace(/_/g, " ")}</Tag>
-                    </>
-                  )}
-                </li>
-              ))
-            ) : (
-              <li className="muted">—</li>
-            )}
-          </ul>
-        </section>
-        <section className="d-sec">
-          <h4>prompt</h4>
-          <pre className="d-prompt" id="d-prompt">
-            {pane.prompt || "—"}
-          </pre>
-        </section>
-        {pane.planMode && <PlanPanel pane={pane} token={token} />}
-        <PeekPanel pane={pane} token={token} />
-      </div>
+      {pane.notStarted ? (
+        /* 未開始(synthetic)行の縮約表示: pane / worktree / prompt / peek は
+         * 実体が無いので出さない(PeekPanel を mount しない = /api/peek 不発)。
+         * pane が起動すると同じ rowKey のままこの分岐が実 row 表示に切り替わる。 */
+        <div className="drawer-body">
+          <section className="d-sec">
+            <h4>issue</h4>
+            <dl className="d-kv">
+              <dt>issue</dt>
+              <dd id="d-state">
+                <IssueStateTag state={pane.issueState} unknownLabel="UNKNOWN" />
+              </dd>
+              <dt>状態</dt>
+              <dd id="d-not-started">
+                {NOT_STARTED_NOTES[pane.tmuxState] ?? NOT_STARTED_NOTES["unknown"]}
+              </dd>
+            </dl>
+          </section>
+          <WaveSection pane={pane} repo={repo} />
+          <PrsSection pane={pane} repo={repo} />
+        </div>
+      ) : (
+        <div className="drawer-body">
+          <section className="d-sec">
+            <h4>pane</h4>
+            <dl className="d-kv">
+              <dt>agent</dt>
+              <dd id="d-agent">{pane.agent || "—"}</dd>
+              <dt>pane</dt>
+              <dd id="d-pane">{pane.paneId || "—"}</dd>
+              <dt>tmux</dt>
+              <dd id="d-tmux">{pane.alive ? "live" : pane.tmuxState || "stale"}</dd>
+              <dt>run</dt>
+              <dd id="d-run">
+                {pane.agentState === "running" || pane.agentState === "done" ? (
+                  <AgentStateTag state={pane.agentState} />
+                ) : (
+                  <span className="muted">—</span>
+                )}
+              </dd>
+              <dt>title</dt>
+              <dd id="d-title">{pane.tmuxTitle || "—"}</dd>
+              <dt>created</dt>
+              <dd id="d-created">{fmtCreated(pane.createdAt)}</dd>
+              <dt>issue</dt>
+              <dd id="d-state">
+                <IssueStateTag state={pane.issueState} unknownLabel="UNKNOWN" />
+              </dd>
+            </dl>
+          </section>
+          <WaveSection pane={pane} repo={repo} />
+          <section className="d-sec">
+            <h4>worktree</h4>
+            <dl className="d-kv">
+              <dt>path</dt>
+              <dd id="d-path">
+                {(pane.worktreePath || "—") + (pane.worktreeErr ? ` (${pane.worktreeErr})` : "")}
+              </dd>
+              <dt>branch</dt>
+              <dd id="d-branch">{pane.branchName || "—"}</dd>
+              <dt>diff</dt>
+              <dd id="d-diff">{pane.diffSummary || "—"}</dd>
+              <dt>state</dt>
+              <dd id="d-dirty">
+                <DirtyTag state={pane.dirtyState} unknownLabel="unknown" />
+              </dd>
+            </dl>
+          </section>
+          <PrsSection pane={pane} repo={repo} />
+          <section className="d-sec">
+            <h4>prompt</h4>
+            <pre className="d-prompt" id="d-prompt">
+              {pane.prompt || "—"}
+            </pre>
+          </section>
+          {pane.planMode && <PlanPanel pane={pane} token={token} />}
+          <PeekPanel pane={pane} token={token} />
+        </div>
+      )}
     </aside>
   );
 }

--- a/web/src/components/Drawer.tsx
+++ b/web/src/components/Drawer.tsx
@@ -4,7 +4,7 @@ import { usePeek } from "../hooks/usePeek";
 import { usePlan } from "../hooks/usePlan";
 import { fmtCreated } from "../lib/format";
 import { issueUrl } from "../lib/github";
-import { blockerLabel, fmtWave } from "../lib/pane";
+import { blockerLabel, fmtWave, notStartedNote } from "../lib/pane";
 import type { PaneView } from "../lib/types";
 import { AgentStateTag, DirtyTag, GhLink, IssueStateTag, PrPill, Tag } from "./ui";
 
@@ -30,13 +30,6 @@ function PlanPanel({ pane, token }: { pane: PaneView; token: string }) {
 
 /* 未開始(synthetic)行の状態説明。tmuxState は Go 側 syntheticTmuxState の
  * closed / deferred / queued / unknown と 1:1。 */
-const NOT_STARTED_NOTES: Record<string, string> = {
-  queued: "未開始 — この子 issue の pane はまだ起動していません。",
-  deferred: "未開始 — open な blocker があるため待機中です。",
-  closed: "pane が起動しないまま issue は close されました。",
-  unknown: "未開始 — issue 状態を取得できていません。",
-};
-
 function WaveSection({ pane, repo }: { pane: PaneView; repo: string }) {
   return (
     <section className="d-sec">
@@ -183,7 +176,7 @@ export function Drawer({
               </dd>
               <dt>状態</dt>
               <dd id="d-not-started">
-                {NOT_STARTED_NOTES[pane.tmuxState] ?? NOT_STARTED_NOTES["unknown"]}
+                {notStartedNote(pane.tmuxState)}
               </dd>
             </dl>
           </section>

--- a/web/src/components/FilterBar.tsx
+++ b/web/src/components/FilterBar.tsx
@@ -13,6 +13,8 @@ const STATIC_DROPDOWNS: readonly { key: string; ariaLabel: string; options: read
       ["closed", "closed"],
       ["live", "live"],
       ["stale", "stale"],
+      ["queued", "queued"], // 未開始(synthetic)行の tmux 状態
+      ["deferred", "deferred"], // blocker 待ちの未開始行
     ],
   },
   {

--- a/web/src/components/Hud.tsx
+++ b/web/src/components/Hud.tsx
@@ -1,13 +1,17 @@
 import type { CSSProperties } from "react";
 import type { Rollup } from "../lib/types";
 
-const EMPTY_ROLLUP: Pick<Rollup, "total" | "merged" | "pending" | "live" | "running" | "blocked"> = {
+const EMPTY_ROLLUP: Pick<
+  Rollup,
+  "total" | "merged" | "pending" | "live" | "running" | "blocked" | "notStarted"
+> = {
   total: 0,
   merged: 0,
   pending: 0,
   live: 0,
   running: 0,
   blocked: 0,
+  notStarted: 0,
 };
 
 export function Hud({ rollup }: { rollup: Rollup | null | undefined }) {
@@ -27,6 +31,11 @@ export function Hud({ rollup }: { rollup: Rollup | null | undefined }) {
         <div className="stat">
           <label>running</label>
           <b id="s-running">{r.running ?? 0}</b>
+        </div>
+        <div className="stat">
+          <label>queued</label>
+          {/* 未開始(synthetic)行数。旧 snapshot にはフィールドが無いので ?? 0 */}
+          <b id="s-queued">{r.notStarted ?? 0}</b>
         </div>
         <div className="stat">
           <label>merged</label>

--- a/web/src/components/Hud.tsx
+++ b/web/src/components/Hud.tsx
@@ -33,7 +33,7 @@ export function Hud({ rollup }: { rollup: Rollup | null | undefined }) {
           <b id="s-running">{r.running ?? 0}</b>
         </div>
         <div className="stat">
-          <label>queued</label>
+          <label>not started</label>
           {/* 未開始(synthetic)行数。旧 snapshot にはフィールドが無いので ?? 0 */}
           <b id="s-queued">{r.notStarted ?? 0}</b>
         </div>

--- a/web/src/components/SessionSection.tsx
+++ b/web/src/components/SessionSection.tsx
@@ -56,14 +56,11 @@ function PaneRow({
     e.preventDefault();
     onSelect();
   };
+  // 未開始(synthetic)行は .ghost で一段引いた表示。rowKey は同じなので
+  // pane が起動した snapshot からはそのまま実 row として描画される。
+  const cls = `row${pane.notStarted ? " ghost" : ""}${selected ? " selected" : ""}`;
   return (
-    <tr
-      className={selected ? "row selected" : "row"}
-      tabIndex={0}
-      ref={registerRow}
-      onClick={onClick}
-      onKeyDown={onKeyDown}
-    >
+    <tr className={cls} tabIndex={0} ref={registerRow} onClick={onClick} onKeyDown={onKeyDown}>
       <td className="c-issue">
         <GhLink url={issueUrl(repo, pane.issueNum)}>#{pane.issueNum}</GhLink>
       </td>

--- a/web/src/lib/pane.ts
+++ b/web/src/lib/pane.ts
@@ -70,3 +70,15 @@ export function findPane(snap: Snapshot | null, key: string | null): PaneView | 
   }
   return null;
 }
+
+/* 未開始(synthetic)行の Drawer 状態説明文。キーは tmuxState。 */
+const NOT_STARTED_NOTES: Record<string, string> = {
+  queued: "未開始 — この子 issue の pane はまだ起動していません。",
+  deferred: "未開始 — open な blocker があるため待機中です。",
+  closed: "pane が起動しないまま issue は close されました。",
+  unknown: "未開始 — issue 状態を取得できていません。",
+};
+
+export function notStartedNote(tmuxState: string): string {
+  return NOT_STARTED_NOTES[tmuxState] ?? NOT_STARTED_NOTES["unknown"]!;
+}

--- a/web/src/lib/sort.ts
+++ b/web/src/lib/sort.ts
@@ -18,7 +18,7 @@ export const SORTS: Record<string, SortKeyFn> = {
   },
   dirty: (p) => ({ clean: 0, dirty: 1, unknown: 2 })[p.dirtyState] ?? 3,
   ci: (p) => ({ fail: 0, pending: 1, pass: 2 })[paneCI(p)] ?? 3,
-  tmux: (p) => (p.alive ? 0 : 1),
+  tmux: (p) => (p.alive ? 0 : p.notStarted ? 2 : 1), // alive < stale < 未開始(synthetic)
   state: (p) => String(p.issueState ?? "").toLowerCase(),
   pr: (p) => {
     const pr = prPrimary(p.prs);

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -46,15 +46,19 @@ export interface PaneView {
   waveLabel?: string;
   blockers: BlockerStatus[];
   blocked: boolean;
+  /* 記録 pane の無い「未開始」子 issue の synthetic 行。pane 由来フィールドは
+   * zero、tmuxState は closed / deferred / queued / unknown(TUI と同一文字列) */
+  notStarted?: boolean;
 }
 
 export interface Rollup {
-  total: number;
+  total: number; // synthetic(未開始)行込み
   merged: number;
   pending: number;
   live: number;
   running: number;
   blocked: number;
+  notStarted: number; // 未開始子 issue(synthetic 行)数
   allMerged: boolean;
 }
 

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -58,7 +58,7 @@ export interface Rollup {
   live: number;
   running: number;
   blocked: number;
-  notStarted: number; // 未開始子 issue(synthetic 行)数
+  notStarted?: number; // 未開始子 issue(synthetic 行)数。旧サーバーの snapshot は省略
   allMerged: boolean;
 }
 

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -429,6 +429,9 @@ tbody tr.selected td{
   border-bottom-color:color-mix(in srgb, var(--asagi) 35%, transparent);
 }
 tbody tr.selected td:first-child{ box-shadow:inset 2px 0 0 var(--asagi); }
+/* 未開始(synthetic)行 — pane がまだ無い「予定」の子 issue。透明度を落とし
+   破線の下罫線で実 row と区別する。選択時の浅葱アクセントは通常行と同じ。 */
+tbody tr.ghost td{ opacity:.55; border-bottom-style:dashed; }
 td.c-issue{ color:var(--ai); font-weight:500; }
 /* c-name / c-branch の上限は --maxw と連動して手動スケール(1416/1180 = 1.2x)。
    --maxw を変えるときはここも見直すこと。 */

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -431,7 +431,9 @@ tbody tr.selected td{
 tbody tr.selected td:first-child{ box-shadow:inset 2px 0 0 var(--asagi); }
 /* 未開始(synthetic)行 — pane がまだ無い「予定」の子 issue。透明度を落とし
    破線の下罫線で実 row と区別する。選択時の浅葱アクセントは通常行と同じ。 */
-tbody tr.ghost td{ opacity:.55; border-bottom-style:dashed; }
+/* 選択中は減光しない(選択ハイライト/浅葱アクセントを通常行と同等に保つ) */
+tbody tr.ghost:not(.selected) td{ opacity:.55; }
+tbody tr.ghost td{ border-bottom-style:dashed; }
 td.c-issue{ color:var(--ai); font-weight:500; }
 /* c-name / c-branch の上限は --maxw と連動して手動スケール(1416/1180 = 1.2x)。
    --maxw を変えるときはここも見直すこと。 */

--- a/web/src/test/app.test.tsx
+++ b/web/src/test/app.test.tsx
@@ -268,7 +268,14 @@ describe("フィルタ", () => {
     act(() => trigger.focus());
     await user.keyboard("{ArrowDown}"); // trigger 上の ↓ で開く
     const opts = within(screen.getByRole("listbox")).getAllByRole("option");
-    expect(opts.map((o) => o.textContent)).toEqual(["open", "closed", "live", "stale"]);
+    expect(opts.map((o) => o.textContent)).toEqual([
+      "open",
+      "closed",
+      "live",
+      "stale",
+      "queued",
+      "deferred",
+    ]);
     expect(opts[0]).toHaveFocus();
     expect(opts[0]).toHaveAttribute("tabindex", "0");
     expect(opts[1]).toHaveAttribute("tabindex", "-1");
@@ -278,11 +285,11 @@ describe("フィルタ", () => {
     expect(opts[1]).toHaveAttribute("tabindex", "0");
     expect(opts[0]).toHaveAttribute("tabindex", "-1");
 
-    await user.keyboard("{ArrowUp}{ArrowUp}"); // 先頭から上へはラップして末尾
-    expect(opts[3]).toHaveFocus();
+    await user.keyboard("{ArrowUp}{ArrowUp}"); // 先頭から上へはラップして末尾(deferred)
+    expect(opts[opts.length - 1]).toHaveFocus();
 
     await user.keyboard("{Enter}");
-    expect(screen.getByRole("listitem", { name: "フィルタ state:stale を外す" })).toBeInTheDocument();
+    expect(screen.getByRole("listitem", { name: "フィルタ state:deferred を外す" })).toBeInTheDocument();
     expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
     expect(trigger).toHaveFocus();
   });
@@ -723,8 +730,9 @@ describe("未開始(queued)子 issue", () => {
     render(<App />);
     streamSnapshot(queuedSnapshot());
 
-    const stateSel = screen.getByRole("combobox", { name: "issue / tmux 状態で絞り込み" });
-    await user.selectOptions(stateSel, "queued");
+    // GitHub PR 風 popover(#249): trigger を開いて queued option を選ぶ
+    await user.click(screen.getByRole("button", { name: "issue / tmux 状態で絞り込み" }));
+    await user.click(screen.getByRole("option", { name: "queued" }));
     expect(screen.getByText("Queued child")).toBeInTheDocument();
     expect(screen.queryByText("Fix login")).not.toBeInTheDocument();
     expect(screen.queryByText("Deferred child")).not.toBeInTheDocument();

--- a/web/src/test/app.test.tsx
+++ b/web/src/test/app.test.tsx
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { App } from "../components/App";
 import type { Snapshot } from "../lib/types";
 import { FakeEventSource, installFakeEventSource, removeEventSource } from "./fakeEventSource";
-import { makePane, makeRollup, makeSession, makeSnapshot } from "./fixtures";
+import { makePane, makeQueuedPane, makeRollup, makeSession, makeSnapshot } from "./fixtures";
 import { server } from "./server";
 
 /* App 全体の統合テスト。モックはネットワーク境界のみ:
@@ -673,6 +673,118 @@ describe("drawer リサイズ", () => {
     expect(
       within(drawer2).getByRole("separator", { name: "詳細パネルの幅を変更" }),
     ).toHaveAttribute("aria-valuenow", "960");
+  });
+});
+
+describe("未開始(queued)子 issue", () => {
+  /* 起動済み 1 + 未開始 2(queued / deferred)の snapshot。Go 側 Build の
+   * synthetic 行と同じワイヤ形。 */
+  function queuedSnapshot() {
+    return makeSnapshot(
+      [
+        makeSession(
+          "142",
+          [
+            makePane({ issueNum: 101, displayName: "Fix login", agent: "claude", paneId: "%1" }),
+            makeQueuedPane({ issueNum: 103, displayName: "Queued child" }),
+            makeQueuedPane({
+              issueNum: 104,
+              displayName: "Deferred child",
+              tmuxState: "deferred",
+              blocked: true,
+              blockers: [{ num: 103, state: "OPEN" }],
+            }),
+          ],
+          { notStarted: 2 },
+        ),
+      ],
+      { rollup: makeRollup({ total: 3, live: 1, notStarted: 2 }) },
+    );
+  }
+
+  it("ghost 行として tmux 列に queued / deferred を描画し、HUD に未開始数が出る", () => {
+    const { container } = render(<App />);
+    streamSnapshot(queuedSnapshot());
+
+    const queuedRow = screen.getByText("Queued child").closest("tr")!;
+    expect(queuedRow).toHaveClass("ghost");
+    expect(queuedRow).toHaveTextContent("queued");
+    const deferredRow = screen.getByText("Deferred child").closest("tr")!;
+    expect(deferredRow).toHaveClass("ghost");
+    expect(deferredRow).toHaveTextContent("deferred");
+    // 起動済みの行は ghost にならない
+    expect(screen.getByText("Fix login").closest("tr")).not.toHaveClass("ghost");
+    // HUD の queued カウンタ(rollup.notStarted)
+    expect(container.querySelector("#s-queued")).toHaveTextContent("2");
+  });
+
+  it("state:queued フィルタで未開始行だけに絞れる", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+    streamSnapshot(queuedSnapshot());
+
+    const stateSel = screen.getByRole("combobox", { name: "issue / tmux 状態で絞り込み" });
+    await user.selectOptions(stateSel, "queued");
+    expect(screen.getByText("Queued child")).toBeInTheDocument();
+    expect(screen.queryByText("Fix login")).not.toBeInTheDocument();
+    expect(screen.queryByText("Deferred child")).not.toBeInTheDocument();
+    expect(screen.getByText("1 / 3")).toBeInTheDocument();
+  });
+
+  it("未開始行の drawer は縮約表示になり /api/peek を呼ばない", async () => {
+    let peekCalls = 0;
+    server.use(
+      http.get("/api/peek", () => {
+        peekCalls++;
+        return HttpResponse.json({ paneId: "?", lines: 80, capturedAt: "", output: "" });
+      }),
+    );
+    const user = userEvent.setup();
+    render(<App />);
+    streamSnapshot(queuedSnapshot());
+
+    await user.click(screen.getByText("Deferred child"));
+    const drawer = await screen.findByRole("complementary", { name: "ペイン詳細" });
+    expect(
+      within(drawer).getByText("未開始 — open な blocker があるため待機中です。"),
+    ).toBeInTheDocument();
+    // wave/blockers と PR は出すが、pane / worktree / prompt / peek は出さない
+    expect(within(drawer).getByText("wave / blockers")).toBeInTheDocument();
+    expect(within(drawer).getByText("pull requests")).toBeInTheDocument();
+    expect(within(drawer).getByRole("link", { name: "#103" })).toBeInTheDocument();
+    expect(within(drawer).queryByText("worktree")).not.toBeInTheDocument();
+    expect(within(drawer).queryByText("prompt")).not.toBeInTheDocument();
+    expect(within(drawer).queryByText(/peek/)).not.toBeInTheDocument();
+    expect(peekCalls).toBe(0);
+  });
+
+  it("pane 起動で同じ行キーのまま実 row に置き換わる", async () => {
+    server.use(peekHandler(() => "booted"));
+    const user = userEvent.setup();
+    render(<App />);
+    streamSnapshot(queuedSnapshot());
+
+    // 未開始行を選択 → 次の snapshot で同 issue の pane が起動
+    await user.click(screen.getByText("Queued child"));
+    await screen.findByRole("complementary", { name: "ペイン詳細" });
+
+    act(() => {
+      FakeEventSource.latest().emitSnapshot(
+        makeSnapshot([
+          makeSession("142", [
+            makePane({ issueNum: 101, displayName: "Fix login" }),
+            makePane({ issueNum: 103, displayName: "Queued child", paneId: "%3", alive: true }),
+          ]),
+        ]),
+      );
+    });
+    // rowKey(142#103)が安定しているので drawer は開いたまま実 row 表示に切り替わる
+    const drawer = screen.getByRole("complementary", { name: "ペイン詳細" });
+    expect(within(drawer).getByText("worktree")).toBeInTheDocument();
+    expect(await within(drawer).findByText("booted")).toBeInTheDocument();
+    // 行側("Queued child" は drawer ヘッダにも出るので table 内に限定)
+    const row = within(screen.getByRole("table")).getByText("Queued child").closest("tr");
+    expect(row).not.toHaveClass("ghost");
   });
 });
 

--- a/web/src/test/fixtures.ts
+++ b/web/src/test/fixtures.ts
@@ -8,6 +8,7 @@ export function makeRollup(over: Partial<Rollup> = {}): Rollup {
     live: 0,
     running: 0,
     blocked: 0,
+    notStarted: 0,
     allMerged: false,
     ...over,
   };
@@ -32,6 +33,32 @@ export function makePane(over: Partial<PaneView> = {}): PaneView {
     tmuxState: "live",
     blockers: [],
     blocked: false,
+    ...over,
+  };
+}
+
+/* 未開始(synthetic)子 issue 行 — Go 側 Build が emit する synthetic PaneView
+ * と同じ形(pane 由来フィールドは zero、diff/dirty は "-")。 */
+export function makeQueuedPane(over: Partial<PaneView> = {}): PaneView {
+  return {
+    issueNum: 103,
+    slug: "",
+    displayName: "Queued child",
+    agent: "",
+    branchName: "",
+    paneId: "",
+    worktreePath: "",
+    createdAt: "",
+    alive: false,
+    issueState: "OPEN",
+    prs: null,
+    hasMergedPr: false,
+    diffSummary: "-",
+    dirtyState: "-",
+    tmuxState: "queued",
+    blockers: [],
+    blocked: false,
+    notStarted: true,
     ...over,
   };
 }

--- a/web/src/test/fixtures.ts
+++ b/web/src/test/fixtures.ts
@@ -56,6 +56,7 @@ export function makeQueuedPane(over: Partial<PaneView> = {}): PaneView {
     diffSummary: "-",
     dirtyState: "-",
     tmuxState: "queued",
+    ciStatus: "-", // Go 側は synthetic 行にも常に CIStatus を入れる
     blockers: [],
     blocked: false,
     notStarted: true,


### PR DESCRIPTION
## 概要

TUI 版と同様に、まだ pane が起動されていない wave graph 上の子 issue を Web ダッシュボードのリストに表示します(ダッシュボード改善 6 連 PR の 1 つ)。

- `Collectors.Waves` を `WaveGraph` 返しに変更(従来 `graph.Children` を捨てていた)。`sessionview.Build` が未記録の子を synthetic `PaneView` として emit
- `TmuxState` は TUI と同一文字列(`queued` / `deferred` / `closed` / `unknown`)— `state:queued` フィルタがそのまま効く。`SyntheticTmuxState` / `NormalizeParent` を sessionview から export し **TUI と単一実装を共有**
- web: ghost 行(減光 + 破線)、state ドロップダウンに queued/deferred、未開始行の Drawer は縮約表示(peek を出さず状態説明文)、HUD に `not started` カウンタ、`rowKey` が安定なので pane 起動時にその場で実 row へ morph
- Rollup: 進捗バーが「セッション完了」を表すよう synthetic も算入。**PR が merge されないまま CLOSED になった子(not-planned 等)は除外**(行は表示)— 算入すると Pending に永久に残り 100% に到達不能。merged 済み CLOSED 子は「pane なしで完了」として Total/Merged に算入

## レビューで直した重要指摘

- **gh API 予算崩壊**: 子の PR fetch が 20 秒 tick に乗りコストが「起動 pane 数」→「全子 issue 数」化(レビュー 3 angle + 実検証中にレート制限到達で実証)→ wave パス(60 秒 cadence)内へ移動 + CLOSED 終端スキップ
- **waveCache 無剪定**: `--cleanup` 済み親の子を永遠に fetch するリーク → state に無い親を prune
- **torn frame**: 子 PR を waveCache 公開**前**に fetch(2 秒 tick との競合で PR/CI 欠落フレームが SSE 配信されるのを防止)
- **OPEN→CLOSED 遷移の再取得漏れ**(codex P2): スキップ条件を「graph とキャッシュの両方が CLOSED」に
- エイリアス親("0100"/"100")で synthetic 行の帰属が build ごとに揺れて SSE が毎 tick 発火 → sortedParents に raw タイブレーク

## 検証

- `go test ./...` / `make lint-web` / `make test-web`(53 tests)green、`make build-go` OK
- Playwright + 実 GitHub データ(親 #220)で実動確認: 記録 3 行 + synthetic 4 行(#224 queued / #225-227 deferred)、state:queued フィルタ、縮約 Drawer、/api/peek 不発、HUD not started=4。GitHub レート制限中も degraded マージで synthetic 行が保持されることを確認
- /post-work-review 実施済み(code-review 6 angle → 修正 → codex:review 2 反復で approve)

## 既知の制約(TUI と同一挙動)

- 記録 pane がひとつも無い親はセッション自体が出ない
- 複数親の graph に載る子は、pane 未起動の間それぞれの親に ghost 行が出る

## マージ順

6 連 PR は独立に main へ。`chore/web-oxlint-oxfmt` だけ最後にマージしてください。`feat/dashboard-plan-view` と sessionview/model.go・types.ts・Drawer.tsx で軽微なコンフリクトの可能性(後着が rebase)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)