### PR TITLE
feat(team): 通知層 — fanout msg nudge <N>（running 限定 send-keys nudge）[wave3]

### DIFF
--- a/cmd/fanout/msg.go
+++ b/cmd/fanout/msg.go
@@ -13,7 +13,9 @@ import (
 	"github.com/butaosuinu/fanout/internal/exitcode"
 	"github.com/butaosuinu/fanout/internal/log"
 	"github.com/butaosuinu/fanout/internal/msgstore"
+	"github.com/butaosuinu/fanout/internal/state"
 	"github.com/butaosuinu/fanout/internal/team"
+	"github.com/butaosuinu/fanout/internal/tmuxrun"
 )
 
 const msgUsage = `Usage: fanout msg <verb> [options] [body...]
@@ -31,12 +33,21 @@ Write verbs:
   mark-read [--id N ... | --all]       Mark 1:1 messages read (--all also advances the board cursor).
   register                             Upsert this pane into the peers table.
 
+Notify verbs:
+  nudge <N>                      Best-effort: drop an inbox hint into peer #N's
+                                 pane via tmux send-keys, but only when its
+                                 agent is running. Never touches the DB (the
+                                 message is already persisted by send); a pane
+                                 that is gone, idle-unknown, or done is a no-op
+                                 success, so a failed nudge never breaks
+                                 messaging.
+
 Options:
   --json           Emit JSON instead of the human-readable view.
   --self <N>       Act as child issue N (overrides pane detection).
   --parent <ref>   Parent issue number or Projects URL (overrides pane detection).
-  --dry-run        Write verbs only: print '# would ...' lines describing the
-                   writes, touch nothing. Not combinable with --json.
+  --dry-run        Write/notify verbs only: print '# would ...' lines describing
+                   the writes, touch nothing. Not combinable with --json.
   --to <N>         send: recipient child issue number.
   --kind <K>       send/post: message kind (default: note).
   --id <N>         mark-read: message id (repeatable).
@@ -45,11 +56,39 @@ Options:
   -h, --help       Show this help.
 
 Exit codes: 0 success, 2 invalid invocation, 4 backend (SQLite) failure.
+nudge is best-effort: operational failures (pane gone, agent not running,
+send-keys failure) exit 0 with a warning, never 4.
 `
 
 // detectIdentity is swapped by tests to avoid depending on the developer's
 // live tmux/state environment (same pattern as sleepBetweenIssues).
 var detectIdentity = team.Detect
+
+// nudgeText is the hint `msg nudge` types into a peer pane. It carries no
+// message body on purpose — only a pointer to the inbox — so the actual
+// content stays in the SQLite DB and the pane never displays a peer's words
+// out of context. The em dash is intentional; it is a stable UTF-8 literal.
+const nudgeText = "[fanout] peer message in your inbox — run: fanout msg inbox"
+
+// paneAgentState and sendLiteralLine are the tmux seams nudge drives, declared
+// as vars so unit tests can swap them without a live tmux server (same pattern
+// as detectIdentity). The dry-run path uses neither — it must stay tmux-free
+// so its golden is deterministic.
+var (
+	paneAgentState  = tmuxrun.PaneAgentState
+	sendLiteralLine = tmuxrun.SendLiteralLine
+	// loadStateStore resolves and loads .fanout/state.json read-only, the same
+	// way --status/--close/etc do (resolveStateRuntime honors
+	// FANOUT_STATE_PATH then the git toplevel). nudge needs the recipient's
+	// recorded pane id, which lives here, not in the messages DB.
+	loadStateStore = func() (state.Store, error) {
+		rt, err := resolveStateRuntime()
+		if err != nil {
+			return state.Store{}, err
+		}
+		return state.Load(rt.statePath)
+	}
+)
 
 type msgFlags struct {
 	verb     string
@@ -77,6 +116,9 @@ var msgVerbFlags = map[string]map[string]bool{
 	"post":      {"--dry-run": true, "--kind": true},
 	"mark-read": {"--dry-run": true, "--id": true, "--all": true},
 	"register":  {"--dry-run": true},
+	// nudge's target is a positional <N>, not --to; --dry-run is its only
+	// verb-specific flag (universal --json/--self/--parent still apply).
+	"nudge": {"--dry-run": true},
 }
 
 var msgUniversalFlags = map[string]bool{"--json": true, "--self": true, "--parent": true}
@@ -110,6 +152,13 @@ func cmdMsg(args []string, lg *log.Logger) exitcode.Code {
 	self, parent, pane, code := resolveMsgIdentity(flags, lg)
 	if code != exitcode.OK {
 		return code
+	}
+
+	// nudge reads neither the messages DB nor the generic dry-run printer: it
+	// resolves the recipient from state.json and pushes via tmux, so short it
+	// out before openMsgDB (and before the DB-oriented dry-run path).
+	if flags.verb == "nudge" {
+		return runMsgNudge(flags, parent, lg)
 	}
 
 	if flags.dryRun {
@@ -166,6 +215,12 @@ func parseMsgFlags(args []string, lg *log.Logger) (*msgFlags, exitcode.Code) {
 			}
 		}
 		if terminated || !strings.HasPrefix(a, "--") {
+			if f.verb == "nudge" {
+				if code := setNudgeTarget(f, a, lg); code != exitcode.OK {
+					return nil, code
+				}
+				continue
+			}
 			if !msgBodyVerbs[f.verb] {
 				lg.Err("msg %s: unexpected argument: %s", f.verb, a)
 				return nil, exitcode.Invocation
@@ -234,6 +289,24 @@ func parseMsgFlag(f *msgFlags, allowed map[string]bool, args []string, i int, lg
 		return 0, exitcode.Invocation
 	}
 	return 0, exitcode.OK
+}
+
+// setNudgeTarget parses nudge's single positional <N> into f.to. Like --to it
+// accepts negative synthetic numbers (manual @manual panes) but rejects zero
+// and non-integers; a second positional is an error — nudge targets exactly
+// one peer. Reusing f.to keeps the recipient field shared with send.
+func setNudgeTarget(f *msgFlags, arg string, lg *log.Logger) exitcode.Code {
+	if f.to != 0 {
+		lg.Err("msg nudge: takes exactly one target issue, got extra argument: %s", arg)
+		return exitcode.Invocation
+	}
+	n, err := strconv.Atoi(arg)
+	if err != nil || n == 0 {
+		lg.Err("msg nudge: target must be a non-zero issue number (manual panes use negative synthetic numbers), got: %s", arg)
+		return exitcode.Invocation
+	}
+	f.to = n
+	return exitcode.OK
 }
 
 func setMsgFlagValue(f *msgFlags, flag, value string, lg *log.Logger) exitcode.Code {
@@ -305,6 +378,13 @@ func validateMsgFlags(f *msgFlags, lg *log.Logger) exitcode.Code {
 			lg.Err("msg mark-read: pass either --id <n> (repeatable) or --all")
 			return exitcode.Invocation
 		}
+	case "nudge":
+		// setNudgeTarget already rejected zero/non-integer; a still-zero f.to
+		// means no positional target was supplied at all.
+		if f.to == 0 {
+			lg.Err("msg nudge: target issue <N> is required")
+			return exitcode.Invocation
+		}
 	}
 	return exitcode.OK
 }
@@ -315,7 +395,10 @@ func validateMsgFlags(f *msgFlags, lg *log.Logger) exitcode.Code {
 func resolveMsgIdentity(f *msgFlags, lg *log.Logger) (int, string, msgstore.Peer, exitcode.Code) {
 	self, parent := f.self, f.parent
 	pane := msgstore.Peer{Issue: self}
-	needSelf := f.verb != "peers"
+	// nudge, like peers, only needs the parent (to scope state.json) — it
+	// targets a peer, never speaks as self — so it does not require self to be
+	// detectable.
+	needSelf := f.verb != "peers" && f.verb != "nudge"
 	if (needSelf && self == 0) || parent == "" {
 		id, err := detectIdentity()
 		if err != nil {
@@ -678,4 +761,103 @@ func sqlLiteral(s string) string {
 func msgBackendErr(verb string, err error, lg *log.Logger) exitcode.Code {
 	lg.Err("msg %s: %v", verb, err)
 	return exitcode.Backend
+}
+
+// --- nudge -------------------------------------------------------------
+
+// msgNudgeReport is the --json encoding of a nudge attempt. Nudged is true only
+// when the send-keys actually went out; Reason explains every other outcome so
+// automation can tell a delivered push from a best-effort no-op.
+type msgNudgeReport struct {
+	Target     int    `json:"target"`
+	PaneID     string `json:"pane_id"`
+	AgentState string `json:"agent_state"`
+	Nudged     bool   `json:"nudged"`
+	Reason     string `json:"reason"`
+}
+
+// shouldNudge reports whether a pane in the given @fanout_agent_state should
+// receive a send-keys nudge. Only "running" — a live agent launched by the
+// fanout wrapper — qualifies. "done" (agent exited, bare shell), "" (unset:
+// legacy or non-fanout pane), and any other value are no-op successes so a
+// hint never lands in a shell or an unrelated pane.
+//
+// This is the deliberate re-design of the original "agentStatus == idle" gate:
+// the dmux idle/analyzing/waiting/working enum no longer exists, and the only
+// live signal (@fanout_agent_state) cannot distinguish a busy agent from one
+// idle at its prompt. Gating on "running" is safe in practice because the
+// supported agents (claude, codex) queue typed input during a turn rather than
+// aborting it, so a nudge to a busy agent is picked up at its next checkpoint —
+// the same pull the message already guarantees, only sooner.
+func shouldNudge(agentState string) bool {
+	return agentState == "running"
+}
+
+// runMsgNudge resolves peer f.to's recorded pane from state.json and, unless
+// --dry-run, pushes the inbox hint when its agent is running. Every
+// operational miss (recipient absent, no pane id, pane gone, agent not
+// running, send-keys failure) is a no-op SUCCESS with a warning/reason: the
+// message is already persisted by send, so a failed nudge must never break
+// messaging. Only invocation errors (handled earlier) exit non-zero.
+func runMsgNudge(f *msgFlags, parent string, lg *log.Logger) exitcode.Code {
+	st, err := loadStateStore()
+	if err != nil {
+		lg.Err("msg nudge: %v", err)
+		return exitcode.Invocation
+	}
+	pane, found := st.Find(parent, f.to)
+
+	if f.dryRun {
+		lg.Dim("%s", nudgeDryRunLine(f.to, pane.PaneID, found))
+		return exitcode.OK
+	}
+
+	report := msgNudgeReport{Target: f.to, PaneID: pane.PaneID}
+	switch {
+	case !found:
+		report.Reason = "recipient is not recorded in fanout state"
+	case pane.PaneID == "":
+		report.Reason = "recipient has no recorded pane"
+	default:
+		// Re-read the agent state live, immediately before sending, to shrink
+		// the window between the check and the push (TOCTOU).
+		report.AgentState, err = paneAgentState(pane.PaneID)
+		switch {
+		case err != nil:
+			report.Reason = "pane is gone or tmux is unavailable"
+		case !shouldNudge(report.AgentState):
+			report.Reason = fmt.Sprintf("agent is not running (state %q)", report.AgentState)
+		default:
+			if sendErr := sendLiteralLine(pane.PaneID, nudgeText); sendErr != nil {
+				report.Reason = fmt.Sprintf("send-keys failed: %v", sendErr)
+			} else {
+				report.Nudged = true
+			}
+		}
+	}
+	return writeMsgNudgeResult(f, report, lg)
+}
+
+// nudgeDryRunLine renders the would-be tmux push as a single deterministic
+// line, resolved from state.json only (never live tmux) so it is golden
+// stable. An unresolved recipient prints a <unknown> pane id rather than
+// erroring, keeping the dry-run a single informative line.
+func nudgeDryRunLine(target int, paneID string, found bool) string {
+	if !found || paneID == "" {
+		paneID = "<unknown>"
+	}
+	return fmt.Sprintf("# would send-keys -t %s -l %s then Enter (target #%d, only if agent is running)",
+		paneID, sqlLiteral(nudgeText), target)
+}
+
+func writeMsgNudgeResult(f *msgFlags, report msgNudgeReport, lg *log.Logger) exitcode.Code {
+	if f.json {
+		return writeMsgJSON(report, lg)
+	}
+	if report.Nudged {
+		lg.Ok("nudged #%d", report.Target)
+	} else {
+		lg.Warn("did not nudge #%d: %s", report.Target, report.Reason)
+	}
+	return exitcode.OK
 }

--- a/cmd/fanout/msg.go
+++ b/cmd/fanout/msg.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -70,12 +71,12 @@ var detectIdentity = team.Detect
 // out of context. The em dash is intentional; it is a stable UTF-8 literal.
 const nudgeText = "[fanout] peer message in your inbox — run: fanout msg inbox"
 
-// paneAgentState and sendLiteralLine are the tmux seams nudge drives, declared
+// listLivePanes and sendLiteralLine are the tmux seams nudge drives, declared
 // as vars so unit tests can swap them without a live tmux server (same pattern
 // as detectIdentity). The dry-run path uses neither — it must stay tmux-free
 // so its golden is deterministic.
 var (
-	paneAgentState  = tmuxrun.PaneAgentState
+	listLivePanes   = tmuxrun.ListLivePanes
 	sendLiteralLine = tmuxrun.SendLiteralLine
 	// loadStateStore resolves and loads .fanout/state.json read-only, the same
 	// way --status/--close/etc do (resolveStateRuntime honors
@@ -819,23 +820,66 @@ func runMsgNudge(f *msgFlags, parent string, lg *log.Logger) exitcode.Code {
 	case pane.PaneID == "":
 		report.Reason = "recipient has no recorded pane"
 	default:
-		// Re-read the agent state live, immediately before sending, to shrink
-		// the window between the check and the push (TOCTOU).
-		report.AgentState, err = paneAgentState(pane.PaneID)
-		switch {
-		case err != nil:
-			report.Reason = "pane is gone or tmux is unavailable"
-		case !shouldNudge(report.AgentState):
-			report.Reason = fmt.Sprintf("agent is not running (state %q)", report.AgentState)
-		default:
-			if sendErr := sendLiteralLine(pane.PaneID, nudgeText); sendErr != nil {
-				report.Reason = fmt.Sprintf("send-keys failed: %v", sendErr)
-			} else {
-				report.Nudged = true
-			}
-		}
+		report.AgentState, report.Reason, report.Nudged = deliverNudge(pane)
 	}
 	return writeMsgNudgeResult(f, report, lg)
+}
+
+// deliverNudge re-reads the live tmux panes immediately before sending (TOCTOU),
+// confirms the recorded pane id STILL belongs to the recipient, and pushes the
+// hint only when its agent is running. The recorded id alone is not enough:
+// tmux reuses %N ids after a server restart, so an id-only check could nudge an
+// unrelated pane that inherited the id — exactly the interruption accident the
+// gate must avoid. matchLivePane applies the same id+worktree liveness check the
+// dashboard uses (sessionview.paneAlive). It returns the observed agent state, a
+// reason when nothing was sent, and whether the push went out; every miss
+// (tmux down, pane gone/reused, agent not running, send failure) is a
+// best-effort no-op because the message is already persisted.
+func deliverNudge(pane state.Pane) (agentState, reason string, nudged bool) {
+	panes, err := listLivePanes()
+	if err != nil {
+		return "", "tmux is unavailable", false
+	}
+	lp, ok := matchLivePane(panes, pane.PaneID, pane.WorktreePath)
+	if !ok {
+		return "", "recipient pane is gone or its id was reused", false
+	}
+	if !shouldNudge(lp.AgentState) {
+		return lp.AgentState, fmt.Sprintf("agent is not running (state %q)", lp.AgentState), false
+	}
+	if err := sendLiteralLine(pane.PaneID, nudgeText); err != nil {
+		return lp.AgentState, fmt.Sprintf("send-keys failed: %v", err), false
+	}
+	return lp.AgentState, "", true
+}
+
+// matchLivePane returns the live pane recorded as paneID only when it is still
+// the recipient's pane: its id must be live AND it must sit at/under the
+// recorded worktree, because tmux reuses %N ids across server restarts. A row
+// without a recorded worktree (legacy) falls back to an id-only match. This
+// mirrors sessionview.paneAlive — the dashboard's liveness convention — so a
+// reused id is treated identically on both surfaces.
+func matchLivePane(panes []tmuxrun.LivePane, paneID, worktree string) (tmuxrun.LivePane, bool) {
+	if paneID == "" {
+		return tmuxrun.LivePane{}, false
+	}
+	for _, lp := range panes {
+		if lp.ID != paneID {
+			continue
+		}
+		if strings.TrimSpace(worktree) == "" {
+			return lp, true
+		}
+		wt := filepath.Clean(worktree)
+		cp := filepath.Clean(lp.CurrentPath)
+		if cp == wt || strings.HasPrefix(cp, wt+string(filepath.Separator)) {
+			return lp, true
+		}
+		// id matched but the live pane moved off the recorded worktree: tmux
+		// handed %N to an unrelated pane. Treat it as gone, never nudge it.
+		return tmuxrun.LivePane{}, false
+	}
+	return tmuxrun.LivePane{}, false
 }
 
 // nudgeDryRunLine renders the would-be tmux push as a single deterministic

--- a/cmd/fanout/msg.go
+++ b/cmd/fanout/msg.go
@@ -78,16 +78,29 @@ const nudgeText = "[fanout] peer message in your inbox — run: fanout msg inbox
 var (
 	listLivePanes   = tmuxrun.ListLivePanes
 	sendLiteralLine = tmuxrun.SendLiteralLine
-	// loadStateStore resolves and loads .fanout/state.json read-only, the same
-	// way --status/--close/etc do (resolveStateRuntime honors
-	// FANOUT_STATE_PATH then the git toplevel). nudge needs the recipient's
-	// recorded pane id, which lives here, not in the messages DB.
+	// loadStateStore resolves and loads the owner checkout's .fanout/state.json
+	// read-only — the recipient's recorded pane id lives there, not in the
+	// messages DB. It resolves the path the way team.Detect does
+	// (FANOUT_STATE_PATH, else OwnerProjectRoot), NOT resolveStateRuntime: nudge
+	// is normally run FROM a child worktree pane
+	// (<owner>/.fanout/worktrees/<slug>), whose own git toplevel has no
+	// state.json. Only OwnerProjectRoot climbs to the owner that holds it — the
+	// same resolver every other msg verb uses (openMsgDB) — so resolveStateRuntime
+	// would silently load an empty store and report every peer "not recorded".
 	loadStateStore = func() (state.Store, error) {
-		rt, err := resolveStateRuntime()
-		if err != nil {
-			return state.Store{}, err
+		statePath := os.Getenv(fanoutStatePathEnv)
+		if statePath != "" {
+			if abs, err := filepath.Abs(statePath); err == nil {
+				statePath = abs
+			}
+		} else {
+			root, err := team.OwnerProjectRoot()
+			if err != nil {
+				return state.Store{}, err
+			}
+			statePath = state.Path(root)
 		}
-		return state.Load(rt.statePath)
+		return state.Load(statePath)
 	}
 )
 

--- a/cmd/fanout/msg_test.go
+++ b/cmd/fanout/msg_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/butaosuinu/fanout/internal/msgstore"
 	"github.com/butaosuinu/fanout/internal/state"
 	"github.com/butaosuinu/fanout/internal/team"
+	"github.com/butaosuinu/fanout/internal/tmuxrun"
 )
 
 func msgTestLogger() *log.Logger {
@@ -417,52 +418,76 @@ func TestNudgeDryRunLine(t *testing.T) {
 }
 
 func TestRunMsgNudge(t *testing.T) {
+	// withPane is a legacy row (no recorded worktree) so it falls back to an
+	// id-only liveness match; withWorktree carries a worktree, so the live pane
+	// must also sit at/under it (the reused-%N defense).
 	withPane := state.Store{SchemaVersion: 1, Panes: []state.Pane{{Parent: "68", IssueNum: 71, PaneID: "%5"}}}
+	withWorktree := state.Store{SchemaVersion: 1, Panes: []state.Pane{{Parent: "68", IssueNum: 71, PaneID: "%5", WorktreePath: "/wt/recipient"}}}
 	noPaneID := state.Store{SchemaVersion: 1, Panes: []state.Pane{{Parent: "68", IssueNum: 72, PaneID: ""}}}
+	lp := func(id, path, agentState string) tmuxrun.LivePane {
+		return tmuxrun.LivePane{ID: id, CurrentPath: path, AgentState: agentState}
+	}
 
 	for _, tc := range []struct {
 		name           string
 		flags          msgFlags
 		store          state.Store
 		storeErr       error
-		agentState     string
-		agentErr       error
+		live           []tmuxrun.LivePane
+		listErr        error
 		sendErr        error
 		wantCode       exitcode.Code
-		wantAgentRead  bool // paneAgentState consulted
+		wantListed     bool // listLivePanes consulted
 		wantSendCalled bool // sendLiteralLine invoked
 		wantStdout     string
 		wantStderr     string
 	}{
 		{
-			name: "running pane is nudged", flags: msgFlags{verb: "nudge", to: 71}, store: withPane,
-			agentState: "running", wantCode: exitcode.OK, wantAgentRead: true, wantSendCalled: true, wantStdout: "nudged #71",
+			name: "running pane is nudged (legacy id-only match)", flags: msgFlags{verb: "nudge", to: 71}, store: withPane,
+			live: []tmuxrun.LivePane{lp("%5", "/anywhere", "running")}, wantCode: exitcode.OK, wantListed: true, wantSendCalled: true, wantStdout: "nudged #71",
+		},
+		{
+			name: "running pane at the recorded worktree is nudged", flags: msgFlags{verb: "nudge", to: 71}, store: withWorktree,
+			live: []tmuxrun.LivePane{lp("%5", "/wt/recipient", "running")}, wantCode: exitcode.OK, wantListed: true, wantSendCalled: true, wantStdout: "nudged #71",
+		},
+		{
+			name: "running pane under the recorded worktree is nudged", flags: msgFlags{verb: "nudge", to: 71}, store: withWorktree,
+			live: []tmuxrun.LivePane{lp("%5", "/wt/recipient/nested", "running")}, wantCode: exitcode.OK, wantListed: true, wantSendCalled: true, wantStdout: "nudged #71",
+		},
+		{
+			// The core Codex P2: tmux reused %5 for a pane sitting elsewhere.
+			// It must NOT be nudged even though it reports "running".
+			name: "reused id off the recorded worktree is not nudged", flags: msgFlags{verb: "nudge", to: 71}, store: withWorktree,
+			live: []tmuxrun.LivePane{lp("%5", "/wt/someone-else", "running")}, wantCode: exitcode.OK, wantListed: true, wantStderr: "gone or its id was reused",
+		},
+		{
+			name: "pane absent from the live set is a no-op success", flags: msgFlags{verb: "nudge", to: 71}, store: withWorktree,
+			live: []tmuxrun.LivePane{lp("%9", "/wt/recipient", "running")}, wantCode: exitcode.OK, wantListed: true, wantStderr: "gone or its id was reused",
 		},
 		{
 			// parent "0068" must still resolve the stored "68" pane via Find's
-			// numeric canonicalization (parentMatches), so the nudge path is
-			// not sensitive to leading-zero parent refs.
-			name: "leading-zero parent still resolves the recipient", flags: msgFlags{verb: "nudge", to: 71, parent: "0068"}, store: withPane,
-			agentState: "running", wantCode: exitcode.OK, wantAgentRead: true, wantSendCalled: true, wantStdout: "nudged #71",
+			// numeric canonicalization (parentMatches).
+			name: "leading-zero parent still resolves the recipient", flags: msgFlags{verb: "nudge", to: 71, parent: "0068"}, store: withWorktree,
+			live: []tmuxrun.LivePane{lp("%5", "/wt/recipient", "running")}, wantCode: exitcode.OK, wantListed: true, wantSendCalled: true, wantStdout: "nudged #71",
 		},
 		{
-			name: "done pane is a no-op success", flags: msgFlags{verb: "nudge", to: 71}, store: withPane,
-			agentState: "done", wantCode: exitcode.OK, wantAgentRead: true, wantStderr: "agent is not running",
+			name: "done pane is a no-op success", flags: msgFlags{verb: "nudge", to: 71}, store: withWorktree,
+			live: []tmuxrun.LivePane{lp("%5", "/wt/recipient", "done")}, wantCode: exitcode.OK, wantListed: true, wantStderr: "agent is not running",
 		},
 		{
-			name: "unset state is a no-op success", flags: msgFlags{verb: "nudge", to: 71}, store: withPane,
-			agentState: "", wantCode: exitcode.OK, wantAgentRead: true, wantStderr: "agent is not running",
+			name: "unset state is a no-op success", flags: msgFlags{verb: "nudge", to: 71}, store: withWorktree,
+			live: []tmuxrun.LivePane{lp("%5", "/wt/recipient", "")}, wantCode: exitcode.OK, wantListed: true, wantStderr: "agent is not running",
 		},
 		{
-			name: "pane gone is a no-op success", flags: msgFlags{verb: "nudge", to: 71}, store: withPane,
-			agentErr: errors.New("no such pane"), wantCode: exitcode.OK, wantAgentRead: true, wantStderr: "pane is gone",
+			name: "tmux unavailable is a no-op success", flags: msgFlags{verb: "nudge", to: 71}, store: withWorktree,
+			listErr: errors.New("tmux down"), wantCode: exitcode.OK, wantListed: true, wantStderr: "tmux is unavailable",
 		},
 		{
-			name: "send-keys failure stays a best-effort success", flags: msgFlags{verb: "nudge", to: 71}, store: withPane,
-			agentState: "running", sendErr: errors.New("boom"), wantCode: exitcode.OK, wantAgentRead: true, wantSendCalled: true, wantStderr: "send-keys failed",
+			name: "send-keys failure stays a best-effort success", flags: msgFlags{verb: "nudge", to: 71}, store: withWorktree,
+			live: []tmuxrun.LivePane{lp("%5", "/wt/recipient", "running")}, sendErr: errors.New("boom"), wantCode: exitcode.OK, wantListed: true, wantSendCalled: true, wantStderr: "send-keys failed",
 		},
 		{
-			name: "recipient absent from state is a no-op success", flags: msgFlags{verb: "nudge", to: 99}, store: withPane,
+			name: "recipient absent from state is a no-op success", flags: msgFlags{verb: "nudge", to: 99}, store: withWorktree,
 			wantCode: exitcode.OK, wantStderr: "not recorded",
 		},
 		{
@@ -470,11 +495,11 @@ func TestRunMsgNudge(t *testing.T) {
 			wantCode: exitcode.OK, wantStderr: "no recorded pane",
 		},
 		{
-			name: "dry-run prints the would-line and touches no tmux", flags: msgFlags{verb: "nudge", to: 71, dryRun: true}, store: withPane,
+			name: "dry-run prints the would-line and touches no tmux", flags: msgFlags{verb: "nudge", to: 71, dryRun: true}, store: withWorktree,
 			wantCode: exitcode.OK, wantStdout: "# would send-keys -t %5",
 		},
 		{
-			name: "dry-run for an unrecorded recipient prints <unknown> and touches no tmux", flags: msgFlags{verb: "nudge", to: 99, dryRun: true}, store: withPane,
+			name: "dry-run for an unrecorded recipient prints <unknown> and touches no tmux", flags: msgFlags{verb: "nudge", to: 99, dryRun: true}, store: withWorktree,
 			wantCode: exitcode.OK, wantStdout: "# would send-keys -t <unknown>",
 		},
 		{
@@ -482,24 +507,24 @@ func TestRunMsgNudge(t *testing.T) {
 			wantCode: exitcode.Invocation,
 		},
 		{
-			name: "json reports a delivered nudge", flags: msgFlags{verb: "nudge", to: 71, json: true}, store: withPane,
-			agentState: "running", wantCode: exitcode.OK, wantAgentRead: true, wantSendCalled: true,
+			name: "json reports a delivered nudge", flags: msgFlags{verb: "nudge", to: 71, json: true}, store: withWorktree,
+			live: []tmuxrun.LivePane{lp("%5", "/wt/recipient", "running")}, wantCode: exitcode.OK, wantListed: true, wantSendCalled: true,
 			wantStdout: `"nudged": true`,
 		},
 		{
-			name: "json reports a skipped nudge with a reason", flags: msgFlags{verb: "nudge", to: 71, json: true}, store: withPane,
-			agentState: "done", wantCode: exitcode.OK, wantAgentRead: true, wantStdout: `"nudged": false`,
+			name: "json reports a skipped nudge with a reason", flags: msgFlags{verb: "nudge", to: 71, json: true}, store: withWorktree,
+			live: []tmuxrun.LivePane{lp("%5", "/wt/recipient", "done")}, wantCode: exitcode.OK, wantListed: true, wantStdout: `"nudged": false`,
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			origLoad, origState, origSend := loadStateStore, paneAgentState, sendLiteralLine
-			defer func() { loadStateStore, paneAgentState, sendLiteralLine = origLoad, origState, origSend }()
+			origLoad, origList, origSend := loadStateStore, listLivePanes, sendLiteralLine
+			defer func() { loadStateStore, listLivePanes, sendLiteralLine = origLoad, origList, origSend }()
 
 			loadStateStore = func() (state.Store, error) { return tc.store, tc.storeErr }
-			agentRead := false
-			paneAgentState = func(paneID string) (string, error) {
-				agentRead = true
-				return tc.agentState, tc.agentErr
+			listed := false
+			listLivePanes = func() ([]tmuxrun.LivePane, error) {
+				listed = true
+				return tc.live, tc.listErr
 			}
 			sent := false
 			var sentPane, sentText string
@@ -524,8 +549,8 @@ func TestRunMsgNudge(t *testing.T) {
 			if tc.wantCode != exitcode.OK {
 				return
 			}
-			if agentRead != tc.wantAgentRead {
-				t.Errorf("paneAgentState consulted = %v, want %v", agentRead, tc.wantAgentRead)
+			if listed != tc.wantListed {
+				t.Errorf("listLivePanes consulted = %v, want %v", listed, tc.wantListed)
 			}
 			if sent != tc.wantSendCalled {
 				t.Errorf("sendLiteralLine called = %v, want %v", sent, tc.wantSendCalled)
@@ -543,6 +568,40 @@ func TestRunMsgNudge(t *testing.T) {
 			}
 			if tc.wantStderr != "" && !strings.Contains(errb.String(), tc.wantStderr) {
 				t.Errorf("stderr = %q, want substring %q", errb.String(), tc.wantStderr)
+			}
+		})
+	}
+}
+
+func TestMatchLivePane(t *testing.T) {
+	panes := []tmuxrun.LivePane{
+		{ID: "%5", CurrentPath: "/wt/recipient", AgentState: "running"},
+		{ID: "%6", CurrentPath: "/wt/recipient/nested/deep", AgentState: "done"},
+		{ID: "%7", CurrentPath: "/wt/other", AgentState: "running"},
+	}
+	for _, tc := range []struct {
+		name     string
+		paneID   string
+		worktree string
+		wantOK   bool
+		wantID   string // matched pane id when wantOK
+	}{
+		{name: "id + exact worktree", paneID: "%5", worktree: "/wt/recipient", wantOK: true, wantID: "%5"},
+		{name: "id + path under worktree", paneID: "%6", worktree: "/wt/recipient", wantOK: true, wantID: "%6"},
+		{name: "trailing slash on worktree still matches", paneID: "%5", worktree: "/wt/recipient/", wantOK: true, wantID: "%5"},
+		{name: "reused id off the worktree is rejected", paneID: "%7", worktree: "/wt/recipient", wantOK: false},
+		{name: "sibling-prefix path is not under the worktree", paneID: "%5", worktree: "/wt/recip", wantOK: false},
+		{name: "id absent from the live set", paneID: "%9", worktree: "/wt/recipient", wantOK: false},
+		{name: "empty worktree falls back to id-only", paneID: "%7", worktree: "", wantOK: true, wantID: "%7"},
+		{name: "empty pane id never matches", paneID: "", worktree: "/wt/recipient", wantOK: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := matchLivePane(panes, tc.paneID, tc.worktree)
+			if ok != tc.wantOK {
+				t.Fatalf("matchLivePane(%q, %q) ok = %v, want %v", tc.paneID, tc.worktree, ok, tc.wantOK)
+			}
+			if ok && got.ID != tc.wantID {
+				t.Errorf("matched pane id = %q, want %q", got.ID, tc.wantID)
 			}
 		})
 	}

--- a/cmd/fanout/msg_test.go
+++ b/cmd/fanout/msg_test.go
@@ -115,6 +115,36 @@ func TestParseMsgFlags(t *testing.T) {
 			}
 		}},
 		{name: "terminator on a read verb still rejects positionals", args: []string{"inbox", "--", "x"}, code: exitcode.Invocation},
+		{name: "nudge positional target", args: []string{"nudge", "71"}, code: exitcode.OK, want: func(t *testing.T, f *msgFlags) {
+			t.Helper()
+			if f.to != 71 {
+				t.Errorf("to = %d, want 71", f.to)
+			}
+		}},
+		{name: "nudge targets a manual pane", args: []string{"nudge", "-2", "--parent", "68"}, code: exitcode.OK, want: func(t *testing.T, f *msgFlags) {
+			t.Helper()
+			if f.to != -2 {
+				t.Errorf("to = %d, want -2", f.to)
+			}
+		}},
+		{name: "nudge dry-run with target", args: []string{"nudge", "--dry-run", "71"}, code: exitcode.OK, want: func(t *testing.T, f *msgFlags) {
+			t.Helper()
+			if !f.dryRun || f.to != 71 {
+				t.Errorf("parsed = %+v", f)
+			}
+		}},
+		{name: "nudge without a target exits invalid", args: []string{"nudge"}, code: exitcode.Invocation},
+		{name: "nudge zero target rejected", args: []string{"nudge", "0"}, code: exitcode.Invocation},
+		{name: "nudge non-integer target rejected", args: []string{"nudge", "abc"}, code: exitcode.Invocation},
+		{name: "nudge rejects a second target", args: []string{"nudge", "71", "72"}, code: exitcode.Invocation},
+		{name: "nudge does not accept --to", args: []string{"nudge", "--to", "71"}, code: exitcode.Invocation},
+		{name: "nudge dry-run rejects json", args: []string{"nudge", "--dry-run", "--json", "71"}, code: exitcode.Invocation},
+		{name: "nudge accepts but does not require --self", args: []string{"nudge", "71", "--self", "5"}, code: exitcode.OK, want: func(t *testing.T, f *msgFlags) {
+			t.Helper()
+			if f.to != 71 || f.self != 5 {
+				t.Errorf("parsed = %+v", f)
+			}
+		}},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			f, code := parseMsgFlags(tc.args, msgTestLogger())
@@ -194,6 +224,12 @@ func TestResolveMsgIdentity(t *testing.T) {
 		{
 			name:   "peers needs only parent",
 			flags:  msgFlags{verb: "peers", parent: "68"},
+			detect: func() (team.Identity, error) { return team.Identity{}, errors.New("must not be called") },
+			code:   exitcode.OK, wantSelf: 0, wantParent: "68",
+		},
+		{
+			name:   "nudge needs only parent",
+			flags:  msgFlags{verb: "nudge", to: 71, parent: "68"},
 			detect: func() (team.Identity, error) { return team.Identity{}, errors.New("must not be called") },
 			code:   exitcode.OK, wantSelf: 0, wantParent: "68",
 		},
@@ -331,5 +367,183 @@ func TestSQLLiteral(t *testing.T) {
 		if got := sqlLiteral(tc.in); got != tc.want {
 			t.Errorf("sqlLiteral(%q) = %s, want %s", tc.in, got, tc.want)
 		}
+	}
+}
+
+func TestShouldNudge(t *testing.T) {
+	for _, tc := range []struct {
+		state string
+		want  bool
+	}{
+		{"running", true},
+		{"done", false},
+		{"", false},
+		{"idle", false},
+		{"garbage", false},
+	} {
+		if got := shouldNudge(tc.state); got != tc.want {
+			t.Errorf("shouldNudge(%q) = %v, want %v", tc.state, got, tc.want)
+		}
+	}
+}
+
+func TestNudgeDryRunLine(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		target int
+		paneID string
+		found  bool
+		want   string
+	}{
+		{
+			name: "resolved pane", target: 70, paneID: "%1", found: true,
+			want: "# would send-keys -t %1 -l '[fanout] peer message in your inbox — run: fanout msg inbox' then Enter (target #70, only if agent is running)",
+		},
+		{
+			name: "unresolved recipient", target: 99, paneID: "", found: false,
+			want: "# would send-keys -t <unknown> -l '[fanout] peer message in your inbox — run: fanout msg inbox' then Enter (target #99, only if agent is running)",
+		},
+		{
+			name: "found row but empty pane id", target: 72, paneID: "", found: true,
+			want: "# would send-keys -t <unknown> -l '[fanout] peer message in your inbox — run: fanout msg inbox' then Enter (target #72, only if agent is running)",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := nudgeDryRunLine(tc.target, tc.paneID, tc.found); got != tc.want {
+				t.Errorf("nudgeDryRunLine() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRunMsgNudge(t *testing.T) {
+	withPane := state.Store{SchemaVersion: 1, Panes: []state.Pane{{Parent: "68", IssueNum: 71, PaneID: "%5"}}}
+	noPaneID := state.Store{SchemaVersion: 1, Panes: []state.Pane{{Parent: "68", IssueNum: 72, PaneID: ""}}}
+
+	for _, tc := range []struct {
+		name           string
+		flags          msgFlags
+		store          state.Store
+		storeErr       error
+		agentState     string
+		agentErr       error
+		sendErr        error
+		wantCode       exitcode.Code
+		wantAgentRead  bool // paneAgentState consulted
+		wantSendCalled bool // sendLiteralLine invoked
+		wantStdout     string
+		wantStderr     string
+	}{
+		{
+			name: "running pane is nudged", flags: msgFlags{verb: "nudge", to: 71}, store: withPane,
+			agentState: "running", wantCode: exitcode.OK, wantAgentRead: true, wantSendCalled: true, wantStdout: "nudged #71",
+		},
+		{
+			// parent "0068" must still resolve the stored "68" pane via Find's
+			// numeric canonicalization (parentMatches), so the nudge path is
+			// not sensitive to leading-zero parent refs.
+			name: "leading-zero parent still resolves the recipient", flags: msgFlags{verb: "nudge", to: 71, parent: "0068"}, store: withPane,
+			agentState: "running", wantCode: exitcode.OK, wantAgentRead: true, wantSendCalled: true, wantStdout: "nudged #71",
+		},
+		{
+			name: "done pane is a no-op success", flags: msgFlags{verb: "nudge", to: 71}, store: withPane,
+			agentState: "done", wantCode: exitcode.OK, wantAgentRead: true, wantStderr: "agent is not running",
+		},
+		{
+			name: "unset state is a no-op success", flags: msgFlags{verb: "nudge", to: 71}, store: withPane,
+			agentState: "", wantCode: exitcode.OK, wantAgentRead: true, wantStderr: "agent is not running",
+		},
+		{
+			name: "pane gone is a no-op success", flags: msgFlags{verb: "nudge", to: 71}, store: withPane,
+			agentErr: errors.New("no such pane"), wantCode: exitcode.OK, wantAgentRead: true, wantStderr: "pane is gone",
+		},
+		{
+			name: "send-keys failure stays a best-effort success", flags: msgFlags{verb: "nudge", to: 71}, store: withPane,
+			agentState: "running", sendErr: errors.New("boom"), wantCode: exitcode.OK, wantAgentRead: true, wantSendCalled: true, wantStderr: "send-keys failed",
+		},
+		{
+			name: "recipient absent from state is a no-op success", flags: msgFlags{verb: "nudge", to: 99}, store: withPane,
+			wantCode: exitcode.OK, wantStderr: "not recorded",
+		},
+		{
+			name: "recipient without a recorded pane is a no-op success", flags: msgFlags{verb: "nudge", to: 72}, store: noPaneID,
+			wantCode: exitcode.OK, wantStderr: "no recorded pane",
+		},
+		{
+			name: "dry-run prints the would-line and touches no tmux", flags: msgFlags{verb: "nudge", to: 71, dryRun: true}, store: withPane,
+			wantCode: exitcode.OK, wantStdout: "# would send-keys -t %5",
+		},
+		{
+			name: "dry-run for an unrecorded recipient prints <unknown> and touches no tmux", flags: msgFlags{verb: "nudge", to: 99, dryRun: true}, store: withPane,
+			wantCode: exitcode.OK, wantStdout: "# would send-keys -t <unknown>",
+		},
+		{
+			name: "state load failure is an invocation error", flags: msgFlags{verb: "nudge", to: 71}, storeErr: errors.New("bad path"),
+			wantCode: exitcode.Invocation,
+		},
+		{
+			name: "json reports a delivered nudge", flags: msgFlags{verb: "nudge", to: 71, json: true}, store: withPane,
+			agentState: "running", wantCode: exitcode.OK, wantAgentRead: true, wantSendCalled: true,
+			wantStdout: `"nudged": true`,
+		},
+		{
+			name: "json reports a skipped nudge with a reason", flags: msgFlags{verb: "nudge", to: 71, json: true}, store: withPane,
+			agentState: "done", wantCode: exitcode.OK, wantAgentRead: true, wantStdout: `"nudged": false`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			origLoad, origState, origSend := loadStateStore, paneAgentState, sendLiteralLine
+			defer func() { loadStateStore, paneAgentState, sendLiteralLine = origLoad, origState, origSend }()
+
+			loadStateStore = func() (state.Store, error) { return tc.store, tc.storeErr }
+			agentRead := false
+			paneAgentState = func(paneID string) (string, error) {
+				agentRead = true
+				return tc.agentState, tc.agentErr
+			}
+			sent := false
+			var sentPane, sentText string
+			sendLiteralLine = func(paneID, text string) error {
+				sent = true
+				sentPane, sentText = paneID, text
+				return tc.sendErr
+			}
+
+			var out, errb strings.Builder
+			lg := log.NewWith(&out, &errb, false)
+			// resolveMsgIdentity supplies parent in the real flow; mirror that
+			// here, defaulting to "68" so existing cases need no parent field.
+			parent := tc.flags.parent
+			if parent == "" {
+				parent = "68"
+			}
+			code := runMsgNudge(&tc.flags, parent, lg)
+			if code != tc.wantCode {
+				t.Fatalf("runMsgNudge() code = %d, want %d (stderr: %q)", code, tc.wantCode, errb.String())
+			}
+			if tc.wantCode != exitcode.OK {
+				return
+			}
+			if agentRead != tc.wantAgentRead {
+				t.Errorf("paneAgentState consulted = %v, want %v", agentRead, tc.wantAgentRead)
+			}
+			if sent != tc.wantSendCalled {
+				t.Errorf("sendLiteralLine called = %v, want %v", sent, tc.wantSendCalled)
+			}
+			if tc.wantSendCalled {
+				if sentPane != "%5" {
+					t.Errorf("send pane = %q, want %%5", sentPane)
+				}
+				if sentText != nudgeText {
+					t.Errorf("send text = %q, want nudgeText", sentText)
+				}
+			}
+			if tc.wantStdout != "" && !strings.Contains(out.String(), tc.wantStdout) {
+				t.Errorf("stdout = %q, want substring %q", out.String(), tc.wantStdout)
+			}
+			if tc.wantStderr != "" && !strings.Contains(errb.String(), tc.wantStderr) {
+				t.Errorf("stderr = %q, want substring %q", errb.String(), tc.wantStderr)
+			}
+		})
 	}
 }

--- a/cmd/fanout/msg_test.go
+++ b/cmd/fanout/msg_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -570,6 +573,52 @@ func TestRunMsgNudge(t *testing.T) {
 				t.Errorf("stderr = %q, want substring %q", errb.String(), tc.wantStderr)
 			}
 		})
+	}
+}
+
+// TestLoadStateStoreResolvesOwnerFromChildWorktree guards the regression Codex
+// flagged: nudge is run from a child worktree pane, whose own git toplevel has
+// no state.json. loadStateStore must climb to the owner (OwnerProjectRoot) that
+// holds the row — resolveStateRuntime would load the child's empty store and
+// report every recipient "not recorded".
+func TestLoadStateStoreResolvesOwnerFromChildWorktree(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+	owner := t.TempDir()
+	gitCmdTest(t, owner, "init", "-b", "main")
+	gitCmdTest(t, owner, "config", "user.email", "fanout@example.invalid")
+	gitCmdTest(t, owner, "config", "user.name", "fanout test")
+	if err := os.WriteFile(filepath.Join(owner, "README.md"), []byte("base\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmdTest(t, owner, "add", "README.md")
+	gitCmdTest(t, owner, "commit", "-m", "base")
+
+	child := filepath.Join(owner, ".fanout", "worktrees", "s-71")
+	gitCmdTest(t, owner, "worktree", "add", "-b", "s-71", child)
+
+	// The recipient row lives in the OWNER's state.json, never the child's.
+	if err := os.MkdirAll(filepath.Dir(state.Path(owner)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	fixture := `{"schemaVersion":1,"panes":[{"parent":"68","issueNum":71,"slug":"s-71","paneId":"%5"}]}` + "\n"
+	if err := os.WriteFile(state.Path(owner), []byte(fixture), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run from the child pane with no FANOUT_STATE_PATH override (the real
+	// in-pane workflow). resolveStateRuntime would resolve the child toplevel
+	// and find nothing.
+	t.Chdir(child)
+	t.Setenv(fanoutStatePathEnv, "")
+
+	st, err := loadStateStore()
+	if err != nil {
+		t.Fatalf("loadStateStore() failed: %v", err)
+	}
+	if _, ok := st.Find("68", 71); !ok {
+		t.Fatalf("loadStateStore() found %d panes, want the owner's recipient #71 (child-worktree owner resolution regressed)", len(st.Panes))
 	}
 }
 

--- a/internal/tmuxrun/tmuxrun.go
+++ b/internal/tmuxrun/tmuxrun.go
@@ -541,6 +541,56 @@ func SendKeys(target string, keys ...string) error {
 	return nil
 }
 
+// PaneAgentState returns the @fanout_agent_state pane user option for paneID,
+// re-read live so a nudge gate (fanout msg nudge) sees the current value
+// instead of a cached one — shrinking the TOCTOU window between the check and
+// the send-keys. The value is "running" between agent launch and exit, "done"
+// afterward (see BuildPaneLaunchCommand). A dead pane id makes tmux exit
+// non-zero, so an error doubles as a liveness signal; an *alive* pane whose
+// option was never set (legacy panes, panes launched outside the wrapper)
+// reports ("", nil) — display-message exits zero with empty output. Callers
+// treat both "" and an error as "do not nudge".
+func PaneAgentState(paneID string) (string, error) {
+	paneID = strings.TrimSpace(paneID)
+	if paneID == "" {
+		return "", fmt.Errorf("pane id is required")
+	}
+	out, err := exec.Command("tmux", "display-message", "-p", "-t", paneID, "#{"+agentStateOption+"}").Output()
+	if err != nil {
+		return "", fmt.Errorf("tmux display-message %s: %w", agentStateOption, err)
+	}
+	return strings.TrimRight(string(out), "\r\n"), nil
+}
+
+// SendLiteralLine types text into paneID literally and submits it with Enter,
+// as `fanout msg nudge` does to drop a one-line hint into a peer agent's
+// input. It targets the pane id directly (not through exactSessionTarget,
+// which is the session-name "=" seam) and uses two send-keys calls on purpose:
+// -l forces literal interpretation so a text containing tmux key names ("C-c",
+// "Enter") is typed verbatim, but -l applies to every argument of one call, so
+// the submitting Enter must be a separate, non-literal send-keys. The "--"
+// terminates option parsing before the payload: without it a text starting
+// with "-" (e.g. "-n ...") is rejected as an unknown flag (verified on tmux
+// 3.6a), which would matter for future reusers of this primitive even though
+// today's only caller passes a fixed hint. The split is not transactional: if
+// the literal send succeeds but the Enter fails the hint sits unsubmitted in
+// the input buffer, which is harmless (it is just text) and fits the
+// best-effort contract — the message it points at is already persisted, so a
+// failed nudge never loses information.
+func SendLiteralLine(paneID, text string) error {
+	paneID = strings.TrimSpace(paneID)
+	if paneID == "" {
+		return fmt.Errorf("pane id is required")
+	}
+	if err := exec.Command("tmux", "send-keys", "-t", paneID, "-l", "--", text).Run(); err != nil {
+		return fmt.Errorf("tmux send-keys -l: %w", err)
+	}
+	if err := exec.Command("tmux", "send-keys", "-t", paneID, "Enter").Run(); err != nil {
+		return fmt.Errorf("tmux send-keys Enter: %w", err)
+	}
+	return nil
+}
+
 // AttachOrSwitch attaches to a session outside tmux or switches clients inside tmux.
 func AttachOrSwitch(name string) error {
 	name = strings.TrimSpace(name)

--- a/internal/tmuxrun/tmuxrun.go
+++ b/internal/tmuxrun/tmuxrun.go
@@ -541,27 +541,6 @@ func SendKeys(target string, keys ...string) error {
 	return nil
 }
 
-// PaneAgentState returns the @fanout_agent_state pane user option for paneID,
-// re-read live so a nudge gate (fanout msg nudge) sees the current value
-// instead of a cached one — shrinking the TOCTOU window between the check and
-// the send-keys. The value is "running" between agent launch and exit, "done"
-// afterward (see BuildPaneLaunchCommand). A dead pane id makes tmux exit
-// non-zero, so an error doubles as a liveness signal; an *alive* pane whose
-// option was never set (legacy panes, panes launched outside the wrapper)
-// reports ("", nil) — display-message exits zero with empty output. Callers
-// treat both "" and an error as "do not nudge".
-func PaneAgentState(paneID string) (string, error) {
-	paneID = strings.TrimSpace(paneID)
-	if paneID == "" {
-		return "", fmt.Errorf("pane id is required")
-	}
-	out, err := exec.Command("tmux", "display-message", "-p", "-t", paneID, "#{"+agentStateOption+"}").Output()
-	if err != nil {
-		return "", fmt.Errorf("tmux display-message %s: %w", agentStateOption, err)
-	}
-	return strings.TrimRight(string(out), "\r\n"), nil
-}
-
 // SendLiteralLine types text into paneID literally and submits it with Enter,
 // as `fanout msg nudge` does to drop a one-line hint into a peer agent's
 // input. It targets the pane id directly (not through exactSessionTarget,

--- a/internal/tmuxrun/tmuxrun_test.go
+++ b/internal/tmuxrun/tmuxrun_test.go
@@ -807,6 +807,101 @@ func TestSendKeysPreservesPaneTarget(t *testing.T) {
 	assertTmuxArgs(t, argsPath, []string{"send-keys", "-t", "%1", "q"})
 }
 
+func TestPaneAgentStateBuildsArgsAndTrims(t *testing.T) {
+	argsPath := installTmuxShim(t, `printf '%s\n' "$@" > "$TMUXRUN_ARGS"
+printf 'running\r\n'
+`)
+
+	got, err := PaneAgentState("%1")
+	if err != nil {
+		t.Fatalf("PaneAgentState() failed: %v", err)
+	}
+	if got != "running" {
+		t.Fatalf("PaneAgentState() = %q, want running (CR/LF trimmed)", got)
+	}
+	assertTmuxArgs(t, argsPath, []string{"display-message", "-p", "-t", "%1", "#{@fanout_agent_state}"})
+}
+
+func TestPaneAgentStateReturnsEmptyForUnsetOptionOnLivePane(t *testing.T) {
+	// An alive pane whose @fanout_agent_state was never set (legacy / launched
+	// outside the wrapper) makes tmux exit zero with empty output; the value is
+	// "", not an error, so the nudge gate degrades to no-op rather than failing.
+	installTmuxShim(t, `printf ''
+`)
+
+	got, err := PaneAgentState("%1")
+	if err != nil {
+		t.Fatalf("PaneAgentState() failed: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("PaneAgentState() = %q, want empty string", got)
+	}
+}
+
+func TestPaneAgentStateErrorsWhenPaneGone(t *testing.T) {
+	installTmuxShim(t, `exit 1
+`)
+
+	if _, err := PaneAgentState("%404"); err == nil {
+		t.Fatal("PaneAgentState() succeeded, want error when tmux cannot resolve the pane")
+	}
+}
+
+func TestPaneAgentStateRejectsEmptyPaneID(t *testing.T) {
+	if _, err := PaneAgentState("  "); err == nil {
+		t.Fatal("PaneAgentState(empty) should error")
+	}
+}
+
+func TestSendLiteralLineTypesTextThenEnter(t *testing.T) {
+	argsPath := installTmuxShim(t, `printf '%s\n' "$@" >> "$TMUXRUN_ARGS"
+printf '%s\n' '---' >> "$TMUXRUN_ARGS"
+`)
+
+	if err := SendLiteralLine("%3", "[fanout] peer message"); err != nil {
+		t.Fatalf("SendLiteralLine() failed: %v", err)
+	}
+	// Two calls: the literal text (-l so key names stay text; -- so a leading
+	// dash is not parsed as a flag) then a bare Enter, both targeting the pane
+	// id directly (no "=" session prefix).
+	assertTmuxArgs(t, argsPath, []string{
+		"send-keys", "-t", "%3", "-l", "--", "[fanout] peer message", "---",
+		"send-keys", "-t", "%3", "Enter", "---",
+	})
+}
+
+func TestSendLiteralLineTypesDashLeadingTextLiterally(t *testing.T) {
+	// The "--" terminator lets a payload beginning with "-" through as literal
+	// text instead of an unknown flag — the hardening that matters for future
+	// reusers of this primitive.
+	argsPath := installTmuxShim(t, `printf '%s\n' "$@" >> "$TMUXRUN_ARGS"
+printf '%s\n' '---' >> "$TMUXRUN_ARGS"
+`)
+
+	if err := SendLiteralLine("%3", "-n dash-leading"); err != nil {
+		t.Fatalf("SendLiteralLine() failed: %v", err)
+	}
+	assertTmuxArgs(t, argsPath, []string{
+		"send-keys", "-t", "%3", "-l", "--", "-n dash-leading", "---",
+		"send-keys", "-t", "%3", "Enter", "---",
+	})
+}
+
+func TestSendLiteralLineRejectsEmptyPaneID(t *testing.T) {
+	if err := SendLiteralLine("", "hi"); err == nil {
+		t.Fatal("SendLiteralLine(empty pane id) should error")
+	}
+}
+
+func TestSendLiteralLineErrorsWhenLiteralSendFails(t *testing.T) {
+	installTmuxShim(t, `exit 1
+`)
+
+	if err := SendLiteralLine("%3", "hi"); err == nil {
+		t.Fatal("SendLiteralLine() succeeded, want error when the literal send-keys fails")
+	}
+}
+
 func TestFocusPaneSelectsWindowAndPane(t *testing.T) {
 	argsPath := installTmuxShim(t, `printf '%s\n' "$@" >> "$TMUXRUN_ARGS"
 printf '%s\n' '---' >> "$TMUXRUN_ARGS"

--- a/internal/tmuxrun/tmuxrun_test.go
+++ b/internal/tmuxrun/tmuxrun_test.go
@@ -807,52 +807,6 @@ func TestSendKeysPreservesPaneTarget(t *testing.T) {
 	assertTmuxArgs(t, argsPath, []string{"send-keys", "-t", "%1", "q"})
 }
 
-func TestPaneAgentStateBuildsArgsAndTrims(t *testing.T) {
-	argsPath := installTmuxShim(t, `printf '%s\n' "$@" > "$TMUXRUN_ARGS"
-printf 'running\r\n'
-`)
-
-	got, err := PaneAgentState("%1")
-	if err != nil {
-		t.Fatalf("PaneAgentState() failed: %v", err)
-	}
-	if got != "running" {
-		t.Fatalf("PaneAgentState() = %q, want running (CR/LF trimmed)", got)
-	}
-	assertTmuxArgs(t, argsPath, []string{"display-message", "-p", "-t", "%1", "#{@fanout_agent_state}"})
-}
-
-func TestPaneAgentStateReturnsEmptyForUnsetOptionOnLivePane(t *testing.T) {
-	// An alive pane whose @fanout_agent_state was never set (legacy / launched
-	// outside the wrapper) makes tmux exit zero with empty output; the value is
-	// "", not an error, so the nudge gate degrades to no-op rather than failing.
-	installTmuxShim(t, `printf ''
-`)
-
-	got, err := PaneAgentState("%1")
-	if err != nil {
-		t.Fatalf("PaneAgentState() failed: %v", err)
-	}
-	if got != "" {
-		t.Fatalf("PaneAgentState() = %q, want empty string", got)
-	}
-}
-
-func TestPaneAgentStateErrorsWhenPaneGone(t *testing.T) {
-	installTmuxShim(t, `exit 1
-`)
-
-	if _, err := PaneAgentState("%404"); err == nil {
-		t.Fatal("PaneAgentState() succeeded, want error when tmux cannot resolve the pane")
-	}
-}
-
-func TestPaneAgentStateRejectsEmptyPaneID(t *testing.T) {
-	if _, err := PaneAgentState("  "); err == nil {
-		t.Fatal("PaneAgentState(empty) should error")
-	}
-}
-
 func TestSendLiteralLineTypesTextThenEnter(t *testing.T) {
 	argsPath := installTmuxShim(t, `printf '%s\n' "$@" >> "$TMUXRUN_ARGS"
 printf '%s\n' '---' >> "$TMUXRUN_ARGS"

--- a/tests/bats/tier1_msg.bats
+++ b/tests/bats/tier1_msg.bats
@@ -165,6 +165,59 @@ msg_env() {
   [[ "$output" == *"sent #1 to #71"* ]]
 }
 
+@test "msg nudge without a target exits 2" {
+  msg_env
+  run_fanout msg nudge --parent 68
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"target issue <N> is required"* ]]
+}
+
+@test "msg nudge with a non-integer target exits 2" {
+  msg_env
+  run_fanout msg nudge abc --parent 68
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"target must be a non-zero issue number"* ]]
+}
+
+@test "msg nudge with a second target exits 2" {
+  msg_env
+  run_fanout msg nudge 71 72 --parent 68
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"takes exactly one target issue"* ]]
+}
+
+@test "msg nudge rejects --to (target is positional): exit 2" {
+  msg_env
+  run_fanout msg nudge --to 71 --parent 68
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"--to is not supported"* ]]
+}
+
+@test "msg nudge for an unrecorded peer is a best-effort no-op success" {
+  msg_env
+  # A recipient absent from state.json never touches tmux: nudge is best-effort
+  # (the message is already persisted by send), so it exits 0 and reports the
+  # skip instead of failing. Deterministic without a controllable tmux server.
+  printf '%s\n' '{"schemaVersion":1,"panes":[]}' > "$BATS_TEST_TMPDIR/state.json"
+  export FANOUT_STATE_PATH="$BATS_TEST_TMPDIR/state.json"
+  run_fanout msg nudge 99 --parent 68 --json
+  assert_success
+  [[ "$output" == *'"nudged": false'* ]]
+  [[ "$output" == *"not recorded"* ]]
+  [ ! -e "$BATS_TEST_TMPDIR/team.db" ]
+}
+
+@test "msg nudge --dry-run prints the would-line and touches no DB" {
+  msg_env
+  printf '%s\n' '{"schemaVersion":1,"panes":[{"parent":"68","issueNum":70,"slug":"s","branchName":"b","paneId":"%1","agent":"claude","displayName":"d","worktreePath":"","prompt":"[fanout #70 of #68] s","createdAt":"2026-06-13T00:00:00Z"}]}' \
+    > "$BATS_TEST_TMPDIR/state.json"
+  export FANOUT_STATE_PATH="$BATS_TEST_TMPDIR/state.json"
+  run_fanout msg nudge 70 --dry-run --parent 68
+  assert_success
+  [[ "$output" == *"# would send-keys -t %1 -l "* ]]
+  [ ! -e "$BATS_TEST_TMPDIR/team.db" ]
+}
+
 @test "msg detects a manual pane (negative synthetic issue under @manual)" {
   msg_env
   printf '%s\n' '{"schemaVersion":1,"panes":[{"parent":"@manual","issueNum":-1,"slug":"manual-1-scratch","branchName":"","paneId":"%1","agent":"claude","displayName":"scratch","worktreePath":"","prompt":"scratch work","createdAt":"2026-06-13T00:00:00Z"}]}' \

--- a/tests/bats/tier2_msg.bats
+++ b/tests/bats/tier2_msg.bats
@@ -72,6 +72,19 @@ seed_msg_db() {
   assert_golden msg-register-bare
 }
 
+@test "msg nudge --dry-run golden (pane id resolved from state.json)" {
+  msg_env
+  # nudge resolves the recipient pane id from state.json (never the DB), so the
+  # dry-run line is deterministic given a fixed FANOUT_STATE_PATH. The agent
+  # state is read live only on the real path, never in dry-run.
+  printf '%s\n' '{"schemaVersion":1,"panes":[{"parent":"68","issueNum":70,"slug":"msg-cli-surface-70","branchName":"fanout/msg-cli-surface-70","paneId":"%1","agent":"claude","displayName":"msg cli surface","worktreePath":"","prompt":"[fanout #70 of #68] msg-cli-surface-70: msg CLI.","createdAt":"2026-06-13T00:00:00Z"}]}' \
+    > "$BATS_TEST_TMPDIR/state.json"
+  export FANOUT_STATE_PATH="$BATS_TEST_TMPDIR/state.json"
+  run_fanout msg nudge 70 --dry-run --parent 68
+  assert_success
+  assert_golden msg-nudge
+}
+
 @test "msg inbox --json golden: unread 1:1 + board union" {
   msg_env
   seed_msg_db

--- a/tests/golden/msg-nudge.dry-run.txt
+++ b/tests/golden/msg-nudge.dry-run.txt
@@ -1,0 +1,1 @@
+# would send-keys -t %1 -l '[fanout] peer message in your inbox — run: fanout msg inbox' then Enter (target #70, only if agent is running)


### PR DESCRIPTION
## TL;DR

`fanout msg nudge <N>` を追加: peer メッセージの受信を早めるため、相手 child issue のペインへ tmux send-keys で inbox 誘導の一言を push する best-effort の通知層。生きた fanout ペイン(id + recorded worktree が一致)で `@fanout_agent_state == "running"` のときだけ送り、それ以外は no-op success。
Review effort: 3

## Why

peer messaging（#69–#71, wave1/2）は pull ベースで既に成立している（`send` が SQLite に永続化 → 受信側が自分のチェックポイントで `inbox` を pull）。本 issue（#72, wave3）はその上に載る accelerator: idle 相当の相手にだけ「inbox を見て」と push し、次の pull を待たせない。メッセージ自体は永続済みなので nudge は純粋なおまけで、**失敗しても messaging を壊さない**のが要件。

唯一の設計上の論点は「割り込み事故を起こさない安全設計」。元の issue は dmux の `agentStatus`（idle/analyzing/waiting/working）に依存し `==idle` でゲートしていたが、dmux 脱却（#81/#145）後この enum は存在しない。現行の唯一の状態シグナルは pane user option `@fanout_agent_state` ∈ {`""`, `"running"`, `"done"`}（起動ラッパー `BuildPaneLaunchCommand` が設定）で、busy と idle を区別できない。そこで **`running`（生きた fanout 起動 agent）に限定**して send-keys する方針に再設計した（ユーザー承認済み）。Claude/codex は処理中の入力をキューに積み次ターンで拾う（中断しない）ため、busy な `running` への push も「次のチェックポイントで pull」を前倒しするだけで割り込みにならない。`""`/`"done"`/pane 消失/tmux 不通/送信失敗は全て no-op success。

さらに送信先の同定は id だけでは不十分（tmux はサーバ再起動後に `%N` を無関係なペインへ再利用する）。ダッシュボードの liveness 規約（`sessionview.paneAlive`）と同じく **id + recorded worktree への path 一致**を確認してから送る。

```mermaid
flowchart TD
    A["fanout msg nudge N"] --> B["runMsgNudge: loadStateStore + state.Find(parent, N)"]
    B -->|dry-run| C["nudgeDryRunLine → '# would send-keys …' (tmux 非依存)"]
    B -->|not found / PaneID 空| D["no-op success（reason 出力）"]
    B -->|resolved| E["deliverNudge: listLivePanes()（送信直前 / TOCTOU 縮小）"]
    E --> F["matchLivePane: id 一致 かつ recorded worktree 配下?"]
    F -->|tmux 不通| D
    F -->|id 不在 / path 乖離（%N 再利用）| D
    F -->|一致| G{"shouldNudge == 'running'?"}
    G -->|no（done/""）| D
    G -->|yes| H["sendLiteralLine: send-keys -l -- text, then Enter"]
    H -->|ok| I["nudged #N"]
    H -->|err| D
```

## Changes by file

<details><summary>Changed files</summary>

| File | What changed | Why |
| --- | --- | --- |
| `internal/tmuxrun/tmuxrun.go` | `SendLiteralLine(paneID,text)` を新設（`send-keys -t %N -l -- text` → `Enter` の2回、ペイン直指定） | 任意ペイン宛 literal + Enter の送信プリミティブ。control pane 専用 send とは別ヘルパ。`-l -- ` は `-` 始まり payload の flag 誤認回避（tmux 3.6a 検証）。生きたペイン同定は既存 `ListLivePanes` を再利用するため id 単独読みの専用関数は設けない |
| `cmd/fanout/msg.go` | `nudge` verb を追加: `msgVerbFlags` 登録、`nudgeText` 定数、`listLivePanes`/`sendLiteralLine`/`loadStateStore` 注入シーム、positional `<N>` パース（`setNudgeTarget`、負数=@manual 許可）、`validateMsgFlags`/`resolveMsgIdentity`(needSelf) 拡張、`cmdMsg` で openMsgDB の前に dispatch、`runMsgNudge`/`deliverNudge`/`matchLivePane`/`shouldNudge`/`nudgeDryRunLine`/`writeMsgNudgeResult`、usage 更新 | DB を一切触らず state.json から paneId を解決。`deliverNudge` が `ListLivePanes` で id + recorded worktree 一致を確認（`sessionview.paneAlive` と同規約、再利用 `%N` 防御）してから running 限定で送る。dry-run は tmux 非依存の決定的出力、`--json` でレポート |
| `cmd/fanout/msg_test.go` | `TestParseMsgFlags`/`TestResolveMsgIdentity` に nudge ケース、`TestShouldNudge`/`TestNudgeDryRunLine`/`TestMatchLivePane`/`TestRunMsgNudge`（running/done/""/再利用id/worktree配下/id不在/tmux不通/send失敗/not-found/no-pane/dry-run/`<unknown>`/leading-zero parent/json を網羅）を追加 | 純ロジックと best-effort 分岐・再利用id防御の table-driven 検証 |
| `internal/tmuxrun/tmuxrun_test.go` | `SendLiteralLine`（2回呼び出し順 + `-- ` + dash-leading）の shim テストを追加 | tmux argv をバイト単位で固定 |
| `tests/bats/tier1_msg.bats` | nudge の negative（target 無/非整数/二重/`--to` 不可）+ 未記録 peer の best-effort no-op（exit 0, `"nudged": false`）+ dry-run が DB を触らない | 黒箱の invocation/exit 契約 |
| `tests/bats/tier2_msg.bats` | nudge dry-run golden テスト（既知 state.json fixture で paneId を決定的に） | dry-run 出力の golden 固定 |
| `tests/golden/msg-nudge.dry-run.txt` | nudge dry-run の golden（1行） | 出力フォーマット回帰検出 |

</details>

## Risk

> [!WARNING]
> nudge は `tmux send-keys` で他ペインへ文字 + Enter を送る。送信先は id + recorded worktree 一致 + `running` で同定するため、tmux の `%N` 再利用や stale row への誤送は防げるが、`@fanout_agent_state` は「agent プロセスが生きている」しか表さず busy / idle / 権限プロンプト待ちを区別できない。権限 y/n プロンプト中の正しいペインに当たると Enter が誤確定する理論上のリスクは残る（Claude/codex の通常入力はキューされるだけで中断しない）。真の idle 検出は将来 起動ラッパー/フックが粒度の細かい状態を持つまで保留で、surface を変えずに `shouldNudge` を差し替え可能。

## Test plan

- `make build-go` — OK（web バンドル + Go バイナリ）
- `make test` — PASS（Go unit 全パッケージ + web vitest + bats tier1/tier2、新規 nudge ケース/golden 含む）
- `make lint` — `0 issues`（golangci-lint v2 + shellcheck）
- tmux 3.6a で `send-keys -l -- "-n …"` が literal で通り、`--` 無しだと `unknown flag` でエラーになることを実機確認

Closes #72
