### PR TITLE
chore(web): oxlint / oxfmt を導入し CI の web lint を三段化(⚠️ 6 連 PR の最後に rebase-merge)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -57,7 +57,8 @@ the README before changing CLI behavior.
 - The dashboard web UI (`web/`) lints with `make lint-web` (oxlint + oxfmt
   `--check` + `tsc --noEmit`; configs `web/.oxlintrc.json` /
   `web/.oxfmtrc.json`) and formats with `make fmt-web` (oxfmt, printWidth
-  100). Keep `make lint` Node-free; web checks stay in `lint-web`.
+  100; scope is `web/src` + `vite.config.ts` — CSS and web/ root JSON are
+  excluded). Keep `make lint` Node-free; web checks stay in `lint-web`.
 - Run `git config blame.ignoreRevsFile .git-blame-ignore-revs` once per clone
   so bulk-formatting commits stay out of `git blame`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,10 @@ the README before changing CLI behavior.
   golangci-lint version; the pinned version (`.golangci-lint-version`) wins.
 - To bump golangci-lint, edit `.golangci-lint-version` (the Makefile and the
   CI lint job both read it) and fix any new findings in the same PR.
+- The dashboard web UI (`web/`) lints with `make lint-web` (oxlint + oxfmt
+  `--check` + `tsc --noEmit`; configs `web/.oxlintrc.json` /
+  `web/.oxfmtrc.json`) and formats with `make fmt-web` (oxfmt, printWidth
+  100). Keep `make lint` Node-free; web checks stay in `lint-web`.
 - Run `git config blame.ignoreRevsFile .git-blame-ignore-revs` once per clone
   so bulk-formatting commits stay out of `git blame`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ pinned golangci-lint v2 (`.golangci-lint-version`, config `.golangci.yml`) +
 shellcheck of the test shims (Node-free on purpose; the web lint is
 `make lint-web` = oxlint + oxfmt `--check` + tsc, configs `web/.oxlintrc.json`
 / `web/.oxfmtrc.json`). `make fmt` formats Go (gofumpt/goimports),
-`make fmt-web` formats `web/` (oxfmt, printWidth 100), `make fix` runs
+`make fmt-web` formats `web/src` + `vite.config.ts` (oxfmt, printWidth 100; CSS と web/ 直下の JSON は対象外), `make fix` runs
 `go fix` idiom updates (run `make test` after applying), and `make vuln` runs
 govulncheck (network; deliberately not part of `lint`).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,8 +15,10 @@ bundle-less checkout compiling without Node, serving a fallback page). `make
 test` runs the Go unit tests, the web UI vitest suite (`make test-web`), and
 the bats black-box suite against the binary via `FANOUT_BIN`; `make lint` is
 pinned golangci-lint v2 (`.golangci-lint-version`, config `.golangci.yml`) +
-shellcheck of the test shims (Node-free on purpose; the web type check is
-`make lint-web`). `make fmt` formats (gofumpt/goimports), `make fix` runs
+shellcheck of the test shims (Node-free on purpose; the web lint is
+`make lint-web` = oxlint + oxfmt `--check` + tsc, configs `web/.oxlintrc.json`
+/ `web/.oxfmtrc.json`). `make fmt` formats Go (gofumpt/goimports),
+`make fmt-web` formats `web/` (oxfmt, printWidth 100), `make fix` runs
 `go fix` idiom updates (run `make test` after applying), and `make vuln` runs
 govulncheck (network; deliberately not part of `lint`).
 

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ GOLANGCI_LINT_VERSION ?= $(shell cat .golangci-lint-version)
 GOLANGCI_LINT_BIN     := $(CURDIR)/.cache/tools/golangci-lint-$(GOLANGCI_LINT_VERSION)
 GOLANGCI_LINT_CACHE   ?= $(CURDIR)/.cache/golangci-lint
 
-.PHONY: install link uninstall build-go build-web clean-go clean-web install-integrations link-integrations uninstall-integrations go-test test test-web test-tier1 test-tier2 lint lint-go lint-shell lint-web fmt fix vuln check-bats
+.PHONY: install link uninstall build-go build-web clean-go clean-web install-integrations link-integrations uninstall-integrations go-test test test-web test-tier1 test-tier2 lint lint-go lint-shell lint-web fmt fmt-web fix vuln check-bats
 
 # The dashboard web UI (web/, React + Vite) is built into $(STATIC_DIR) and
 # embedded via go:embed. The bundle is never committed, so building the binary
@@ -115,7 +115,10 @@ uninstall: uninstall-integrations
 #                       (vitest) + Tier 1 + Tier 2 black-box tests against it
 #                       via FANOUT_BIN.
 # `make test-web`     — dashboard web UI tests (vitest; needs Node + pnpm).
-# `make lint-web`     — dashboard web UI type check (tsc --noEmit).
+# `make lint-web`     — dashboard web UI lint: oxlint + oxfmt --check + type
+#                       check (tsc --noEmit), cheap-first. Needs Node + pnpm;
+#                       `make lint` stays Node-free on purpose.
+# `make fmt-web`      — dashboard web UI formatting (oxfmt; web/.oxfmtrc.json).
 # `make test-tier1`   — flag / prerequisite tests, no live tmux panes.
 # `make test-tier2`   — --dry-run golden tests against fixture scenarios.
 # `make lint`         — pinned golangci-lint v2 (.golangci.yml) plus shellcheck
@@ -162,8 +165,12 @@ go-test:
 test-web: $(WEB_DIR)/node_modules/.installed
 	cd $(WEB_DIR) && $(PNPM) run test
 
+# Cheap-first: oxlint (ms) -> oxfmt --check (ms) -> tsc (s).
 lint-web: $(WEB_DIR)/node_modules/.installed
-	cd $(WEB_DIR) && $(PNPM) run typecheck
+	cd $(WEB_DIR) && $(PNPM) run lint && $(PNPM) run fmt:check && $(PNPM) run typecheck
+
+fmt-web: $(WEB_DIR)/node_modules/.installed
+	cd $(WEB_DIR) && $(PNPM) run fmt
 
 # Binary install because upstream does not guarantee `go install`; the URL is
 # pinned to the release tag.

--- a/README.ja.md
+++ b/README.ja.md
@@ -197,8 +197,9 @@ make test-tier1     # フラグ / prereq テストのみ
 make test-tier2     # --dry-run ゴールデン出力テスト (fixture 駆動)
 make test-web       # ダッシュボード Web UI テスト (vitest)
 make lint           # pinned golangci-lint v2 (.golangci.yml) + テスト用 shim の shellcheck
-make lint-web       # ダッシュボード Web UI の型チェック (tsc --noEmit)
+make lint-web       # ダッシュボード Web UI の lint (oxlint + oxfmt --check + tsc --noEmit)
 make fmt            # golangci-lint fmt による gofumpt/goimports 整形
+make fmt-web        # ダッシュボード Web UI の整形 (oxfmt)
 make fix            # go fix のイディオム更新 (適用後は make test を実行)
 make vuln           # govulncheck (ネットワーク要。意図的に make lint には含めない)
 make build-web      # ダッシュボード Web UI を internal/dashboard/static/ にビルド

--- a/README.md
+++ b/README.md
@@ -207,8 +207,9 @@ make test-tier1     # flag/prereq tests only
 make test-tier2     # --dry-run golden tests against fixture scenarios
 make test-web       # dashboard web UI tests (vitest)
 make lint           # pinned golangci-lint v2 (.golangci.yml) + shellcheck of the test shims
-make lint-web       # dashboard web UI type check (tsc --noEmit)
+make lint-web       # dashboard web UI lint (oxlint + oxfmt --check + tsc --noEmit)
 make fmt            # gofumpt/goimports formatting via golangci-lint fmt
+make fmt-web        # dashboard web UI formatting (oxfmt)
 make fix            # go fix idiom updates (run make test after applying)
 make vuln           # govulncheck (network; deliberately not part of make lint)
 make build-web      # build the dashboard web UI bundle into internal/dashboard/static/

--- a/web/.oxfmtrc.json
+++ b/web/.oxfmtrc.json
@@ -1,0 +1,7 @@
+{
+  // printWidth 100: 既存の手 wrap に最も近く、一括 reformat の diff が最小になる幅。
+  "printWidth": 100,
+  // style.css は対象外 — PAPER BREEZE の手揃え(カラム整列・1 行ルール)を機械整形で
+  // 壊さない。oxfmt の整形対象は TS/TSX のみ。
+  "ignorePatterns": ["**/*.css"]
+}

--- a/web/.oxlintrc.json
+++ b/web/.oxlintrc.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  // type-aware モードは使わない — 型起因の検査は tsc (pnpm run typecheck) が担当。
+  "plugins": ["react", "typescript", "unicorn", "oxc"],
+  "categories": {
+    "correctness": "error",
+    "suspicious": "warn"
+  },
+  "env": {
+    "browser": true,
+    "builtin": true
+  },
+  "rules": {
+    // noUncheckedIndexedAccess 由来の `m[1]!` イディオム (filter.ts 等) を保護する。
+    "typescript/no-non-null-assertion": "off",
+    // automatic JSX runtime (tsconfig jsx: "react-jsx") なので React の import は不要。
+    "react/react-in-jsx-scope": "off",
+    // 既存コードはスプレッドコピー後に sort しており非破壊。toSorted は lib ES2022 に無い。
+    "unicorn/no-array-sort": "off",
+    "no-unused-vars": ["error", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }]
+  },
+  "overrides": [
+    {
+      "files": ["src/test/**", "src/**/*.test.ts", "src/**/*.test.tsx"],
+      "plugins": ["vitest"],
+      "env": { "vitest": true }
+    }
+  ]
+}

--- a/web/.oxlintrc.json
+++ b/web/.oxlintrc.json
@@ -1,7 +1,10 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
   // type-aware モードは使わない — 型起因の検査は tsc (pnpm run typecheck) が担当。
-  "plugins": ["react", "typescript", "unicorn", "oxc"],
+  // eslint(core)は oxlint 1.69 では plugins 指定に関わらず常時有効だが、
+  // ドキュメントは「plugins 指定で default を置換」とも読めるため、no-unused-vars 等の
+  // core ルールが必ず効くよう明示しておく(test override も同様)。
+  "plugins": ["eslint", "react", "typescript", "unicorn", "oxc"],
   "categories": {
     "correctness": "error",
     "suspicious": "warn"
@@ -43,7 +46,7 @@
       // 「指定すると置換」とも読めるため、バージョン非依存に base プラグインも
       // 明示して test に base ルールが必ず適用されるようにする。
       "files": ["src/test/**", "src/**/*.test.ts", "src/**/*.test.tsx"],
-      "plugins": ["react", "typescript", "unicorn", "oxc", "vitest"],
+      "plugins": ["eslint", "react", "typescript", "unicorn", "oxc", "vitest"],
       "env": { "vitest": true }
     }
   ]

--- a/web/.oxlintrc.json
+++ b/web/.oxlintrc.json
@@ -11,15 +11,25 @@
     "builtin": true
   },
   "rules": {
-    // noUncheckedIndexedAccess 由来の `m[1]!` イディオム (filter.ts 等) を保護する。
-    "typescript/no-non-null-assertion": "off",
     // automatic JSX runtime (tsconfig jsx: "react-jsx") なので React の import は不要。
     "react/react-in-jsx-scope": "off",
     // 既存コードはスプレッドコピー後に sort しており非破壊。toSorted は lib ES2022 に無い。
     "unicorn/no-array-sort": "off",
-    "no-unused-vars": ["error", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }]
+    "no-unused-vars": ["error", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_" }],
+    // ^_ プレフィックスが unused-vars の公認イディオムなので、underscore を
+    // 咎める rule とは両立しない(suspicious は --max-warnings=0 で CI を
+    // 落とすため、矛盾警告を残せない)。
+    "eslint/no-underscore-dangle": "off"
   },
   "overrides": [
+    {
+      // noUncheckedIndexedAccess 由来の `m[1]!` イディオム (filter.ts / sort.ts
+      // 等の正規表現・境界チェック直後) は lib / test に集中している。
+      // components / hooks では `!` は tsc も黙らせる本物の危険なので rule を
+      // 生かしたままにする。
+      "files": ["src/lib/**", "src/test/**"],
+      "rules": { "typescript/no-non-null-assertion": "off" }
+    },
     {
       "files": ["src/test/**", "src/**/*.test.ts", "src/**/*.test.tsx"],
       "plugins": ["vitest"],

--- a/web/.oxlintrc.json
+++ b/web/.oxlintrc.json
@@ -23,7 +23,10 @@
     // Restriction ルールはカテゴリに含まれないので明示 enable が必要。これを
     // 書かないと off override も no-op になり、components/hooks の `!` も
     // 素通りしてしまう。lib/test だけ override で外す(下記)。
-    "typescript/no-non-null-assertion": "error"
+    "typescript/no-non-null-assertion": "error",
+    // describe ブロック内に snapshot ファクトリや MSW handler を置くのは
+    // テストの一般的な可読パターン。外スコープ強制は構成を散らすので off。
+    "unicorn/consistent-function-scoping": "off"
   },
   "overrides": [
     {

--- a/web/.oxlintrc.json
+++ b/web/.oxlintrc.json
@@ -19,7 +19,11 @@
     // ^_ プレフィックスが unused-vars の公認イディオムなので、underscore を
     // 咎める rule とは両立しない(suspicious は --max-warnings=0 で CI を
     // 落とすため、矛盾警告を残せない)。
-    "eslint/no-underscore-dangle": "off"
+    "eslint/no-underscore-dangle": "off",
+    // Restriction ルールはカテゴリに含まれないので明示 enable が必要。これを
+    // 書かないと off override も no-op になり、components/hooks の `!` も
+    // 素通りしてしまう。lib/test だけ override で外す(下記)。
+    "typescript/no-non-null-assertion": "error"
   },
   "overrides": [
     {
@@ -31,8 +35,12 @@
       "rules": { "typescript/no-non-null-assertion": "off" }
     },
     {
+      // vitest プラグイン/globals は test ファイルにだけ足す。oxlint 1.69 の
+      // 実挙動では override の plugins は base にマージされるが、ドキュメントは
+      // 「指定すると置換」とも読めるため、バージョン非依存に base プラグインも
+      // 明示して test に base ルールが必ず適用されるようにする。
       "files": ["src/test/**", "src/**/*.test.ts", "src/**/*.test.tsx"],
-      "plugins": ["vitest"],
+      "plugins": ["react", "typescript", "unicorn", "oxc", "vitest"],
       "env": { "vitest": true }
     }
   ]

--- a/web/package.json
+++ b/web/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "lint": "oxlint",
+    "lint": "oxlint --max-warnings=0",
     "lint:fix": "oxlint --fix",
     "fmt": "oxfmt src vite.config.ts",
     "fmt:check": "oxfmt --check src vite.config.ts",

--- a/web/package.json
+++ b/web/package.json
@@ -10,6 +10,10 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "lint": "oxlint",
+    "lint:fix": "oxlint --fix",
+    "fmt": "oxfmt src vite.config.ts",
+    "fmt:check": "oxfmt --check src vite.config.ts",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest"
@@ -28,6 +32,8 @@
     "@vitejs/plugin-react": "^6.0.2",
     "jsdom": "^29.1.1",
     "msw": "^2.14.6",
+    "oxfmt": "0.54.0",
+    "oxlint": "^1.69.0",
     "typescript": "^6.0.3",
     "vite": "^8.0.16",
     "vitest": "^4.1.8"

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -42,6 +42,12 @@ importers:
       msw:
         specifier: ^2.14.6
         version: 2.14.6(@types/node@25.9.3)(typescript@6.0.3)
+      oxfmt:
+        specifier: 0.54.0
+        version: 0.54.0
+      oxlint:
+        specifier: ^1.69.0
+        version: 1.69.0
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
@@ -204,6 +210,250 @@ packages:
 
   '@oxc-project/types@0.133.0':
     resolution: {integrity: sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==}
+
+  '@oxfmt/binding-android-arm-eabi@0.54.0':
+    resolution: {integrity: sha512-NAtpl/SiaeU103e7/OmZw0MvUnsUUopW7hEm/ecegJg7YM0skQaA0IXEZoyTV6NUdiNPupdIUreRqUZTShbn/g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxfmt/binding-android-arm64@0.54.0':
+    resolution: {integrity: sha512-B4VZfBUlKK1rmMChsssNZbkZjE8+FzG3avMjGgMDwbGxXRoXkoeXiAZ+78Oa+eyDPHvDCiUb4zH/vmCOUSafLQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxfmt/binding-darwin-arm64@0.54.0':
+    resolution: {integrity: sha512-i02vF75b+ePsQP3tHqSxVYI5S6b8X/xqdPu7/mDHXtpgXLTYXi3jJmfHU0j+dnZZDKaYTx/ioCK7QYJmtiJR2g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxfmt/binding-darwin-x64@0.54.0':
+    resolution: {integrity: sha512-8VMFvGvooXj7mswkbrhdVZ2/sgiDaBzWpkkbtO+qGDLV4EfJd67nQadHkQC0ZNbaWA9ajXfqI6i7PZLIeDzxEQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxfmt/binding-freebsd-x64@0.54.0':
+    resolution: {integrity: sha512-0cRHnp43WN1Jrc5s0BdbdKgR1XirdvHy7TAFi3JEsoEVQVJxTXMbpVd76sxXlgRswNMDhVFSJw+y7Eb8mEavFQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.54.0':
+    resolution: {integrity: sha512-JyQAk3hK/OEtup7Rw6kZwfdzbKqTVD5jXXb8Xpfay29suwZyfBDMVW/bj4RqEPySYWc6zCp198pOluf8n5uYzg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.54.0':
+    resolution: {integrity: sha512-qnvLatTpM8vtvjOfcckBOzJjk+n6ce/wwpP8OFeUrD5aNLYcKyWAitwj+Rk3PK9jGanbZvKsJnv14JGQ6XqFdw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm64-gnu@0.54.0':
+    resolution: {integrity: sha512-SMkhnCzIYZYDk9vw3W/80eeYKmrMpGF0Giuxt4HruFlCH7jEtnPeb3SdQKMfgYi/dgtaf+hZAb5XWPYnxqCQ3w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-arm64-musl@0.54.0':
+    resolution: {integrity: sha512-QrwJlBFFKnxOd95TAaszpMbZBLzMoYMpGaQTZF8oibacnF5rv8l12IhILhQRPmksWiBqg0YSe2Mnl7ayeJAHSA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.54.0':
+    resolution: {integrity: sha512-WILatiol/TUHTlhod7R09+7Az/XlhKwmY1MHfLZNmewltPWNN/EwxP2rQSHahibZ/cB8gmckEBjBOByD+5bYsQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.54.0':
+    resolution: {integrity: sha512-f05YMG4BH4G8S4ME6UM6fi1MnJ9094mrnvO5Pa4SJlMfWlUM+1/ZWMEF4NnjM7shZAvbHsHRuVYpUo0PHC4P9Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-riscv64-musl@0.54.0':
+    resolution: {integrity: sha512-UfL+2hj1ClNqcCRT9s8vBU4axDpjxgVxX96G+9DYAYjoc5b0u15CJtn2jgsi9iM+EbGNc5CW1HVRgwVu76UsSA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-linux-s390x-gnu@0.54.0':
+    resolution: {integrity: sha512-3/XZe931Hka+J6NjnaqJzYpsWWxDTuRdUdwSQHnOuJEgbC+SehIMFJS8hsEjV7LBhVSL2OCnRLvbVW8O97XIyw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-x64-gnu@0.54.0':
+    resolution: {integrity: sha512-Ik93RlObtu43GbxApafayFjwYE06L6Xr08cSwpBPYbDrLp2ReZx0Jm1DqwRyYRnukUJy+rK2WaEvUQOxdytU9Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-x64-musl@0.54.0':
+    resolution: {integrity: sha512-yZcakmPlD86CNymknd7KfW+FH+qfbqJH+i0h69CYfV1+KMoVeM9UED+8+TDVoU4haxI0NxY7RPCvRLy3Sqd2Qg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-openharmony-arm64@0.54.0':
+    resolution: {integrity: sha512-GiVBZNnEZnKu00f1jTg49nomv187d0GQX+O+ocykoLeiaALuEO+swoTehHn9TehTfi7V8H0i0e/yvUjCqnwk1w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxfmt/binding-win32-arm64-msvc@0.54.0':
+    resolution: {integrity: sha512-J0SSB8Z1Fre2sxRolYcW6Rl1RQmKdQ2hnHyq4YJrfBRiXTObLw4DXnIVraM/UyqGqwOi7yTrQA4VT7DPxlHVKA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxfmt/binding-win32-ia32-msvc@0.54.0':
+    resolution: {integrity: sha512-O61UDVj8zz6yXJjkHPf05VaMLOXmEF8P5kf/N0W7AQMmd6bcQogl+KJc7rMutKTL524oE9iH32JXZClBFmEQIg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxfmt/binding-win32-x64-msvc@0.54.0':
+    resolution: {integrity: sha512-1MDpqJPiFqxWtIHas8vkb1VZ7f7eKyTffAwmO8isxQYMaG1OFKsH666BWLeXQLO+IWNfiMssLD55hbR1lIPTqg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxlint/binding-android-arm-eabi@1.69.0':
+    resolution: {integrity: sha512-DKQQbD5cZ/MYfDgDI7YGyGD9FSxABlsBsYFo5p26lloob543tP9+4N3guwdXIYJN+7HSZxLe8YJuwcOWw5qnHg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxlint/binding-android-arm64@1.69.0':
+    resolution: {integrity: sha512-lEhb+I5pr4inux+JFwfCa1HRq3Os7NirEFQ0H1I35SVEHPm6byX0Ah47xmRha3qi6LAkxUcxViL8o/9PivjzBg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxlint/binding-darwin-arm64@1.69.0':
+    resolution: {integrity: sha512-GY2YE8lOZW59BW1Ia1y+1gR0XyjrZRvVWHAr8LGeGhYHE0OQJ/7cRKXTkx1P+E9/6awEc3SX8a68SFTjh/E//A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint/binding-darwin-x64@1.69.0':
+    resolution: {integrity: sha512-ax1oZnOjHX3LB7myQyHEaQkDwfLb6str3/nSP6O7EVUviQGNkEGzGV0EqcBJWK+Ufwx0l4xPgyYayurvhAdl2Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint/binding-freebsd-x64@1.69.0':
+    resolution: {integrity: sha512-kHWeHv4g2h8NY+mpCxzCtY4uerMJWTN/TSnNj1CPbakFpHEJ6cTya2wWV0pDSYWOJ2+0UiEbhn3AtXxHtsnKjg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.69.0':
+    resolution: {integrity: sha512-gq84vM1a1oEehXo27YCDzGVcxPsZDI1yswZwz2Da1/cbnWtrL16XZZnz0G/+gIU8edtHpfjxq5c+vWEHqJfWoQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm-musleabihf@1.69.0':
+    resolution: {integrity: sha512-kIqEa98JQ0VRyrcncxA417m2AzasqTlD+FyVT1AksjvjkqQcvm7pBWYvoW3/mpyOP2XYvi5nSCCTIe6De1yu5g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm64-gnu@1.69.0':
+    resolution: {integrity: sha512-j+xYiXozxGWx2cpjCrwwGR4awTxPFsRv3JZrv23RCogEPMc4R7UqjHW47p/RG0aRlbWiROCJ8coUfCwy0dvzHA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-arm64-musl@1.69.0':
+    resolution: {integrity: sha512-xEPpNppTfN1l/nM7gYSf9iocscu/as+p/7vxkLeLEKnYU+09Dm+5V6IhDYDh+Uz6FajEupWwCLt5SOG0y1PCKg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-linux-ppc64-gnu@1.69.0':
+    resolution: {integrity: sha512-Ug0+eU7HJBlek+SjklYH62IlOMirEJsdxpihH0kSqX0XdrDD4NdHpQc10fK1JC35yn6KrrcN+uYzlHD38XAf8Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-riscv64-gnu@1.69.0':
+    resolution: {integrity: sha512-iEyI3GIg0l/s3G4qy2TlaaWKdzj4PJJStwtlocpDTC00PY9hZueotf6OKUj9+yfQh0lrpBW/pLMgTztbAHKJEg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-riscv64-musl@1.69.0':
+    resolution: {integrity: sha512-NjHjpiI4WIKSMwuoJSZi5VToPeoYOS1FR52HLIDG6lidMdqquusgtODb4iLk0+lb1q3Z0nv2/aPRcC/olmpQGg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-linux-s390x-gnu@1.69.0':
+    resolution: {integrity: sha512-Ai/prDewoItkDXbp38gwGZi41DycZbUTZJ3UidwoHgQC0/DaqC2TGdtBTQLJ6hSD+SAxASzh8+/eSBPmxfOacA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-x64-gnu@1.69.0':
+    resolution: {integrity: sha512-Gt3KHgp46mRKz4sJeaASmKvD8ayXookRw07RMf+NowhEztGGDZ7VrXpoW96XuKJLjFukWizOFVNjmYb/u7caNQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-x64-musl@1.69.0':
+    resolution: {integrity: sha512-7tQhJ2+p/oHv1zcfnjYI7YVzC/7iBaVOfIvFYtxdJ5F45mWgEdrCyXZXZGfiLey5t/5JhOhsaMnnv1kAzckd7g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-openharmony-arm64@1.69.0':
+    resolution: {integrity: sha512-vmWz6TKp/3hfA4lksR0zHBv/6xuX1jhym6eqOjdH2DXsDDHZWcp2f0KG0VCAnlVbIrjk29G4wAWMXb/Hn1YobA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxlint/binding-win32-arm64-msvc@1.69.0':
+    resolution: {integrity: sha512-9RExaLgmaw6IoIkU9cTpT71mLfI0xZ86iZH8x518LVsOkjquJMYqb9P7KpC8lgd1t0Dxs41p2pxynq4XR3Ttzw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint/binding-win32-ia32-msvc@1.69.0':
+    resolution: {integrity: sha512-1907kRPF8/PrcIw1E7LMs9JbVrpgnt/MvFdss3an8oDkYNAACXzTntV3t3869ZZhMZxb2AzRGbz1pA/jdFatXA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxlint/binding-win32-x64-msvc@1.69.0':
+    resolution: {integrity: sha512-w8SOXv3mT9Fi6jY8OXdXCfnvX/3KNLXGNr4HEz2TA7S4Mv/PYAOmpB8y/ge40mxvBMgGNaSaaDwZpAsQn7HtWA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
 
   '@rolldown/binding-android-arm64@1.0.3':
     resolution: {integrity: sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==}
@@ -695,6 +945,32 @@ packages:
   outvariant@1.4.3:
     resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
 
+  oxfmt@0.54.0:
+    resolution: {integrity: sha512-DjnMwn7smSLF+Mc2+pRItnuPftm/dkUFpY/d4+33y9TfKrsHZo8GLhmUg9BrOIUEy94Rlom1Q11N6vuhE+e0oQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      svelte: ^5.0.0
+      vite-plus: '*'
+    peerDependenciesMeta:
+      svelte:
+        optional: true
+      vite-plus:
+        optional: true
+
+  oxlint@1.69.0:
+    resolution: {integrity: sha512-ypZkK/aDc5NQV8zIR6s2H2Tl3aNW8FmJ1m9+2qsaYuRenl8vgnHNCGwTHviWJdUQzglOlHFchgopdtGhSy17Rw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      oxlint-tsgolint: '>=0.22.1'
+      vite-plus: '*'
+    peerDependenciesMeta:
+      oxlint-tsgolint:
+        optional: true
+      vite-plus:
+        optional: true
+
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
@@ -818,6 +1094,10 @@ packages:
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@2.1.0:
+    resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
+    engines: {node: ^20.0.0 || >=22.0.0}
 
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
@@ -1125,6 +1405,120 @@ snapshots:
   '@open-draft/until@2.1.0': {}
 
   '@oxc-project/types@0.133.0': {}
+
+  '@oxfmt/binding-android-arm-eabi@0.54.0':
+    optional: true
+
+  '@oxfmt/binding-android-arm64@0.54.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-arm64@0.54.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-x64@0.54.0':
+    optional: true
+
+  '@oxfmt/binding-freebsd-x64@0.54.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.54.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.54.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-gnu@0.54.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-musl@0.54.0':
+    optional: true
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.54.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.54.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-musl@0.54.0':
+    optional: true
+
+  '@oxfmt/binding-linux-s390x-gnu@0.54.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-gnu@0.54.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-musl@0.54.0':
+    optional: true
+
+  '@oxfmt/binding-openharmony-arm64@0.54.0':
+    optional: true
+
+  '@oxfmt/binding-win32-arm64-msvc@0.54.0':
+    optional: true
+
+  '@oxfmt/binding-win32-ia32-msvc@0.54.0':
+    optional: true
+
+  '@oxfmt/binding-win32-x64-msvc@0.54.0':
+    optional: true
+
+  '@oxlint/binding-android-arm-eabi@1.69.0':
+    optional: true
+
+  '@oxlint/binding-android-arm64@1.69.0':
+    optional: true
+
+  '@oxlint/binding-darwin-arm64@1.69.0':
+    optional: true
+
+  '@oxlint/binding-darwin-x64@1.69.0':
+    optional: true
+
+  '@oxlint/binding-freebsd-x64@1.69.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.69.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-musleabihf@1.69.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-gnu@1.69.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-musl@1.69.0':
+    optional: true
+
+  '@oxlint/binding-linux-ppc64-gnu@1.69.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-gnu@1.69.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-musl@1.69.0':
+    optional: true
+
+  '@oxlint/binding-linux-s390x-gnu@1.69.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-gnu@1.69.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-musl@1.69.0':
+    optional: true
+
+  '@oxlint/binding-openharmony-arm64@1.69.0':
+    optional: true
+
+  '@oxlint/binding-win32-arm64-msvc@1.69.0':
+    optional: true
+
+  '@oxlint/binding-win32-ia32-msvc@1.69.0':
+    optional: true
+
+  '@oxlint/binding-win32-x64-msvc@1.69.0':
+    optional: true
 
   '@rolldown/binding-android-arm64@1.0.3':
     optional: true
@@ -1536,6 +1930,52 @@ snapshots:
 
   outvariant@1.4.3: {}
 
+  oxfmt@0.54.0:
+    dependencies:
+      tinypool: 2.1.0
+    optionalDependencies:
+      '@oxfmt/binding-android-arm-eabi': 0.54.0
+      '@oxfmt/binding-android-arm64': 0.54.0
+      '@oxfmt/binding-darwin-arm64': 0.54.0
+      '@oxfmt/binding-darwin-x64': 0.54.0
+      '@oxfmt/binding-freebsd-x64': 0.54.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.54.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.54.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.54.0
+      '@oxfmt/binding-linux-arm64-musl': 0.54.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.54.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.54.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.54.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.54.0
+      '@oxfmt/binding-linux-x64-gnu': 0.54.0
+      '@oxfmt/binding-linux-x64-musl': 0.54.0
+      '@oxfmt/binding-openharmony-arm64': 0.54.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.54.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.54.0
+      '@oxfmt/binding-win32-x64-msvc': 0.54.0
+
+  oxlint@1.69.0:
+    optionalDependencies:
+      '@oxlint/binding-android-arm-eabi': 1.69.0
+      '@oxlint/binding-android-arm64': 1.69.0
+      '@oxlint/binding-darwin-arm64': 1.69.0
+      '@oxlint/binding-darwin-x64': 1.69.0
+      '@oxlint/binding-freebsd-x64': 1.69.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.69.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.69.0
+      '@oxlint/binding-linux-arm64-gnu': 1.69.0
+      '@oxlint/binding-linux-arm64-musl': 1.69.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.69.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.69.0
+      '@oxlint/binding-linux-riscv64-musl': 1.69.0
+      '@oxlint/binding-linux-s390x-gnu': 1.69.0
+      '@oxlint/binding-linux-x64-gnu': 1.69.0
+      '@oxlint/binding-linux-x64-musl': 1.69.0
+      '@oxlint/binding-openharmony-arm64': 1.69.0
+      '@oxlint/binding-win32-arm64-msvc': 1.69.0
+      '@oxlint/binding-win32-ia32-msvc': 1.69.0
+      '@oxlint/binding-win32-x64-msvc': 1.69.0
+
   parse5@8.0.1:
     dependencies:
       entities: 8.0.0
@@ -1651,6 +2091,8 @@ snapshots:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
+
+  tinypool@2.1.0: {}
 
   tinyrainbow@3.1.0: {}
 

--- a/web/src/components/App.tsx
+++ b/web/src/components/App.tsx
@@ -1,7 +1,14 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from "react";
 import { useSnapshot } from "../hooks/useSnapshot";
 import { readToken } from "../lib/api";
-import { filterTokens, matches, parseQuery, removeToken, replaceToken, stripKey } from "../lib/filter";
+import {
+  filterTokens,
+  matches,
+  parseQuery,
+  removeToken,
+  replaceToken,
+  stripKey,
+} from "../lib/filter";
 import { clock, degradedMessages } from "../lib/format";
 import { deriveAgents, deriveWaves } from "../lib/options";
 import { findPane } from "../lib/pane";
@@ -144,7 +151,9 @@ export function App() {
                 <section className="session">
                   <div className="empty">
                     <span className="ji">no panes in the breeze</span>
-                    {total ? "フィルタに一致するペインがありません" : "アクティブなセッションがありません"}
+                    {total
+                      ? "フィルタに一致するペインがありません"
+                      : "アクティブなセッションがありません"}
                   </div>
                 </section>
               )}
@@ -170,7 +179,13 @@ export function App() {
           </div>
         </div>
         {selectedPane && selected && (
-          <Drawer key={selected} pane={selectedPane} repo={repo} token={token} onClose={closeDrawer} />
+          <Drawer
+            key={selected}
+            pane={selectedPane}
+            repo={repo}
+            token={token}
+            onClose={closeDrawer}
+          />
         )}
       </div>
     </>

--- a/web/src/components/Drawer.tsx
+++ b/web/src/components/Drawer.tsx
@@ -15,12 +15,23 @@ function PlanPanel({ pane, token }: { pane: PaneView; token: string }) {
       <h4>plan — 提案中のプラン</h4>
       {/* capture 出力は敵性入力 — markdown レンダせずテキストノードのみで描画。
           tabIndex: 長い plan のスクロールをキーボードで届くように */}
-      <pre className="plan-card" id="plan-pre" tabIndex={0} role="region" aria-label="提案中のプラン">
+      <pre
+        className="plan-card"
+        id="plan-pre"
+        tabIndex={0}
+        role="region"
+        aria-label="提案中のプラン"
+      >
         {plan.text}
       </pre>
       <div className="plan-meta" id="plan-meta" aria-live="polite">
         <span>{plan.loading ? "取得中…" : plan.meta}</span>
-        <button type="button" className="plan-reload" onClick={plan.refetch} disabled={plan.loading}>
+        <button
+          type="button"
+          className="plan-reload"
+          onClick={plan.refetch}
+          disabled={plan.loading}
+        >
           再取得
         </button>
       </div>
@@ -175,9 +186,7 @@ export function Drawer({
                 <IssueStateTag state={pane.issueState} unknownLabel="UNKNOWN" />
               </dd>
               <dt>状態</dt>
-              <dd id="d-not-started">
-                {notStartedNote(pane.tmuxState)}
-              </dd>
+              <dd id="d-not-started">{notStartedNote(pane.tmuxState)}</dd>
             </dl>
           </section>
           <WaveSection pane={pane} repo={repo} />

--- a/web/src/components/FilterBar.tsx
+++ b/web/src/components/FilterBar.tsx
@@ -4,63 +4,64 @@ import { FilterDropdown, type Option } from "./FilterDropdown";
 
 /* 静的キーのドロップダウン定義。options をモジュール定数にすることで
  * memo(FilterDropdown) が snapshot tick の再レンダーをスキップできる。 */
-const STATIC_DROPDOWNS: readonly { key: string; ariaLabel: string; options: readonly Option[] }[] = [
-  {
-    key: "state",
-    ariaLabel: "issue / tmux 状態で絞り込み",
-    options: [
-      ["open", "open"],
-      ["closed", "closed"],
-      ["live", "live"],
-      ["stale", "stale"],
-      ["queued", "queued"], // 未開始(synthetic)行の tmux 状態
-      ["deferred", "deferred"], // blocker 待ちの未開始行
-    ],
-  },
-  {
-    key: "run",
-    ariaLabel: "agent 実行状態で絞り込み",
-    options: [
-      ["running", "running"],
-      ["done", "done"],
-    ],
-  },
-  {
-    key: "ci",
-    ariaLabel: "CI 結果で絞り込み",
-    options: [
-      ["pass", "pass"],
-      ["fail", "fail"],
-      ["pending", "pending"],
-    ],
-  },
-  {
-    key: "dirty",
-    ariaLabel: "worktree の dirty 状態で絞り込み",
-    options: [
-      ["yes", "yes"],
-      ["no", "no"],
-    ],
-  },
-  {
-    key: "live",
-    ariaLabel: "tmux ペイン生死で絞り込み",
-    options: [
-      ["yes", "yes"],
-      ["no", "no"],
-    ],
-  },
-  {
-    key: "pr",
-    ariaLabel: "PR 状態で絞り込み",
-    options: [
-      ["merged", "merged"],
-      ["open", "open"],
-      ["closed", "closed"],
-      ["none", "none"],
-    ],
-  },
-];
+const STATIC_DROPDOWNS: readonly { key: string; ariaLabel: string; options: readonly Option[] }[] =
+  [
+    {
+      key: "state",
+      ariaLabel: "issue / tmux 状態で絞り込み",
+      options: [
+        ["open", "open"],
+        ["closed", "closed"],
+        ["live", "live"],
+        ["stale", "stale"],
+        ["queued", "queued"], // 未開始(synthetic)行の tmux 状態
+        ["deferred", "deferred"], // blocker 待ちの未開始行
+      ],
+    },
+    {
+      key: "run",
+      ariaLabel: "agent 実行状態で絞り込み",
+      options: [
+        ["running", "running"],
+        ["done", "done"],
+      ],
+    },
+    {
+      key: "ci",
+      ariaLabel: "CI 結果で絞り込み",
+      options: [
+        ["pass", "pass"],
+        ["fail", "fail"],
+        ["pending", "pending"],
+      ],
+    },
+    {
+      key: "dirty",
+      ariaLabel: "worktree の dirty 状態で絞り込み",
+      options: [
+        ["yes", "yes"],
+        ["no", "no"],
+      ],
+    },
+    {
+      key: "live",
+      ariaLabel: "tmux ペイン生死で絞り込み",
+      options: [
+        ["yes", "yes"],
+        ["no", "no"],
+      ],
+    },
+    {
+      key: "pr",
+      ariaLabel: "PR 状態で絞り込み",
+      options: [
+        ["merged", "merged"],
+        ["open", "open"],
+        ["closed", "closed"],
+        ["none", "none"],
+      ],
+    },
+  ];
 
 export function FilterBar({
   filter,
@@ -91,8 +92,18 @@ export function FilterBar({
       {STATIC_DROPDOWNS.map((d) => (
         <FilterDropdown key={d.key} {...dd(d.key)} ariaLabel={d.ariaLabel} options={d.options} />
       ))}
-      <FilterDropdown {...dd("agent")} ariaLabel="agent で絞り込み" options={agentOptions} searchable />
-      <FilterDropdown {...dd("wave")} ariaLabel="wave で絞り込み" options={waveOptions} searchable />
+      <FilterDropdown
+        {...dd("agent")}
+        ariaLabel="agent で絞り込み"
+        options={agentOptions}
+        searchable
+      />
+      <FilterDropdown
+        {...dd("wave")}
+        ariaLabel="wave で絞り込み"
+        options={waveOptions}
+        searchable
+      />
       <span id="chips" role="list" aria-label="適用中のフィルタ">
         {tokens.map((t) => (
           <button

--- a/web/src/components/FilterDropdown.tsx
+++ b/web/src/components/FilterDropdown.tsx
@@ -149,7 +149,8 @@ export const FilterDropdown = memo(function FilterDropdown({
 
   /* Tab 等でフォーカスが外に出たら閉じる(外側 click は pointerdown が先に処理) */
   const onBlur = (e: FocusEvent) => {
-    if (open && e.relatedTarget && !rootRef.current?.contains(e.relatedTarget as Node)) setOpen(false);
+    if (open && e.relatedTarget && !rootRef.current?.contains(e.relatedTarget as Node))
+      setOpen(false);
   };
 
   return (
@@ -219,7 +220,13 @@ export const FilterDropdown = memo(function FilterDropdown({
                 onClick={() => pick([v, l])}
                 onFocus={() => setCursor(i)} // click / Tab でのフォーカス移動も roving に反映
               >
-                <svg className="fd-check" viewBox="0 0 16 16" width="12" height="12" aria-hidden="true">
+                <svg
+                  className="fd-check"
+                  viewBox="0 0 16 16"
+                  width="12"
+                  height="12"
+                  aria-hidden="true"
+                >
                   <path
                     d="M3.2 8.6 6.6 12l6.2-7.4"
                     fill="none"

--- a/web/src/components/Nav.tsx
+++ b/web/src/components/Nav.tsx
@@ -12,10 +12,30 @@ function ThemeToggle() {
       aria-pressed={theme === "dark"}
       onClick={toggle}
     >
-      <svg className="ic-moon" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" aria-hidden="true">
+      <svg
+        className="ic-moon"
+        width="15"
+        height="15"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        aria-hidden="true"
+      >
         <path d="M20.4 14.2A8.6 8.6 0 0 1 9.8 3.6a8.6 8.6 0 1 0 10.6 10.6Z" />
       </svg>
-      <svg className="ic-sun" width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" aria-hidden="true">
+      <svg
+        className="ic-sun"
+        width="15"
+        height="15"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        aria-hidden="true"
+      >
         <circle cx="12" cy="12" r="4.2" />
         <path d="M12 2.5v2.4M12 19.1v2.4M2.5 12h2.4M19.1 12h2.4M5.2 5.2l1.7 1.7M17.1 17.1l1.7 1.7M18.8 5.2l-1.7 1.7M6.9 17.1l-1.7 1.7" />
       </svg>
@@ -23,7 +43,15 @@ function ThemeToggle() {
   );
 }
 
-export function Nav({ repo, projectRoot, conn }: { repo: string; projectRoot: string; conn: ConnState }) {
+export function Nav({
+  repo,
+  projectRoot,
+  conn,
+}: {
+  repo: string;
+  projectRoot: string;
+  conn: ConnState;
+}) {
   return (
     <header className="nav">
       <div className="nav-inner">

--- a/web/src/components/SessionSection.tsx
+++ b/web/src/components/SessionSection.tsx
@@ -165,7 +165,9 @@ export function SessionSection({
                 <th
                   key={key}
                   data-sort={key}
-                  aria-sort={sortKey === key ? (sortDir === 1 ? "ascending" : "descending") : "none"}
+                  aria-sort={
+                    sortKey === key ? (sortDir === 1 ? "ascending" : "descending") : "none"
+                  }
                   onClick={() => onSort(key)}
                 >
                   {label}

--- a/web/src/components/ui.tsx
+++ b/web/src/components/ui.tsx
@@ -2,7 +2,15 @@ import type { ReactNode } from "react";
 import { prUrl } from "../lib/github";
 import type { PRRef } from "../lib/types";
 
-export function Tag({ cls = "", title, children }: { cls?: string; title?: string; children: ReactNode }) {
+export function Tag({
+  cls = "",
+  title,
+  children,
+}: {
+  cls?: string;
+  title?: string;
+  children: ReactNode;
+}) {
   return (
     <span className={cls ? `tag ${cls}` : "tag"} title={title}>
       {children}
@@ -13,7 +21,15 @@ export function Tag({ cls = "", title, children }: { cls?: string; title?: strin
 /* url が空(repo 未解決・@manual の負番号 issue など)ならリンク化せず子を
  * そのまま返す。url の安全性は lib/github の検証で担保済み — ここでは新しい
  * URL を組み立てないこと。 */
-export function GhLink({ url, cls = "gh", children }: { url: string; cls?: string; children: ReactNode }) {
+export function GhLink({
+  url,
+  cls = "gh",
+  children,
+}: {
+  url: string;
+  cls?: string;
+  children: ReactNode;
+}) {
   if (!url) return <>{children}</>;
   return (
     <a className={cls} href={url} target="_blank" rel="noopener noreferrer">
@@ -40,7 +56,13 @@ export function DirtyTag({ state, unknownLabel = "—" }: { state: string; unkno
 
 /* issue 状態のタグ。unknown 時の表示は行("?")とドロワー("UNKNOWN")で
  * 異なるため引数化する。 */
-export function IssueStateTag({ state, unknownLabel = "?" }: { state: string; unknownLabel?: string }) {
+export function IssueStateTag({
+  state,
+  unknownLabel = "?",
+}: {
+  state: string;
+  unknownLabel?: string;
+}) {
   if (state === "OPEN") return <Tag cls="t-open">OPEN</Tag>;
   if (state === "CLOSED") return <Tag>CLOSED</Tag>;
   return <span className="muted">{unknownLabel}</span>;

--- a/web/src/hooks/usePlan.ts
+++ b/web/src/hooks/usePlan.ts
@@ -26,7 +26,12 @@ type ViewState = Omit<PlanView, "refetch">;
  * 一度表示できた plan は alive が落ちても保持する(pane 終了で読みかけの文書を
  * 消さない)。 */
 export function usePlan(pane: { paneId: string; alive: boolean } | null, token: string): PlanView {
-  const [view, setView] = useState<ViewState>({ text: LOADING, meta: "—", found: false, loading: true });
+  const [view, setView] = useState<ViewState>({
+    text: LOADING,
+    meta: "—",
+    found: false,
+    loading: true,
+  });
   const [generation, setGeneration] = useState(0);
   const refetch = useCallback(() => setGeneration((g) => g + 1), []);
   const paneId = pane?.paneId ?? null;
@@ -37,7 +42,14 @@ export function usePlan(pane: { paneId: string; alive: boolean } | null, token: 
     if (!alive) {
       // 取得済みの plan は残す(snapshot の alive 反転で文書を吹き飛ばさない)
       setView((v) =>
-        v.found ? v : { text: "(plan を取得できません — ペインは終了しています)", meta: "—", found: false, loading: false },
+        v.found
+          ? v
+          : {
+              text: "(plan を取得できません — ペインは終了しています)",
+              meta: "—",
+              found: false,
+              loading: false,
+            },
       );
       return;
     }

--- a/web/src/hooks/useSnapshot.ts
+++ b/web/src/hooks/useSnapshot.ts
@@ -79,12 +79,12 @@ export function useSnapshot(token: string): { snap: Snapshot | null; conn: ConnS
       setConn({ up: true, label: "streaming" });
       setSnap(JSON.parse((e as MessageEvent).data) as Snapshot);
     });
-    es.onerror = () => {
+    es.addEventListener("error", () => {
       if (disposed) return;
       setConn({ up: false, label: "stream lost" });
       es.close();
       startPolling();
-    };
+    });
 
     return () => {
       disposed = true;

--- a/web/src/lib/filter.test.ts
+++ b/web/src/lib/filter.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it } from "vitest";
 import { makePane } from "../test/fixtures";
-import { filterTokens, matches, parseQuery, removeToken, replaceToken, stripKey, tokenForKey } from "./filter";
+import {
+  filterTokens,
+  matches,
+  parseQuery,
+  removeToken,
+  replaceToken,
+  stripKey,
+  tokenForKey,
+} from "./filter";
 
 describe("parseQuery", () => {
   it("key:value トークンと自由語を区別する", () => {
@@ -68,7 +76,10 @@ describe("matches", () => {
     expect(matches(makePane({ ciStatus: "-" }), q("ci:fail"))).toBe(false);
     // ciStatus 不在の旧 snapshot は worst-of-prs に fallback
     expect(
-      matches(makePane({ prs: [{ number: 1, state: "OPEN", mergedAt: null, ci: "fail" }] }), q("ci:fail")),
+      matches(
+        makePane({ prs: [{ number: 1, state: "OPEN", mergedAt: null, ci: "fail" }] }),
+        q("ci:fail"),
+      ),
     ).toBe(true);
   });
 
@@ -109,7 +120,10 @@ describe("トークン操作", () => {
   });
 
   it("replaceToken は同キーを上書きする", () => {
-    expect(replaceToken(["state:open", "claude"], "state", "closed")).toEqual(["claude", "state:closed"]);
+    expect(replaceToken(["state:open", "claude"], "state", "closed")).toEqual([
+      "claude",
+      "state:closed",
+    ]);
   });
 
   it("removeToken は完全一致のみ外す", () => {
@@ -128,7 +142,9 @@ describe("トークン操作", () => {
   });
 
   it("stripKey は同キーのトークンを重複・大文字違いごと全て外す", () => {
-    expect(stripKey(["state:open", "STATE:closed", "agent:claude"], "state")).toEqual(["agent:claude"]);
+    expect(stripKey(["state:open", "STATE:closed", "agent:claude"], "state")).toEqual([
+      "agent:claude",
+    ]);
     expect(stripKey(["claude"], "state")).toEqual(["claude"]);
   });
 });

--- a/web/src/lib/filter.test.ts
+++ b/web/src/lib/filter.test.ts
@@ -24,9 +24,9 @@ describe("parseQuery", () => {
   });
 });
 
-describe("matches", () => {
-  const q = (s: string) => parseQuery(s);
+const q = (s: string) => parseQuery(s);
 
+describe("matches", () => {
   it("自由語は haystack(名前・ブランチ・wave 等)を部分一致で見る", () => {
     const p = makePane({ displayName: "Fix Login", branchName: "fanout/fix-login" });
     expect(matches(p, q("login"))).toBe(true);

--- a/web/src/lib/filter.ts
+++ b/web/src/lib/filter.ts
@@ -59,13 +59,22 @@ export function matches(p: PaneView, terms: Term[]): boolean {
     switch (t.key) {
       case "state":
         // tmux 状態(live/stale)に一致するならそれを、さもなくば issue 状態を見る
-        if ((p.tmuxState === t.value ? p.tmuxState : String(p.issueState ?? "").toLowerCase()) !== t.value) return false;
+        if (
+          (p.tmuxState === t.value ? p.tmuxState : String(p.issueState ?? "").toLowerCase()) !==
+          t.value
+        )
+          return false;
         break;
       case "run":
         if ((p.agentState ?? "") !== t.value) return false;
         break;
       case "agent":
-        if (!String(p.agent ?? "").toLowerCase().includes(t.value)) return false;
+        if (
+          !String(p.agent ?? "")
+            .toLowerCase()
+            .includes(t.value)
+        )
+          return false;
         break;
       case "wave":
         if (

--- a/web/src/lib/github.ts
+++ b/web/src/lib/github.ts
@@ -22,7 +22,7 @@ export function prUrl(repo: string, n: number): string {
  * github.com Projects URL(プレフィックス検証つきパススルー)。それ以外は "". */
 export function parentUrl(repo: string, parent: string): string {
   if (/^\d+$/.test(parent)) return issueUrl(repo, Number(parent));
-  if (/^https:\/\/github\.com\//.test(parent)) return parent;
+  if (parent.startsWith("https://github.com/")) return parent;
   return "";
 }
 

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -3,7 +3,9 @@ import { createRoot } from "react-dom/client";
 import { App } from "./components/App";
 import "./style.css";
 
-createRoot(document.getElementById("root")!).render(
+const rootEl = document.getElementById("root");
+if (!rootEl) throw new Error("#root element not found");
+createRoot(rootEl).render(
   <StrictMode>
     <App />
   </StrictMode>,

--- a/web/src/test/app.test.tsx
+++ b/web/src/test/app.test.tsx
@@ -63,6 +63,9 @@ function basicSnapshot() {
   );
 }
 
+/* テーブルのデータ行(ヘッダ行を除く) */
+const bodyRows = () => within(screen.getByRole("table")).getAllByRole("row").slice(1);
+
 function peekHandler(outputFor: (pane: string | null) => string) {
   return http.get("/api/peek", ({ request }) => {
     const pane = new URL(request.url).searchParams.get("pane");
@@ -394,7 +397,6 @@ describe("ソート", () => {
     render(<App />);
     streamSnapshot(basicSnapshot());
 
-    const bodyRows = () => within(screen.getByRole("table")).getAllByRole("row").slice(1);
     // 初期は issueNum 昇順
     expect(bodyRows()[0]).toHaveTextContent("Fix login");
 

--- a/web/src/test/app.test.tsx
+++ b/web/src/test/app.test.tsx
@@ -118,9 +118,7 @@ describe("snapshot 描画", () => {
 
   it("degraded フラグで banner を表示し、正常時は隠す", () => {
     render(<App />);
-    streamSnapshot(
-      makeSnapshot([], { degraded: { tmux: true, github: true } }),
-    );
+    streamSnapshot(makeSnapshot([], { degraded: { tmux: true, github: true } }));
     const banner = screen.getByRole("status");
     expect(banner).toHaveTextContent("GitHub データ取得が不安定");
     expect(banner).toHaveTextContent("tmux が利用できません");
@@ -198,14 +196,20 @@ describe("フィルタ", () => {
     const listbox = screen.getByRole("listbox", { name: "issue / tmux 状態で絞り込み" });
     await user.click(within(listbox).getByRole("option", { name: "open" }));
 
-    expect(screen.getByRole("listitem", { name: "フィルタ state:open を外す" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("listitem", { name: "フィルタ state:open を外す" }),
+    ).toBeInTheDocument();
     expect(screen.queryByRole("listbox")).not.toBeInTheDocument(); // 選択で閉じる
     expect(trigger).toHaveFocus();
 
     await user.click(trigger);
     await user.click(screen.getByRole("option", { name: "closed" }));
-    expect(screen.queryByRole("listitem", { name: "フィルタ state:open を外す" })).not.toBeInTheDocument();
-    expect(screen.getByRole("listitem", { name: "フィルタ state:closed を外す" })).toBeInTheDocument();
+    expect(
+      screen.queryByRole("listitem", { name: "フィルタ state:open を外す" }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("listitem", { name: "フィルタ state:closed を外す" }),
+    ).toBeInTheDocument();
   });
 
   it("アクティブ option は aria-selected で示し、再クリックでトグルオフする", async () => {
@@ -221,10 +225,15 @@ describe("フィルタ", () => {
     await user.click(trigger);
     const opt = screen.getByRole("option", { name: "open" });
     expect(opt).toHaveAttribute("aria-selected", "true");
-    expect(screen.getByRole("option", { name: "closed" })).toHaveAttribute("aria-selected", "false");
+    expect(screen.getByRole("option", { name: "closed" })).toHaveAttribute(
+      "aria-selected",
+      "false",
+    );
 
     await user.click(opt);
-    expect(screen.queryByRole("listitem", { name: "フィルタ state:open を外す" })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("listitem", { name: "フィルタ state:open を外す" }),
+    ).not.toBeInTheDocument();
     expect(screen.getByRole("searchbox")).toHaveValue("");
     expect(trigger).not.toHaveClass("on");
   });
@@ -292,7 +301,9 @@ describe("フィルタ", () => {
     expect(opts[opts.length - 1]).toHaveFocus();
 
     await user.keyboard("{Enter}");
-    expect(screen.getByRole("listitem", { name: "フィルタ state:deferred を外す" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("listitem", { name: "フィルタ state:deferred を外す" }),
+    ).toBeInTheDocument();
     expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
     expect(trigger).toHaveFocus();
   });
@@ -312,7 +323,9 @@ describe("フィルタ", () => {
     await user.keyboard("cod");
     expect(within(listbox).queryByRole("option", { name: "claude" })).not.toBeInTheDocument();
     await user.keyboard("{Enter}");
-    expect(screen.getByRole("listitem", { name: "フィルタ agent:codex を外す" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("listitem", { name: "フィルタ agent:codex を外す" }),
+    ).toBeInTheDocument();
 
     await user.click(screen.getByRole("button", { name: "wave で絞り込み" }));
     await user.click(screen.getByRole("option", { name: "w2" }));
@@ -357,7 +370,9 @@ describe("フィルタ", () => {
     await user.keyboard("c"); // open → closed へジャンプ
     expect(screen.getByRole("option", { name: "closed" })).toHaveFocus();
     await user.keyboard("{Enter}");
-    expect(screen.getByRole("listitem", { name: "フィルタ state:closed を外す" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("listitem", { name: "フィルタ state:closed を外す" }),
+    ).toBeInTheDocument();
   });
 
   it("label 表記の別名トークン(wave:w2)もアクティブ表示・トグルオフできる", async () => {
@@ -635,7 +650,11 @@ describe("drawer リサイズ", () => {
   beforeEach(() => {
     // hook はビューポート上限(innerWidth - 360)でも clamp する。jsdom 既定の
     // 1024px だと上限 921px になりドラッグ値が読みにくいので広い画面に固定。
-    Object.defineProperty(window, "innerWidth", { value: 2000, configurable: true, writable: true });
+    Object.defineProperty(window, "innerWidth", {
+      value: 2000,
+      configurable: true,
+      writable: true,
+    });
   });
   const openDrawer = async (user: ReturnType<typeof userEvent.setup>, name: string) => {
     await user.click(screen.getByText(name));

--- a/web/src/test/fakeEventSource.ts
+++ b/web/src/test/fakeEventSource.ts
@@ -2,7 +2,7 @@ import { vi } from "vitest";
 
 /* jsdom に EventSource が無いので、テストから手動で open / snapshot / error を
  * 発火できる代替を global 注入する。アプリ側(useSnapshot)は本物と同じ API
- * (addEventListener / onerror / close)しか使わない。 */
+ * (addEventListener / close)しか使わない。 */
 export class FakeEventSource {
   static instances: FakeEventSource[] = [];
 
@@ -14,7 +14,6 @@ export class FakeEventSource {
 
   url: string;
   closed = false;
-  onerror: ((e: Event) => void) | null = null;
   private listeners = new Map<string, Set<(e: MessageEvent) => void>>();
 
   constructor(url: string) {
@@ -46,7 +45,7 @@ export class FakeEventSource {
   }
 
   emitError(): void {
-    this.onerror?.(new Event("error"));
+    this.dispatch("error", new MessageEvent("error"));
   }
 
   private dispatch(type: string, e: MessageEvent): void {

--- a/web/src/test/fixtures.ts
+++ b/web/src/test/fixtures.ts
@@ -64,7 +64,11 @@ export function makeQueuedPane(over: Partial<PaneView> = {}): PaneView {
   };
 }
 
-export function makeSession(parent: string, panes: PaneView[], rollup: Partial<Rollup> = {}): Session {
+export function makeSession(
+  parent: string,
+  panes: PaneView[],
+  rollup: Partial<Rollup> = {},
+): Session {
   return { parent, panes, rollup: makeRollup({ total: panes.length, ...rollup }) };
 }
 


### PR DESCRIPTION
> [!IMPORTANT]
> **このPRは 6 連 PR(#249-#253)の最後にマージしてください。** 一括 reformat を含むため、先にマージすると他 PR が全てコンフリクトします。また **squash ではなく rebase-merge** でマージしてください(squash すると設定・lint 修正と機械的 reformat が 1 コミットに混ざり、`.git-blame-ignore-revs` に入れると実変更まで blame から消えます — #205 の轍)。

## 概要

web/ SPA に oxlint + oxfmt を導入し、CI に組み込みます(ダッシュボード改善 6 連 PR の 1 つ)。

- **oxlint** `^1.69.0`(stable なので caret)— `--max-warnings=0` で suspicious カテゴリも CI を落とす実効的な構成。rule 調整は全て根拠コメント付き(automatic JSX runtime / 非破壊 sort / `^_` イディオムとの矛盾解消)。`typescript/no-non-null-assertion` の off は **src/lib・src/test に限定**(components/hooks の `!` は tsc も黙らせる本物の危険なので rule を生かす)
- **oxfmt** `0.54.0`(pre-1.0 なので exact pin)— printWidth 100(既存の手 wrap に最も近く reformat diff 最小)。**CSS は対象外**(手揃えされた style.css 546 行が全行書き換わるため。`fmt` の範囲は `web/src` + `vite.config.ts`)
- `make lint-web` = oxlint → oxfmt --check → tsc --noEmit(安い順)。`make fmt-web` 新設。**root の `make lint` と CI lint job は Node-free のまま不変**
- CI: 既存 web job が `make lint-web` 経由で自動的に拾う(新 job なし)
- oxlint 指摘 4 件の実修正(`fix(web)` コミットで分離・レビュー可能): github.ts の regex→startsWith、useSnapshot の onerror→addEventListener 統一、テストヘルパのモジュールスコープ昇格
- 一括 reformat(+112/-28、9 files)は**常に tip の機械的コミット**(`git diff HEAD~1 -- web/src` は `make fmt-web` 再実行と一致)

## マージ手順(tip コミットメッセージにも記載)

1. #249-#253 がマージされたら、tip の reformat コミットを drop して origin/main に rebase(フォーマットコンフリクトは手で解消しない)
2. `make fmt-web` を再実行し、同名コミットを積み直して force-with-lease
3. **rebase-merge** でマージ
4. マージ後、reformat コミットの SHA を `.git-blame-ignore-revs` に追記(AGENTS.md の規約)

## 検証

- `make lint-web`(oxlint --max-warnings=0 + fmt:check + typecheck)/ `make test-web`(49 tests)/ `make build-web` green
- `make fmt-web` の冪等性確認(2 回目が空 diff)
- oxlint の実効性は意図的な違反で検知確認済み(設定キーの silent-ignore 対策)
- /post-work-review 実施済み(code-review 3 angle → 設定修正 → codex:review approve)

🤖 Generated with [Claude Code](https://claude.com/claude-code)