### PR TITLE
feat(skills): pr-watch skill / コマンドを追加（PR 監視・自動対処ループ）

### DIFF
--- a/claude/commands/pr-watch.md
+++ b/claude/commands/pr-watch.md
@@ -1,0 +1,30 @@
+---
+description: Watch the current branch's PR and autonomously handle merge conflicts, failing CI, and review comments until it is mergeable / approved / green.
+argument-hint: "[pr-number | pr-url]"
+---
+
+Invoke the `pr-watch` skill to monitor and auto-resolve a pull request after it
+has been created. See the `pr-watch` skill (`~/.claude/skills/pr-watch/SKILL.md`)
+for the full workflow, safety guardrails, and termination conditions.
+
+Arguments: `$ARGUMENTS`
+
+- If `$ARGUMENTS` is empty, target the PR attached to the **current git
+  branch** (`gh pr view`). If there is no PR for this branch, tell the user to
+  create one first and stop — this command does not create PRs.
+- If `$ARGUMENTS` is a PR number (`^#?\d+$`, strip a leading `#`) or a PR URL,
+  target that PR instead.
+
+This runs **one monitoring pass** (state → conflicts → CI → review comments →
+push), then reports. Conflicts/CI/review are time-delayed and recur, so for
+continuous watching wrap it in the dynamic loop: **`/loop /pr-watch`** (no
+interval — the skill self-paces with `ScheduleWakeup`: short while CI is
+running, long while idle). The loop ends when the PR is merged/closed, reaches
+approved + green + no unresolved threads, you stop it, or the skill detects it
+is stuck on the same problem (oscillation safety).
+
+Behavior is fully autonomous within guardrails: rebase + auto-resolve confident
+conflicts then `git push --force-with-lease`, read failing CI logs and fix the
+cause, address review comments in code and reply after pushing. It never
+force-pushes others' PRs or protected branches, never auto-merges the PR unless
+explicitly told to, and escalates conflicts/CI/review that need human judgment.

--- a/claude/skills/pr-watch/SKILL.md
+++ b/claude/skills/pr-watch/SKILL.md
@@ -51,7 +51,7 @@ PR を出した瞬間が終わりではない。ベースブランチが進め�
 ## 対象 PR の特定
 
 ```bash
-gh pr view ${pr:+"$pr"} --json number,state,isDraft,mergeable,mergeStateStatus,reviewDecision,headRefName,baseRefName,author,headRepository,headRepositoryOwner,isCrossRepository,maintainerCanModify,url,title,statusCheckRollup
+gh pr view ${pr:+"$pr"} --json number,state,isDraft,mergeable,mergeStateStatus,reviewDecision,reviewRequests,headRefName,baseRefName,author,headRepository,headRepositoryOwner,isCrossRepository,maintainerCanModify,url,title,statusCheckRollup
 ```
 
 引数で PR 番号 / URL が渡されたらそれを `$pr` とし、無引数（現在ブランチの PR を対象）なら `$pr` は空。`$pr` が**非空のときだけ**位置引数として渡す（`gh pr view ${pr:+"$pr"} …` のように、空なら**引数を付けない**）。`gh pr view ""` / `gh pr checks ""` は空文字でも argv エントリになり、`gh` の「引数なし＝現在ブランチの PR」フォールバックを壊すので、`"$pr"` をそのまま空で渡してはいけない。`$pr` が非空なら、この pass の全 gh 呼び出し（`gh pr view`・`gh pr checks`・GraphQL の `$num`）に必ず渡す — 無引数で叩くと別ブランチ指定時に別の PR を監視してしまう。
@@ -83,7 +83,7 @@ me=$(gh api user -q .login)
 
 `author.login` を要に置くのは、`headRepositoryOwner.login` は **リポジトリ／org の owner であって PR author とは限らない**ため（自分の repo や org に collaborator がブランチを作って PR を開くと head owner は自分/org でも author は他人）。逆に head owner で絞ると、自分が author の org PR を弾いてしまう。`maintainerCanModify=true`（fork の「メンテナの編集を許可」）は認可根拠にしない（コミット追記の許可であって履歴 rewrite の許可ではない）。
 
-**push 先 remote `<head-remote>` の解決**: PR の `headRepository`（owner/name・URL）に**実際に一致する local remote**を `git remote -v` から探して使う（`isCrossRepository` に関わらず。`origin` 決め打ちにしないのは、fork レイアウトで `origin` が fork を指すと PR head を取り違えるため）。**一致する remote が無い場合**（自分の fork PR だが clone に base remote しか無い等。`gh pr checkout` は PR を出すが fork remote を追加しないことがある）は、**`git remote add <name> <headRepository.url>` で名前付き remote を足して `git fetch <name> "$head"` してから**、その remote 経由で通常どおり `git push --force-with-lease <name> HEAD:"$head"` する。**raw URL を直接 push 先にする `git push --force-with-lease <url> …` は使わない** — URL には remote-tracking ref が無く、`--force-with-lease`（暗黙形）が比較対象を持てずに stale 扱いで reject される。どうしても URL 直 push が要るなら、fetch した head SHA を明示 lease 値にする（`--force-with-lease="$head":<fetched-sha>`）。それでも解決できなければエスカレーション。
+**push 先 remote `<head-remote>` の解決**: PR の `headRepository`（owner/name・URL）に**実際に一致する local remote**を `git remote -v` から探して使う（`isCrossRepository` に関わらず。`origin` 決め打ちにしないのは、fork レイアウトで `origin` が fork を指すと PR head を取り違えるため）。**一致する remote が無い場合**（自分の fork PR だが clone に base remote しか無い等。`gh pr checkout` は PR を出すが fork remote を追加しないことがある）は、fork の **clone URL を導出してから** 名前付き remote を足す。`gh pr view --json headRepository` は `id`/`name`/`nameWithOwner` しか返さず **URL を含まない**ので、`headRepository.nameWithOwner` と PR のホスト（`url` のホスト部）から URL を組み立てる（例: `https://github.com/<nameWithOwner>.git`）か、`gh repo view <nameWithOwner> --json url -q .url` で取得する。そのうえで **`git remote add <name> <url>` → `git fetch <name> "$head"`** してから、その remote 経由で通常どおり `git push --force-with-lease <name> HEAD:"$head"` する。**raw URL を直接 push 先にする `git push --force-with-lease <url> …` は使わない** — URL には remote-tracking ref が無く、`--force-with-lease`（暗黙形）が比較対象を持てずに stale 扱いで reject される。どうしても URL 直 push が要るなら、fetch した head SHA を明示 lease 値にする（`--force-with-lease="$head":<fetched-sha>`）。それでも解決できなければエスカレーション。
 
 **ローカル HEAD が PR head を含むか検証**（rebase / force-push の前に必ず）:
 
@@ -107,7 +107,7 @@ git merge-base --is-ancestor FETCH_HEAD HEAD   # PR head が HEAD の祖先か
 1. `gh pr view --json …`（PR 状態）。
 2. CI: `gh pr checks ${pr:+"$pr"} --json name,state,bucket,link,workflow`（`$pr` を必ず渡す。`bucket` が `pass`/`fail`/`pending`/`skipping`/`cancel`）。**`gh pr checks` は pending チェックがあると exit 8、失敗があると非 0 を返す**ので、exit code を成否判定に使わず、`gh pr checks ${pr:+"$pr"} --json … || true` のように**必ず JSON を取り切ってから `bucket` で判断**する（exit 8 をコマンド失敗として扱うと、push→pending の窓でループが止まる）。
 3. 未解決レビュースレッド: E-1 の `reviewThreads` GraphQL を**この時点で**叩き、`isResolved=false` の件数（と中身・各スレッドの先頭/最新コメント）を持っておく。`reviewDecision` は COMMENTED レビューでは変わらないので、スレッドを実際に数えないと未解決指摘を見落とす。
-4. サマリ／トップレベルの actionable: E-1 と同じ `gh pr view ${pr:+"$pr"} --json latestReviews,comments,reviewDecision` を取り、`latestReviews` の本文（`CHANGES_REQUESTED` だけでなく **`COMMENTED` も含め**、具体的な修正依頼があるもの）・対応要求のトップレベルコメントを拾う。これらは**未解決 `reviewThread` を作らず `reviewDecision` も変えない**ことがあるので、B はスレッド数だけでなくこの「未対応のサマリ/トップレベル指摘」も 0 か見る（さもないと、レビュー本文に依頼が残っていても approve/green で完了扱いになる）。純粋な情報共有のみの COMMENTED は対象外。
+4. サマリ／トップレベルの actionable: E-1 と同じ `gh pr view ${pr:+"$pr"} --json latestReviews,comments,reviewDecision` を取り、`latestReviews` の本文（`CHANGES_REQUESTED` だけでなく **`COMMENTED` も含め**、具体的な修正依頼があるもの）・対応要求のトップレベルコメントを拾う。これらは**未解決 `reviewThread` を作らず `reviewDecision` も変えない**ことがあるので、B はスレッド数だけでなくこの「未対応のサマリ/トップレベル指摘」も 0 か見る（さもないと、レビュー本文に依頼が残っていても approve/green で完了扱いになる）。純粋な情報共有のみの COMMENTED は対象外。**`gh pr view --json comments` はトップレベルコメントを `first:100` でしか取らない**ので、100 を超える PR では GraphQL（`issueComments`/`comments` の `pageInfo.endCursor`）で全ページ辿ってから完了/ skip 判定に使う（後ろのページの actionable コメントを取りこぼさない）。
 
 ### B. 終了判定（最初に行う）
 
@@ -115,10 +115,10 @@ git merge-base --is-ancestor FETCH_HEAD HEAD   # PR head が HEAD の祖先か
 
 - `state` が `MERGED` または `CLOSED` → **完了**。終了報告して loop を抜ける。
 - `state=OPEN` かつ **`isDraft=false`** かつ **マージ可能**（`mergeable=MERGEABLE`。`mergeStateStatus` は `CLEAN` を厳密要求しない — 後述）かつ CI（必須チェック）が全 `pass`/`skipping` かつ **A-3 の未対応スレッドが 0 かつ A-4 の未対応サマリ/トップレベル指摘が 0** かつ **承認シグナルが立っている** → **完了**。「マージ可能・グリーン・承認（または不要）で未対応のレビュー指摘なし」と報告して loop を抜ける（PR の自動マージはしない。後述「やらないこと」）。
-  - **`mergeStateStatus` は厳密に `CLEAN` でなくてよい**。up-to-date を必須にしないリポジトリでは、ベースが進んでも `mergeable=MERGEABLE` のまま `mergeStateStatus=BEHIND` になり、衝突が無いので C で rebase する必要もない。この状態を `CLEAN` でないからと弾くと、対処対象が無いのに永遠に完了できない。完了判定は **`mergeable=MERGEABLE` + 必須チェック pass** を軸にし、`DIRTY`（衝突）や `BLOCKED`（必須未達）だけを「未完了」とみなす。
+  - **`mergeStateStatus` は厳密に `CLEAN` でなくてよいが、`BEHIND` は条件付き**。up-to-date を**必須にしない**リポジトリでは、ベースが進んでも `mergeable=MERGEABLE` のまま `mergeStateStatus=BEHIND` になり、衝突が無いので rebase 不要 → この `BEHIND` は完了可。だが**up-to-date を必須にする**リポジトリ（ブランチ保護の `required_status_checks.strict` = `requiresStrictStatusChecks` が true）では、`BEHIND` のままだと GitHub がマージをブロックする → この場合は完了にせず C の rebase で追従させる。strict 設定は `gh api repos/$owner/$repo/branches/$base/protection`（権限があれば）で確認し、取れなければ安全側に倒して `BEHIND` は rebase する。完了判定は **`mergeable=MERGEABLE` + 必須チェック pass + （`CLEAN` または strict 不要の `BEHIND`）** を軸にし、`DIRTY`（衝突）/ `BLOCKED`（必須未達）/ strict な `BEHIND` を「未完了」とみなす。
   - 「承認シグナル」は**レビュアー構成で変わる**。次のいずれかで承認相当とみなす:
     1. `reviewDecision=APPROVED`。
-    2. **レビューが要求されていない**: ブランチ保護で必須レビューが無く、`reviewDecision` が `null`/空でレビュー依頼も無い（待つべき人間レビューが存在しない）→ 承認を待たず完了可。`null` を「未承認」と取り違えて永遠に待たない。
+    2. **レビューが要求されていない**: ブランチ保護で必須レビューが無く、`reviewDecision` が `null`/空で、**かつ `reviewRequests` が空**（手動で依頼された未応答の人間レビュアーもいない）→ 承認を待たず完了可。`reviewRequests` を見ずに `null` だけで判断すると、手動依頼したレビュアーの到着前に完了してしまう。
     3. 自動レビュー bot（例: codex-connector）運用では、その bot の**再レビューが clean（新規 actionable なし）**＝ 👍/approve 相当（[[feedback_codex_review_approval]]）。
   - 「未対応」は E の skip ルール（自分が既に対応・返信済みでレビュアーの新規反応待ちのものは対応済み扱い）を適用して数える。`reviewDecision` だけで「指摘なし」と即断しない（COMMENTED スレッドやトップレベルコメントを取りこぼす）。
 - `state=OPEN` で **CI green・衝突なし・未対応指摘 0 だが、必須の人間レビューが要求されていてまだ `APPROVED` でない**（`reviewDecision=REVIEW_REQUIRED`/`CHANGES_REQUESTED` 解消待ち等）→ **完了にはせず「reviewer-wait（アイドル）」として監視を継続**する。ここで loop を抜けると、遅れて来るレビュー / CI 変化を取りこぼす。長間隔（後述）で「対処対象なし・承認待ち。約 N 分後に再確認」と報告して再 pass する（ただし上記のとおり、レビューが**そもそも不要**なら待たずに完了する）。

--- a/claude/skills/pr-watch/SKILL.md
+++ b/claude/skills/pr-watch/SKILL.md
@@ -107,7 +107,7 @@ git merge-base --is-ancestor FETCH_HEAD HEAD   # PR head が HEAD の祖先か
 1. `gh pr view --json …`（PR 状態）。
 2. CI: `gh pr checks ${pr:+"$pr"} --json name,state,bucket,link,workflow`（`$pr` を必ず渡す。`bucket` が `pass`/`fail`/`pending`/`skipping`/`cancel`）。**`gh pr checks` は pending チェックがあると exit 8、失敗があると非 0 を返す**ので、exit code を成否判定に使わず、`gh pr checks ${pr:+"$pr"} --json … || true` のように**必ず JSON を取り切ってから `bucket` で判断**する（exit 8 をコマンド失敗として扱うと、push→pending の窓でループが止まる）。
 3. 未解決レビュースレッド: E-1 の `reviewThreads` GraphQL を**この時点で**叩き、`isResolved=false` の件数（と中身・各スレッドの先頭/最新コメント）を持っておく。`reviewDecision` は COMMENTED レビューでは変わらないので、スレッドを実際に数えないと未解決指摘を見落とす。
-4. サマリ／トップレベルの actionable: E-1 と同じ `gh pr view ${pr:+"$pr"} --json latestReviews,comments,reviewDecision` を取り、`latestReviews` の `state=CHANGES_REQUESTED` 本文・対応要求のトップレベルコメントを拾う。これらは**未解決 `reviewThread` を作らず `reviewDecision` も変えない**ことがあるので、B はスレッド数だけでなくこの「未対応のサマリ/トップレベル指摘」も 0 か見る（さもないと、トップレベルに actionable コメントが残っていても approve/green で完了扱いになる）。
+4. サマリ／トップレベルの actionable: E-1 と同じ `gh pr view ${pr:+"$pr"} --json latestReviews,comments,reviewDecision` を取り、`latestReviews` の本文（`CHANGES_REQUESTED` だけでなく **`COMMENTED` も含め**、具体的な修正依頼があるもの）・対応要求のトップレベルコメントを拾う。これらは**未解決 `reviewThread` を作らず `reviewDecision` も変えない**ことがあるので、B はスレッド数だけでなくこの「未対応のサマリ/トップレベル指摘」も 0 か見る（さもないと、レビュー本文に依頼が残っていても approve/green で完了扱いになる）。純粋な情報共有のみの COMMENTED は対象外。
 
 ### B. 終了判定（最初に行う）
 
@@ -155,7 +155,7 @@ git merge-base --is-ancestor FETCH_HEAD HEAD   # PR head が HEAD の祖先か
 
 ### D. CI 失敗対応
 
-`gh pr checks ${pr:+"$pr"} --json name,state,bucket,link,workflow` で **`bucket` が `fail` または `cancel`** のチェックを特定する（`cancel`=キャンセルされた必須チェックを無視すると、B は「全 pass でない」ので完了できず、D が拾わないと永遠に idle/long-poll になる）。`cancel` は原因修正の対象ではなく、まず `gh run rerun <run-id>`（外部 CI なら再実行をユーザーに促す）で回し直し、繰り返すならエスカレーション。`fail` は以下で原因を直す:
+`gh pr checks ${pr:+"$pr"} --json name,state,bucket,link,workflow` で **`bucket` が `fail` または `cancel`** のチェックを特定する（`cancel`=キャンセルされた必須チェックを無視すると、B は「全 pass でない」ので完了できず、D が拾わないと永遠に idle/long-poll になる）。`cancel` は原因修正の対象ではなく、まず `gh run rerun -R "$owner/$repo" <run-id>`（外部 CI なら再実行をユーザーに促す）で回し直し、繰り返すならエスカレーション。`fail` は以下で原因を直す:
 
 1. 失敗チェックが **GitHub Actions の run か外部 CI かをまず判別する**。`gh pr checks --json` の各チェックの `link` が GitHub Actions の run URL（`…/actions/runs/<id>…`）か、`workflow` が埋まっているものだけが Actions。Actions なら失敗 run のログを **失敗ジョブのみ**精読する（run id は `link` から、または `gh run list -R "$owner/$repo" --branch "$head" --json databaseId,conclusion,workflowName` で取得）:
 
@@ -170,16 +170,16 @@ git merge-base --is-ancestor FETCH_HEAD HEAD   # PR head が HEAD の祖先か
    **外部 CI（Buildkite / CircleCI / Jenkins 等、`link` が Actions の run でないチェック）は `gh run` で辿れない**。`gh run view` を当てに行かず、チェックの `link` URL を開いて原因を読むか、ログに自動アクセスできなければ「外部 CI `<name>` が失敗。`<link>` を確認してほしい」とユーザーにエスカレーションする。
 2. 原因を特定して修正する（lint / 型 / テスト / ビルド）。修正前に「CI の何が・なぜ落ちたか」と「何を直すか」を 1〜2 文で宣言。
 3. 修正を commit → `git push --force-with-lease "<head-remote>" HEAD:"$head"`（新規コミットを足すだけだが、`push.default` 依存を避けるため push 先は常に「push 先 remote の解決」で決めた `<head-remote>` の head ref に明示ピンする。rebase していないので fast-forward になり lease は通る）。push 後、CI は再実行されるので、この pass では「修正を push した。CI 再実行を待つ」とし、次 pass は短間隔で再確認する。
-4. **flaky / インフラ起因が疑われる失敗**（タイムアウト、外部サービス 5xx、無関係なネットワークエラー）はコード修正で直らない。1 回は再実行を促し（`gh run rerun <run-id> --failed` の提案）、それでも再現するならユーザーにエスカレーション。コードに無い原因をコードで延々いじらない。
+4. **flaky / インフラ起因が疑われる失敗**（タイムアウト、外部サービス 5xx、無関係なネットワークエラー）はコード修正で直らない。1 回は再実行を促し（`gh run rerun -R "$owner/$repo" <run-id> --failed` の提案）、それでも再現するならユーザーにエスカレーション。コードに無い原因をコードで延々いじらない。
 
-5. **必須チェックが未報告で `mergeStateStatus=BLOCKED`**（ブランチ保護が待っている required status が `gh pr checks` に `fail`/`cancel` として出てこない＝まだ走っていない / 報告が来ていない）の取り扱い。この状態は `fail`/`cancel` が無いので 1〜4 で拾えず、B も `BLOCKED` で完了できないため、**何もしないと idle で永遠にポーリングしてしまう**。`bucket=pending` の required チェックが進行中なら短間隔で待つ（CI 進行中扱い）。どのチェックも走っておらず required status が**欠落**しているなら、その required workflow を `gh run rerun`／再 dispatch するか、自動で起こせないなら「required チェック `<name>` が未報告で BLOCKED。手動でトリガー / 設定確認が要る」とユーザーにエスカレーションする（漫然と long-poll しない）。
+5. **必須チェックが未報告で `mergeStateStatus=BLOCKED`**（ブランチ保護が待っている required status が `gh pr checks` に `fail`/`cancel` として出てこない＝まだ走っていない / 報告が来ていない）の取り扱い。この状態は `fail`/`cancel` が無いので 1〜4 で拾えず、B も `BLOCKED` で完了できないため、**何もしないと idle で永遠にポーリングしてしまう**。`bucket=pending` の required チェックが進行中なら短間隔で待つ（CI 進行中扱い）。どのチェックも走っておらず required status が**欠落**しているなら、その required workflow を `gh run rerun -R "$owner/$repo"`／再 dispatch するか、自動で起こせないなら「required チェック `<name>` が未報告で BLOCKED。手動でトリガー / 設定確認が要る」とユーザーにエスカレーションする（漫然と long-poll しない）。
 
 ### E. レビューコメント対応
 
 未対応のレビュー指摘を集めて、コードで対処する。対象は**インラインスレッドだけではない** — 次の 2 系統を両方拾う:
 
 1. 取得:
-   - **サマリ／トップレベルの requested changes**: `gh pr view ${pr:+"$pr"} --json latestReviews,comments,reviewDecision`。レビュアーが inline ではなくレビュー本文やトップレベルコメントだけで変更を求めると、GitHub は **未解決 `reviewThread` を作らない**。`reviewDecision=CHANGES_REQUESTED` なのにインラインスレッドが 0、というケースがあるので、`latestReviews` の `state=CHANGES_REQUESTED` の本文や、対応を要求する PR コメント本文も**対処すべきレビュー作業として扱う**（これを見ないと「直す対象が無い」と誤判断して永遠に idle になる）。**判断には `latestReviews`（レビュアーごとの現在状態。承認・dismiss 済みは反映される）を使い、歴史的な `reviews` 全件は使わない** — 後で approve / dismiss された古い `CHANGES_REQUESTED` を蒸し返して対処対象にしてしまうため。
+   - **サマリ／トップレベルの requested changes**: `gh pr view ${pr:+"$pr"} --json latestReviews,comments,reviewDecision`。レビュアーが inline ではなくレビュー本文やトップレベルコメントだけで変更を求めると、GitHub は **未解決 `reviewThread` を作らない**。`reviewDecision` も変わらないことがある（承認後の追記や、必須レビューの無い repo では `state=COMMENTED` で出る）。そこで、`latestReviews` の本文を **`state=CHANGES_REQUESTED` に限らず `COMMENTED` も含めて読み**、対応を要求している（具体的な修正依頼がある）ものは対処対象として扱う。`comments`（PR の issue コメント）も同様に対応要求を拾う。これを見ないと「直す対象が無い」と誤判断して、レビュー本文に残った依頼を放置したまま完了/ idle になる。**判断には `latestReviews`（レビュアーごとの現在状態。承認・dismiss 済みは反映される）を使い、歴史的な `reviews` 全件は使わない** — 後で approve / dismiss された古い指摘を蒸し返さないため。純粋に情報共有だけの COMMENTED（具体的依頼が無い）は対処不要として扱う。
    - **未解決のインラインスレッド**（どの指摘がまだ open か）は GraphQL で `isResolved` を見る:
 
      ```bash
@@ -190,7 +190,7 @@ git merge-base --is-ancestor FETCH_HEAD HEAD   # PR head が HEAD の祖先か
              reviewThreads(first:100, after:$endCursor){
                pageInfo{ hasNextPage endCursor }
                nodes{ isResolved isOutdated path line originalLine diffSide
-                 topLevel: comments(first:1){ nodes{ databaseId body diffHunk } }
+                 topLevel: comments(first:1){ nodes{ fullDatabaseId databaseId body diffHunk } }
                  latest:   comments(last:1){ nodes{ author{login} createdAt body } } } } } } }' \
        -F owner="$owner" -F repo="$repo" -F num="$num"
      ```
@@ -212,7 +212,7 @@ git merge-base --is-ancestor FETCH_HEAD HEAD   # PR head が HEAD の祖先か
    設計判断・仕様確認を伴う指摘（「この方針で良いか」「ここは別実装にすべきでは」等、機械的に直せないもの）は無理に実装せず、その旨を整理してユーザーにエスカレーションする。
 3. 修正を commit → `git push --force-with-lease "<head-remote>" HEAD:"$head"`（C/D と同じく push 先は解決済み `<head-remote>` の head ref に明示ピン。素の `git push` は使わない）。
 4. **fix を push してから**返信する（順序が逆だと「直した」と言ったのに反映されていない状態を作る）。返信は対応コミットを参照して簡潔に:
-   - 個別インラインスレッドへの返信は **スレッド先頭コメントの `databaseId`**（E-1 で控えた `topLevel.nodes[0].databaseId`）に対して行う。返信コメントの ID を渡すと reply エンドポイントは 404 を返すので、必ず top-level ID を使う: `gh api repos/$owner/$repo/pulls/$num/comments/<top_level_databaseId>/replies -f body="<対応内容と commit>"`
+   - 個別インラインスレッドへの返信は **スレッド先頭コメントの id**（E-1 で控えた `topLevel.nodes[0].fullDatabaseId`）に対して行う。返信コメントの ID を渡すと reply エンドポイントは 404 を返すので、必ず top-level ID を使う: `gh api repos/$owner/$repo/pulls/$num/comments/<top_level_id>/replies -f body="<対応内容と commit>"`。**id は `fullDatabaseId` を使う** — 近年の大きいコメント id は GraphQL の `Int` 型 `databaseId` に収まらず `null` になりうるが、REST の reply エンドポイントは数値 id を要求する。`fullDatabaseId`（文字列の完全な数値 id）なら取りこぼさない。
    - 全体への一言: `gh pr comment -R "$owner/$repo" "$num" --body "<要約>"`（`-R` で対象 PR のリポジトリを明示する。bare `$num` だけだと、URL 指定や triangular checkout で `gh` のデフォルトリポジトリ側の別 `#num` に付いたり失敗したりする。REST replies が `$owner/$repo` を使うのと揃える）。
 5. **スレッドの resolve は確信があるときだけ**。基本はレビュアーに委ねる（自分で resolve すると、レビュアーが再確認する前に閉じてしまう）。
 
@@ -293,5 +293,5 @@ C/D/E のどれも該当しなければ、この pass は「対処対象なし�
 - **rebase が複雑で自動解決不能**: `git rebase --abort` で安全に戻し、どの hunk が・なぜ駄目かを添えてユーザーへ（C-4）。
 - **`--force-with-lease` が reject**: 他者が同ブランチに push 済み。`git fetch` で取り込み、状況をユーザーに共有してから再評価。勝手に `--force` で踏み潰さない。
 - **CI ログが巨大**: `gh run view <run-id> --log-failed` で失敗ジョブのみ取得。全文は読まない。
-- **CI が flaky / インフラ起因**: コード修正で直らない。1 回 `gh run rerun <run-id> --failed` を促し、再現するならエスカレーション（D-4）。
+- **CI が flaky / インフラ起因**: コード修正で直らない。1 回 `gh run rerun -R "$owner/$repo" <run-id> --failed` を促し、再現するならエスカレーション（D-4）。
 - **対象 PR がドラフト（`isDraft=true`）**: レビュー / マージ前提が揃わない。衝突・CI の追従はしてよいが、「ドラフトのままなので approve/マージ判定はスキップ」と明示する。

--- a/claude/skills/pr-watch/SKILL.md
+++ b/claude/skills/pr-watch/SKILL.md
@@ -51,12 +51,12 @@ PR を出した瞬間が終わりではない。ベースブランチが進め�
 ## 対象 PR の特定
 
 ```bash
-gh pr view "$pr" --json number,state,isDraft,mergeable,mergeStateStatus,reviewDecision,headRefName,baseRefName,author,headRepository,headRepositoryOwner,isCrossRepository,maintainerCanModify,url,title,statusCheckRollup
+gh pr view ${pr:+"$pr"} --json number,state,isDraft,mergeable,mergeStateStatus,reviewDecision,headRefName,baseRefName,author,headRepository,headRepositoryOwner,isCrossRepository,maintainerCanModify,url,title,statusCheckRollup
 ```
 
-引数で PR 番号 / URL が渡されたらそれを `$pr` とし、無引数（現在ブランチの PR を対象）なら `$pr` は空。**この pass の全 gh 呼び出し（`gh pr view "$pr"`・`gh pr checks "$pr"`・GraphQL の番号 `$num`）に必ず `$pr`/`$num` を渡す**。無引数の `gh pr checks` / `gh pr view` は「現在ブランチの PR」を読むので、別ブランチから番号/URL 指定したのに無引数で叩くと**別の PR を監視してしまう**。
+引数で PR 番号 / URL が渡されたらそれを `$pr` とし、無引数（現在ブランチの PR を対象）なら `$pr` は空。`$pr` が**非空のときだけ**位置引数として渡す（`gh pr view ${pr:+"$pr"} …` のように、空なら**引数を付けない**）。`gh pr view ""` / `gh pr checks ""` は空文字でも argv エントリになり、`gh` の「引数なし＝現在ブランチの PR」フォールバックを壊すので、`"$pr"` をそのまま空で渡してはいけない。`$pr` が非空なら、この pass の全 gh 呼び出し（`gh pr view`・`gh pr checks`・GraphQL の `$num`）に必ず渡す — 無引数で叩くと別ブランチ指定時に別の PR を監視してしまう。
 
-`headRefName` が現在のローカルブランチ名と一致することを確認する（不一致ならユーザーに確認）。
+`headRefName` が現在のローカルブランチ名と一致することを確認する。**不一致（= 別ブランチから番号/URL でその PR を対象にしている）の場合は、confirm だけで先へ進まない**。C/D/E は `HEAD:"$head"` に push するので、現在 HEAD が対象 PR と無関係なブランチのままだと**別ブランチのコミットで PR を上書き**してしまう。まず `gh pr checkout "$pr"`（または `<head-remote>` から `$head` を fetch してそのブランチへ）で対象 PR head をチェックアウトしてから進むか、それができないならこの pass を止めてユーザーにエスカレーションする。
 
 主要フィールドの意味:
 
@@ -103,16 +103,17 @@ git merge-base --is-ancestor FETCH_HEAD HEAD   # PR head が HEAD の祖先か
 この pass の判断材料を、**B の終了判定に必要なものまで含めて先に揃える**（B が「CI 全 pass」「未対応のレビュー指摘 0」を見るのに、それらを A で取っていないと取りこぼす）。4 つを取る:
 
 1. `gh pr view --json …`（PR 状態）。
-2. CI: `gh pr checks "$pr" --json name,state,bucket,link,workflow`（`$pr` を必ず渡す。`bucket` が `pass`/`fail`/`pending`/`skipping`/`cancel`）。**`gh pr checks` は pending チェックがあると exit 8、失敗があると非 0 を返す**ので、exit code を成否判定に使わず、`gh pr checks "$pr" --json … || true` のように**必ず JSON を取り切ってから `bucket` で判断**する（exit 8 をコマンド失敗として扱うと、push→pending の窓でループが止まる）。
+2. CI: `gh pr checks ${pr:+"$pr"} --json name,state,bucket,link,workflow`（`$pr` を必ず渡す。`bucket` が `pass`/`fail`/`pending`/`skipping`/`cancel`）。**`gh pr checks` は pending チェックがあると exit 8、失敗があると非 0 を返す**ので、exit code を成否判定に使わず、`gh pr checks ${pr:+"$pr"} --json … || true` のように**必ず JSON を取り切ってから `bucket` で判断**する（exit 8 をコマンド失敗として扱うと、push→pending の窓でループが止まる）。
 3. 未解決レビュースレッド: E-1 の `reviewThreads` GraphQL を**この時点で**叩き、`isResolved=false` の件数（と中身・各スレッドの先頭/最新コメント）を持っておく。`reviewDecision` は COMMENTED レビューでは変わらないので、スレッドを実際に数えないと未解決指摘を見落とす。
-4. サマリ／トップレベルの actionable: E-1 と同じ `gh pr view "$pr" --json latestReviews,comments,reviewDecision` を取り、`latestReviews` の `state=CHANGES_REQUESTED` 本文・対応要求のトップレベルコメントを拾う。これらは**未解決 `reviewThread` を作らず `reviewDecision` も変えない**ことがあるので、B はスレッド数だけでなくこの「未対応のサマリ/トップレベル指摘」も 0 か見る（さもないと、トップレベルに actionable コメントが残っていても approve/green で完了扱いになる）。
+4. サマリ／トップレベルの actionable: E-1 と同じ `gh pr view ${pr:+"$pr"} --json latestReviews,comments,reviewDecision` を取り、`latestReviews` の `state=CHANGES_REQUESTED` 本文・対応要求のトップレベルコメントを拾う。これらは**未解決 `reviewThread` を作らず `reviewDecision` も変えない**ことがあるので、B はスレッド数だけでなくこの「未対応のサマリ/トップレベル指摘」も 0 か見る（さもないと、トップレベルに actionable コメントが残っていても approve/green で完了扱いになる）。
 
 ### B. 終了判定（最初に行う）
 
 対処に入る前に、まず「もう終わっていないか」を見る。無駄な rebase / 修正を避けるため、この判定を pass の先頭に置く:
 
 - `state` が `MERGED` または `CLOSED` → **完了**。終了報告して loop を抜ける。
-- `state=OPEN` かつ `mergeable=MERGEABLE`（`mergeStateStatus=CLEAN`）かつ CI が全 `pass`/`skipping` かつ **A-3 の未対応スレッドが 0 かつ A-4 の未対応サマリ/トップレベル指摘が 0** → **やることなし＝実質完了**。「マージ可能・グリーンで未対応のレビュー指摘なし」と報告して loop を抜ける（PR の自動マージはしない。後述「やらないこと」）。完了判定はスレッド数だけでなく **A-4 のサマリ/トップレベル指摘も 0** であることを要件にする（`reviewDecision` だけで「指摘なし」と即断しない — COMMENTED スレッドやトップレベルコメントを取りこぼす）。なお「未対応」は E の skip ルール（自分が既に対応・返信済みでレビュアーの新規反応待ちのものは対応済み扱い）を適用して数える。
+- `state=OPEN` かつ **`isDraft=false`** かつ `mergeable=MERGEABLE`（`mergeStateStatus=CLEAN`）かつ CI が全 `pass`/`skipping` かつ **A-3 の未対応スレッドが 0 かつ A-4 の未対応サマリ/トップレベル指摘が 0** → **やることなし＝実質完了**。「マージ可能・グリーンで未対応のレビュー指摘なし」と報告して loop を抜ける（PR の自動マージはしない。後述「やらないこと」）。完了判定はスレッド数だけでなく **A-4 のサマリ/トップレベル指摘も 0** であることを要件にする（`reviewDecision` だけで「指摘なし」と即断しない — COMMENTED スレッドやトップレベルコメントを取りこぼす）。なお「未対応」は E の skip ルール（自分が既に対応・返信済みでレビュアーの新規反応待ちのものは対応済み扱い）を適用して数える。
+- **`isDraft=true`（ドラフト）なら完了にしない**。ドラフトはレビュー / マージ前提が揃わないので、衝突・CI の追従（C/D）は続けつつ「ドラフトのままなので approve/マージ判定はスキップ。ready 化待ち」と報告して**監視を継続**する（ここで loop を抜けると、ビルド途中のドラフトで監視が止まってしまう）。
 - それ以外 → C 以降で対処対象を洗う。
 
 ### C. マージコンフリクト対応（rebase + 自動解決）
@@ -145,7 +146,7 @@ git merge-base --is-ancestor FETCH_HEAD HEAD   # PR head が HEAD の祖先か
 
 ### D. CI 失敗対応
 
-`gh pr checks "$pr" --json name,state,bucket,link,workflow` で **`bucket` が `fail` または `cancel`** のチェックを特定する（`cancel`=キャンセルされた必須チェックを無視すると、B は「全 pass でない」ので完了できず、D が拾わないと永遠に idle/long-poll になる）。`cancel` は原因修正の対象ではなく、まず `gh run rerun <run-id>`（外部 CI なら再実行をユーザーに促す）で回し直し、繰り返すならエスカレーション。`fail` は以下で原因を直す:
+`gh pr checks ${pr:+"$pr"} --json name,state,bucket,link,workflow` で **`bucket` が `fail` または `cancel`** のチェックを特定する（`cancel`=キャンセルされた必須チェックを無視すると、B は「全 pass でない」ので完了できず、D が拾わないと永遠に idle/long-poll になる）。`cancel` は原因修正の対象ではなく、まず `gh run rerun <run-id>`（外部 CI なら再実行をユーザーに促す）で回し直し、繰り返すならエスカレーション。`fail` は以下で原因を直す:
 
 1. 失敗チェックが **GitHub Actions の run か外部 CI かをまず判別する**。`gh pr checks --json` の各チェックの `link` が GitHub Actions の run URL（`…/actions/runs/<id>…`）か、`workflow` が埋まっているものだけが Actions。Actions なら失敗 run のログを **失敗ジョブのみ**精読する（run id は `link` から、または `gh run list --branch "$head" --json databaseId,conclusion,workflowName` で取得）:
 
@@ -165,7 +166,7 @@ git merge-base --is-ancestor FETCH_HEAD HEAD   # PR head が HEAD の祖先か
 未対応のレビュー指摘を集めて、コードで対処する。対象は**インラインスレッドだけではない** — 次の 2 系統を両方拾う:
 
 1. 取得:
-   - **サマリ／トップレベルの requested changes**: `gh pr view "$pr" --json latestReviews,comments,reviewDecision`。レビュアーが inline ではなくレビュー本文やトップレベルコメントだけで変更を求めると、GitHub は **未解決 `reviewThread` を作らない**。`reviewDecision=CHANGES_REQUESTED` なのにインラインスレッドが 0、というケースがあるので、`latestReviews` の `state=CHANGES_REQUESTED` の本文や、対応を要求する PR コメント本文も**対処すべきレビュー作業として扱う**（これを見ないと「直す対象が無い」と誤判断して永遠に idle になる）。**判断には `latestReviews`（レビュアーごとの現在状態。承認・dismiss 済みは反映される）を使い、歴史的な `reviews` 全件は使わない** — 後で approve / dismiss された古い `CHANGES_REQUESTED` を蒸し返して対処対象にしてしまうため。
+   - **サマリ／トップレベルの requested changes**: `gh pr view ${pr:+"$pr"} --json latestReviews,comments,reviewDecision`。レビュアーが inline ではなくレビュー本文やトップレベルコメントだけで変更を求めると、GitHub は **未解決 `reviewThread` を作らない**。`reviewDecision=CHANGES_REQUESTED` なのにインラインスレッドが 0、というケースがあるので、`latestReviews` の `state=CHANGES_REQUESTED` の本文や、対応を要求する PR コメント本文も**対処すべきレビュー作業として扱う**（これを見ないと「直す対象が無い」と誤判断して永遠に idle になる）。**判断には `latestReviews`（レビュアーごとの現在状態。承認・dismiss 済みは反映される）を使い、歴史的な `reviews` 全件は使わない** — 後で approve / dismiss された古い `CHANGES_REQUESTED` を蒸し返して対処対象にしてしまうため。
    - **未解決のインラインスレッド**（どの指摘がまだ open か）は GraphQL で `isResolved` を見る:
 
      ```bash
@@ -175,16 +176,16 @@ git merge-base --is-ancestor FETCH_HEAD HEAD   # PR head が HEAD の祖先か
            pullRequest(number:$num){
              reviewThreads(first:100, after:$endCursor){
                pageInfo{ hasNextPage endCursor }
-               nodes{ isResolved isOutdated path
-                 topLevel: comments(first:1){ nodes{ databaseId } }
+               nodes{ isResolved isOutdated path line originalLine diffSide
+                 topLevel: comments(first:1){ nodes{ databaseId body diffHunk } }
                  latest:   comments(last:1){ nodes{ author{login} createdAt } } } } } } }' \
        -F owner="$owner" -F repo="$repo" -F num="$num"
      ```
 
      **必ず全ページを辿る**（`--paginate` + `pageInfo.endCursor`）。`first:100` の 1 ページだけ見ると、スレッドが 100 を超える PR で後ろのページの未解決スレッドを取りこぼし、B が「未解決 0」と誤判定して完了してしまう。
 
-     スレッドごとに 2 つを別々に取る:
-     - **`topLevel`（`comments(first:1)`）の `databaseId`** = 返信先。reply エンドポイント（E-4）はこの先頭コメント ID しか受け付けない。
+     スレッドごとに次を取る:
+     - **`topLevel`（`comments(first:1)`）の `databaseId` / `body` / `diffHunk`**、および スレッドの `path`/`line` = **対処すべき指摘そのもの**（本文・該当ハンク・位置）と返信先。reply エンドポイント（E-4）はこの先頭コメント ID しか受け付けない。**`body` を取らないと実装すべき内容が分からず、推測 / 空振りエスカレーションに陥る**ので必ず取得する。
      - **`latest`（`comments(last:1)`）の `author`/`createdAt`** = skip 判定用の最新コメント。`comments(first:N)` で「古い方」を取って最新だと誤認しない（N を超えるとレビュアーの新しい反応を見落とし、対応済みと誤判定する）。スレッドのコメントが多いときは `last:` か末尾ページで最新を確実に取る。
 
 2. `isResolved=false` のスレッド **および 1 で拾ったサマリ／トップレベルの requested-change 本文**を対象に、指摘内容をコードで対処する。インラインスレッドが 0 でも `reviewDecision=CHANGES_REQUESTED` が残っているなら、レビュー本文側に対処対象があるとみなして拾う。

--- a/claude/skills/pr-watch/SKILL.md
+++ b/claude/skills/pr-watch/SKILL.md
@@ -83,7 +83,7 @@ me=$(gh api user -q .login)
 
 `author.login` を要に置くのは、`headRepositoryOwner.login` は **リポジトリ／org の owner であって PR author とは限らない**ため（自分の repo や org に collaborator がブランチを作って PR を開くと head owner は自分/org でも author は他人）。逆に head owner で絞ると、自分が author の org PR を弾いてしまう。`maintainerCanModify=true`（fork の「メンテナの編集を許可」）は認可根拠にしない（コミット追記の許可であって履歴 rewrite の許可ではない）。
 
-**push 先 remote `<head-remote>` の解決**: PR の `headRepository`（owner/name・URL）に**実際に一致する local remote**を `git remote -v` から探して使う（`isCrossRepository` に関わらず。`origin` 決め打ちにしないのは、fork レイアウトで `origin` が fork を指すと PR head を取り違えるため）。**一致する remote が無い場合**（自分の fork PR だが clone に base remote しか無い等。`gh pr checkout` は PR を出すが fork remote を追加しないことがある）は、`git remote add <name> <headRepository.url>` で remote を足して fetch するか、push 時に `headRepository` の URL を直接 refspec 先に使う（`git push --force-with-lease <url> HEAD:"$head"`）。それでも解決できなければエスカレーション。
+**push 先 remote `<head-remote>` の解決**: PR の `headRepository`（owner/name・URL）に**実際に一致する local remote**を `git remote -v` から探して使う（`isCrossRepository` に関わらず。`origin` 決め打ちにしないのは、fork レイアウトで `origin` が fork を指すと PR head を取り違えるため）。**一致する remote が無い場合**（自分の fork PR だが clone に base remote しか無い等。`gh pr checkout` は PR を出すが fork remote を追加しないことがある）は、**`git remote add <name> <headRepository.url>` で名前付き remote を足して `git fetch <name> "$head"` してから**、その remote 経由で通常どおり `git push --force-with-lease <name> HEAD:"$head"` する。**raw URL を直接 push 先にする `git push --force-with-lease <url> …` は使わない** — URL には remote-tracking ref が無く、`--force-with-lease`（暗黙形）が比較対象を持てずに stale 扱いで reject される。どうしても URL 直 push が要るなら、fetch した head SHA を明示 lease 値にする（`--force-with-lease="$head":<fetched-sha>`）。それでも解決できなければエスカレーション。
 
 **ローカル HEAD が PR head を含むか検証**（rebase / force-push の前に必ず）:
 
@@ -114,10 +114,14 @@ git merge-base --is-ancestor FETCH_HEAD HEAD   # PR head が HEAD の祖先か
 対処に入る前に、まず「もう終わっていないか」を見る。無駄な rebase / 修正を避けるため、この判定を pass の先頭に置く:
 
 - `state` が `MERGED` または `CLOSED` → **完了**。終了報告して loop を抜ける。
-- `state=OPEN` かつ **`isDraft=false`** かつ `mergeable=MERGEABLE`（`mergeStateStatus=CLEAN`）かつ CI が全 `pass`/`skipping` かつ **A-3 の未対応スレッドが 0 かつ A-4 の未対応サマリ/トップレベル指摘が 0** かつ **承認シグナルが立っている** → **完了**。「マージ可能・グリーン・承認済みで未対応のレビュー指摘なし」と報告して loop を抜ける（PR の自動マージはしない。後述「やらないこと」）。
-  - 「承認シグナル」は**レビュアーの種類で変わる**: 人間レビュアーが要るリポジトリでは `reviewDecision=APPROVED`。自動レビュー bot（例: codex-connector）では、その bot が再レビューして**新規 actionable を出さない clean 状態**が approve 相当（[[feedback_codex_review_approval]] のように 👍/clean をもって承認とみなす運用）。どちらの承認シグナルを使うかは pass の冒頭で決める。
+- `state=OPEN` かつ **`isDraft=false`** かつ **マージ可能**（`mergeable=MERGEABLE`。`mergeStateStatus` は `CLEAN` を厳密要求しない — 後述）かつ CI（必須チェック）が全 `pass`/`skipping` かつ **A-3 の未対応スレッドが 0 かつ A-4 の未対応サマリ/トップレベル指摘が 0** かつ **承認シグナルが立っている** → **完了**。「マージ可能・グリーン・承認（または不要）で未対応のレビュー指摘なし」と報告して loop を抜ける（PR の自動マージはしない。後述「やらないこと」）。
+  - **`mergeStateStatus` は厳密に `CLEAN` でなくてよい**。up-to-date を必須にしないリポジトリでは、ベースが進んでも `mergeable=MERGEABLE` のまま `mergeStateStatus=BEHIND` になり、衝突が無いので C で rebase する必要もない。この状態を `CLEAN` でないからと弾くと、対処対象が無いのに永遠に完了できない。完了判定は **`mergeable=MERGEABLE` + 必須チェック pass** を軸にし、`DIRTY`（衝突）や `BLOCKED`（必須未達）だけを「未完了」とみなす。
+  - 「承認シグナル」は**レビュアー構成で変わる**。次のいずれかで承認相当とみなす:
+    1. `reviewDecision=APPROVED`。
+    2. **レビューが要求されていない**: ブランチ保護で必須レビューが無く、`reviewDecision` が `null`/空でレビュー依頼も無い（待つべき人間レビューが存在しない）→ 承認を待たず完了可。`null` を「未承認」と取り違えて永遠に待たない。
+    3. 自動レビュー bot（例: codex-connector）運用では、その bot の**再レビューが clean（新規 actionable なし）**＝ 👍/approve 相当（[[feedback_codex_review_approval]]）。
   - 「未対応」は E の skip ルール（自分が既に対応・返信済みでレビュアーの新規反応待ちのものは対応済み扱い）を適用して数える。`reviewDecision` だけで「指摘なし」と即断しない（COMMENTED スレッドやトップレベルコメントを取りこぼす）。
-- `state=OPEN` で **CI green・衝突なし・未対応指摘 0 だが、承認シグナルがまだ立っていない**（`reviewDecision=REVIEW_REQUIRED`/空でレビュー待ち、bot 再レビュー待ち等）→ **完了にはせず「reviewer-wait（アイドル）」として監視を継続**する。ここで loop を抜けると、この skill が本来拾うべき**遅れて来るレビュー / CI 変化を取りこぼす**。長間隔（後述）で「対処対象なし・承認待ち。約 N 分後に再確認」と報告して再 pass する。
+- `state=OPEN` で **CI green・衝突なし・未対応指摘 0 だが、必須の人間レビューが要求されていてまだ `APPROVED` でない**（`reviewDecision=REVIEW_REQUIRED`/`CHANGES_REQUESTED` 解消待ち等）→ **完了にはせず「reviewer-wait（アイドル）」として監視を継続**する。ここで loop を抜けると、遅れて来るレビュー / CI 変化を取りこぼす。長間隔（後述）で「対処対象なし・承認待ち。約 N 分後に再確認」と報告して再 pass する（ただし上記のとおり、レビューが**そもそも不要**なら待たずに完了する）。
 - **`isDraft=true`（ドラフト）なら完了にしない**。ドラフトはレビュー / マージ前提が揃わないので、衝突・CI の追従（C/D）は続けつつ「ドラフトのままなので approve/マージ判定はスキップ。ready 化待ち」と報告して**監視を継続**する（ここで loop を抜けると、ビルド途中のドラフトで監視が止まってしまう）。
 - それ以外 → C 以降で対処対象を洗う。
 
@@ -126,7 +130,7 @@ git merge-base --is-ancestor FETCH_HEAD HEAD   # PR head が HEAD の祖先か
 `mergeable=CONFLICTING` または `mergeStateStatus` が `DIRTY` / `BEHIND` のとき:
 
 1. 作業ツリーが dirty なら、まず未コミット変更を commit するか stash するかを判断（勝手に捨てない）。
-2. ベースを取得して rebase。**rebase 先は PR の base リポジトリの `$base`（= `baseRefName`）**であって、head（fork）側の同名ブランチではない。fork PR では `origin` が fork を指し base リポジトリは別 remote（`upstream` 等）のことがあるので、base リポジトリを指す remote を `<base-remote>` として解決してから当てる（非 fork なら `origin`。判別に迷うなら base repo の URL から直接 fetch する）:
+2. ベースを取得して rebase。**rebase 先は PR の base リポジトリの `$base`（= `baseRefName`）**であって、head（fork）側の同名ブランチではない。`<base-remote>` は **PR の base リポジトリ（`baseRefName` を持つ repo = `gh pr view` が対象とする repo の `owner/name`・URL）に一致する local remote**を `git remote -v` から探して解決する。`isCrossRepository` フラグで「非 fork なら origin」と決め打ちにしないこと — triangular clone（`origin`=自分の fork、`upstream`=base repo）では `isCrossRepository=false` でも `origin` は base ではないので、fork 側の古い/不在の `$base` に rebase してしまう。一致 remote が無ければ base repo の URL から直接 fetch する:
 
    ```bash
    git fetch "<base-remote>" "$base"   # 例: git fetch origin main / git fetch upstream main
@@ -153,11 +157,13 @@ git merge-base --is-ancestor FETCH_HEAD HEAD   # PR head が HEAD の祖先か
 
 `gh pr checks ${pr:+"$pr"} --json name,state,bucket,link,workflow` で **`bucket` が `fail` または `cancel`** のチェックを特定する（`cancel`=キャンセルされた必須チェックを無視すると、B は「全 pass でない」ので完了できず、D が拾わないと永遠に idle/long-poll になる）。`cancel` は原因修正の対象ではなく、まず `gh run rerun <run-id>`（外部 CI なら再実行をユーザーに促す）で回し直し、繰り返すならエスカレーション。`fail` は以下で原因を直す:
 
-1. 失敗チェックが **GitHub Actions の run か外部 CI かをまず判別する**。`gh pr checks --json` の各チェックの `link` が GitHub Actions の run URL（`…/actions/runs/<id>…`）か、`workflow` が埋まっているものだけが Actions。Actions なら失敗 run のログを **失敗ジョブのみ**精読する（run id は `link` から、または `gh run list --branch "$head" --json databaseId,conclusion,workflowName` で取得）:
+1. 失敗チェックが **GitHub Actions の run か外部 CI かをまず判別する**。`gh pr checks --json` の各チェックの `link` が GitHub Actions の run URL（`…/actions/runs/<id>…`）か、`workflow` が埋まっているものだけが Actions。Actions なら失敗 run のログを **失敗ジョブのみ**精読する（run id は `link` から、または `gh run list -R "$owner/$repo" --branch "$head" --json databaseId,conclusion,workflowName` で取得）:
 
    ```bash
-   gh run view <run-id> --log-failed
+   gh run view -R "$owner/$repo" <run-id> --log-failed
    ```
+
+   **`gh run` 系には必ず `-R "$owner/$repo"`（対象 PR のリポジトリ）を付ける**。付けないと、PR を URL 指定したときや triangular/fork checkout で `gh` のデフォルトリポジトリが PR の base と異なる場合、別リポジトリの run を見に行って失敗 run を取り損ねる。
 
    ログ全文ではなく失敗部分だけを取るのは、出力肥大とトークン浪費を避けるため。
 
@@ -207,7 +213,7 @@ git merge-base --is-ancestor FETCH_HEAD HEAD   # PR head が HEAD の祖先か
 3. 修正を commit → `git push --force-with-lease "<head-remote>" HEAD:"$head"`（C/D と同じく push 先は解決済み `<head-remote>` の head ref に明示ピン。素の `git push` は使わない）。
 4. **fix を push してから**返信する（順序が逆だと「直した」と言ったのに反映されていない状態を作る）。返信は対応コミットを参照して簡潔に:
    - 個別インラインスレッドへの返信は **スレッド先頭コメントの `databaseId`**（E-1 で控えた `topLevel.nodes[0].databaseId`）に対して行う。返信コメントの ID を渡すと reply エンドポイントは 404 を返すので、必ず top-level ID を使う: `gh api repos/$owner/$repo/pulls/$num/comments/<top_level_databaseId>/replies -f body="<対応内容と commit>"`
-   - 全体への一言: `gh pr comment "$num" --body "<要約>"`
+   - 全体への一言: `gh pr comment -R "$owner/$repo" "$num" --body "<要約>"`（`-R` で対象 PR のリポジトリを明示する。bare `$num` だけだと、URL 指定や triangular checkout で `gh` のデフォルトリポジトリ側の別 `#num` に付いたり失敗したりする。REST replies が `$owner/$repo` を使うのと揃える）。
 5. **スレッドの resolve は確信があるときだけ**。基本はレビュアーに委ねる（自分で resolve すると、レビュアーが再確認する前に閉じてしまう）。
 
 C/D/E のどれも該当しなければ、この pass は「対処対象なし」。終了判定 B に戻って完了か継続待ちかを決める。

--- a/claude/skills/pr-watch/SKILL.md
+++ b/claude/skills/pr-watch/SKILL.md
@@ -164,23 +164,30 @@ git merge-base --is-ancestor FETCH_HEAD HEAD   # PR head が HEAD の祖先か
 未対応のレビュー指摘を集めて、コードで対処する。対象は**インラインスレッドだけではない** — 次の 2 系統を両方拾う:
 
 1. 取得:
-   - **サマリ／トップレベルの requested changes**: `gh pr view "$pr" --json reviews,comments,latestReviews,reviewDecision`。レビュアーが inline ではなくレビュー本文やトップレベルコメントだけで変更を求めると、GitHub は **未解決 `reviewThread` を作らない**。`reviewDecision=CHANGES_REQUESTED` なのにインラインスレッドが 0、というケースがあるので、`latestReviews`/`reviews` の `state=CHANGES_REQUESTED` の本文や、対応を要求する PR コメント本文も**対処すべきレビュー作業として扱う**（これを見ないと「直す対象が無い」と誤判断して永遠に idle になる）。
+   - **サマリ／トップレベルの requested changes**: `gh pr view "$pr" --json latestReviews,comments,reviewDecision`。レビュアーが inline ではなくレビュー本文やトップレベルコメントだけで変更を求めると、GitHub は **未解決 `reviewThread` を作らない**。`reviewDecision=CHANGES_REQUESTED` なのにインラインスレッドが 0、というケースがあるので、`latestReviews` の `state=CHANGES_REQUESTED` の本文や、対応を要求する PR コメント本文も**対処すべきレビュー作業として扱う**（これを見ないと「直す対象が無い」と誤判断して永遠に idle になる）。**判断には `latestReviews`（レビュアーごとの現在状態。承認・dismiss 済みは反映される）を使い、歴史的な `reviews` 全件は使わない** — 後で approve / dismiss された古い `CHANGES_REQUESTED` を蒸し返して対処対象にしてしまうため。
    - **未解決のインラインスレッド**（どの指摘がまだ open か）は GraphQL で `isResolved` を見る:
 
      ```bash
-     gh api graphql -f query='
-       query($owner:String!,$repo:String!,$num:Int!){
+     gh api graphql --paginate -f query='
+       query($owner:String!,$repo:String!,$num:Int!,$endCursor:String){
          repository(owner:$owner,name:$repo){
            pullRequest(number:$num){
-             reviewThreads(first:100){
+             reviewThreads(first:100, after:$endCursor){
+               pageInfo{ hasNextPage endCursor }
                nodes{ isResolved isOutdated path
                  comments(first:20){ nodes{ databaseId author{login} body } } } } } } }' \
        -F owner="$owner" -F repo="$repo" -F num="$num"
      ```
 
+     **必ず全ページを辿る**（`--paginate` + `pageInfo.endCursor`）。`first:100` の 1 ページだけ見ると、スレッドが 100 を超える PR で後ろのページの未解決スレッドを取りこぼし、B が「未解決 0」と誤判定して完了してしまう。
+
      各スレッドについて **先頭（top-level）コメントの `databaseId`**（= `comments.nodes[0].databaseId`）を控えておく。返信エンドポイント（E-4）はこの top-level ID しか受け付けないため。
 
-2. `isResolved=false` のスレッド **および 1 で拾ったサマリ／トップレベルの requested-change 本文**を対象に、指摘内容をコードで対処する。インラインスレッドが 0 でも `reviewDecision=CHANGES_REQUESTED` が残っているなら、レビュー本文側に対処対象があるとみなして拾う。設計判断・仕様確認を伴う指摘（「この方針で良いか」「ここは別実装にすべきでは」等、機械的に直せないもの）は無理に実装せず、その旨を整理してユーザーにエスカレーションする。
+2. `isResolved=false` のスレッド **および 1 で拾ったサマリ／トップレベルの requested-change 本文**を対象に、指摘内容をコードで対処する。インラインスレッドが 0 でも `reviewDecision=CHANGES_REQUESTED` が残っているなら、レビュー本文側に対処対象があるとみなして拾う。
+
+   **ただし「自分（watcher）が既に対応・返信済み」のスレッドは再処理しない**。resolve はレビュアーに委ねる方針（E-5）なので、対応済みスレッドも次 pass まで `isResolved=false` のまま見える。スレッドの**最新コメントが自分の返信**で、それ以降にレビュアーの新規コメントが無いなら「対応済み・レビュアー待ち」とみなして skip する（スレッドごとに「自分が最後に返信した commit / 時刻」を記憶し、レビュアーが新たに反応＝新規コメント追加 or resolve するまで触らない）。これをやらないと同じ修正・返信を毎 pass 重複させ、oscillation に陥る。
+
+   設計判断・仕様確認を伴う指摘（「この方針で良いか」「ここは別実装にすべきでは」等、機械的に直せないもの）は無理に実装せず、その旨を整理してユーザーにエスカレーションする。
 3. 修正を commit → `git push --force-with-lease "<head-remote>" HEAD:"$head"`（C/D と同じく push 先は解決済み `<head-remote>` の head ref に明示ピン。素の `git push` は使わない）。
 4. **fix を push してから**返信する（順序が逆だと「直した」と言ったのに反映されていない状態を作る）。返信は対応コミットを参照して簡潔に:
    - 個別インラインスレッドへの返信は **スレッド先頭コメントの `databaseId`**（E-1 で控えた `comments.nodes[0].databaseId`）に対して行う。返信コメントの ID を渡すと reply エンドポイントは 404 を返すので、必ず top-level ID を使う: `gh api repos/$owner/$repo/pulls/$num/comments/<top_level_databaseId>/replies -f body="<対応内容と commit>"`
@@ -232,7 +239,7 @@ C/D/E のどれも該当しなければ、この pass は「対処対象なし�
 ## 安全ガードレール
 
 - **全 push は解決済み `<head-remote>` の head ref に明示ピンする**（`git push [--force-with-lease] <head-remote> HEAD:<headRefName>`）。C の rebase 後・D の CI 修正・E のレビュー修正のいずれも対象。refspec 無しの素の push（`push.default` 依存で別ブランチを巻き込みうる）や無印 `--force` は使わない。fork PR では `<head-remote>` が `origin` でない／push 権限が無いことがあるので、解決手順で確認できなければ force-push せずエスカレーション。lease 失敗 = 他者更新ありとみなし、fetch して再評価し、状況をユーザーへ。
-- **操作対象は自分の head トピックブランチのみ**。`headRefName` が現在ブランチと一致することを確認してから触る。**force-push の認可は「`headRefName` の head リポジトリ owner == 今の認証ユーザー（`gh api user -q .login`）」だけで判断する**。`maintainerCanModify=true`（fork PR で「メンテナの編集を許可」）は認可根拠にしない — 履歴 rewrite の許可ではないので、他者 fork に force-push するとガードレール違反になる。**他者が作成した PR、`main` / `master` / `release/*` 等の保護ブランチには force-push しない**。
+- **操作対象は自分の head トピックブランチのみ**。`headRefName` が現在ブランチと一致することを確認してから触る。**force-push の認可は「head リポジトリ owner == 今の認証ユーザー（`gh api user -q .login`）」かつ「PR `author` == 同ユーザー」の両方で判断する**（「push 先 remote の解決と force-push 認可」と同一基準）。owner だけで判断すると、自分が owner の repo に collaborator が作ったブランチを rewrite してしまう。`maintainerCanModify=true`（fork PR で「メンテナの編集を許可」）も認可根拠にしない — 履歴 rewrite の許可ではないので、他者 fork に force-push するとガードレール違反になる。**他者が作成した PR、`main` / `master` / `release/*` 等の保護ブランチには force-push しない**。
 - **衝突を片側採用で機械的に潰さない**。確信が持てる hunk だけ自動解決し、意味的判断が要る箇所は abort してエスカレーション（C-4）。
 - **リポジトリのレビューゲートを尊重する**。`gh pr create` を `.claude/hooks/` 等でゲートしているリポジトリ（この repo の `pre-pr-review-gate.sh` 等）では、この skill は PR を作らないのでゲート対象外だが、push する fix にも品質基準を勝手に下げない。エスケープハッチ（`FANOUT_SKIP_PR_REVIEW` 等）を無断で使わない。
 - **CI を直すために CI 設定（ワークフロー yaml）を緩めて通す、テストを消して通す等の「通すための改竄」をしない**。原因を直すのが目的。設定変更が本当に必要なら理由を添えてユーザーに確認。

--- a/claude/skills/pr-watch/SKILL.md
+++ b/claude/skills/pr-watch/SKILL.md
@@ -51,10 +51,12 @@ PR を出した瞬間が終わりではない。ベースブランチが進め�
 ## 対象 PR の特定
 
 ```bash
-gh pr view --json number,state,isDraft,mergeable,mergeStateStatus,reviewDecision,headRefName,baseRefName,headRepositoryOwner,isCrossRepository,maintainerCanModify,url,title,statusCheckRollup
+gh pr view "$pr" --json number,state,isDraft,mergeable,mergeStateStatus,reviewDecision,headRefName,baseRefName,author,headRepository,headRepositoryOwner,isCrossRepository,maintainerCanModify,url,title,statusCheckRollup
 ```
 
-引数で PR 番号 / URL が渡された場合は `gh pr view <番号またはURL> --json …` で対象を固定する。`headRefName` が現在のローカルブランチ名と一致することを確認する（一致しなければ、対象 PR と作業ブランチがずれているのでユーザーに確認）。
+引数で PR 番号 / URL が渡されたらそれを `$pr` とし、無引数（現在ブランチの PR を対象）なら `$pr` は空。**この pass の全 gh 呼び出し（`gh pr view "$pr"`・`gh pr checks "$pr"`・GraphQL の番号 `$num`）に必ず `$pr`/`$num` を渡す**。無引数の `gh pr checks` / `gh pr view` は「現在ブランチの PR」を読むので、別ブランチから番号/URL 指定したのに無引数で叩くと**別の PR を監視してしまう**。
+
+`headRefName` が現在のローカルブランチ名と一致することを確認する（不一致ならユーザーに確認）。
 
 主要フィールドの意味:
 
@@ -62,28 +64,35 @@ gh pr view --json number,state,isDraft,mergeable,mergeStateStatus,reviewDecision
 - `mergeable`: `MERGEABLE` / `CONFLICTING` / `UNKNOWN`（`UNKNOWN` は GitHub が計算中。数十秒後に再取得すれば確定する — この pass では「不明」として扱い、短間隔で再 pass）
 - `mergeStateStatus`: `CLEAN` / `DIRTY`（衝突）/ `BEHIND`（ベースが進んでいる）/ `BLOCKED`（必須レビュー・チェック未達）/ `UNSTABLE`（CI が落ち / 進行中だが技術的にはマージ可）/ `HAS_HOOKS` / `DRAFT` / `UNKNOWN`
 - `reviewDecision`: `APPROVED` / `CHANGES_REQUESTED` / `REVIEW_REQUIRED` / 空
-- `isCrossRepository` / `headRepositoryOwner` / `maintainerCanModify`: PR head が fork にあるか（後述「push 先 remote の解決」で使う）
+- `author` / `headRepository` / `headRepositoryOwner` / `isCrossRepository` / `maintainerCanModify`: PR の作者と head の所在（後述「push 先 remote の解決と force-push 認可」で使う）
 
-### push 先 remote の解決（fork 対応・以降の全 push で使う）
+### push 先 remote の解決と force-push 認可（以降の全 push で使う）
 
-C/D/E のどの push もこの解決結果に従う。head ref を `$head`（= `headRefName`）とし、push 先 remote を次で決める。
+C/D/E のどの push もこの解決に従う。head ref を `$head`（= `headRefName`）とする。
 
-まず **force-push の認可**を判定する。基準は「head リポジトリの owner が今の認証ユーザー自身か」**だけ**:
+**force-push 認可**: 次を**両方**満たすときだけ force-push 可。どちらか欠けたら force-push せずエスカレーション:
 
 ```bash
 me=$(gh api user -q .login)
-# headRepositoryOwner.login と $me が一致するか
 ```
 
-- `headRepositoryOwner.login == $me`（= 自分のブランチ。非 fork PR は head owner が base owner と同じく自分）→ force-push **可**。
-- `headRepositoryOwner.login != $me`（= 他者の fork）→ **`maintainerCanModify=true`（「メンテナの編集を許可」）でも force-push しない**。履歴改変は「他者 PR に触らない」ガードレールそのものの違反で、`maintainerCanModify` は維持者によるコミット追記を許すだけで履歴 rewrite の許可ではない。新規コミット追記が要るケースも含め、他者 fork はユーザーにエスカレーションして判断を仰ぐ。
+1. `headRepositoryOwner.login == $me`（head リポジトリが自分のもの）。
+2. PR の `author.login == $me`（自分が開いた PR）。
 
-そのうえで push 先 remote を決める:
+両方要求するのは、`headRepositoryOwner.login` は **リポジトリの owner であって PR author とは限らない**ため。自分の repo に collaborator がブランチを作って PR を開いた場合、head owner は自分でも author は他人なので、author を見ないと他人のブランチを rewrite してしまう。`maintainerCanModify=true`（fork の「メンテナの編集を許可」）も認可根拠にしない（コミット追記の許可であって履歴 rewrite の許可ではない）。
 
-- `isCrossRepository=false`（head が base リポジトリにある通常ケース）→ 押し先は `origin`。
-- `isCrossRepository=true` かつ force-push 認可済み（自分の fork）→ `origin` に押すと base 側に別 ref を作るだけで **PR head は変わらない**。`gh pr checkout <num>` で正しい remote と追跡ブランチを設定し、その remote（`gh pr checkout` が作る `<owner>` 由来の remote、または `headRepositoryOwner.login` の fork を指す remote）へ押す。
+**push 先 remote `<head-remote>` の解決**: `isCrossRepository` に関わらず、PR の `headRepository`（owner/name・URL）に**実際に一致する local remote**を `git remote -v` から探して使う。`origin` 決め打ちにしないのは、fork レイアウト（`origin`=自分の fork、`upstream`=base repo）では `isCrossRepository=false` でも PR head が base repo 側に居て、`origin` に押すと別 ref を作るだけで PR head が変わらないため。一致する remote が無い（自分の）fork PR は `gh pr checkout <num>` で remote/追跡ブランチを用意してそれを使う。解決できなければエスカレーション。
 
-以降このドキュメントで `<head-remote>` と書いたら、ここで解決した remote を指す。全 push は明示 refspec `<head-remote> HEAD:"$head"` で行う（refspec を省略しない）。force-push 認可が取れない他者 fork では、ここで止めてエスカレーションし、以降の C/D/E の push は行わない。
+**ローカル HEAD が PR head を含むか検証**（rebase / force-push の前に必ず）:
+
+```bash
+git fetch "<head-remote>" "$head"
+git merge-base --is-ancestor FETCH_HEAD HEAD   # PR head が HEAD の祖先か
+```
+
+これが false（ローカルが PR head より後ろ / 乖離）なら、remote-tracking 的には `--force-with-lease` が通ってしまい **PR ブランチにしか無いコミットを取りこぼす**恐れがある。その場合は force-push せず、取り込み（`git pull --rebase` 等）かエスカレーションで HEAD を PR head の先端に揃えてから進む。
+
+以降このドキュメントで `<head-remote>` と書いたら、ここで解決した remote を指す。全 push は明示 refspec `<head-remote> HEAD:"$head"` で行う（refspec を省略しない）。認可が取れない / remote 解決できない / HEAD 検証に失敗したケースでは、ここで止めてエスカレーションし、以降の C/D/E の push は行わない。
 
 ## 1 反復（pass）の手順
 
@@ -94,7 +103,7 @@ me=$(gh api user -q .login)
 この pass の判断材料を、**B の終了判定に必要なものまで含めて先に揃える**（B が「CI 全 pass」「未解決スレッド 0」を見るのに、それらを A で取っていないと取りこぼす）。3 つを取る:
 
 1. `gh pr view --json …`（PR 状態）。
-2. CI: `gh pr checks --json name,state,bucket,link,workflow`（`bucket` が `pass`/`fail`/`pending`/`skipping`/`cancel`）。**`gh pr checks` は pending チェックがあると exit 8、失敗があると非 0 を返す**ので、exit code を成否判定に使わず、`gh pr checks … --json … || true` のように**必ず JSON を取り切ってから `bucket` で判断**する（exit 8 をコマンド失敗として扱うと、push→pending の窓でループが止まる）。
+2. CI: `gh pr checks "$pr" --json name,state,bucket,link,workflow`（`$pr` を必ず渡す。`bucket` が `pass`/`fail`/`pending`/`skipping`/`cancel`）。**`gh pr checks` は pending チェックがあると exit 8、失敗があると非 0 を返す**ので、exit code を成否判定に使わず、`gh pr checks "$pr" --json … || true` のように**必ず JSON を取り切ってから `bucket` で判断**する（exit 8 をコマンド失敗として扱うと、push→pending の窓でループが止まる）。
 3. 未解決レビュースレッド: E-1 の `reviewThreads` GraphQL を**この時点で**叩き、`isResolved=false` の件数（と中身）を持っておく。`reviewDecision` は COMMENTED レビューでは変わらないので、スレッドを実際に数えないと未解決指摘を見落とす。
 
 ### B. 終了判定（最初に行う）
@@ -129,12 +138,13 @@ me=$(gh api user -q .login)
 
    - 明示 refspec `<head-remote> HEAD:"$head"` にするのは、ローカルの `push.default`（`matching` だと全一致ブランチを push する）や upstream のズレに依存させず、**この PR の head ref だけ**を更新するため。refspec 無しの素の `git push --force-with-lease` は config 次第で意図しないブランチを巻き込みうるので、自律実行では使わない。fork PR では `<head-remote>` が `origin` ではないことに注意（解決手順に従う）。
    - `--force-with-lease` は、自分が最後に見た時点から remote の head が他者に更新されていたら**上書きせず失敗させる**ため。lease 失敗が出たら「他者が同じブランチに push した」とみなし、`git fetch` して取り込み、状況をユーザーに共有してから再評価する（無印 `--force` は使わない）。
+6. **rebase + push したら、この pass はここで終了する**。A で取った CI 結果・レビュースレッドは push 前の旧 head SHA に紐づくので、同じ pass のまま D/E に進むと**古いログや outdated なコメントを基に誤修正する**。短間隔の `ScheduleWakeup`（~270s）を入れて次 pass で新しい head SHA の状態を取り直し、その上で D/E を評価する。
 
-`BEHIND` だが衝突なし（ベースが進んだだけ）の場合も、ブランチ保護で「up-to-date 必須」なら同様に rebase + push でベースに追従させる。衝突が無ければ自動解決の判断は不要。
+`BEHIND` だが衝突なし（ベースが進んだだけ）の場合も、ブランチ保護で「up-to-date 必須」なら同様に rebase + push でベースに追従させる。衝突が無ければ自動解決の判断は不要。いずれも push したらこの pass は終了し、再取得してから先へ進む。
 
 ### D. CI 失敗対応
 
-`gh pr checks --json name,state,bucket,link,workflow` で `bucket=fail` のチェックを特定する:
+`gh pr checks "$pr" --json name,state,bucket,link,workflow` で **`bucket` が `fail` または `cancel`** のチェックを特定する（`cancel`=キャンセルされた必須チェックを無視すると、B は「全 pass でない」ので完了できず、D が拾わないと永遠に idle/long-poll になる）。`cancel` は原因修正の対象ではなく、まず `gh run rerun <run-id>`（外部 CI なら再実行をユーザーに促す）で回し直し、繰り返すならエスカレーション。`fail` は以下で原因を直す:
 
 1. 失敗チェックが **GitHub Actions の run か外部 CI かをまず判別する**。`gh pr checks --json` の各チェックの `link` が GitHub Actions の run URL（`…/actions/runs/<id>…`）か、`workflow` が埋まっているものだけが Actions。Actions なら失敗 run のログを **失敗ジョブのみ**精読する（run id は `link` から、または `gh run list --branch "$head" --json databaseId,conclusion,workflowName` で取得）:
 
@@ -151,10 +161,10 @@ me=$(gh api user -q .login)
 
 ### E. レビューコメント対応
 
-未対応のレビュー指摘を集めて、コードで対処する:
+未対応のレビュー指摘を集めて、コードで対処する。対象は**インラインスレッドだけではない** — 次の 2 系統を両方拾う:
 
 1. 取得:
-   - サマリレビューと PR 全体コメント: `gh pr view --json reviews,comments,latestReviews`
+   - **サマリ／トップレベルの requested changes**: `gh pr view "$pr" --json reviews,comments,latestReviews,reviewDecision`。レビュアーが inline ではなくレビュー本文やトップレベルコメントだけで変更を求めると、GitHub は **未解決 `reviewThread` を作らない**。`reviewDecision=CHANGES_REQUESTED` なのにインラインスレッドが 0、というケースがあるので、`latestReviews`/`reviews` の `state=CHANGES_REQUESTED` の本文や、対応を要求する PR コメント本文も**対処すべきレビュー作業として扱う**（これを見ないと「直す対象が無い」と誤判断して永遠に idle になる）。
    - **未解決のインラインスレッド**（どの指摘がまだ open か）は GraphQL で `isResolved` を見る:
 
      ```bash
@@ -170,7 +180,7 @@ me=$(gh api user -q .login)
 
      各スレッドについて **先頭（top-level）コメントの `databaseId`**（= `comments.nodes[0].databaseId`）を控えておく。返信エンドポイント（E-4）はこの top-level ID しか受け付けないため。
 
-2. `isResolved=false` のスレッドだけを対象に、指摘内容をコードで対処する。設計判断・仕様確認を伴う指摘（「この方針で良いか」「ここは別実装にすべきでは」等、機械的に直せないもの）は無理に実装せず、その旨を整理してユーザーにエスカレーションする。
+2. `isResolved=false` のスレッド **および 1 で拾ったサマリ／トップレベルの requested-change 本文**を対象に、指摘内容をコードで対処する。インラインスレッドが 0 でも `reviewDecision=CHANGES_REQUESTED` が残っているなら、レビュー本文側に対処対象があるとみなして拾う。設計判断・仕様確認を伴う指摘（「この方針で良いか」「ここは別実装にすべきでは」等、機械的に直せないもの）は無理に実装せず、その旨を整理してユーザーにエスカレーションする。
 3. 修正を commit → `git push --force-with-lease "<head-remote>" HEAD:"$head"`（C/D と同じく push 先は解決済み `<head-remote>` の head ref に明示ピン。素の `git push` は使わない）。
 4. **fix を push してから**返信する（順序が逆だと「直した」と言ったのに反映されていない状態を作る）。返信は対応コミットを参照して簡潔に:
    - 個別インラインスレッドへの返信は **スレッド先頭コメントの `databaseId`**（E-1 で控えた `comments.nodes[0].databaseId`）に対して行う。返信コメントの ID を渡すと reply エンドポイントは 404 を返すので、必ず top-level ID を使う: `gh api repos/$owner/$repo/pulls/$num/comments/<top_level_databaseId>/replies -f body="<対応内容と commit>"`

--- a/claude/skills/pr-watch/SKILL.md
+++ b/claude/skills/pr-watch/SKILL.md
@@ -1,0 +1,236 @@
+---
+name: pr-watch
+description: PR を作成したあと、マージコンフリクト・レビューコメント・CI 失敗を監視して自動で対処し続けるループ skill。現在ブランチの PR を gh で特定し、ベース更新による衝突は rebase + 自動解決して force-with-lease push、failing CI はログを読んで修正、レビューの requested changes はコードで対応して返信する — マージ可能 / approve / グリーンになるまで（または解決困難な箇所が出るまで）完全自律で回す。ユーザーが「PR 作ったあと見張って」「コンフリクト直して」「レビュー対応して」「PR を監視 / babysit して」「CI 直して」「PR がマージできる状態まで持っていって」等と言ったとき、PR を作成した直後の文脈、または /pr-watch・/loop /pr-watch が呼ばれたときに必ず使う。「dashboard」「visualization」のような明示語が無くても、PR 作成直後に「あとよろしく」的な依頼が来たらこの skill を呼ぶこと — 衝突・レビュー・CI は時間差で来るので、単発対応より監視ループの方が取りこぼさない。
+---
+
+# pr-watch
+
+PR 作成後に発生する 3 種の差し込み — **マージコンフリクト / レビューコメント / CI 失敗** — を、監視ループで完全自律に処理し続ける skill。
+
+## なぜこれが要るか
+
+PR を出した瞬間が終わりではない。ベースブランチが進めば衝突し、レビュアーは数時間後に requested changes を付け、CI は数分かけて落ちる。これらは**時間差で・繰り返し**やってくるので、人間が単発で対応すると「気づいたら conflict のまま放置」「レビュー返したつもりが CI 落ちてた」が起きる。
+
+この skill は、現在ブランチの PR 1 本を対象に「状態を見る → 対処できることを全部やる → push → 少し待つ → また見る」を、PR がマージ可能・approve・グリーンに揃うまで回す**オーケストレーター**。衝突解決・コード修正・返信は自分でやるが、意味的に判断が要る箇所（壊すと困る衝突、設計判断を伴うレビュー指摘）は無理に処理せず人間にエスカレーションする。レビューの良し悪しの判断そのものは `code-review` 系 skill に任せ、ここは「検知して対処してまた見る」の制御に徹する。
+
+## 適用範囲と前提
+
+- **対象**: 現在 git ブランチに紐づく PR 1 本（`gh pr view` で自動特定）。引数で PR 番号 / URL を渡せばそれを対象にする。
+- **git リポジトリ外なら早期終了**: `git rev-parse --is-inside-work-tree` が false なら、「ここは git リポジトリではないので pr-watch は使えない」と伝えて終了。
+- **gh 未認証なら早期終了**: `gh auth status` が通らなければ `gh auth login` を案内して終了。
+- **PR が無いなら何もしない**: `gh pr view` が PR 不在を返したら、「このブランチにはまだ PR が無い。先に PR を作ってから呼んで」と伝えて終了。この skill は PR を**作らない**（作成は別フロー。作成直後にこの skill を呼ぶ運用）。
+- **対象は自分の head トピックブランチのみ**: 後述の安全ガードレールの通り、他者の PR や保護ブランチは触らない。
+
+## 全体フロー
+
+```
+[ユーザー: /pr-watch or 「PR 見張って」or PR 作成直後]
+        │
+        ▼
+  対象 PR を特定 (gh pr view --json …)
+        │
+        ▼
+ ┌───── 1 pass ────────────────────────────────┐
+ │  A. 状態取得                                  │
+ │  B. 終了判定 (merged/closed/揃った → 完了)     │
+ │  C. コンフリクト対応 (rebase + 自動解決 + push)│
+ │  D. CI 失敗対応 (log 精読 → 修正 → push)       │
+ │  E. レビューコメント対応 (修正 → push → 返信)  │
+ └──────────────┬──────────────────────────────┘
+                │ まだ揃っていない
+                ▼
+   ScheduleWakeup で間隔を選んで再 pass
+   (CI 実行中=短間隔 / アイドル=長間隔)
+                │
+                ▼
+   揃った / ユーザー停止 / oscillation 検知 → 終了報告
+```
+
+`/loop /pr-watch`（dynamic / self-paced）で回すのが基本。`/pr-watch` 単発でも 1 pass を回し、まだ揃っていなければ継続監視を案内する（後述「ループ制御」）。
+
+## 対象 PR の特定
+
+```bash
+gh pr view --json number,state,isDraft,mergeable,mergeStateStatus,reviewDecision,headRefName,baseRefName,headRepositoryOwner,isCrossRepository,maintainerCanModify,url,title,statusCheckRollup
+```
+
+引数で PR 番号 / URL が渡された場合は `gh pr view <番号またはURL> --json …` で対象を固定する。`headRefName` が現在のローカルブランチ名と一致することを確認する（一致しなければ、対象 PR と作業ブランチがずれているのでユーザーに確認）。
+
+主要フィールドの意味:
+
+- `state`: `OPEN` / `MERGED` / `CLOSED`
+- `mergeable`: `MERGEABLE` / `CONFLICTING` / `UNKNOWN`（`UNKNOWN` は GitHub が計算中。数十秒後に再取得すれば確定する — この pass では「不明」として扱い、短間隔で再 pass）
+- `mergeStateStatus`: `CLEAN` / `DIRTY`（衝突）/ `BEHIND`（ベースが進んでいる）/ `BLOCKED`（必須レビュー・チェック未達）/ `UNSTABLE`（CI が落ち / 進行中だが技術的にはマージ可）/ `HAS_HOOKS` / `DRAFT` / `UNKNOWN`
+- `reviewDecision`: `APPROVED` / `CHANGES_REQUESTED` / `REVIEW_REQUIRED` / 空
+- `isCrossRepository` / `headRepositoryOwner` / `maintainerCanModify`: PR head が fork にあるか（後述「push 先 remote の解決」で使う）
+
+### push 先 remote の解決（fork 対応・以降の全 push で使う）
+
+C/D/E のどの push もこの解決結果に従う。head ref を `$head`（= `headRefName`）とし、push 先 remote を次で決める:
+
+- `isCrossRepository=false`（head が base リポジトリにある通常ケース）→ 押し先は `origin`。
+- `isCrossRepository=true`（head が fork にある）→ `origin` に押すと base 側に別 ref を作るだけで **PR head は変わらない**。`gh pr checkout <num>` で正しい remote と追跡ブランチを設定し、その remote（`gh pr checkout` が作る `<owner>` 由来の remote、または `headRepositoryOwner.login` の fork を指す remote）へ押す。fork に push 権限が無い（`maintainerCanModify=false` かつ自分が head リポジトリの owner でない）なら **force-push せずエスカレーション**。
+
+以降このドキュメントで `<head-remote>` と書いたら、ここで解決した remote を指す。全 push は明示 refspec `<head-remote> HEAD:"$head"` で行う（refspec を省略しない）。
+
+## 1 反復（pass）の手順
+
+各ステップの前に「いま何をするか」を 1 文で宣言してから動く（例:「衝突しているので origin/main へ rebase します」）。長い前置きは不要。
+
+### A. 状態取得
+
+上記 `gh pr view --json …` を 1 回叩いて、この pass の判断材料を揃える。CI の詳細が要るときだけ続けて `gh pr checks --json name,state,bucket,link,workflow` を叩く（`bucket` が `pass`/`fail`/`pending`/`skipping`/`cancel` を返す）。
+
+### B. 終了判定（最初に行う）
+
+対処に入る前に、まず「もう終わっていないか」を見る。無駄な rebase / 修正を避けるため、この判定を pass の先頭に置く:
+
+- `state` が `MERGED` または `CLOSED` → **完了**。終了報告して loop を抜ける。
+- `state=OPEN` かつ `reviewDecision=APPROVED` かつ `mergeable=MERGEABLE`（`mergeStateStatus=CLEAN`）かつ CI が全 `pass`/`skipping` かつ未解決レビュースレッド 0 → **やることなし＝実質完了**。「マージ可能・承認済み・グリーンで未解決指摘なし」と報告して loop を抜ける（PR の自動マージはしない。後述「やらないこと」）。
+- それ以外 → C 以降で対処対象を洗う。
+
+### C. マージコンフリクト対応（rebase + 自動解決）
+
+`mergeable=CONFLICTING` または `mergeStateStatus` が `DIRTY` / `BEHIND` のとき:
+
+1. 作業ツリーが dirty なら、まず未コミット変更を commit するか stash するかを判断（勝手に捨てない）。
+2. ベースを取得して rebase:
+
+   ```bash
+   git fetch origin "$base"            # base は baseRefName
+   git rebase "origin/$base"
+   ```
+
+3. 衝突が出たら、**確信が持てる箇所だけ自動解決**する。確信の基準は「両側の意図が明確で、機械的にどちらか / 両方を残せば正しいと言い切れる」こと（例: import 行の併合、片側が単なる行追加、フォーマット差）。解決したら `git add` → `git rebase --continue`。
+4. **意味的に判断が要る衝突は自動解決しない**: 同じ関数を両側で別ロジックに書き換えている、削除 vs 変更がぶつかる、テストの期待値が両側で食い違う等。`git rebase --abort` で安全な状態へ戻し、後述の oscillation セーフティと同じ要領でユーザーに状況を渡してエスカレーションする（どの hunk が・なぜ自動解決できないかを具体的に）。
+5. rebase 完了後、push。**push 先は「push 先 remote の解決」で決めた `<head-remote>` の head ref に明示ピン留めする**（`$head` は `headRefName`）:
+
+   ```bash
+   git push --force-with-lease "<head-remote>" HEAD:"$head"
+   ```
+
+   - 明示 refspec `<head-remote> HEAD:"$head"` にするのは、ローカルの `push.default`（`matching` だと全一致ブランチを push する）や upstream のズレに依存させず、**この PR の head ref だけ**を更新するため。refspec 無しの素の `git push --force-with-lease` は config 次第で意図しないブランチを巻き込みうるので、自律実行では使わない。fork PR では `<head-remote>` が `origin` ではないことに注意（解決手順に従う）。
+   - `--force-with-lease` は、自分が最後に見た時点から remote の head が他者に更新されていたら**上書きせず失敗させる**ため。lease 失敗が出たら「他者が同じブランチに push した」とみなし、`git fetch` して取り込み、状況をユーザーに共有してから再評価する（無印 `--force` は使わない）。
+
+`BEHIND` だが衝突なし（ベースが進んだだけ）の場合も、ブランチ保護で「up-to-date 必須」なら同様に rebase + push でベースに追従させる。衝突が無ければ自動解決の判断は不要。
+
+### D. CI 失敗対応
+
+`gh pr checks --json name,state,bucket,link,workflow` で `bucket=fail` のチェックを特定する:
+
+1. 失敗したワークフロー実行のログを精読する。run id は失敗チェックの `link` から辿るか、`gh run list --branch "$head" --json databaseId,conclusion,workflowName` で取得し、**失敗ジョブのみ**を読む:
+
+   ```bash
+   gh run view <run-id> --log-failed
+   ```
+
+   ログ全文ではなく失敗部分だけを取るのは、出力肥大とトークン浪費を避けるため。
+2. 原因を特定して修正する（lint / 型 / テスト / ビルド）。修正前に「CI の何が・なぜ落ちたか」と「何を直すか」を 1〜2 文で宣言。
+3. 修正を commit → `git push --force-with-lease "<head-remote>" HEAD:"$head"`（新規コミットを足すだけだが、`push.default` 依存を避けるため push 先は常に「push 先 remote の解決」で決めた `<head-remote>` の head ref に明示ピンする。rebase していないので fast-forward になり lease は通る）。push 後、CI は再実行されるので、この pass では「修正を push した。CI 再実行を待つ」とし、次 pass は短間隔で再確認する。
+4. **flaky / インフラ起因が疑われる失敗**（タイムアウト、外部サービス 5xx、無関係なネットワークエラー）はコード修正で直らない。1 回は再実行を促し（`gh run rerun <run-id> --failed` の提案）、それでも再現するならユーザーにエスカレーション。コードに無い原因をコードで延々いじらない。
+
+### E. レビューコメント対応
+
+未対応のレビュー指摘を集めて、コードで対処する:
+
+1. 取得:
+   - サマリレビューと PR 全体コメント: `gh pr view --json reviews,comments,latestReviews`
+   - **未解決のインラインスレッド**（どの指摘がまだ open か）は GraphQL で `isResolved` を見る:
+
+     ```bash
+     gh api graphql -f query='
+       query($owner:String!,$repo:String!,$num:Int!){
+         repository(owner:$owner,name:$repo){
+           pullRequest(number:$num){
+             reviewThreads(first:100){
+               nodes{ isResolved isOutdated path
+                 comments(first:20){ nodes{ databaseId author{login} body } } } } } } }' \
+       -F owner="$owner" -F repo="$repo" -F num="$num"
+     ```
+
+2. `isResolved=false` のスレッドだけを対象に、指摘内容をコードで対処する。設計判断・仕様確認を伴う指摘（「この方針で良いか」「ここは別実装にすべきでは」等、機械的に直せないもの）は無理に実装せず、その旨を整理してユーザーにエスカレーションする。
+3. 修正を commit → `git push --force-with-lease "<head-remote>" HEAD:"$head"`（C/D と同じく push 先は解決済み `<head-remote>` の head ref に明示ピン。素の `git push` は使わない）。
+4. **fix を push してから**返信する（順序が逆だと「直した」と言ったのに反映されていない状態を作る）。返信は対応コミットを参照して簡潔に:
+   - 個別インラインスレッドへの返信: `gh api repos/$owner/$repo/pulls/$num/comments/<comment_databaseId>/replies -f body="<対応内容と commit>"`
+   - 全体への一言: `gh pr comment "$num" --body "<要約>"`
+5. **スレッドの resolve は確信があるときだけ**。基本はレビュアーに委ねる（自分で resolve すると、レビュアーが再確認する前に閉じてしまう）。
+
+C/D/E のどれも該当しなければ、この pass は「対処対象なし」。終了判定 B に戻って完了か継続待ちかを決める。
+
+## ループ制御とポーリング間隔
+
+この skill は**外部イベント待ちの長期ループ**。`/loop /pr-watch`（interval なしの dynamic mode）で回し、`ScheduleWakeup` で自分のペースを決めるのが基本形。
+
+間隔の選び方（Anthropic prompt cache は約 5 分 TTL。これを跨ぐと次回はキャッシュミスになる）:
+
+- **CI が実行中 / push 直後で再実行待ち / `mergeable=UNKNOWN`（GitHub 計算中）** → 短間隔 `~270s`。数分で変わる状態を追うので、キャッシュ窓に収める。
+- **対処対象が無く、人間レビュー待ちでアイドル** → 長間隔 `~1200–1800s`（20–30 分）。すぐ変わらないものを 5 分ごとに見てもキャッシュを焼くだけ。
+- **300s ちょうどは選ばない**（キャッシュミスを払うのに元が取れない最悪値）。短くするなら 270s、長くするなら 1200s 以上。
+
+1 pass で actionable が無いときの間隔は「**いま何を待っているか**」で決める。間隔ポリシーと矛盾させないこと:
+
+- **CI が実行中 / push 直後で再実行待ち / `mergeable=UNKNOWN`** → まだ状態が動くので**短間隔（~270s）**。actionable が無くても長間隔に送らない（落ちたらすぐ拾うため）。
+- **CI も green・衝突なし・新規レビューも無く、人間レビュー待ちで完全アイドル** → **長間隔（~1200–1800s）**。
+
+「今は対処対象なし（待っているもの: CI 実行中 / 人間レビュー など）。約 N 分後に再確認する」と 1 文報告してから、上記で選んだ間隔の `ScheduleWakeup` を入れる。完了（終了判定 B）したら `ScheduleWakeup` を入れずにループを終える。
+
+`/loop` を使わず `/pr-watch` 単発で呼ばれた場合は、1 pass を回して現状を報告し、まだ揃っていなければ「継続監視するなら `/loop /pr-watch` で回してください」と案内する（単発呼び出しで延々と待ち続けない）。
+
+## Oscillation セーフティ（暴走・無限 force-push 防止）
+
+完全自律 + force-push なので、同じ問題を直しきれずに繰り返すと無限ループ・無駄な履歴改変になる。これを防ぐため、各 pass で**直前 pass の対処対象を正規化リストで記憶**する:
+
+- コンフリクト: 衝突ファイル群 `<path>` の集合
+- CI: 失敗ジョブ `<workflow>/<job>` の集合
+- レビュー: 未解決スレッド `<path>:<指摘要旨1行>` の集合
+
+そして:
+
+- **2 pass 連続で同一集合かつ無進捗**（同じファイルが衝突し続ける / 同じ CI が落ち続ける / 同じ指摘が未解決のまま）なら、自動修正に入らず AskUserQuestion で 3 択を出す:
+
+  > pr-watch が 2 回連続で同じ問題を解消できていません: [概要]。
+  > (a) この項目は無視して残りの監視を続ける
+  > (b) 一旦停止する（自分で手を入れたい）
+  > (c) 別アプローチでもう一度だけ試す
+
+- **完全一致でなくても、3 pass 連続で同じファイル群に同種の問題が出続ける**なら同様に状況共有して判断を仰ぐ（文言だけ変わって本質が同じケースの保険）。
+
+「上限なしで揃うまで回す」運用でも、この振動検知だけは必ず効かせる。
+
+## 安全ガードレール
+
+- **全 push は解決済み `<head-remote>` の head ref に明示ピンする**（`git push [--force-with-lease] <head-remote> HEAD:<headRefName>`）。C の rebase 後・D の CI 修正・E のレビュー修正のいずれも対象。refspec 無しの素の push（`push.default` 依存で別ブランチを巻き込みうる）や無印 `--force` は使わない。fork PR では `<head-remote>` が `origin` でない／push 権限が無いことがあるので、解決手順で確認できなければ force-push せずエスカレーション。lease 失敗 = 他者更新ありとみなし、fetch して再評価し、状況をユーザーへ。
+- **操作対象は自分の head トピックブランチのみ**。`headRefName` が現在ブランチと一致することを確認してから触る。**他者が作成した PR、`main` / `master` / `release/*` 等の保護ブランチには force-push しない**。
+- **衝突を片側採用で機械的に潰さない**。確信が持てる hunk だけ自動解決し、意味的判断が要る箇所は abort してエスカレーション（C-4）。
+- **リポジトリのレビューゲートを尊重する**。`gh pr create` を `.claude/hooks/` 等でゲートしているリポジトリ（この repo の `pre-pr-review-gate.sh` 等）では、この skill は PR を作らないのでゲート対象外だが、push する fix にも品質基準を勝手に下げない。エスケープハッチ（`FANOUT_SKIP_PR_REVIEW` 等）を無断で使わない。
+- **CI を直すために CI 設定（ワークフロー yaml）を緩めて通す、テストを消して通す等の「通すための改竄」をしない**。原因を直すのが目的。設定変更が本当に必要なら理由を添えてユーザーに確認。
+
+## 終了報告
+
+ループ終了時（完了 / ユーザー停止 / oscillation 検知のいずれか）に 2〜3 文で:
+
+- 何 pass 回したか
+- 衝突 / CI / レビューを各何件処理したか（rebase 回数、push 回数、返信したスレッド数）
+- 最終状態（`MERGED` / approve+green で揃った / ユーザー判断で停止 / oscillation で残った項目）
+- 残課題があれば箇条書き（自動解決できなかった衝突、設計判断が要るレビュー指摘、flaky CI など）
+
+長い総括は不要。ユーザーは PR を見れば中身は分かる。
+
+## やらないこと
+
+- **PR の作成**: この skill は作成後の監視・対処担当。作成は別フロー。
+- **PR の自動マージ**: 「揃った」状態に持っていくところまで。明示的に「揃ったらマージして」と指示されない限り `gh pr merge` はしない（マージは不可逆で、タイミング・方式の判断が要る）。
+- **他者 PR・保護ブランチへの force-push**。
+- **レビュー指摘の良し悪し判定そのもの**: レビューの本質判断は `code-review` 系 skill の領分。ここは検知と対処と返信の制御。
+- **「通すための」CI 改竄 / テスト削除 / ゲート回避**。
+- **メモリへの新規エントリ追加**: この skill 自体がルールの保管庫。
+
+## トラブルシューティング
+
+- **`gh` 未認証**: `gh auth status` 失敗 → `gh auth login` を案内して終了。
+- **`mergeable=UNKNOWN` が続く**: GitHub がマージ可否を計算中。短間隔（~270s）で再 pass すれば確定する。確定前に rebase を急がない。
+- **rebase が複雑で自動解決不能**: `git rebase --abort` で安全に戻し、どの hunk が・なぜ駄目かを添えてユーザーへ（C-4）。
+- **`--force-with-lease` が reject**: 他者が同ブランチに push 済み。`git fetch` で取り込み、状況をユーザーに共有してから再評価。勝手に `--force` で踏み潰さない。
+- **CI ログが巨大**: `gh run view <run-id> --log-failed` で失敗ジョブのみ取得。全文は読まない。
+- **CI が flaky / インフラ起因**: コード修正で直らない。1 回 `gh run rerun <run-id> --failed` を促し、再現するならエスカレーション（D-4）。
+- **対象 PR がドラフト（`isDraft=true`）**: レビュー / マージ前提が揃わない。衝突・CI の追従はしてよいが、「ドラフトのままなので approve/マージ判定はスキップ」と明示する。

--- a/claude/skills/pr-watch/SKILL.md
+++ b/claude/skills/pr-watch/SKILL.md
@@ -76,12 +76,14 @@ C/D/E のどの push もこの解決に従う。head ref を `$head`（= `headRe
 me=$(gh api user -q .login)
 ```
 
-1. `headRepositoryOwner.login == $me`（head リポジトリが自分のもの）。
-2. PR の `author.login == $me`（自分が開いた PR）。
+1. PR の `author.login == $me`（自分が開いた PR）。
+2. **head ブランチに push 権限がある**。判定:
+   - `isCrossRepository == false`（head が base リポジトリにある = 通常の同一リポジトリ PR）→ そのリポジトリで作業できている以上 push 権限あり。**`headRepositoryOwner.login` が自分か org かは問わない**（org リポジトリでは head owner は org になるが、自分が author でメンバーなら push できる）。
+   - `isCrossRepository == true`（head が fork）→ `headRepositoryOwner.login == $me`（自分の fork）のときだけ push 権限あり。他者の fork は不可。
 
-両方要求するのは、`headRepositoryOwner.login` は **リポジトリの owner であって PR author とは限らない**ため。自分の repo に collaborator がブランチを作って PR を開いた場合、head owner は自分でも author は他人なので、author を見ないと他人のブランチを rewrite してしまう。`maintainerCanModify=true`（fork の「メンテナの編集を許可」）も認可根拠にしない（コミット追記の許可であって履歴 rewrite の許可ではない）。
+`author.login` を要に置くのは、`headRepositoryOwner.login` は **リポジトリ／org の owner であって PR author とは限らない**ため（自分の repo や org に collaborator がブランチを作って PR を開くと head owner は自分/org でも author は他人）。逆に head owner で絞ると、自分が author の org PR を弾いてしまう。`maintainerCanModify=true`（fork の「メンテナの編集を許可」）は認可根拠にしない（コミット追記の許可であって履歴 rewrite の許可ではない）。
 
-**push 先 remote `<head-remote>` の解決**: `isCrossRepository` に関わらず、PR の `headRepository`（owner/name・URL）に**実際に一致する local remote**を `git remote -v` から探して使う。`origin` 決め打ちにしないのは、fork レイアウト（`origin`=自分の fork、`upstream`=base repo）では `isCrossRepository=false` でも PR head が base repo 側に居て、`origin` に押すと別 ref を作るだけで PR head が変わらないため。一致する remote が無い（自分の）fork PR は `gh pr checkout <num>` で remote/追跡ブランチを用意してそれを使う。解決できなければエスカレーション。
+**push 先 remote `<head-remote>` の解決**: PR の `headRepository`（owner/name・URL）に**実際に一致する local remote**を `git remote -v` から探して使う（`isCrossRepository` に関わらず。`origin` 決め打ちにしないのは、fork レイアウトで `origin` が fork を指すと PR head を取り違えるため）。**一致する remote が無い場合**（自分の fork PR だが clone に base remote しか無い等。`gh pr checkout` は PR を出すが fork remote を追加しないことがある）は、`git remote add <name> <headRepository.url>` で remote を足して fetch するか、push 時に `headRepository` の URL を直接 refspec 先に使う（`git push --force-with-lease <url> HEAD:"$head"`）。それでも解決できなければエスカレーション。
 
 **ローカル HEAD が PR head を含むか検証**（rebase / force-push の前に必ず）:
 
@@ -112,7 +114,10 @@ git merge-base --is-ancestor FETCH_HEAD HEAD   # PR head が HEAD の祖先か
 対処に入る前に、まず「もう終わっていないか」を見る。無駄な rebase / 修正を避けるため、この判定を pass の先頭に置く:
 
 - `state` が `MERGED` または `CLOSED` → **完了**。終了報告して loop を抜ける。
-- `state=OPEN` かつ **`isDraft=false`** かつ `mergeable=MERGEABLE`（`mergeStateStatus=CLEAN`）かつ CI が全 `pass`/`skipping` かつ **A-3 の未対応スレッドが 0 かつ A-4 の未対応サマリ/トップレベル指摘が 0** → **やることなし＝実質完了**。「マージ可能・グリーンで未対応のレビュー指摘なし」と報告して loop を抜ける（PR の自動マージはしない。後述「やらないこと」）。完了判定はスレッド数だけでなく **A-4 のサマリ/トップレベル指摘も 0** であることを要件にする（`reviewDecision` だけで「指摘なし」と即断しない — COMMENTED スレッドやトップレベルコメントを取りこぼす）。なお「未対応」は E の skip ルール（自分が既に対応・返信済みでレビュアーの新規反応待ちのものは対応済み扱い）を適用して数える。
+- `state=OPEN` かつ **`isDraft=false`** かつ `mergeable=MERGEABLE`（`mergeStateStatus=CLEAN`）かつ CI が全 `pass`/`skipping` かつ **A-3 の未対応スレッドが 0 かつ A-4 の未対応サマリ/トップレベル指摘が 0** かつ **承認シグナルが立っている** → **完了**。「マージ可能・グリーン・承認済みで未対応のレビュー指摘なし」と報告して loop を抜ける（PR の自動マージはしない。後述「やらないこと」）。
+  - 「承認シグナル」は**レビュアーの種類で変わる**: 人間レビュアーが要るリポジトリでは `reviewDecision=APPROVED`。自動レビュー bot（例: codex-connector）では、その bot が再レビューして**新規 actionable を出さない clean 状態**が approve 相当（[[feedback_codex_review_approval]] のように 👍/clean をもって承認とみなす運用）。どちらの承認シグナルを使うかは pass の冒頭で決める。
+  - 「未対応」は E の skip ルール（自分が既に対応・返信済みでレビュアーの新規反応待ちのものは対応済み扱い）を適用して数える。`reviewDecision` だけで「指摘なし」と即断しない（COMMENTED スレッドやトップレベルコメントを取りこぼす）。
+- `state=OPEN` で **CI green・衝突なし・未対応指摘 0 だが、承認シグナルがまだ立っていない**（`reviewDecision=REVIEW_REQUIRED`/空でレビュー待ち、bot 再レビュー待ち等）→ **完了にはせず「reviewer-wait（アイドル）」として監視を継続**する。ここで loop を抜けると、この skill が本来拾うべき**遅れて来るレビュー / CI 変化を取りこぼす**。長間隔（後述）で「対処対象なし・承認待ち。約 N 分後に再確認」と報告して再 pass する。
 - **`isDraft=true`（ドラフト）なら完了にしない**。ドラフトはレビュー / マージ前提が揃わないので、衝突・CI の追従（C/D）は続けつつ「ドラフトのままなので approve/マージ判定はスキップ。ready 化待ち」と報告して**監視を継続**する（ここで loop を抜けると、ビルド途中のドラフトで監視が止まってしまう）。
 - それ以外 → C 以降で対処対象を洗う。
 
@@ -161,6 +166,8 @@ git merge-base --is-ancestor FETCH_HEAD HEAD   # PR head が HEAD の祖先か
 3. 修正を commit → `git push --force-with-lease "<head-remote>" HEAD:"$head"`（新規コミットを足すだけだが、`push.default` 依存を避けるため push 先は常に「push 先 remote の解決」で決めた `<head-remote>` の head ref に明示ピンする。rebase していないので fast-forward になり lease は通る）。push 後、CI は再実行されるので、この pass では「修正を push した。CI 再実行を待つ」とし、次 pass は短間隔で再確認する。
 4. **flaky / インフラ起因が疑われる失敗**（タイムアウト、外部サービス 5xx、無関係なネットワークエラー）はコード修正で直らない。1 回は再実行を促し（`gh run rerun <run-id> --failed` の提案）、それでも再現するならユーザーにエスカレーション。コードに無い原因をコードで延々いじらない。
 
+5. **必須チェックが未報告で `mergeStateStatus=BLOCKED`**（ブランチ保護が待っている required status が `gh pr checks` に `fail`/`cancel` として出てこない＝まだ走っていない / 報告が来ていない）の取り扱い。この状態は `fail`/`cancel` が無いので 1〜4 で拾えず、B も `BLOCKED` で完了できないため、**何もしないと idle で永遠にポーリングしてしまう**。`bucket=pending` の required チェックが進行中なら短間隔で待つ（CI 進行中扱い）。どのチェックも走っておらず required status が**欠落**しているなら、その required workflow を `gh run rerun`／再 dispatch するか、自動で起こせないなら「required チェック `<name>` が未報告で BLOCKED。手動でトリガー / 設定確認が要る」とユーザーにエスカレーションする（漫然と long-poll しない）。
+
 ### E. レビューコメント対応
 
 未対応のレビュー指摘を集めて、コードで対処する。対象は**インラインスレッドだけではない** — 次の 2 系統を両方拾う:
@@ -178,7 +185,7 @@ git merge-base --is-ancestor FETCH_HEAD HEAD   # PR head が HEAD の祖先か
                pageInfo{ hasNextPage endCursor }
                nodes{ isResolved isOutdated path line originalLine diffSide
                  topLevel: comments(first:1){ nodes{ databaseId body diffHunk } }
-                 latest:   comments(last:1){ nodes{ author{login} createdAt } } } } } } }' \
+                 latest:   comments(last:1){ nodes{ author{login} createdAt body } } } } } } }' \
        -F owner="$owner" -F repo="$repo" -F num="$num"
      ```
 
@@ -186,7 +193,7 @@ git merge-base --is-ancestor FETCH_HEAD HEAD   # PR head が HEAD の祖先か
 
      スレッドごとに次を取る:
      - **`topLevel`（`comments(first:1)`）の `databaseId` / `body` / `diffHunk`**、および スレッドの `path`/`line` = **対処すべき指摘そのもの**（本文・該当ハンク・位置）と返信先。reply エンドポイント（E-4）はこの先頭コメント ID しか受け付けない。**`body` を取らないと実装すべき内容が分からず、推測 / 空振りエスカレーションに陥る**ので必ず取得する。
-     - **`latest`（`comments(last:1)`）の `author`/`createdAt`** = skip 判定用の最新コメント。`comments(first:N)` で「古い方」を取って最新だと誤認しない（N を超えるとレビュアーの新しい反応を見落とし、対応済みと誤判定する）。スレッドのコメントが多いときは `last:` か末尾ページで最新を確実に取る。
+     - **`latest`（`comments(last:1)`）の `author`/`createdAt`/`body`** = skip 判定用の最新コメント。`comments(first:N)` で「古い方」を取って最新だと誤認しない（N を超えるとレビュアーの新しい反応を見落とし、対応済みと誤判定する）。スレッドのコメントが多いときは `last:` か末尾ページで最新を確実に取る。**最新が自分でなくレビュアーの新規返信のとき（再対応が必要なケース）は、対処すべき指摘は `topLevel.body` ではなく `latest.body`（レビュアーの新しい要求）**。古い先頭コメントだけ見て stale な内容を直さない。
 
 2. `isResolved=false` のスレッド **および 1 で拾ったサマリ／トップレベルの requested-change 本文**を対象に、指摘内容をコードで対処する。インラインスレッドが 0 でも `reviewDecision=CHANGES_REQUESTED` が残っているなら、レビュー本文側に対処対象があるとみなして拾う。
 
@@ -248,7 +255,7 @@ C/D/E のどれも該当しなければ、この pass は「対処対象なし�
 ## 安全ガードレール
 
 - **全 push は解決済み `<head-remote>` の head ref に明示ピンする**（`git push [--force-with-lease] <head-remote> HEAD:<headRefName>`）。C の rebase 後・D の CI 修正・E のレビュー修正のいずれも対象。refspec 無しの素の push（`push.default` 依存で別ブランチを巻き込みうる）や無印 `--force` は使わない。fork PR では `<head-remote>` が `origin` でない／push 権限が無いことがあるので、解決手順で確認できなければ force-push せずエスカレーション。lease 失敗 = 他者更新ありとみなし、fetch して再評価し、状況をユーザーへ。
-- **操作対象は自分の head トピックブランチのみ**。`headRefName` が現在ブランチと一致することを確認してから触る。**force-push の認可は「head リポジトリ owner == 今の認証ユーザー（`gh api user -q .login`）」かつ「PR `author` == 同ユーザー」の両方で判断する**（「push 先 remote の解決と force-push 認可」と同一基準）。owner だけで判断すると、自分が owner の repo に collaborator が作ったブランチを rewrite してしまう。`maintainerCanModify=true`（fork PR で「メンテナの編集を許可」）も認可根拠にしない — 履歴 rewrite の許可ではないので、他者 fork に force-push するとガードレール違反になる。**他者が作成した PR、`main` / `master` / `release/*` 等の保護ブランチには force-push しない**。
+- **操作対象は自分の head トピックブランチのみ**。`headRefName` が現在ブランチと一致することを確認してから触る。**force-push の認可は「PR `author` == 今の認証ユーザー（`gh api user -q .login`）」かつ「head ブランチに push 権限がある（同一リポジトリ PR は可／fork は `headRepositoryOwner.login==自分` の自分の fork のみ）」で判断する**（「push 先 remote の解決と force-push 認可」と同一基準）。head owner だけで絞ると org リポジトリの自分の PR（head owner=org）を弾くか、collaborator の同一リポジトリ PR を rewrite してしまうので、author を要に置く。`maintainerCanModify=true`（fork PR で「メンテナの編集を許可」）は認可根拠にしない — 履歴 rewrite の許可ではないので、他者 fork に force-push するとガードレール違反になる。**他者が作成した PR、`main` / `master` / `release/*` 等の保護ブランチには force-push しない**。
 - **衝突を片側採用で機械的に潰さない**。確信が持てる hunk だけ自動解決し、意味的判断が要る箇所は abort してエスカレーション（C-4）。
 - **リポジトリのレビューゲートを尊重する**。`gh pr create` を `.claude/hooks/` 等でゲートしているリポジトリ（この repo の `pre-pr-review-gate.sh` 等）では、この skill は PR を作らないのでゲート対象外だが、push する fix にも品質基準を勝手に下げない。エスケープハッチ（`FANOUT_SKIP_PR_REVIEW` 等）を無断で使わない。
 - **CI を直すために CI 設定（ワークフロー yaml）を緩めて通す、テストを消して通す等の「通すための改竄」をしない**。原因を直すのが目的。設定変更が本当に必要なら理由を添えてユーザーに確認。

--- a/claude/skills/pr-watch/SKILL.md
+++ b/claude/skills/pr-watch/SKILL.md
@@ -66,12 +66,24 @@ gh pr view --json number,state,isDraft,mergeable,mergeStateStatus,reviewDecision
 
 ### push 先 remote の解決（fork 対応・以降の全 push で使う）
 
-C/D/E のどの push もこの解決結果に従う。head ref を `$head`（= `headRefName`）とし、push 先 remote を次で決める:
+C/D/E のどの push もこの解決結果に従う。head ref を `$head`（= `headRefName`）とし、push 先 remote を次で決める。
+
+まず **force-push の認可**を判定する。基準は「head リポジトリの owner が今の認証ユーザー自身か」**だけ**:
+
+```bash
+me=$(gh api user -q .login)
+# headRepositoryOwner.login と $me が一致するか
+```
+
+- `headRepositoryOwner.login == $me`（= 自分のブランチ。非 fork PR は head owner が base owner と同じく自分）→ force-push **可**。
+- `headRepositoryOwner.login != $me`（= 他者の fork）→ **`maintainerCanModify=true`（「メンテナの編集を許可」）でも force-push しない**。履歴改変は「他者 PR に触らない」ガードレールそのものの違反で、`maintainerCanModify` は維持者によるコミット追記を許すだけで履歴 rewrite の許可ではない。新規コミット追記が要るケースも含め、他者 fork はユーザーにエスカレーションして判断を仰ぐ。
+
+そのうえで push 先 remote を決める:
 
 - `isCrossRepository=false`（head が base リポジトリにある通常ケース）→ 押し先は `origin`。
-- `isCrossRepository=true`（head が fork にある）→ `origin` に押すと base 側に別 ref を作るだけで **PR head は変わらない**。`gh pr checkout <num>` で正しい remote と追跡ブランチを設定し、その remote（`gh pr checkout` が作る `<owner>` 由来の remote、または `headRepositoryOwner.login` の fork を指す remote）へ押す。fork に push 権限が無い（`maintainerCanModify=false` かつ自分が head リポジトリの owner でない）なら **force-push せずエスカレーション**。
+- `isCrossRepository=true` かつ force-push 認可済み（自分の fork）→ `origin` に押すと base 側に別 ref を作るだけで **PR head は変わらない**。`gh pr checkout <num>` で正しい remote と追跡ブランチを設定し、その remote（`gh pr checkout` が作る `<owner>` 由来の remote、または `headRepositoryOwner.login` の fork を指す remote）へ押す。
 
-以降このドキュメントで `<head-remote>` と書いたら、ここで解決した remote を指す。全 push は明示 refspec `<head-remote> HEAD:"$head"` で行う（refspec を省略しない）。
+以降このドキュメントで `<head-remote>` と書いたら、ここで解決した remote を指す。全 push は明示 refspec `<head-remote> HEAD:"$head"` で行う（refspec を省略しない）。force-push 認可が取れない他者 fork では、ここで止めてエスカレーションし、以降の C/D/E の push は行わない。
 
 ## 1 反復（pass）の手順
 
@@ -79,14 +91,18 @@ C/D/E のどの push もこの解決結果に従う。head ref を `$head`（= `
 
 ### A. 状態取得
 
-上記 `gh pr view --json …` を 1 回叩いて、この pass の判断材料を揃える。CI の詳細が要るときだけ続けて `gh pr checks --json name,state,bucket,link,workflow` を叩く（`bucket` が `pass`/`fail`/`pending`/`skipping`/`cancel` を返す）。
+この pass の判断材料を、**B の終了判定に必要なものまで含めて先に揃える**（B が「CI 全 pass」「未解決スレッド 0」を見るのに、それらを A で取っていないと取りこぼす）。3 つを取る:
+
+1. `gh pr view --json …`（PR 状態）。
+2. CI: `gh pr checks --json name,state,bucket,link,workflow`（`bucket` が `pass`/`fail`/`pending`/`skipping`/`cancel`）。**`gh pr checks` は pending チェックがあると exit 8、失敗があると非 0 を返す**ので、exit code を成否判定に使わず、`gh pr checks … --json … || true` のように**必ず JSON を取り切ってから `bucket` で判断**する（exit 8 をコマンド失敗として扱うと、push→pending の窓でループが止まる）。
+3. 未解決レビュースレッド: E-1 の `reviewThreads` GraphQL を**この時点で**叩き、`isResolved=false` の件数（と中身）を持っておく。`reviewDecision` は COMMENTED レビューでは変わらないので、スレッドを実際に数えないと未解決指摘を見落とす。
 
 ### B. 終了判定（最初に行う）
 
 対処に入る前に、まず「もう終わっていないか」を見る。無駄な rebase / 修正を避けるため、この判定を pass の先頭に置く:
 
 - `state` が `MERGED` または `CLOSED` → **完了**。終了報告して loop を抜ける。
-- `state=OPEN` かつ `reviewDecision=APPROVED` かつ `mergeable=MERGEABLE`（`mergeStateStatus=CLEAN`）かつ CI が全 `pass`/`skipping` かつ未解決レビュースレッド 0 → **やることなし＝実質完了**。「マージ可能・承認済み・グリーンで未解決指摘なし」と報告して loop を抜ける（PR の自動マージはしない。後述「やらないこと」）。
+- `state=OPEN` かつ `reviewDecision=APPROVED` かつ `mergeable=MERGEABLE`（`mergeStateStatus=CLEAN`）かつ CI が全 `pass`/`skipping` かつ **A-3 で数えた未解決レビュースレッドが 0** → **やることなし＝実質完了**。「マージ可能・承認済み・グリーンで未解決指摘なし」と報告して loop を抜ける（PR の自動マージはしない。後述「やらないこと」）。未解決スレッドの 0 判定は必ず A-3 の `reviewThreads` 実取得に基づくこと（`reviewDecision` だけで「指摘なし」と即断しない — COMMENTED スレッドを取りこぼす）。
 - それ以外 → C 以降で対処対象を洗う。
 
 ### C. マージコンフリクト対応（rebase + 自動解決）
@@ -94,12 +110,14 @@ C/D/E のどの push もこの解決結果に従う。head ref を `$head`（= `
 `mergeable=CONFLICTING` または `mergeStateStatus` が `DIRTY` / `BEHIND` のとき:
 
 1. 作業ツリーが dirty なら、まず未コミット変更を commit するか stash するかを判断（勝手に捨てない）。
-2. ベースを取得して rebase:
+2. ベースを取得して rebase。**rebase 先は PR の base リポジトリの `$base`（= `baseRefName`）**であって、head（fork）側の同名ブランチではない。fork PR では `origin` が fork を指し base リポジトリは別 remote（`upstream` 等）のことがあるので、base リポジトリを指す remote を `<base-remote>` として解決してから当てる（非 fork なら `origin`。判別に迷うなら base repo の URL から直接 fetch する）:
 
    ```bash
-   git fetch origin "$base"            # base は baseRefName
-   git rebase "origin/$base"
+   git fetch "<base-remote>" "$base"   # 例: git fetch origin main / git fetch upstream main
+   git rebase FETCH_HEAD               # いま fetch したベースちょうどに当てる（remote 名のズレに影響されない）
    ```
+
+   `origin/$base` を直書きしないのは、fork 運用だと fork 側の古い・別物のベースに rebase してしまい、real base に対してまだ behind / conflicting な head を push しかねないため。
 
 3. 衝突が出たら、**確信が持てる箇所だけ自動解決**する。確信の基準は「両側の意図が明確で、機械的にどちらか / 両方を残せば正しいと言い切れる」こと（例: import 行の併合、片側が単なる行追加、フォーマット差）。解決したら `git add` → `git rebase --continue`。
 4. **意味的に判断が要る衝突は自動解決しない**: 同じ関数を両側で別ロジックに書き換えている、削除 vs 変更がぶつかる、テストの期待値が両側で食い違う等。`git rebase --abort` で安全な状態へ戻し、後述の oscillation セーフティと同じ要領でユーザーに状況を渡してエスカレーションする（どの hunk が・なぜ自動解決できないかを具体的に）。
@@ -118,13 +136,15 @@ C/D/E のどの push もこの解決結果に従う。head ref を `$head`（= `
 
 `gh pr checks --json name,state,bucket,link,workflow` で `bucket=fail` のチェックを特定する:
 
-1. 失敗したワークフロー実行のログを精読する。run id は失敗チェックの `link` から辿るか、`gh run list --branch "$head" --json databaseId,conclusion,workflowName` で取得し、**失敗ジョブのみ**を読む:
+1. 失敗チェックが **GitHub Actions の run か外部 CI かをまず判別する**。`gh pr checks --json` の各チェックの `link` が GitHub Actions の run URL（`…/actions/runs/<id>…`）か、`workflow` が埋まっているものだけが Actions。Actions なら失敗 run のログを **失敗ジョブのみ**精読する（run id は `link` から、または `gh run list --branch "$head" --json databaseId,conclusion,workflowName` で取得）:
 
    ```bash
    gh run view <run-id> --log-failed
    ```
 
    ログ全文ではなく失敗部分だけを取るのは、出力肥大とトークン浪費を避けるため。
+
+   **外部 CI（Buildkite / CircleCI / Jenkins 等、`link` が Actions の run でないチェック）は `gh run` で辿れない**。`gh run view` を当てに行かず、チェックの `link` URL を開いて原因を読むか、ログに自動アクセスできなければ「外部 CI `<name>` が失敗。`<link>` を確認してほしい」とユーザーにエスカレーションする。
 2. 原因を特定して修正する（lint / 型 / テスト / ビルド）。修正前に「CI の何が・なぜ落ちたか」と「何を直すか」を 1〜2 文で宣言。
 3. 修正を commit → `git push --force-with-lease "<head-remote>" HEAD:"$head"`（新規コミットを足すだけだが、`push.default` 依存を避けるため push 先は常に「push 先 remote の解決」で決めた `<head-remote>` の head ref に明示ピンする。rebase していないので fast-forward になり lease は通る）。push 後、CI は再実行されるので、この pass では「修正を push した。CI 再実行を待つ」とし、次 pass は短間隔で再確認する。
 4. **flaky / インフラ起因が疑われる失敗**（タイムアウト、外部サービス 5xx、無関係なネットワークエラー）はコード修正で直らない。1 回は再実行を促し（`gh run rerun <run-id> --failed` の提案）、それでも再現するならユーザーにエスカレーション。コードに無い原因をコードで延々いじらない。
@@ -148,10 +168,12 @@ C/D/E のどの push もこの解決結果に従う。head ref を `$head`（= `
        -F owner="$owner" -F repo="$repo" -F num="$num"
      ```
 
+     各スレッドについて **先頭（top-level）コメントの `databaseId`**（= `comments.nodes[0].databaseId`）を控えておく。返信エンドポイント（E-4）はこの top-level ID しか受け付けないため。
+
 2. `isResolved=false` のスレッドだけを対象に、指摘内容をコードで対処する。設計判断・仕様確認を伴う指摘（「この方針で良いか」「ここは別実装にすべきでは」等、機械的に直せないもの）は無理に実装せず、その旨を整理してユーザーにエスカレーションする。
 3. 修正を commit → `git push --force-with-lease "<head-remote>" HEAD:"$head"`（C/D と同じく push 先は解決済み `<head-remote>` の head ref に明示ピン。素の `git push` は使わない）。
 4. **fix を push してから**返信する（順序が逆だと「直した」と言ったのに反映されていない状態を作る）。返信は対応コミットを参照して簡潔に:
-   - 個別インラインスレッドへの返信: `gh api repos/$owner/$repo/pulls/$num/comments/<comment_databaseId>/replies -f body="<対応内容と commit>"`
+   - 個別インラインスレッドへの返信は **スレッド先頭コメントの `databaseId`**（E-1 で控えた `comments.nodes[0].databaseId`）に対して行う。返信コメントの ID を渡すと reply エンドポイントは 404 を返すので、必ず top-level ID を使う: `gh api repos/$owner/$repo/pulls/$num/comments/<top_level_databaseId>/replies -f body="<対応内容と commit>"`
    - 全体への一言: `gh pr comment "$num" --body "<要約>"`
 5. **スレッドの resolve は確信があるときだけ**。基本はレビュアーに委ねる（自分で resolve すると、レビュアーが再確認する前に閉じてしまう）。
 
@@ -200,7 +222,7 @@ C/D/E のどれも該当しなければ、この pass は「対処対象なし�
 ## 安全ガードレール
 
 - **全 push は解決済み `<head-remote>` の head ref に明示ピンする**（`git push [--force-with-lease] <head-remote> HEAD:<headRefName>`）。C の rebase 後・D の CI 修正・E のレビュー修正のいずれも対象。refspec 無しの素の push（`push.default` 依存で別ブランチを巻き込みうる）や無印 `--force` は使わない。fork PR では `<head-remote>` が `origin` でない／push 権限が無いことがあるので、解決手順で確認できなければ force-push せずエスカレーション。lease 失敗 = 他者更新ありとみなし、fetch して再評価し、状況をユーザーへ。
-- **操作対象は自分の head トピックブランチのみ**。`headRefName` が現在ブランチと一致することを確認してから触る。**他者が作成した PR、`main` / `master` / `release/*` 等の保護ブランチには force-push しない**。
+- **操作対象は自分の head トピックブランチのみ**。`headRefName` が現在ブランチと一致することを確認してから触る。**force-push の認可は「`headRefName` の head リポジトリ owner == 今の認証ユーザー（`gh api user -q .login`）」だけで判断する**。`maintainerCanModify=true`（fork PR で「メンテナの編集を許可」）は認可根拠にしない — 履歴 rewrite の許可ではないので、他者 fork に force-push するとガードレール違反になる。**他者が作成した PR、`main` / `master` / `release/*` 等の保護ブランチには force-push しない**。
 - **衝突を片側採用で機械的に潰さない**。確信が持てる hunk だけ自動解決し、意味的判断が要る箇所は abort してエスカレーション（C-4）。
 - **リポジトリのレビューゲートを尊重する**。`gh pr create` を `.claude/hooks/` 等でゲートしているリポジトリ（この repo の `pre-pr-review-gate.sh` 等）では、この skill は PR を作らないのでゲート対象外だが、push する fix にも品質基準を勝手に下げない。エスケープハッチ（`FANOUT_SKIP_PR_REVIEW` 等）を無断で使わない。
 - **CI を直すために CI 設定（ワークフロー yaml）を緩めて通す、テストを消して通す等の「通すための改竄」をしない**。原因を直すのが目的。設定変更が本当に必要なら理由を添えてユーザーに確認。

--- a/claude/skills/pr-watch/SKILL.md
+++ b/claude/skills/pr-watch/SKILL.md
@@ -100,18 +100,19 @@ git merge-base --is-ancestor FETCH_HEAD HEAD   # PR head が HEAD の祖先か
 
 ### A. 状態取得
 
-この pass の判断材料を、**B の終了判定に必要なものまで含めて先に揃える**（B が「CI 全 pass」「未解決スレッド 0」を見るのに、それらを A で取っていないと取りこぼす）。3 つを取る:
+この pass の判断材料を、**B の終了判定に必要なものまで含めて先に揃える**（B が「CI 全 pass」「未対応のレビュー指摘 0」を見るのに、それらを A で取っていないと取りこぼす）。4 つを取る:
 
 1. `gh pr view --json …`（PR 状態）。
 2. CI: `gh pr checks "$pr" --json name,state,bucket,link,workflow`（`$pr` を必ず渡す。`bucket` が `pass`/`fail`/`pending`/`skipping`/`cancel`）。**`gh pr checks` は pending チェックがあると exit 8、失敗があると非 0 を返す**ので、exit code を成否判定に使わず、`gh pr checks "$pr" --json … || true` のように**必ず JSON を取り切ってから `bucket` で判断**する（exit 8 をコマンド失敗として扱うと、push→pending の窓でループが止まる）。
-3. 未解決レビュースレッド: E-1 の `reviewThreads` GraphQL を**この時点で**叩き、`isResolved=false` の件数（と中身）を持っておく。`reviewDecision` は COMMENTED レビューでは変わらないので、スレッドを実際に数えないと未解決指摘を見落とす。
+3. 未解決レビュースレッド: E-1 の `reviewThreads` GraphQL を**この時点で**叩き、`isResolved=false` の件数（と中身・各スレッドの先頭/最新コメント）を持っておく。`reviewDecision` は COMMENTED レビューでは変わらないので、スレッドを実際に数えないと未解決指摘を見落とす。
+4. サマリ／トップレベルの actionable: E-1 と同じ `gh pr view "$pr" --json latestReviews,comments,reviewDecision` を取り、`latestReviews` の `state=CHANGES_REQUESTED` 本文・対応要求のトップレベルコメントを拾う。これらは**未解決 `reviewThread` を作らず `reviewDecision` も変えない**ことがあるので、B はスレッド数だけでなくこの「未対応のサマリ/トップレベル指摘」も 0 か見る（さもないと、トップレベルに actionable コメントが残っていても approve/green で完了扱いになる）。
 
 ### B. 終了判定（最初に行う）
 
 対処に入る前に、まず「もう終わっていないか」を見る。無駄な rebase / 修正を避けるため、この判定を pass の先頭に置く:
 
 - `state` が `MERGED` または `CLOSED` → **完了**。終了報告して loop を抜ける。
-- `state=OPEN` かつ `reviewDecision=APPROVED` かつ `mergeable=MERGEABLE`（`mergeStateStatus=CLEAN`）かつ CI が全 `pass`/`skipping` かつ **A-3 で数えた未解決レビュースレッドが 0** → **やることなし＝実質完了**。「マージ可能・承認済み・グリーンで未解決指摘なし」と報告して loop を抜ける（PR の自動マージはしない。後述「やらないこと」）。未解決スレッドの 0 判定は必ず A-3 の `reviewThreads` 実取得に基づくこと（`reviewDecision` だけで「指摘なし」と即断しない — COMMENTED スレッドを取りこぼす）。
+- `state=OPEN` かつ `mergeable=MERGEABLE`（`mergeStateStatus=CLEAN`）かつ CI が全 `pass`/`skipping` かつ **A-3 の未対応スレッドが 0 かつ A-4 の未対応サマリ/トップレベル指摘が 0** → **やることなし＝実質完了**。「マージ可能・グリーンで未対応のレビュー指摘なし」と報告して loop を抜ける（PR の自動マージはしない。後述「やらないこと」）。完了判定はスレッド数だけでなく **A-4 のサマリ/トップレベル指摘も 0** であることを要件にする（`reviewDecision` だけで「指摘なし」と即断しない — COMMENTED スレッドやトップレベルコメントを取りこぼす）。なお「未対応」は E の skip ルール（自分が既に対応・返信済みでレビュアーの新規反応待ちのものは対応済み扱い）を適用して数える。
 - それ以外 → C 以降で対処対象を洗う。
 
 ### C. マージコンフリクト対応（rebase + 自動解決）
@@ -175,22 +176,29 @@ git merge-base --is-ancestor FETCH_HEAD HEAD   # PR head が HEAD の祖先か
              reviewThreads(first:100, after:$endCursor){
                pageInfo{ hasNextPage endCursor }
                nodes{ isResolved isOutdated path
-                 comments(first:20){ nodes{ databaseId author{login} body } } } } } } }' \
+                 topLevel: comments(first:1){ nodes{ databaseId } }
+                 latest:   comments(last:1){ nodes{ author{login} createdAt } } } } } } }' \
        -F owner="$owner" -F repo="$repo" -F num="$num"
      ```
 
      **必ず全ページを辿る**（`--paginate` + `pageInfo.endCursor`）。`first:100` の 1 ページだけ見ると、スレッドが 100 を超える PR で後ろのページの未解決スレッドを取りこぼし、B が「未解決 0」と誤判定して完了してしまう。
 
-     各スレッドについて **先頭（top-level）コメントの `databaseId`**（= `comments.nodes[0].databaseId`）を控えておく。返信エンドポイント（E-4）はこの top-level ID しか受け付けないため。
+     スレッドごとに 2 つを別々に取る:
+     - **`topLevel`（`comments(first:1)`）の `databaseId`** = 返信先。reply エンドポイント（E-4）はこの先頭コメント ID しか受け付けない。
+     - **`latest`（`comments(last:1)`）の `author`/`createdAt`** = skip 判定用の最新コメント。`comments(first:N)` で「古い方」を取って最新だと誤認しない（N を超えるとレビュアーの新しい反応を見落とし、対応済みと誤判定する）。スレッドのコメントが多いときは `last:` か末尾ページで最新を確実に取る。
 
 2. `isResolved=false` のスレッド **および 1 で拾ったサマリ／トップレベルの requested-change 本文**を対象に、指摘内容をコードで対処する。インラインスレッドが 0 でも `reviewDecision=CHANGES_REQUESTED` が残っているなら、レビュー本文側に対処対象があるとみなして拾う。
 
-   **ただし「自分（watcher）が既に対応・返信済み」のスレッドは再処理しない**。resolve はレビュアーに委ねる方針（E-5）なので、対応済みスレッドも次 pass まで `isResolved=false` のまま見える。スレッドの**最新コメントが自分の返信**で、それ以降にレビュアーの新規コメントが無いなら「対応済み・レビュアー待ち」とみなして skip する（スレッドごとに「自分が最後に返信した commit / 時刻」を記憶し、レビュアーが新たに反応＝新規コメント追加 or resolve するまで触らない）。これをやらないと同じ修正・返信を毎 pass 重複させ、oscillation に陥る。
+   **ただし「自分（watcher）が既に対応・返信済み」の指摘は再処理しない**。これは**インラインスレッドにもサマリ／トップレベル指摘にも等しく適用する**。resolve はレビュアーに委ねる方針（E-5）なので、対応済みでも次 pass まで `isResolved=false`（スレッド）や `reviewDecision=CHANGES_REQUESTED`／元コメント（サマリ・トップレベル）として見え続ける:
+   - インラインスレッド: クエリの `latest`（`comments(last:1)`）が**自分の返信**で、それ以降にレビュアーの新規コメントが無いなら skip。
+   - サマリ／トップレベル: 自分が当該 requested-change に対する返信（review への返信や `gh pr comment`）を済ませ、その後レビュアーが新たに反応していないなら skip。
+
+   いずれも「自分が最後に対応・返信した commit / 時刻」をスレッド・レビュー単位で記憶し、レビュアーが新たに反応（新規コメント or resolve or 新しいレビュー）するまで触らない。これをやらないと同じ修正・返信を毎 pass 重複させ、oscillation に陥る。
 
    設計判断・仕様確認を伴う指摘（「この方針で良いか」「ここは別実装にすべきでは」等、機械的に直せないもの）は無理に実装せず、その旨を整理してユーザーにエスカレーションする。
 3. 修正を commit → `git push --force-with-lease "<head-remote>" HEAD:"$head"`（C/D と同じく push 先は解決済み `<head-remote>` の head ref に明示ピン。素の `git push` は使わない）。
 4. **fix を push してから**返信する（順序が逆だと「直した」と言ったのに反映されていない状態を作る）。返信は対応コミットを参照して簡潔に:
-   - 個別インラインスレッドへの返信は **スレッド先頭コメントの `databaseId`**（E-1 で控えた `comments.nodes[0].databaseId`）に対して行う。返信コメントの ID を渡すと reply エンドポイントは 404 を返すので、必ず top-level ID を使う: `gh api repos/$owner/$repo/pulls/$num/comments/<top_level_databaseId>/replies -f body="<対応内容と commit>"`
+   - 個別インラインスレッドへの返信は **スレッド先頭コメントの `databaseId`**（E-1 で控えた `topLevel.nodes[0].databaseId`）に対して行う。返信コメントの ID を渡すと reply エンドポイントは 404 を返すので、必ず top-level ID を使う: `gh api repos/$owner/$repo/pulls/$num/comments/<top_level_databaseId>/replies -f body="<対応内容と commit>"`
    - 全体への一言: `gh pr comment "$num" --body "<要約>"`
 5. **スレッドの resolve は確信があるときだけ**。基本はレビュアーに委ねる（自分で resolve すると、レビュアーが再確認する前に閉じてしまう）。
 

--- a/install.sh
+++ b/install.sh
@@ -103,9 +103,14 @@ install_data() {
   fi
 }
 
+# Uninstall runs before the release tarball is fetched/extracted, so the list of
+# integrations to remove cannot be derived from the source the way
+# install_integrations does. Keep this enumeration in sync with whatever
+# claude/commands, claude/skills, and codex/skills the repo ships.
 remove_integrations() {
-  rm -f "$claude_dir/commands/fanout.md"
-  rm -rf "$claude_dir/skills/fanout" "$claude_dir/skills/fanout-issues"
+  rm -f "$claude_dir/commands/fanout.md" "$claude_dir/commands/pr-watch.md"
+  rm -rf "$claude_dir/skills/fanout" "$claude_dir/skills/fanout-issues" \
+    "$claude_dir/skills/post-work-review" "$claude_dir/skills/pr-watch"
   rm -rf "$codex_dir/skills/fanout" "$codex_dir/skills/fanout-issues"
 }
 


### PR DESCRIPTION
## 概要

PR 作成後に時間差で発生する **マージコンフリクト / レビューコメント / CI 失敗** を、現在ブランチの PR に対して完全自律で監視・対処し続ける Claude Code skill `pr-watch` と、薄いラッパ slash command `/pr-watch` を追加します。`fanout` 非依存の素の `gh` / `git` ベースで、ユーザー全体（`~/.claude/skills/`）にも配布できる汎用スキルです。

`/loop /pr-watch`（dynamic）で回す前提。1 pass は「状態取得 → 終了判定 → コンフリクト → CI → レビューコメント → push」で、`ScheduleWakeup` により自己ペーシングします。

## 主な内容

- **コンフリクト**: ベースへ rebase し、確信が持てる hunk だけ自動解決。意味的判断が要る衝突は `git rebase --abort` で安全に戻してエスカレーション。
- **CI 失敗**: `gh run view --log-failed` で失敗ジョブのみ精読 → 原因修正 → push。flaky/インフラ起因は rerun 提案 → 再現でエスカレーション。
- **レビューコメント**: `reviewThreads` の `isResolved=false` を対象にコード対応 → push 後に返信。設計判断を伴う指摘はエスカレーション。
- **安全ガードレール**: 全 push は解決済み `<head-remote>` の head ref に明示ピン（`<remote> HEAD:<headRefName>`、`push.default`/upstream のズレや fork で別ブランチを巻き込まない）。`--force-with-lease` のみ・保護ブランチ不可・PR 自動マージしない・ゲート回避や「通すための」CI/テスト改竄をしない。
- **Oscillation セーフティ**: 2 pass 連続で同一無進捗なら自動修正に入らず `AskUserQuestion` で 3 択。無限 force-push を防ぐ。

## install.sh の非対称修正（同梱）

`install_integrations` は `claude/commands/*.md` と全 skill ディレクトリを data-driven に copy する一方、`remove_integrations` は固定リストで `fanout` / `fanout-issues` しか消していませんでした（`--uninstall` は tarball 展開前に early-exit するため、消す対象を source から導出できない）。`pr-watch` を追加し、既存の取りこぼし `post-work-review` も補完して、`install.sh --uninstall` が現行 integration を完全に消すようにしました。Makefile の `uninstall-integrations` は wildcard 由来で data-driven なため変更不要です。

## テスト / 検証

- ドキュメントのみの変更（Go ビルド挙動・web UI への影響なし）。
- 本文の `gh` コマンド・JSON フィールド（`mergeable` / `mergeStateStatus` / `reviewDecision` / `gh pr checks --json …bucket` / `gh run view --log-failed` / `reviewThreads` GraphQL / replies エンドポイント等）は実在を確認済み。
- `/post-work-review`（code-review プラグイン + codex review ×3 反復）で仕上げ済み。codex の指摘（force-push のブランチピン留め・fork PR の push 先・全 push のピン・CI 実行中の間隔矛盾・uninstall の非対称）をすべて反映し、最終 review は clean。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
