### PR TITLE
feat(dashboard): plan モード pane の提案プランを Drawer に独立表示(GET /api/plan)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,12 +95,16 @@ Build the binary with `make build-go` and validate with `make test`.
   token middleware, SSE, `Cache-Control: no-store` static serving with a
   fallback page when the bundle is absent), `poller.go` (two-tier state/tmux +
   throttled gh refresh, broadcast on change), `sse.go` (channel hub), `peek.go`
-  (`GET /api/peek`, a read-only capture-pane of one recorded pane), and
-  `runfile.go` (`.fanout/dashboard.json` reuse-if-running). The SPA itself
+  (`GET /api/peek`, a read-only capture-pane of one recorded pane; also the
+  `livePaneView` validation chain `plan.go` reuses), `plan.go`
+  (`GET /api/plan`, the last complete `<proposed_plan>` block of a recorded
+  Codex Plan Mode pane), and `runfile.go` (`.fanout/dashboard.json`
+  reuse-if-running). The SPA itself
   lives in `web/` (React + Vite + TS, PAPER BREEZE light/dark matching the
   docs site): `src/lib/` is the pure logic layer (wire types mirroring
   `sessionview` JSON tags, filter/sort/link builders), `src/hooks/` owns
-  transport (`useSnapshot` SSE + polling fallback, `usePeek`, `useTheme`), and
+  transport (`useSnapshot` SSE + polling fallback, `usePeek`, `usePlan`,
+  `useTheme`), and
   tests are integration-first (vitest + testing-library + MSW; SSE via a
   FakeEventSource). `make build-web` emits the bundle into `static/`
   (deterministic names `assets/app.js` / `assets/app.css`, never committed).
@@ -132,10 +136,11 @@ Build the binary with `make build-go` and validate with `make test`.
 - `fanout dashboard --web` is the one HTTP surface, and it is deliberately
   carved out: a read-only, `127.0.0.1`-bound, GET-only, token-gated localhost
   server that only ever reads state/tmux/gh and never mutates repo or GitHub
-  state. `GET /api/peek` stays inside that boundary (a read-only
-  `tmux capture-pane` of a recorded pane), and Google Fonts is the single
-  allowed external fetch from the SPA (loaded `no-referrer` so the tokened URL
-  never leaks). The "no HTTP/sockets" guidance elsewhere is about the legacy
+  state. `GET /api/peek` and `GET /api/plan` stay inside that boundary (both
+  are a read-only `tmux capture-pane` of a recorded pane; `/api/plan` is
+  further gated to panes recorded with `codexPlanMode`), and Google Fonts is
+  the single allowed external fetch from the SPA (loaded `no-referrer` so the
+  tokened URL never leaks). The "no HTTP/sockets" guidance elsewhere is about the legacy
   notification path (outbound only); #137/#142 explicitly delegated the Web UI
   decision to dashboard #117, which this implements standalone (no TUI
   dependency — the future TUI just reuses `internal/sessionview`). Keep it

--- a/README.ja.md
+++ b/README.ja.md
@@ -372,6 +372,12 @@ fanout dashboard --web [--port N] [--open] [--no-token] [--no-keybind]
   メタ情報・wave/blockers・worktree・CI 付き PR・元プロンプトに加え、ペインの
   直近出力を *peek* 表示します（`GET /api/peek`、読み取り専用の
   `tmux capture-pane`、表示中は 5 秒ごとに更新）。
+- **Codex Plan Mode ペインの plan 表示。** `--codex-plan-mode` で起動した
+  ペインでは、ドロワーに *plan* セクションが追加され、ペイン出力中の最後の
+  完全な `<proposed_plan>` ブロックを表示します（`GET /api/plan`、こちらも
+  読み取り専用の `tmux capture-pane`。開いたとき一度だけ取得し、再取得ボタンで
+  手動更新）。長い plan は codex TUI の alternate screen からスクロールアウト
+  して取得できないことがあり、その場合は未検出の旨を表示します。
 - **構造化フィルタ。** フィルタ欄は自由語と
   `state:` / `run:` / `agent:` / `wave:` / `ci:` / `dirty:` / `live:` /
   `issue:` / `pr:` の各 term を AND で組み合わせます — 例:
@@ -381,7 +387,8 @@ fanout dashboard --web [--port N] [--open] [--no-token] [--no-keybind]
   ヘッダのトグル選択は `localStorage`（`fanout.theme`）に保存されます。既定は
   `prefers-color-scheme` に従います。
 - **localhost 限定。** `127.0.0.1` にのみバインドし、GET 専用の endpoint
-  （`/api/snapshot`、SSE の `/api/stream`、`/api/peek`、埋め込み UI）を公開します。
+  （`/api/snapshot`、SSE の `/api/stream`、`/api/peek`、`/api/plan`、
+  埋め込み UI）を公開します。
   `--port` は既定 `0`（OS 割り当ての ephemeral port）で、確定した URL を表示します。
   UI からの唯一の外部リクエストは Google Fonts の stylesheet で、`no-referrer`
   ポリシーにより token 付きダッシュボード URL が外部に漏れることはありません。

--- a/README.md
+++ b/README.md
@@ -442,6 +442,12 @@ fanout dashboard --web [--port N] [--open] [--no-token] [--no-keybind]
   pane metadata, wave/blockers, worktree, PRs with CI, the original prompt,
   and a *peek* at the pane's recent output (`GET /api/peek`, a read-only
   `tmux capture-pane` refreshed every 5 s while open).
+- **Plan view for Codex Plan Mode panes.** For panes launched with
+  `--codex-plan-mode`, the drawer adds a *plan* section showing the last
+  complete `<proposed_plan>` block in the pane's output (`GET /api/plan`,
+  also a read-only `tmux capture-pane`; fetched once on open, with a manual
+  refresh button). A long plan can scroll out of the codex TUI's alternate
+  screen, in which case the section reports that no plan was found.
 - **Structured filtering.** The filter box ANDs free words with
   `state:` / `run:` / `agent:` / `wave:` / `ci:` / `dirty:` / `live:` /
   `issue:` / `pr:` terms — e.g. `agent:claude wave:2 ci:fail run:running`.
@@ -451,8 +457,8 @@ fanout dashboard --web [--port N] [--open] [--no-token] [--no-keybind]
   toggle persists to `localStorage` (`fanout.theme`) and defaults to your
   `prefers-color-scheme`.
 - **localhost only.** The server binds `127.0.0.1` and exposes GET-only
-  endpoints (`/api/snapshot`, an SSE `/api/stream`, `/api/peek`, and the
-  embedded UI). `--port` defaults to `0` (an OS-assigned ephemeral port); the
+  endpoints (`/api/snapshot`, an SSE `/api/stream`, `/api/peek`, `/api/plan`,
+  and the embedded UI). `--port` defaults to `0` (an OS-assigned ephemeral port); the
   chosen URL is printed. The UI's one external request is its Google Fonts
   stylesheet, loaded with a `no-referrer` policy so the tokened dashboard URL
   never leaks.

--- a/cmd/fanout/pane.go
+++ b/cmd/fanout/pane.go
@@ -159,19 +159,20 @@ func createPane(cfg *cliflags.Config, lg *log.Logger, info *fanoutruntime.Info, 
 
 func statePane(req paneRequest, paneID, worktreePath string, now time.Time) state.Pane {
 	return state.Pane{
-		Parent:       req.ParentRef,
-		IssueNum:     req.Number,
-		Slug:         req.Slug,
-		BranchName:   req.BranchName,
-		BaseBranch:   req.Worktree.BaseBranch,
-		PaneID:       paneID,
-		Agent:        req.Agent,
-		DisplayName:  paneTitle(req),
-		WorktreePath: worktreePath,
-		Prompt:       req.Prompt,
-		Wave:         req.Wave,
-		CreatedAt:    now.Format(time.RFC3339),
-		AgentStatus:  "running",
+		Parent:        req.ParentRef,
+		IssueNum:      req.Number,
+		Slug:          req.Slug,
+		BranchName:    req.BranchName,
+		BaseBranch:    req.Worktree.BaseBranch,
+		PaneID:        paneID,
+		Agent:         req.Agent,
+		CodexPlanMode: req.CodexPlanMode,
+		DisplayName:   paneTitle(req),
+		WorktreePath:  worktreePath,
+		Prompt:        req.Prompt,
+		Wave:          req.Wave,
+		CreatedAt:     now.Format(time.RFC3339),
+		AgentStatus:   "running",
 	}
 }
 

--- a/cmd/fanout/pane_test.go
+++ b/cmd/fanout/pane_test.go
@@ -54,6 +54,7 @@ func TestStatePaneCapturesCreatedPaneFields(t *testing.T) {
 		Prompt:              "[fanout #83 of #81] state-idempotency-83: read /tmp/fanout-fanout-83.md and begin.",
 		Agent:               "codex",
 		Wave:                "wave5",
+		CodexPlanMode:       true,
 		Worktree:            worktree.Plan{BaseBranch: "main"},
 	}
 
@@ -76,6 +77,9 @@ func TestStatePaneCapturesCreatedPaneFields(t *testing.T) {
 	}
 	if got.AgentStatus != "running" {
 		t.Fatalf("agentStatus = %q, want running (起動時記録)", got.AgentStatus)
+	}
+	if !got.CodexPlanMode {
+		t.Fatal("codexPlanMode = false, want passthrough of req.CodexPlanMode")
 	}
 }
 

--- a/internal/dashboard/peek.go
+++ b/internal/dashboard/peek.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/butaosuinu/fanout/internal/sessionview"
 	"github.com/butaosuinu/fanout/internal/tmuxrun"
 )
 
@@ -23,26 +24,75 @@ const (
 // it, so the endpoint can never address an arbitrary tmux target.
 var paneIDRe = regexp.MustCompile(`^%[0-9]{1,9}$`)
 
-// hasLivePane reports whether paneID appears in the poller's latest committed
-// snapshot as a live pane. Requiring Alive (not mere presence in state) closes
-// a pane-id-reuse hole: after a tmux server restart an unrelated pane can take
-// over a recorded id, and only the snapshot's liveness check (pane id plus
-// worktree-path match, see sessionview's paneAlive) ties the id back to this
-// child — a bare id match would let /api/peek capture a stranger's terminal.
-// Defined here rather than in poller.go because /api/peek is its only
-// consumer. The zero-value snapshot has nil Sessions, which ranges as empty,
+// livePaneView returns the snapshot row whose pane id is paneID, but only when
+// the poller's latest committed snapshot reports it as a live pane. Requiring
+// Alive (not mere presence in state) closes a pane-id-reuse hole: after a tmux
+// server restart an unrelated pane can take over a recorded id, and only the
+// snapshot's liveness check (pane id plus worktree-path match, see
+// sessionview's paneAlive) ties the id back to this child — a bare id match
+// would let /api/peek or /api/plan capture a stranger's terminal. Defined here
+// rather than in poller.go because the capture endpoints are its only
+// consumers. The zero-value snapshot has nil Sessions, which ranges as empty,
 // so an unpublished snapshot simply reports false.
-func (p *poller) livePaneWorktree(paneID string) (string, bool) {
+func (p *poller) livePaneView(paneID string) (sessionview.PaneView, bool) {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 	for _, sess := range p.latest.Sessions {
 		for i := range sess.Panes {
 			if sess.Panes[i].PaneID == paneID && sess.Panes[i].Alive {
-				return sess.Panes[i].WorktreePath, true
+				return sess.Panes[i], true
 			}
 		}
 	}
-	return "", false
+	return sessionview.PaneView{}, false
+}
+
+// requireLivePane is the request-validation chain GET /api/peek and
+// GET /api/plan share: pane-id shape (400), snapshot liveness via livePaneView
+// (404), and recorded-worktree presence (404 — legacy/hand-written rows
+// without a worktree are alive on an id-only basis, which cannot survive tmux
+// pane-id reuse; without a path to verify against, capture could read an
+// unrelated pane, so refuse). On ok=false the JSON error response has already
+// been written.
+func (s *Server) requireLivePane(w http.ResponseWriter, paneID string) (sessionview.PaneView, bool) {
+	if !paneIDRe.MatchString(paneID) {
+		peekError(w, http.StatusBadRequest, fmt.Sprintf("invalid pane id %q: want a tmux pane id like %%5", paneID))
+		return sessionview.PaneView{}, false
+	}
+	pv, ok := s.poller.livePaneView(paneID)
+	if !ok {
+		peekError(w, http.StatusNotFound, fmt.Sprintf("pane %s is not live in the current sessions", paneID))
+		return sessionview.PaneView{}, false
+	}
+	if pv.WorktreePath == "" {
+		peekError(w, http.StatusNotFound, fmt.Sprintf("pane %s has no recorded worktree to verify against", paneID))
+		return sessionview.PaneView{}, false
+	}
+	return pv, true
+}
+
+// beginPaneCapture is the capture preamble shared by GET /api/peek and
+// GET /api/plan: response headers, the HEAD early-return (getOnly permits
+// HEAD; answer it before running tmux — mirrors handleStream's HEAD
+// early-return — so a probe never triggers a capture), and the request-time
+// tmux revalidation. The snapshot check in requireLivePane can be a
+// cheap-tick stale, which is enough for a tmux restart to hand the id to an
+// unrelated pane; verifying id+path right before reading shrinks that reuse
+// window to the instant before capture. A false return means the response is
+// complete (HEAD answered, or verify failed with 404) and the handler must
+// not capture.
+func (s *Server) beginPaneCapture(w http.ResponseWriter, r *http.Request, paneID, worktree string) bool {
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	if r.Method == http.MethodHead {
+		w.WriteHeader(http.StatusOK)
+		return false
+	}
+	if err := s.verifyPane(paneID, worktree); err != nil {
+		peekError(w, http.StatusNotFound, err.Error())
+		return false
+	}
+	return true
 }
 
 // verifyLivePane is the default Options.VerifyPane: it re-resolves the pane id
@@ -83,8 +133,8 @@ type peekResponse struct {
 // be peeked; lines is clamped to [1, peekMaxLines].
 func (s *Server) handlePeek(w http.ResponseWriter, r *http.Request) {
 	paneID := r.URL.Query().Get("pane")
-	if !paneIDRe.MatchString(paneID) {
-		peekError(w, http.StatusBadRequest, fmt.Sprintf("invalid pane id %q: want a tmux pane id like %%5", paneID))
+	pv, ok := s.requireLivePane(w, paneID)
+	if !ok {
 		return
 	}
 	lines := peekDefaultLines
@@ -96,31 +146,7 @@ func (s *Server) handlePeek(w http.ResponseWriter, r *http.Request) {
 		}
 		lines = min(max(n, 1), peekMaxLines)
 	}
-	worktree, ok := s.poller.livePaneWorktree(paneID)
-	if !ok {
-		peekError(w, http.StatusNotFound, fmt.Sprintf("pane %s is not live in the current sessions", paneID))
-		return
-	}
-	// Legacy/hand-written rows without a recorded worktree are alive on an
-	// id-only basis, which cannot survive tmux pane-id reuse. Without a path
-	// to verify against, capture could read an unrelated pane — refuse.
-	if worktree == "" {
-		peekError(w, http.StatusNotFound, fmt.Sprintf("pane %s has no recorded worktree to verify against", paneID))
-		return
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.Header().Set("Cache-Control", "no-store")
-	// getOnly permits HEAD; answer it before running tmux (mirrors handleStream's
-	// HEAD early-return) so a probe never triggers a capture.
-	if r.Method == http.MethodHead {
-		w.WriteHeader(http.StatusOK)
-		return
-	}
-	// The snapshot check above can be a cheap-tick stale; revalidate id+path
-	// against tmux right before reading so a freshly reused pane id cannot
-	// expose an unrelated pane's contents.
-	if err := s.verifyPane(paneID, worktree); err != nil {
-		peekError(w, http.StatusNotFound, err.Error())
+	if !s.beginPaneCapture(w, r, paneID, pv.WorktreePath) {
 		return
 	}
 	out, err := s.capturePane(paneID, lines)

--- a/internal/dashboard/peek_test.go
+++ b/internal/dashboard/peek_test.go
@@ -183,6 +183,16 @@ func TestPeekInvalidLinesIs400(t *testing.T) {
 	}
 }
 
+// 検証順は pane の生存確認が lines パースより先(共有ヘルパ化に伴う意図的な
+// 契約): 死んだ pane + 不正 lines の組合せは 400 ではなく 404 を返す。
+func TestPeekDeadPaneWithInvalidLinesIs404(t *testing.T) {
+	srv := newPeekServer(t, "", &fakeCapture{})
+	status, _, body := getPeek(t, peekURL(srv.base, map[string]string{"pane": "%999", "lines": "abc"}))
+	if status != http.StatusNotFound {
+		t.Fatalf("dead pane + lines=abc status = %d want 404, body %s", status, body)
+	}
+}
+
 func TestPeekUnknownPaneIs404(t *testing.T) {
 	fake := &fakeCapture{}
 	srv := newPeekServer(t, "", fake)

--- a/internal/dashboard/plan.go
+++ b/internal/dashboard/plan.go
@@ -64,21 +64,30 @@ func (s *Server) handlePlan(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// extractLastPlan は capture 出力中の最後の「完全な」
+// extractLastPlan は capture 出力中の最後の「中身のある完全な」
 // <proposed_plan>...</proposed_plan> ブロックの中身を返す(前後空白は trim)。
-// 探索は LastIndex 2 回の素朴なテキスト検索: 最後の閉じタグ → その手前の
-// 最後の開きタグ。閉じタグ未到達(開きタグのみ)はブロック不成立で false。
-// capture 出力は markdown として構造を持たないので、plan 本文のコードフェンス
-// 内に書かれたタグも本物のタグと区別しない(既知の割り切り — その場合は
-// フェンス内の最後のブロックが勝つ)。
+// 後方走査のテキスト検索: 最後の閉じタグ → その手前の最後の開きタグの組を
+// 候補とし、中身が空・"..." (briefing の指示文
+// 「wrapped in <proposed_plan>...</proposed_plan>」が transcript にエコー
+// された行)のブロックはスキップしてさらに前を探す。閉じタグ未到達
+// (開きタグのみ = 生成中)はブロック不成立で false。capture 出力は構造を
+// 持たないので、plan 本文のコードフェンス内に書かれたタグも本物と区別しない
+// (既知の割り切り)。
 func extractLastPlan(out string) (string, bool) {
-	end := strings.LastIndex(out, planCloseTag)
-	if end < 0 {
-		return "", false
+	rest := out
+	for {
+		end := strings.LastIndex(rest, planCloseTag)
+		if end < 0 {
+			return "", false
+		}
+		start := strings.LastIndex(rest[:end], planOpenTag)
+		if start < 0 {
+			return "", false
+		}
+		body := strings.TrimSpace(rest[start+len(planOpenTag) : end])
+		if body != "" && body != "..." && body != "…" {
+			return body, true
+		}
+		rest = rest[:start] // 空/指示文エコーのブロックより前を探す
 	}
-	start := strings.LastIndex(out[:end], planOpenTag)
-	if start < 0 {
-		return "", false
-	}
-	return strings.TrimSpace(out[start+len(planOpenTag) : end]), true
 }

--- a/internal/dashboard/plan.go
+++ b/internal/dashboard/plan.go
@@ -1,0 +1,84 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// planCaptureLines は plan 抽出のために遡る通常スクリーン履歴の行数。peek の
+// 「直近の出力」と違い plan ブロック全体が必要なので、固定で深めに取る
+// (クエリ可変にはしない — 上限なしの履歴 capture を外から指定させない)。
+const planCaptureLines = 2000
+
+const (
+	planOpenTag  = "<proposed_plan>"
+	planCloseTag = "</proposed_plan>"
+)
+
+// planResponse is the GET /api/plan wire contract the SPA consumes. Found
+// false (with empty Plan) is a successful 200: the pane is a plan-mode pane
+// but no complete plan block is currently in the capturable output (not yet
+// proposed, or scrolled out of the alternate screen).
+type planResponse struct {
+	PaneID     string `json:"paneId"`
+	CapturedAt string `json:"capturedAt"` // RFC3339 UTC
+	Found      bool   `json:"found"`
+	Plan       string `json:"plan"`
+}
+
+// handlePlan serves GET /api/plan?pane=%N: a one-shot read of the last
+// complete <proposed_plan> block in one recorded Codex Plan Mode pane.
+// Validation, headers, HEAD handling, and the error contract are shared with
+// /api/peek (requireLivePane / beginPaneCapture / peekError); the only
+// plan-specific gate is PlanMode — capture stays scoped to panes fanout
+// launched with --codex-plan-mode. The capture is read-only
+// (tmux capture-pane), so the dashboard stays mutation-free.
+func (s *Server) handlePlan(w http.ResponseWriter, r *http.Request) {
+	paneID := r.URL.Query().Get("pane")
+	pv, ok := s.requireLivePane(w, paneID)
+	if !ok {
+		return
+	}
+	if !pv.PlanMode {
+		peekError(w, http.StatusNotFound, fmt.Sprintf("pane %s is not a codex plan-mode pane", paneID))
+		return
+	}
+	if !s.beginPaneCapture(w, r, paneID, pv.WorktreePath) {
+		return
+	}
+	out, err := s.capturePlan(paneID, planCaptureLines)
+	if err != nil {
+		peekError(w, http.StatusBadGateway, "tmux capture-pane: "+err.Error())
+		return
+	}
+	plan, found := extractLastPlan(out)
+	// A failed response write means the client went away; nothing to do here.
+	_ = json.NewEncoder(w).Encode(planResponse{
+		PaneID:     paneID,
+		CapturedAt: time.Now().UTC().Format(time.RFC3339),
+		Found:      found,
+		Plan:       plan,
+	})
+}
+
+// extractLastPlan は capture 出力中の最後の「完全な」
+// <proposed_plan>...</proposed_plan> ブロックの中身を返す(前後空白は trim)。
+// 探索は LastIndex 2 回の素朴なテキスト検索: 最後の閉じタグ → その手前の
+// 最後の開きタグ。閉じタグ未到達(開きタグのみ)はブロック不成立で false。
+// capture 出力は markdown として構造を持たないので、plan 本文のコードフェンス
+// 内に書かれたタグも本物のタグと区別しない(既知の割り切り — その場合は
+// フェンス内の最後のブロックが勝つ)。
+func extractLastPlan(out string) (string, bool) {
+	end := strings.LastIndex(out, planCloseTag)
+	if end < 0 {
+		return "", false
+	}
+	start := strings.LastIndex(out[:end], planOpenTag)
+	if start < 0 {
+		return "", false
+	}
+	return strings.TrimSpace(out[start+len(planOpenTag) : end]), true
+}

--- a/internal/dashboard/plan_test.go
+++ b/internal/dashboard/plan_test.go
@@ -1,0 +1,359 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/butaosuinu/fanout/internal/sessionview"
+)
+
+// planSnapshot is peekSnapshot's pane "%5" flagged (or not) as a Codex Plan
+// Mode pane — the fixture /api/plan validates against.
+func planSnapshot(alive, planMode bool) sessionview.Snapshot {
+	snap := peekSnapshot(alive)
+	snap.Sessions[0].Panes[0].PlanMode = planMode
+	return snap
+}
+
+// newPlanServer is newPeekServer's twin for /api/plan: the fake feeds
+// CapturePlan, and CapturePane gets a tripwire so a handler mix-up fails the
+// test instead of running real tmux.
+func newPlanServer(t *testing.T, token string, capture *fakeCapture) *Server {
+	t.Helper()
+	srv, err := New(Options{
+		ProjectRoot: t.TempDir(),
+		Port:        0,
+		Token:       token,
+		ResolveGH:   func() (string, GHProvider, error) { return "o/n", fakeGH{}, nil },
+		CapturePane: func(string, int) (string, error) {
+			t.Error("CapturePane called from /api/plan")
+			return "", nil
+		},
+		CapturePlan: capture.capture,
+		// Request-time revalidation is exercised by
+		// TestPlanVerifyFailureIs404AndSkipsCapture; everywhere else a no-op
+		// keeps the fixture's liveness authoritative.
+		VerifyPane: func(string, string) error { return nil },
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	publishSnapshot(srv, planSnapshot(true, true))
+	go func() { _ = srv.httpServer.Serve(srv.listener) }()
+	t.Cleanup(func() { _ = srv.httpServer.Close() })
+	waitReady(t, srv.base)
+	return srv
+}
+
+// planURL builds /api/plan with properly URL-encoded query params (a tmux pane
+// id "%5" must travel as pane=%255).
+func planURL(base string, params map[string]string) string {
+	q := url.Values{}
+	for k, v := range params {
+		q.Set(k, v)
+	}
+	return base + "/api/plan?" + q.Encode()
+}
+
+const planFixtureOutput = "noise\n<proposed_plan>\n## Plan\n1. do the thing\n</proposed_plan>\ntrailing"
+
+func TestPlanTokenGate(t *testing.T) {
+	fake := &fakeCapture{out: planFixtureOutput}
+	srv := newPlanServer(t, "secrettoken", fake)
+
+	status, _, _ := getPeek(t, planURL(srv.base, map[string]string{"pane": "%5"}))
+	if status != http.StatusForbidden {
+		t.Fatalf("no-token status = %d want 403", status)
+	}
+	status, _, _ = getPeek(t, planURL(srv.base, map[string]string{"pane": "%5", "token": "nope"}))
+	if status != http.StatusForbidden {
+		t.Fatalf("wrong-token status = %d want 403", status)
+	}
+	if calls, _, _ := fake.snapshot(); calls != 0 {
+		t.Fatalf("capture ran %d time(s) behind the token gate", calls)
+	}
+}
+
+func TestPlanPostIs405(t *testing.T) {
+	srv := newPlanServer(t, "", &fakeCapture{})
+	resp, err := http.Post(planURL(srv.base, map[string]string{"pane": "%5"}), "application/json", strings.NewReader("{}"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("POST status = %d want 405", resp.StatusCode)
+	}
+}
+
+func TestPlanMalformedPaneIs400(t *testing.T) {
+	fake := &fakeCapture{}
+	srv := newPlanServer(t, "", fake)
+	for _, pane := range []string{"abc", "%1;x", "", "%1 extra", "-p", "%"} {
+		status, _, body := getPeek(t, planURL(srv.base, map[string]string{"pane": pane}))
+		if status != http.StatusBadRequest {
+			t.Fatalf("pane %q status = %d want 400", pane, status)
+		}
+		var got map[string]string
+		if err := json.Unmarshal(body, &got); err != nil || got["error"] == "" {
+			t.Fatalf("pane %q body = %s want JSON error", pane, body)
+		}
+	}
+	if calls, _, _ := fake.snapshot(); calls != 0 {
+		t.Fatalf("capture ran %d time(s) on malformed pane ids", calls)
+	}
+}
+
+func TestPlanUnknownPaneIs404(t *testing.T) {
+	fake := &fakeCapture{}
+	srv := newPlanServer(t, "", fake)
+	status, _, body := getPeek(t, planURL(srv.base, map[string]string{"pane": "%999"}))
+	if status != http.StatusNotFound {
+		t.Fatalf("unknown pane status = %d want 404, body %s", status, body)
+	}
+	if calls, _, _ := fake.snapshot(); calls != 0 {
+		t.Fatalf("capture ran %d time(s) for an unknown pane", calls)
+	}
+}
+
+func TestPlanRecordedButDeadPaneIs404(t *testing.T) {
+	fake := &fakeCapture{out: planFixtureOutput}
+	srv := newPlanServer(t, "", fake)
+	publishSnapshot(srv, planSnapshot(false, true))
+
+	status, _, body := getPeek(t, planURL(srv.base, map[string]string{"pane": "%5"}))
+	if status != http.StatusNotFound {
+		t.Fatalf("dead pane status = %d want 404, body %s", status, body)
+	}
+	if calls, _, _ := fake.snapshot(); calls != 0 {
+		t.Fatalf("capture ran %d time(s) for a dead pane", calls)
+	}
+}
+
+// TestPlanNonPlanModePaneIs404 locks in the plan-specific gate: a live,
+// verifiable pane that was NOT launched with --codex-plan-mode must 404
+// without ever capturing — /api/plan never widens into a second generic
+// capture endpoint.
+func TestPlanNonPlanModePaneIs404(t *testing.T) {
+	fake := &fakeCapture{out: planFixtureOutput}
+	srv := newPlanServer(t, "", fake)
+	publishSnapshot(srv, planSnapshot(true, false))
+
+	status, _, body := getPeek(t, planURL(srv.base, map[string]string{"pane": "%5"}))
+	if status != http.StatusNotFound {
+		t.Fatalf("non-plan pane status = %d want 404, body %s", status, body)
+	}
+	var got map[string]string
+	if err := json.Unmarshal(body, &got); err != nil || !strings.Contains(got["error"], "plan-mode") {
+		t.Fatalf("body = %s want a JSON error mentioning plan-mode", body)
+	}
+	if calls, _, _ := fake.snapshot(); calls != 0 {
+		t.Fatalf("capture ran %d time(s) for a non-plan pane", calls)
+	}
+}
+
+func TestPlanRowWithoutWorktreeIs404(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCapture{out: "should never be read"}
+	srv := newPlanServer(t, "", fake)
+	snap := planSnapshot(true, true)
+	snap.Sessions[0].Panes[0].WorktreePath = "" // legacy id-only-alive row
+	publishSnapshot(srv, snap)
+
+	status, _, body := getPeek(t, planURL(srv.base, map[string]string{"pane": "%5"}))
+	if status != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404; body %s", status, body)
+	}
+	if calls, _, _ := fake.snapshot(); calls != 0 {
+		t.Fatalf("capture calls = %d, want 0 (no worktree to verify against)", calls)
+	}
+}
+
+func TestPlanVerifyFailureIs404AndSkipsCapture(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCapture{out: "should never be read"}
+	srv, err := New(Options{
+		ProjectRoot: t.TempDir(),
+		Port:        0,
+		Token:       "",
+		ResolveGH:   func() (string, GHProvider, error) { return "o/n", fakeGH{}, nil },
+		CapturePlan: fake.capture,
+		VerifyPane: func(paneID, worktree string) error {
+			if worktree != "/wt/child" {
+				t.Errorf("VerifyPane worktree = %q, want recorded /wt/child", worktree)
+			}
+			return fmt.Errorf("pane %s is no longer at its recorded worktree", paneID)
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	publishSnapshot(srv, planSnapshot(true, true))
+	go func() { _ = srv.httpServer.Serve(srv.listener) }()
+	t.Cleanup(func() { _ = srv.httpServer.Close() })
+	waitReady(t, srv.base)
+
+	status, _, body := getPeek(t, planURL(srv.base, map[string]string{"pane": "%5"}))
+	if status != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404; body %s", status, body)
+	}
+	if calls, _, _ := fake.snapshot(); calls != 0 {
+		t.Fatalf("capture calls = %d, want 0 (verify failed first)", calls)
+	}
+}
+
+func TestPlanHeadSkipsCapture(t *testing.T) {
+	fake := &fakeCapture{out: "never returned"}
+	srv := newPlanServer(t, "", fake)
+	req, err := http.NewRequest(http.MethodHead, planURL(srv.base, map[string]string{"pane": "%5"}), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("HEAD status = %d want 200", resp.StatusCode)
+	}
+	if calls, _, _ := fake.snapshot(); calls != 0 {
+		t.Fatalf("HEAD triggered %d capture(s)", calls)
+	}
+}
+
+func TestPlanCaptureErrorIs502(t *testing.T) {
+	fake := &fakeCapture{err: errPaneGone}
+	srv := newPlanServer(t, "", fake)
+	status, _, body := getPeek(t, planURL(srv.base, map[string]string{"pane": "%5"}))
+	if status != http.StatusBadGateway {
+		t.Fatalf("status = %d want 502, body %s", status, body)
+	}
+	var got map[string]string
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal %s: %v", body, err)
+	}
+	if !strings.HasPrefix(got["error"], "tmux capture-pane: ") || !strings.Contains(got["error"], errPaneGone.Error()) {
+		t.Fatalf("error = %q", got["error"])
+	}
+}
+
+func TestPlanHappyPath(t *testing.T) {
+	fake := &fakeCapture{out: planFixtureOutput}
+	srv := newPlanServer(t, "", fake)
+
+	status, header, body := getPeek(t, planURL(srv.base, map[string]string{"pane": "%5"}))
+	if status != http.StatusOK {
+		t.Fatalf("status = %d want 200, body %s", status, body)
+	}
+	if ct := header.Get("Content-Type"); !strings.HasPrefix(ct, "application/json") {
+		t.Fatalf("content-type = %q", ct)
+	}
+	if cc := header.Get("Cache-Control"); cc != "no-store" {
+		t.Fatalf("cache-control = %q want no-store", cc)
+	}
+	var got planResponse
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal %s: %v", body, err)
+	}
+	if got.PaneID != "%5" || !got.Found || got.Plan != "## Plan\n1. do the thing" {
+		t.Fatalf("response = %+v", got)
+	}
+	if _, err := time.Parse(time.RFC3339, got.CapturedAt); err != nil {
+		t.Fatalf("capturedAt %q not RFC3339: %v", got.CapturedAt, err)
+	}
+	calls, paneID, lines := fake.snapshot()
+	if calls != 1 || paneID != "%5" || lines != planCaptureLines {
+		t.Fatalf("capture called %d time(s) with (%q, %d) want 1 with (%%5, %d)", calls, paneID, lines, planCaptureLines)
+	}
+}
+
+// TestPlanWithoutBlockIsFoundFalse: a plan-mode pane whose capturable output
+// holds no complete block (not yet proposed, or scrolled out) is a successful
+// 200 with found=false — the SPA distinguishes "no plan yet" from transport
+// errors by this field, not by status code.
+func TestPlanWithoutBlockIsFoundFalse(t *testing.T) {
+	fake := &fakeCapture{out: "codex is still thinking\nno tags here"}
+	srv := newPlanServer(t, "", fake)
+
+	status, _, body := getPeek(t, planURL(srv.base, map[string]string{"pane": "%5"}))
+	if status != http.StatusOK {
+		t.Fatalf("status = %d want 200, body %s", status, body)
+	}
+	var got planResponse
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal %s: %v", body, err)
+	}
+	if got.Found || got.Plan != "" {
+		t.Fatalf("response = %+v want found=false with empty plan", got)
+	}
+}
+
+func TestExtractLastPlan(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		out       string
+		wantPlan  string
+		wantFound bool
+	}{
+		{
+			name:      "単一ブロック(前後空白は trim)",
+			out:       "preamble\n<proposed_plan>\n  ## Plan\n- step 1\n</proposed_plan>\nepilogue",
+			wantPlan:  "## Plan\n- step 1",
+			wantFound: true,
+		},
+		{
+			name:      "複数ブロックは最後の完全なブロックが勝つ",
+			out:       "<proposed_plan>old plan</proposed_plan>\nrevise...\n<proposed_plan>new plan</proposed_plan>",
+			wantPlan:  "new plan",
+			wantFound: true,
+		},
+		{
+			name: "最後の開きタグが未閉鎖でも直前の完全なブロックを返す",
+			out:  "<proposed_plan>done plan</proposed_plan>\n<proposed_plan>still streaming",
+			// LastIndex(close) は完結済みブロックの閉じタグを指し、その手前の
+			// 開きタグと対になる。
+			wantPlan:  "done plan",
+			wantFound: true,
+		},
+		{
+			name:      "開きタグのみ(閉じタグ未到達)は false",
+			out:       "<proposed_plan>\nstreaming half a plan...",
+			wantFound: false,
+		},
+		{
+			name:      "タグなしは false",
+			out:       "plain capture output without any tags",
+			wantFound: false,
+		},
+		{
+			name: "コードフェンス内のタグも本物と区別しない(既知の割り切り)",
+			out:  "<proposed_plan>real plan\n```\n<proposed_plan>example</proposed_plan>\n```\ntail</proposed_plan>",
+			// 素朴なテキスト検索なので、フェンス内の開きタグが「最後の閉じタグ
+			// より前の最後の開きタグ」となり、そこから外側の閉じタグ直前までが
+			// 返る。capture 出力に構造は無く、これ以上の解釈はしない。
+			wantPlan:  "example</proposed_plan>\n```\ntail",
+			wantFound: true,
+		},
+		{
+			name:      "空文字列は false",
+			out:       "",
+			wantFound: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			plan, found := extractLastPlan(tc.out)
+			if found != tc.wantFound {
+				t.Fatalf("found = %v want %v (plan %q)", found, tc.wantFound, plan)
+			}
+			if plan != tc.wantPlan {
+				t.Fatalf("plan = %q want %q", plan, tc.wantPlan)
+			}
+		})
+	}
+}

--- a/internal/dashboard/plan_test.go
+++ b/internal/dashboard/plan_test.go
@@ -294,6 +294,29 @@ func TestPlanWithoutBlockIsFoundFalse(t *testing.T) {
 	}
 }
 
+// HEAD も PlanMode ゲートを通る: 非 plan-mode pane への HEAD は 404
+// (GET が成功しないリクエストは HEAD でも成功しない)。capture は走らない。
+func TestPlanHEADOnNonPlanPaneIs404(t *testing.T) {
+	fake := &fakeCapture{}
+	srv := newPlanServer(t, "", fake)
+	publishSnapshot(srv, planSnapshot(true, false)) // %5 は live だが plan-mode でない
+	req, err := http.NewRequest(http.MethodHead, planURL(srv.base, map[string]string{"pane": "%5"}), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("HEAD non-plan pane status = %d want 404", resp.StatusCode)
+	}
+	if calls, _, _ := fake.snapshot(); calls != 0 {
+		t.Fatalf("capture ran %d time(s)", calls)
+	}
+}
+
 func TestExtractLastPlan(t *testing.T) {
 	for _, tc := range []struct {
 		name      string
@@ -344,6 +367,31 @@ func TestExtractLastPlan(t *testing.T) {
 			name:      "空文字列は false",
 			out:       "",
 			wantFound: false,
+		},
+		{
+			name: "briefing 指示文のエコー(中身が ...)はスキップして前の実ブロックを返す",
+			out:  "<proposed_plan>real plan</proposed_plan>\nwrapped in <proposed_plan>...</proposed_plan>.",
+			// briefing は「wrapped in <proposed_plan>...</proposed_plan>」という
+			// 指示文を含み、transcript にエコーされうる。中身 "..." は plan では
+			// ないので後方走査でスキップする。
+			wantPlan:  "real plan",
+			wantFound: true,
+		},
+		{
+			name:      "指示文のエコーしか無ければ false",
+			out:       "wrapped in <proposed_plan>...</proposed_plan>.",
+			wantFound: false,
+		},
+		{
+			name:      "空白のみのブロックはスキップ(found:true で空 plan を返さない)",
+			out:       "<proposed_plan>  \n</proposed_plan>",
+			wantFound: false,
+		},
+		{
+			name:      "空白のみのブロックの前に実ブロックがあればそれを返す",
+			out:       "<proposed_plan>real</proposed_plan>\n<proposed_plan>\n</proposed_plan>",
+			wantPlan:  "real",
+			wantFound: true,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -43,6 +43,10 @@ type Options struct {
 	// CapturePane is the read-only tmux pane capture behind GET /api/peek.
 	// nil defaults to tmuxrun.CapturePaneOutput; tests inject a fake.
 	CapturePane func(paneID string, lines int) (string, error)
+	// CapturePlan is the read-only tmux capture behind GET /api/plan (scrollback
+	// plus alternate screen, wrapped lines joined). nil defaults to
+	// tmuxrun.CapturePlanSource; tests inject a fake.
+	CapturePlan func(paneID string, lines int) (string, error)
 	// VerifyPane re-checks, at request time, that paneID is still a live tmux
 	// pane sitting at/under the recorded worktree. nil defaults to a
 	// tmuxrun.ListLivePanes-backed check; tests inject a fake.
@@ -61,6 +65,7 @@ type Server struct {
 	base        string // http://127.0.0.1:<port>
 	serveErr    chan error
 	capturePane func(paneID string, lines int) (string, error)
+	capturePlan func(paneID string, lines int) (string, error)
 	verifyPane  func(paneID, worktree string) error
 }
 
@@ -82,6 +87,10 @@ func New(opts Options) (*Server, error) {
 	if capture == nil {
 		capture = tmuxrun.CapturePaneOutput
 	}
+	capturePlan := opts.CapturePlan
+	if capturePlan == nil {
+		capturePlan = tmuxrun.CapturePlanSource
+	}
 	verify := opts.VerifyPane
 	if verify == nil {
 		verify = verifyLivePane
@@ -95,6 +104,7 @@ func New(opts Options) (*Server, error) {
 		base:        fmt.Sprintf("http://%s:%d", loopbackInterface, addr.Port),
 		serveErr:    make(chan error, 1),
 		capturePane: capture,
+		capturePlan: capturePlan,
 		verifyPane:  verify,
 	}
 	handler, err := s.handler()
@@ -170,6 +180,7 @@ func (s *Server) handler() (http.Handler, error) {
 	mux.HandleFunc("/api/snapshot", s.getOnly(s.requireToken(s.handleSnapshot)))
 	mux.HandleFunc("/api/stream", s.getOnly(s.requireToken(s.handleStream)))
 	mux.HandleFunc("/api/peek", s.getOnly(s.requireToken(s.handlePeek)))
+	mux.HandleFunc("/api/plan", s.getOnly(s.requireToken(s.handlePlan)))
 	// Catch-all: the embedded SPA. The HTML shell is token-free so the page can
 	// load and then read ?token= for its /api/* calls.
 	mux.Handle("/", s.getOnly(s.staticHandler(sub)))

--- a/internal/sessionview/aggregate.go
+++ b/internal/sessionview/aggregate.go
@@ -192,6 +192,7 @@ func Build(repo, projectRoot string, c Collectors) Snapshot {
 				DirtyState:   worktreeStat.DirtyState,
 				WorktreeErr:  worktreeErr,
 				TmuxState:    tmuxStateOf(p.PaneID, snap.Degraded.Tmux, alive),
+				PlanMode:     p.CodexPlanMode,
 				Prompt:       p.Prompt,
 				CIStatus:     strings.ToLower(strings.TrimSpace(ghissue.SummarizeCI(prs))),
 				Wave:         wi.Wave,

--- a/internal/sessionview/aggregate_test.go
+++ b/internal/sessionview/aggregate_test.go
@@ -452,6 +452,25 @@ func TestBuildPromptPassthrough(t *testing.T) {
 	}
 }
 
+func TestBuildPlanModePassthrough(t *testing.T) {
+	planPane := pane("1", 2, "%1")
+	planPane.CodexPlanMode = true
+	c := Collectors{
+		Now:       fixedNow,
+		LoadState: storeOf(planPane, pane("1", 3, "%2")),
+		LivePanes: livePanesAt(),
+		IssuePRs:  func(num int) (string, []ghissue.PRRef, error) { return "OPEN", nil, nil },
+		Waves:     wavesNone,
+	}
+	panes := Build("o/n", "/root", c).Sessions[0].Panes
+	if !panes[0].PlanMode {
+		t.Fatal("PlanMode = false want passthrough of the state row CodexPlanMode")
+	}
+	if panes[1].PlanMode {
+		t.Fatal("PlanMode = true for a non-plan row, want false")
+	}
+}
+
 func TestBuildCIStatusFromPrimaryPR(t *testing.T) {
 	c := Collectors{
 		Now:       fixedNow,

--- a/internal/sessionview/model.go
+++ b/internal/sessionview/model.go
@@ -66,13 +66,17 @@ type PaneView struct {
 	// 起動ラッパーが設定する tmux pane user option @fanout_agent_state からの
 	// 動的判定、tmux 不通時は state.json の起動時記録値(AgentStatus)への
 	// fallback。
-	AgentState string            `json:"agentState,omitempty"`
-	Prompt     string            `json:"prompt,omitempty"`    // state row's original prompt
-	CIStatus   string            `json:"ciStatus,omitempty"`  // primary-PR CI via ghissue.SummarizeCI; lowercase
-	Wave       int               `json:"wave,omitempty"`      // DAG depth, 1-based; 0 = unknown
-	WaveLabel  string            `json:"waveLabel,omitempty"` // state row wave label, else parent-body heading
-	Blockers   []blockers.Status `json:"blockers"`            // always non-nil; serializes as []
-	Blocked    bool              `json:"blocked"`             // at least one blocker still OPEN
+	AgentState string `json:"agentState,omitempty"`
+	// PlanMode は Codex Plan Mode(--codex-plan-mode)で起動した記録ペインか
+	// どうか(state row の CodexPlanMode の passthrough)。ダッシュボードは
+	// このフラグで GET /api/plan の対象と Plan セクションの表示を限定する。
+	PlanMode  bool              `json:"planMode,omitempty"`
+	Prompt    string            `json:"prompt,omitempty"`    // state row's original prompt
+	CIStatus  string            `json:"ciStatus,omitempty"`  // primary-PR CI via ghissue.SummarizeCI; lowercase
+	Wave      int               `json:"wave,omitempty"`      // DAG depth, 1-based; 0 = unknown
+	WaveLabel string            `json:"waveLabel,omitempty"` // state row wave label, else parent-body heading
+	Blockers  []blockers.Status `json:"blockers"`            // always non-nil; serializes as []
+	Blocked   bool              `json:"blocked"`             // at least one blocker still OPEN
 }
 
 // Rollup is an aggregate count band, mirroring --status's summary plus liveness.

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -30,14 +30,19 @@ type Pane struct {
 	BranchName string `json:"branchName"`
 	// BaseBranch is the resolved base branch the worktree branched from
 	// (e.g. "main"). Legacy rows recorded before this field load as "".
-	BaseBranch   string `json:"baseBranch,omitempty"`
-	PaneID       string `json:"paneId"`
-	Agent        string `json:"agent"`
-	Wave         string `json:"wave,omitempty"`
-	DisplayName  string `json:"displayName"`
-	WorktreePath string `json:"worktreePath"`
-	Prompt       string `json:"prompt"`
-	CreatedAt    string `json:"createdAt"`
+	BaseBranch string `json:"baseBranch,omitempty"`
+	PaneID     string `json:"paneId"`
+	Agent      string `json:"agent"`
+	// CodexPlanMode は --codex-plan-mode(app-server Plan turn + 対話 Codex TUI)
+	// で起動したペインかどうか。ダッシュボードの GET /api/plan が plan 抽出の
+	// 対象ペインを限定するために参照する。additive なフィールドなので
+	// SchemaVersion は据え置き(旧版 fanout は未知キーとして無視して読める)。
+	CodexPlanMode bool   `json:"codexPlanMode,omitempty"`
+	Wave          string `json:"wave,omitempty"`
+	DisplayName   string `json:"displayName"`
+	WorktreePath  string `json:"worktreePath"`
+	Prompt        string `json:"prompt"`
+	CreatedAt     string `json:"createdAt"`
 	// AgentStatus は起動時に "running" を記録する。終了検知デーモンは無いので
 	// 表示側は tmux の動的判定(起動ラッパーが設定する pane user option
 	// @fanout_agent_state)を優先し、tmux 不通時のみこの記録値に fallback する。

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -178,6 +178,40 @@ func TestAgentStatusRoundTripsAndOmitsWhenEmpty(t *testing.T) {
 	}
 }
 
+func TestCodexPlanModeRoundTripsAndOmitsWhenFalse(t *testing.T) {
+	root := t.TempDir()
+	locked, err := LockProject(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = locked.Unlock() })
+
+	if err = locked.RecordPane(Pane{Parent: "81", IssueNum: 83, CodexPlanMode: true}); err != nil {
+		t.Fatal(err)
+	}
+	if err = locked.RecordPane(Pane{Parent: "81", IssueNum: 84}); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := LoadProject(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, ok := loaded.Find("81", 83)
+	if !ok || !got.CodexPlanMode {
+		t.Fatalf("codexPlanMode = %v (found=%v), want true", got.CodexPlanMode, ok)
+	}
+	data, err := os.ReadFile(Path(root))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// omitempty: plan モードでない行にはキー自体が現れない(additive な
+	// フィールドなので旧 state との差分も plan ペインの行に限られる)
+	if n := strings.Count(string(data), `"codexPlanMode"`); n != 1 {
+		t.Fatalf("codexPlanMode key appears %d times, want 1:\n%s", n, data)
+	}
+}
+
 func TestRecordPaneReplacesSameParentIssue(t *testing.T) {
 	root := t.TempDir()
 	locked, err := LockProject(root)

--- a/internal/tmuxrun/tmuxrun.go
+++ b/internal/tmuxrun/tmuxrun.go
@@ -424,6 +424,53 @@ func CapturePaneOutput(paneID string, lines int) (string, error) {
 	return capturePaneOutput(paneID, lines, false)
 }
 
+// CapturePlanSource はダッシュボードの GET /api/plan が <proposed_plan> ブロック
+// を探すための読み取り専用テキストを返す: 通常スクリーンの履歴
+// (capture-pane -p -J -S -<lines>。-J が折返し行を結合するので、ペイン幅で
+// 分断されたタグも一行に戻る)に、alternate screen 中(codex TUI)はその内容
+// (-a -p -J)を末尾へ連結する。最新レンダが末尾に来るので、last-block 検索では
+// alternate screen 側の plan が勝つ。CapturePaneOutput(peek 用、最新画面優先)
+// とは目的が違うため別関数にしてある。
+func CapturePlanSource(paneID string, lines int) (string, error) {
+	paneID = strings.TrimSpace(paneID)
+	if paneID == "" {
+		return "", fmt.Errorf("pane id is required")
+	}
+	if lines < 0 {
+		return "", fmt.Errorf("lines must be non-negative")
+	}
+	out, err := capturePlanScreen(paneID, lines, false)
+	if err != nil {
+		return "", err
+	}
+	if paneAlternateOn(paneID) {
+		// alternate screen の取得失敗は履歴のみへ degrade(peek と同じ精神:
+		// 追加情報は best-effort、本体の履歴が読めていれば応答は返す)。
+		if alt, altErr := capturePlanScreen(paneID, 0, true); altErr == nil {
+			out += "\n" + alt
+		}
+	}
+	return out, nil
+}
+
+// capturePlanScreen は CapturePlanSource 専用の capture-pane 呼び出し。
+// capturePaneOutput と違い常に -J を付け、折返しで分断された
+// <proposed_plan> タグを結合して検索可能にする。
+func capturePlanScreen(paneID string, lines int, alternateScreen bool) (string, error) {
+	args := []string{"capture-pane", "-p", "-J", "-t", paneID}
+	if alternateScreen {
+		args = []string{"capture-pane", "-a", "-p", "-J", "-t", paneID}
+	}
+	if !alternateScreen && lines > 0 {
+		args = append(args, "-S", fmt.Sprintf("-%d", lines))
+	}
+	out, err := exec.Command("tmux", args...).Output()
+	if err != nil {
+		return "", fmt.Errorf("tmux capture-pane: %w", err)
+	}
+	return string(out), nil
+}
+
 func paneAlternateOn(paneID string) bool {
 	out, err := exec.Command("tmux", "display-message", "-p", "-t", paneID, paneAlternateFormat).Output()
 	return err == nil && strings.TrimSpace(string(out)) == "1"

--- a/internal/tmuxrun/tmuxrun.go
+++ b/internal/tmuxrun/tmuxrun.go
@@ -436,8 +436,9 @@ func CapturePlanSource(paneID string, lines int) (string, error) {
 	if paneID == "" {
 		return "", fmt.Errorf("pane id is required")
 	}
-	if lines < 0 {
-		return "", fmt.Errorf("lines must be non-negative")
+	if lines <= 0 {
+		// 0 を許すと -S が付かず viewport のみの浅い capture に静かに退化する
+		return "", fmt.Errorf("lines must be positive")
 	}
 	out, err := capturePlanScreen(paneID, lines, false)
 	if err != nil {

--- a/internal/tmuxrun/tmuxrun_test.go
+++ b/internal/tmuxrun/tmuxrun_test.go
@@ -902,3 +902,95 @@ func TestListLivePanesDropsDuplicateForgedIDs(t *testing.T) {
 		t.Fatalf("ListLivePanes() = %#v, want only %%7 (duplicate %%5 dropped): %#v", panes, want)
 	}
 }
+
+// installPlanCaptureShim installs a tmux shim answering CapturePlanSource's
+// calls: display-message (alternate_on の問い合わせ) は altOn を、履歴 capture
+// は histBody を、alternate screen capture は altBody を返す。argv は呼び出し
+// ごとに "---" 行で区切って args ファイルへ追記される。
+func installPlanCaptureShim(t *testing.T, altOn, histBody, altBody string) string {
+	t.Helper()
+	script := `printf '%s\n' "$@" >> "$TMUXRUN_ARGS"
+printf '%s\n' '---' >> "$TMUXRUN_ARGS"
+case "$1" in
+display-message)
+	printf '%s\n' '` + altOn + `'
+	;;
+capture-pane)
+	if [ "$2" = "-a" ]; then
+		printf '%s\n' '` + altBody + `'
+	else
+		printf '%s\n' '` + histBody + `'
+	fi
+	;;
+esac
+`
+	return installTmuxShim(t, script)
+}
+
+// splitShimInvocations は "---" 区切りの args ファイル行を呼び出しごとの argv
+// に分解する。
+func splitShimInvocations(lines []string) [][]string {
+	var out [][]string
+	var cur []string
+	for _, line := range lines {
+		if line == "---" {
+			out = append(out, cur)
+			cur = nil
+			continue
+		}
+		cur = append(cur, line)
+	}
+	return out
+}
+
+func TestCapturePlanSourceCapturesJoinedHistory(t *testing.T) {
+	argsPath := installPlanCaptureShim(t, "0", "history with plan", "alt screen")
+
+	out, err := CapturePlanSource("%7", 2000)
+	if err != nil {
+		t.Fatalf("CapturePlanSource() failed: %v", err)
+	}
+	if out != "history with plan\n" {
+		t.Fatalf("output = %q, want history only (alternate screen off)", out)
+	}
+	calls := splitShimInvocations(readTmuxArgs(t, argsPath))
+	if len(calls) != 2 {
+		t.Fatalf("tmux calls = %d (%#v), want history capture + alternate_on probe", len(calls), calls)
+	}
+	// -J が折返し行を結合し、ペイン幅で分断された <proposed_plan> タグを
+	// 一行に戻す。-S -<lines> は通常スクリーンの履歴側にだけ付く。
+	wantHist := []string{"capture-pane", "-p", "-J", "-t", "%7", "-S", "-2000"}
+	if strings.Join(calls[0], "\x00") != strings.Join(wantHist, "\x00") {
+		t.Fatalf("history capture args = %#v, want %#v", calls[0], wantHist)
+	}
+}
+
+func TestCapturePlanSourceAppendsAlternateScreenLast(t *testing.T) {
+	argsPath := installPlanCaptureShim(t, "1", "history with plan", "alt screen render")
+
+	out, err := CapturePlanSource("%7", 2000)
+	if err != nil {
+		t.Fatalf("CapturePlanSource() failed: %v", err)
+	}
+	// alternate screen は末尾連結 — last-block 検索で最新レンダが勝つ。
+	if out != "history with plan\n\nalt screen render\n" {
+		t.Fatalf("output = %q, want history + alternate screen appended last", out)
+	}
+	calls := splitShimInvocations(readTmuxArgs(t, argsPath))
+	if len(calls) != 3 {
+		t.Fatalf("tmux calls = %d (%#v), want history + probe + alternate capture", len(calls), calls)
+	}
+	wantAlt := []string{"capture-pane", "-a", "-p", "-J", "-t", "%7"}
+	if strings.Join(calls[2], "\x00") != strings.Join(wantAlt, "\x00") {
+		t.Fatalf("alternate capture args = %#v, want %#v", calls[2], wantAlt)
+	}
+}
+
+func TestCapturePlanSourceRejectsBadArgs(t *testing.T) {
+	if _, err := CapturePlanSource("", 100); err == nil {
+		t.Fatal("CapturePlanSource(\"\") = nil error, want pane-id error")
+	}
+	if _, err := CapturePlanSource("%1", -1); err == nil {
+		t.Fatal("CapturePlanSource(lines=-1) = nil error, want lines error")
+	}
+}

--- a/web/src/components/Drawer.tsx
+++ b/web/src/components/Drawer.tsx
@@ -1,10 +1,30 @@
 import { Fragment, useEffect } from "react";
 import { usePeek } from "../hooks/usePeek";
+import { usePlan } from "../hooks/usePlan";
 import { fmtCreated } from "../lib/format";
 import { issueUrl } from "../lib/github";
 import { blockerLabel, fmtWave } from "../lib/pane";
 import type { PaneView } from "../lib/types";
 import { AgentStateTag, DirtyTag, GhLink, IssueStateTag, PrPill, Tag } from "./ui";
+
+function PlanPanel({ pane, token }: { pane: PaneView; token: string }) {
+  const plan = usePlan({ paneId: pane.paneId, alive: pane.alive }, token);
+  return (
+    <section className="d-sec">
+      <h4>plan — 提案中のプラン</h4>
+      {/* capture 出力は敵性入力 — markdown レンダせずテキストノードのみで描画 */}
+      <pre className="plan-card" id="plan-pre">
+        {plan.text}
+      </pre>
+      <div className="plan-meta" id="plan-meta">
+        <span>{plan.meta}</span>
+        <button type="button" className="plan-reload" onClick={plan.refetch}>
+          再取得
+        </button>
+      </div>
+    </section>
+  );
+}
 
 function PeekPanel({ pane, token }: { pane: PaneView; token: string }) {
   const peek = usePeek({ paneId: pane.paneId, alive: pane.alive }, token);
@@ -168,6 +188,7 @@ export function Drawer({
             {pane.prompt || "—"}
           </pre>
         </section>
+        {pane.planMode && <PlanPanel pane={pane} token={token} />}
         <PeekPanel pane={pane} token={token} />
       </div>
     </aside>

--- a/web/src/components/Drawer.tsx
+++ b/web/src/components/Drawer.tsx
@@ -12,13 +12,14 @@ function PlanPanel({ pane, token }: { pane: PaneView; token: string }) {
   return (
     <section className="d-sec">
       <h4>plan — 提案中のプラン</h4>
-      {/* capture 出力は敵性入力 — markdown レンダせずテキストノードのみで描画 */}
-      <pre className="plan-card" id="plan-pre">
+      {/* capture 出力は敵性入力 — markdown レンダせずテキストノードのみで描画。
+          tabIndex: 長い plan のスクロールをキーボードで届くように */}
+      <pre className="plan-card" id="plan-pre" tabIndex={0} role="region" aria-label="提案中のプラン">
         {plan.text}
       </pre>
-      <div className="plan-meta" id="plan-meta">
-        <span>{plan.meta}</span>
-        <button type="button" className="plan-reload" onClick={plan.refetch}>
+      <div className="plan-meta" id="plan-meta" aria-live="polite">
+        <span>{plan.loading ? "取得中…" : plan.meta}</span>
+        <button type="button" className="plan-reload" onClick={plan.refetch} disabled={plan.loading}>
           再取得
         </button>
       </div>

--- a/web/src/hooks/usePlan.ts
+++ b/web/src/hooks/usePlan.ts
@@ -6,20 +6,27 @@ import type { PlanResponse } from "../lib/types";
 export interface PlanView {
   text: string;
   meta: string;
+  found: boolean;
+  loading: boolean;
   refetch: () => void;
 }
 
+const LOADING = "(plan を取得中…)";
 const UNAVAILABLE = "(plan を取得できませんでした)";
 const NOT_FOUND =
   "(plan が見つかりません — まだ提案されていないか、画面外へスクロールアウトしています)";
+
+type ViewState = Omit<PlanView, "refetch">;
 
 /* usePeek 踏襲の /api/plan 取得 hook。ただしポーリングはしない: plan は peek の
  * ような流れる出力ではなく一度提案されたら安定する文書なので、mount 時に一度
  * fetch + ユーザーの「再取得」での手動 refetch のみ。capture 由来のテキストは
  * 敵性入力 — 呼び出し側はテキストノード以外で描画しないこと(markdown レンダ禁止)。
- * ペイン切替・unmount 時は effect cleanup が in-flight リクエストを abort する。 */
+ * ペイン切替・unmount 時は effect cleanup が in-flight リクエストを abort する。
+ * 一度表示できた plan は alive が落ちても保持する(pane 終了で読みかけの文書を
+ * 消さない)。 */
 export function usePlan(pane: { paneId: string; alive: boolean } | null, token: string): PlanView {
-  const [view, setView] = useState<Omit<PlanView, "refetch">>({ text: UNAVAILABLE, meta: "—" });
+  const [view, setView] = useState<ViewState>({ text: LOADING, meta: "—", found: false, loading: true });
   const [generation, setGeneration] = useState(0);
   const refetch = useCallback(() => setGeneration((g) => g + 1), []);
   const paneId = pane?.paneId ?? null;
@@ -28,12 +35,16 @@ export function usePlan(pane: { paneId: string; alive: boolean } | null, token: 
   useEffect(() => {
     if (!paneId) return;
     if (!alive) {
-      setView({ text: "(plan を取得できません — ペインは終了しています)", meta: "—" });
+      // 取得済みの plan は残す(snapshot の alive 反転で文書を吹き飛ばさない)
+      setView((v) =>
+        v.found ? v : { text: "(plan を取得できません — ペインは終了しています)", meta: "—", found: false, loading: false },
+      );
       return;
     }
 
     let disposed = false;
     const ctrl = new AbortController();
+    setView((v) => ({ ...v, loading: true, ...(v.found ? {} : { text: LOADING }) }));
 
     const fetchPlan = async () => {
       try {
@@ -43,18 +54,20 @@ export function usePlan(pane: { paneId: string; alive: boolean } | null, token: 
         });
         if (disposed) return;
         if (!res.ok) {
-          setView({ text: UNAVAILABLE, meta: "—" });
+          setView({ text: UNAVAILABLE, meta: "—", found: false, loading: false });
           return;
         }
         const body = (await res.json()) as PlanResponse;
         if (disposed) return;
         setView({
-          text: body.found ? body.plan : NOT_FOUND,
+          text: body.found ? (body.plan ?? "") : NOT_FOUND,
           meta: `captured ${clock(body.capturedAt)}`,
+          found: body.found,
+          loading: false,
         });
       } catch (err) {
         if (disposed || (err instanceof DOMException && err.name === "AbortError")) return;
-        setView({ text: UNAVAILABLE, meta: "—" });
+        setView({ text: UNAVAILABLE, meta: "—", found: false, loading: false });
       }
     };
 

--- a/web/src/hooks/usePlan.ts
+++ b/web/src/hooks/usePlan.ts
@@ -1,0 +1,69 @@
+import { useCallback, useEffect, useState } from "react";
+import { apiUrl } from "../lib/api";
+import { clock } from "../lib/format";
+import type { PlanResponse } from "../lib/types";
+
+export interface PlanView {
+  text: string;
+  meta: string;
+  refetch: () => void;
+}
+
+const UNAVAILABLE = "(plan を取得できませんでした)";
+const NOT_FOUND =
+  "(plan が見つかりません — まだ提案されていないか、画面外へスクロールアウトしています)";
+
+/* usePeek 踏襲の /api/plan 取得 hook。ただしポーリングはしない: plan は peek の
+ * ような流れる出力ではなく一度提案されたら安定する文書なので、mount 時に一度
+ * fetch + ユーザーの「再取得」での手動 refetch のみ。capture 由来のテキストは
+ * 敵性入力 — 呼び出し側はテキストノード以外で描画しないこと(markdown レンダ禁止)。
+ * ペイン切替・unmount 時は effect cleanup が in-flight リクエストを abort する。 */
+export function usePlan(pane: { paneId: string; alive: boolean } | null, token: string): PlanView {
+  const [view, setView] = useState<Omit<PlanView, "refetch">>({ text: UNAVAILABLE, meta: "—" });
+  const [generation, setGeneration] = useState(0);
+  const refetch = useCallback(() => setGeneration((g) => g + 1), []);
+  const paneId = pane?.paneId ?? null;
+  const alive = pane?.alive ?? false;
+
+  useEffect(() => {
+    if (!paneId) return;
+    if (!alive) {
+      setView({ text: "(plan を取得できません — ペインは終了しています)", meta: "—" });
+      return;
+    }
+
+    let disposed = false;
+    const ctrl = new AbortController();
+
+    const fetchPlan = async () => {
+      try {
+        const res = await fetch(apiUrl("/api/plan", token, { pane: paneId }), {
+          cache: "no-store",
+          signal: ctrl.signal,
+        });
+        if (disposed) return;
+        if (!res.ok) {
+          setView({ text: UNAVAILABLE, meta: "—" });
+          return;
+        }
+        const body = (await res.json()) as PlanResponse;
+        if (disposed) return;
+        setView({
+          text: body.found ? body.plan : NOT_FOUND,
+          meta: `captured ${clock(body.capturedAt)}`,
+        });
+      } catch (err) {
+        if (disposed || (err instanceof DOMException && err.name === "AbortError")) return;
+        setView({ text: UNAVAILABLE, meta: "—" });
+      }
+    };
+
+    void fetchPlan();
+    return () => {
+      disposed = true;
+      ctrl.abort();
+    };
+  }, [paneId, alive, token, generation]);
+
+  return { ...view, refetch };
+}

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -39,6 +39,7 @@ export interface PaneView {
   tmuxState: string; // "live" / "stale" / "unknown" / "-"
   tmuxTitle?: string;
   agentState?: string; // "running" / "done" / ""(不明)
+  planMode?: boolean; // Codex Plan Mode 起動ペイン(/api/plan・Plan セクションの対象)
   prompt?: string;
   ciStatus?: string; // lowercase; "-" = primary PR に CI なし
   wave?: number; // 0(unknown)はフィールドごと欠落
@@ -82,4 +83,13 @@ export interface PeekResponse {
   lines: number;
   capturedAt: string;
   output: string;
+}
+
+/* 正は internal/dashboard/plan.go の planResponse。found:false は「plan-mode
+ * ペインだが取得可能な出力に完全な plan ブロックが無い」を表す正常応答(200)。 */
+export interface PlanResponse {
+  paneId: string;
+  capturedAt: string;
+  found: boolean;
+  plan: string;
 }

--- a/web/src/style.css
+++ b/web/src/style.css
@@ -552,6 +552,36 @@ a.gh-pill:hover .tag{ border-color:var(--asagi); color:var(--asagi); }
   white-space:pre-wrap; overflow-wrap:anywhere;
   max-height:180px; overflow-y:auto;
 }
+/* plan — Codex Plan Mode の提案プラン。和紙カード + 浅葱の左罫で、dark terminal
+   風の peek(流れる出力)と「文書」を視覚的に区別する */
+.plan-card{
+  font-family:var(--f-code); font-size:12px; line-height:1.9;
+  color:var(--ink-78);
+  background:var(--paper);
+  border:1px solid var(--suna);
+  border-left:3px solid var(--asagi);
+  border-radius:0 10px 10px 0;
+  padding:12px 14px;
+  white-space:pre-wrap; overflow-wrap:anywhere;
+  max-height:320px; overflow-y:auto;
+}
+.plan-meta{
+  margin-top:7px;
+  display:flex; align-items:center; gap:10px;
+  font-family:var(--f-code); font-size:11px; color:var(--ink-40);
+}
+.plan-reload{
+  margin-left:auto;
+  font-family:var(--f-code); font-size:11px;
+  color:var(--ai);
+  background:transparent;
+  border:1px solid var(--suna); border-radius:999px;
+  padding:2px 12px;
+  cursor:pointer;
+  transition:border-color .25s ease, color .25s ease;
+}
+.plan-reload:hover{ border-color:var(--asagi); color:var(--asagi); }
+
 /* peek — docs サイトの terminal ブロック(両テーマ固定) */
 .terminal{
   background:var(--term-bg);

--- a/web/src/test/app.test.tsx
+++ b/web/src/test/app.test.tsx
@@ -508,6 +508,120 @@ describe("drawer + peek", () => {
   });
 });
 
+describe("plan(Codex Plan Mode)", () => {
+  /* %1 = planMode(codex)、%2 = 通常ペイン。Plan セクションの表示有無を対比する */
+  function planModeSnapshot() {
+    return makeSnapshot([
+      makeSession("142", [
+        makePane({
+          issueNum: 101,
+          displayName: "Fix login",
+          agent: "codex",
+          paneId: "%1",
+          planMode: true,
+        }),
+        makePane({ issueNum: 102, displayName: "Add docs", agent: "codex", paneId: "%2" }),
+      ]),
+    ]);
+  }
+
+  function planHandler(body: () => { found: boolean; plan: string }) {
+    return http.get("/api/plan", ({ request }) => {
+      const pane = new URL(request.url).searchParams.get("pane");
+      return HttpResponse.json({
+        paneId: pane ?? "?",
+        capturedAt: "2026-06-13T01:23:55Z",
+        ...body(),
+      });
+    });
+  }
+
+  it("planMode のペインだけ Plan セクションを表示し、plan 本文を <pre> テキストで描画する", async () => {
+    server.use(
+      peekHandler(() => "boot ok"),
+      planHandler(() => ({ found: true, plan: "## Plan\n1. <b>not html</b>" })),
+    );
+    const user = userEvent.setup();
+    render(<App />);
+    streamSnapshot(planModeSnapshot());
+
+    await user.click(screen.getByText("Fix login"));
+    const drawer = await screen.findByRole("complementary", { name: "ペイン詳細" });
+    expect(within(drawer).getByText("plan — 提案中のプラン")).toBeInTheDocument();
+    // capture 出力は敵性入力 — タグ混じりでもテキストノードとしてそのまま出る
+    const pre = await within(drawer).findByText(/1\. <b>not html<\/b>/);
+    expect(pre.tagName).toBe("PRE");
+    expect(pre.querySelector("b")).toBeNull();
+    expect(drawer.querySelector("#plan-meta")).toHaveTextContent(/captured \d{2}:\d{2}:\d{2}/);
+
+    // 通常ペインには Plan セクション自体が出ない(/api/plan も呼ばれない)
+    await user.click(screen.getByText("Add docs"));
+    await screen.findByRole("complementary", { name: "ペイン詳細" });
+    expect(screen.queryByText("plan — 提案中のプラン")).not.toBeInTheDocument();
+  });
+
+  it("found:false は未検出の説明文言を表示する", async () => {
+    server.use(
+      peekHandler(() => "boot ok"),
+      planHandler(() => ({ found: false, plan: "" })),
+    );
+    const user = userEvent.setup();
+    render(<App />);
+    streamSnapshot(planModeSnapshot());
+
+    await user.click(screen.getByText("Fix login"));
+    expect(await screen.findByText(/plan が見つかりません/)).toBeInTheDocument();
+  });
+
+  it("再取得ボタンで /api/plan を再フェッチする", async () => {
+    let calls = 0;
+    server.use(
+      peekHandler(() => "boot ok"),
+      planHandler(() => {
+        calls++;
+        return { found: true, plan: `plan v${calls}` };
+      }),
+    );
+    const user = userEvent.setup();
+    render(<App />);
+    streamSnapshot(planModeSnapshot());
+
+    await user.click(screen.getByText("Fix login"));
+    expect(await screen.findByText("plan v1")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "再取得" }));
+    expect(await screen.findByText("plan v2")).toBeInTheDocument();
+    expect(screen.queryByText("plan v1")).not.toBeInTheDocument();
+  });
+
+  it("plan はポーリングしない(時間経過では再フェッチされない)", async () => {
+    let planCalls = 0;
+    server.use(
+      peekHandler(() => "boot ok"),
+      planHandler(() => {
+        planCalls++;
+        return { found: true, plan: "stable plan" };
+      }),
+    );
+    vi.useFakeTimers();
+    render(<App />);
+    streamSnapshot(planModeSnapshot());
+
+    fireEvent.click(screen.getByText("Fix login"));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(screen.getByText("stable plan")).toBeInTheDocument();
+    expect(planCalls).toBe(1);
+
+    // peek の 5s ポーリング周期を 3 回分進めても plan は 1 回のまま
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(15000);
+    });
+    expect(planCalls).toBe(1);
+  });
+});
+
 describe("transport フォールバック", () => {
   it("SSE 断でポーリングに移行し、更新が継続する", async () => {
     const polled = makeSnapshot([


### PR DESCRIPTION
## 概要

`--codex-plan-mode` で起動した pane について、Session 詳細(Drawer)に「plan — 提案中のプラン」セクションを独立表示します(ダッシュボード改善 6 連 PR の 1 つ)。plan 本文はどこにも永続化されていないため、tmux capture からサーバー側で抽出する方式です。

- `state.Pane.CodexPlanMode`(additive・omitempty・SchemaVersion 据え置き)を `statePane` で記録し、`PaneView.planMode` としてワイヤに出す
- 新規 `GET /api/plan?pane=%N`(token-gated / GET-only / 127.0.0.1): `tmux capture-pane -p -J -S -2000` の履歴 + alternate screen を連結し、最後の「中身のある完全な」`<proposed_plan>...</proposed_plan>` ブロックを後方走査で抽出。**read-only 境界は不変**(mutation なし・tmux への書込なし)
- peek の検証チェーン(pane 形式 → 生存/worktree → 再検証 → capture)を `requireLivePane`/`beginPaneCapture` に一般化して両エンドポイントで共用(ロジック複製なし)
- web: `usePlan`(fetch-on-mount + 手動再取得、ポーリングなし)+ PlanPanel。capture 出力は敵性入力なので `<pre>` テキストノードのみで描画(markdown レンダ禁止)

## レビューで直した指摘

- **briefing 指示文のエコー誤検出**: briefing の「wrapped in `<proposed_plan>...</proposed_plan>`」が transcript に出ると素朴な LastIndex 抽出が `...` を plan として返す → 後方走査で空 / `...` ブロックをスキップ
- 空白のみブロックが `found:true` + 空 plan を返す契約矛盾 → スキップ対象に
- `usePlan` に loading 状態(初回 fetch 前に失敗文言が見える誤解を解消)、取得済み plan は pane 終了後も保持、`body.plan ?? ""` ガード、再取得は取得中 disabled
- `CapturePlanSource` は lines<=0 拒否(viewport のみへの静かな退化防止)
- 検証順の契約をテストで固定(peek: dead pane + 不正 lines は 404 / plan: HEAD も PlanMode ゲートで 404)

## 検証

- `go test ./...`(plan_test 11 ケースの抽出テーブル含む)/ `make lint-web` / `make test-web`(53 tests)green
- Playwright + 実 tmux pane(`<proposed_plan>` ブロックを出力)で実動確認 8 チェック PASS: planMode pane のみセクション表示・タグ内のみ抽出・再取得・非ポーリング・非 plan pane では API 不発
- /post-work-review 実施済み(code-review 5 angle → 修正 → codex:review approve)

## 既知の制限

- codex TUI は alternate screen のため、pane 高さを超えてスクロールアウトした長い plan は `found:false` になりうる(UI に文言表示)。恒久対応(plan-TUI コントローラでの永続化)は follow-up issue 参照
- コードフェンス内のタグは本物と区別しない(テストで明文化した割り切り)

## マージ順

6 連 PR は独立に main へ。`chore/web-oxlint-oxfmt` だけ最後にマージしてください。`feat/dashboard-queued-children` と model.go・types.ts・Drawer.tsx で軽微なコンフリクトの可能性(後着が rebase)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)