### PR TITLE
feat(planspec): add plan spec JSON package

### DIFF
--- a/internal/planspec/planspec.go
+++ b/internal/planspec/planspec.go
@@ -1,0 +1,260 @@
+// Package planspec loads and validates issue-less fanout plan specifications.
+package planspec
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/butaosuinu/fanout/internal/naming"
+)
+
+const Version = 1
+
+// Spec is the top-level JSON document consumed by fanout plan.
+type Spec struct {
+	Version int    `json:"version"`
+	Plan    Plan   `json:"plan"`
+	Tasks   []Task `json:"tasks"`
+}
+
+// Plan describes the parent plan that owns all tasks in the spec.
+type Plan struct {
+	Slug       string `json:"slug"`
+	Title      string `json:"title"`
+	Source     string `json:"source,omitempty"`
+	BaseBranch string `json:"base_branch,omitempty"`
+}
+
+// Task describes one issue-less fanout task.
+type Task struct {
+	ID          string   `json:"id"`
+	Title       string   `json:"title"`
+	Briefing    string   `json:"briefing"`
+	Slug        string   `json:"slug,omitempty"`
+	DisplayName string   `json:"display_name,omitempty"`
+	Branch      string   `json:"branch,omitempty"`
+	BlockedBy   []string `json:"blocked_by,omitempty"`
+	Wave        string   `json:"wave,omitempty"`
+}
+
+// Load reads, parses, and validates a plan spec JSON file.
+func Load(path string) (Spec, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Spec{}, fmt.Errorf("read plan spec %s: %w", path, err)
+	}
+	var spec Spec
+	if err := json.Unmarshal(data, &spec); err != nil {
+		return Spec{}, fmt.Errorf("parse plan spec %s: %w", path, err)
+	}
+	if err := Validate(spec); err != nil {
+		return Spec{}, fmt.Errorf("validate plan spec %s: %w", path, err)
+	}
+	return spec, nil
+}
+
+// Validate verifies that a plan spec is internally consistent.
+func Validate(spec Spec) error {
+	return spec.Validate()
+}
+
+// Validate verifies that a plan spec is internally consistent.
+func (s Spec) Validate() error {
+	var errs []error
+	if s.Version != Version {
+		errs = append(errs, fmt.Errorf("version must be %d, got %d", Version, s.Version))
+	}
+	errs = append(errs, validateRequiredKebab("plan.slug", s.Plan.Slug)...)
+	if strings.TrimSpace(s.Plan.Title) == "" {
+		errs = append(errs, fmt.Errorf("plan.title is required"))
+	}
+	if len(s.Tasks) == 0 {
+		errs = append(errs, fmt.Errorf("tasks must contain at least one task"))
+	}
+
+	seenIDs := map[string]int{}
+	seenSlugs := map[string]int{}
+	seenBranches := map[string]int{}
+	taskIDs := map[string]bool{}
+	for i, task := range s.Tasks {
+		if task.ID != "" {
+			taskIDs[task.ID] = true
+		}
+		errs = append(errs, validateTask(i, task)...)
+
+		if task.ID != "" {
+			if prev, ok := seenIDs[task.ID]; ok {
+				errs = append(errs, fmt.Errorf("tasks[%d].id %q duplicates tasks[%d].id", i, task.ID, prev))
+			} else {
+				seenIDs[task.ID] = i
+			}
+		}
+
+		if canResolveSlug(task) {
+			slug := task.ResolvedSlug()
+			if prev, ok := seenSlugs[slug]; ok {
+				errs = append(errs, fmt.Errorf("tasks[%d].slug %q duplicates tasks[%d].slug", i, slug, prev))
+			} else {
+				seenSlugs[slug] = i
+			}
+			branch := task.ResolvedBranch()
+			if prev, ok := seenBranches[branch]; ok {
+				errs = append(errs, fmt.Errorf("tasks[%d].branch %q duplicates tasks[%d].branch", i, branch, prev))
+			} else {
+				seenBranches[branch] = i
+			}
+		}
+	}
+
+	for i, task := range s.Tasks {
+		for j, dep := range task.BlockedBy {
+			if !taskIDs[dep] {
+				errs = append(errs, fmt.Errorf("tasks[%d].blocked_by[%d] references unknown task %q", i, j, dep))
+			}
+		}
+	}
+	if cycle := blockedByCycle(s.Tasks, taskIDs); len(cycle) > 0 {
+		errs = append(errs, fmt.Errorf("blocked_by cycle detected: %s", strings.Join(cycle, " -> ")))
+	}
+
+	return errors.Join(errs...)
+}
+
+func validateTask(i int, task Task) []error {
+	var errs []error
+	errs = append(errs, validateRequiredKebab(fmt.Sprintf("tasks[%d].id", i), task.ID)...)
+	if strings.TrimSpace(task.Title) == "" {
+		errs = append(errs, fmt.Errorf("tasks[%d].title is required", i))
+	}
+	if strings.TrimSpace(task.Briefing) == "" {
+		errs = append(errs, fmt.Errorf("tasks[%d].briefing is required", i))
+	}
+	if canResolveSlug(task) {
+		errs = append(errs, validateRequiredKebab(fmt.Sprintf("tasks[%d].slug", i), task.ResolvedSlug())...)
+	}
+	if task.Branch != "" && strings.ContainsAny(task.Branch, " \t\r\n") {
+		errs = append(errs, fmt.Errorf("tasks[%d].branch must not contain whitespace, got %q", i, task.Branch))
+	}
+	return errs
+}
+
+func validateRequiredKebab(field, value string) []error {
+	if value == "" {
+		return []error{fmt.Errorf("%s is required", field)}
+	}
+	var errs []error
+	if len(value) > naming.MaxSlugLength {
+		errs = append(errs, fmt.Errorf("%s length must be <= %d, got %d", field, naming.MaxSlugLength, len(value)))
+	}
+	if !isKebab(value) {
+		errs = append(errs, fmt.Errorf("%s must be lowercase kebab-case (alnum+hyphens, starting with alnum), got %q", field, value))
+	}
+	return errs
+}
+
+func isKebab(value string) bool {
+	for i, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+		case r == '-' && i > 0:
+		default:
+			return false
+		}
+	}
+	return value != ""
+}
+
+func canResolveSlug(task Task) bool {
+	return task.Slug != "" || (task.ID != "" && strings.TrimSpace(task.Title) != "")
+}
+
+// ResolvedSlug returns the explicit task slug or the deterministic default.
+func (t Task) ResolvedSlug() string {
+	return ResolveSlug(t)
+}
+
+// ResolveSlug returns the explicit task slug or the deterministic default.
+func ResolveSlug(task Task) string {
+	if task.Slug != "" {
+		return task.Slug
+	}
+	base := naming.Slugify(task.Title)
+	if base == "" {
+		base = "task"
+	}
+	suffix := "-" + task.ID
+	maxBase := naming.MaxSlugLength - len(suffix)
+	if maxBase < 1 {
+		return task.ID
+	}
+	if len(base) > maxBase {
+		base = strings.Trim(base[:maxBase], "-")
+		if base == "" {
+			base = "task"
+		}
+	}
+	return base + suffix
+}
+
+// ResolvedBranch returns the explicit task branch or the deterministic default.
+func (t Task) ResolvedBranch() string {
+	return ResolveBranch(t)
+}
+
+// ResolveBranch returns the explicit task branch or the deterministic default.
+func ResolveBranch(task Task) string {
+	return naming.BranchName(task.Branch, naming.DefaultBranchPrefix, ResolveSlug(task))
+}
+
+func blockedByCycle(tasks []Task, taskIDs map[string]bool) []string {
+	graph := make(map[string][]string, len(tasks))
+	for _, task := range tasks {
+		if task.ID == "" {
+			continue
+		}
+		for _, dep := range task.BlockedBy {
+			if taskIDs[dep] {
+				graph[task.ID] = append(graph[task.ID], dep)
+			}
+		}
+	}
+
+	state := map[string]int{}
+	stackIndex := map[string]int{}
+	var stack []string
+	var visit func(string) []string
+	visit = func(id string) []string {
+		switch state[id] {
+		case 1:
+			cycle := append([]string{}, stack[stackIndex[id]:]...)
+			return append(cycle, id)
+		case 2:
+			return nil
+		}
+		state[id] = 1
+		stackIndex[id] = len(stack)
+		stack = append(stack, id)
+		for _, dep := range graph[id] {
+			if cycle := visit(dep); len(cycle) > 0 {
+				return cycle
+			}
+		}
+		stack = stack[:len(stack)-1]
+		delete(stackIndex, id)
+		state[id] = 2
+		return nil
+	}
+
+	for _, task := range tasks {
+		if task.ID == "" {
+			continue
+		}
+		if cycle := visit(task.ID); len(cycle) > 0 {
+			return cycle
+		}
+	}
+	return nil
+}

--- a/internal/planspec/planspec_test.go
+++ b/internal/planspec/planspec_test.go
@@ -1,0 +1,334 @@
+package planspec
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/butaosuinu/fanout/internal/naming"
+)
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*Spec)
+		wantErr string
+	}{
+		{
+			name: "valid defaulted spec",
+		},
+		{
+			name: "valid explicit slug and branch",
+			mutate: func(spec *Spec) {
+				spec.Tasks[0].Slug = "base-types"
+				spec.Tasks[0].Branch = "feat/base-types"
+			},
+		},
+		{
+			name: "valid defaulted non ASCII task title",
+			mutate: func(spec *Spec) {
+				spec.Tasks[0].Title = "認証"
+			},
+		},
+		{
+			name: "version mismatch",
+			mutate: func(spec *Spec) {
+				spec.Version = 2
+			},
+			wantErr: "version must be 1, got 2",
+		},
+		{
+			name: "missing plan slug",
+			mutate: func(spec *Spec) {
+				spec.Plan.Slug = ""
+			},
+			wantErr: "plan.slug is required",
+		},
+		{
+			name: "invalid plan slug",
+			mutate: func(spec *Spec) {
+				spec.Plan.Slug = "Auth Refactor"
+			},
+			wantErr: "plan.slug must be lowercase kebab-case",
+		},
+		{
+			name: "plan slug too long",
+			mutate: func(spec *Spec) {
+				spec.Plan.Slug = strings.Repeat("a", naming.MaxSlugLength+1)
+			},
+			wantErr: "plan.slug length must be <= 80, got 81",
+		},
+		{
+			name: "missing plan title",
+			mutate: func(spec *Spec) {
+				spec.Plan.Title = " "
+			},
+			wantErr: "plan.title is required",
+		},
+		{
+			name: "empty task list",
+			mutate: func(spec *Spec) {
+				spec.Tasks = nil
+			},
+			wantErr: "tasks must contain at least one task",
+		},
+		{
+			name: "missing task id",
+			mutate: func(spec *Spec) {
+				spec.Tasks[0].ID = ""
+				spec.Tasks[1].BlockedBy = nil
+			},
+			wantErr: "tasks[0].id is required",
+		},
+		{
+			name: "invalid task id",
+			mutate: func(spec *Spec) {
+				spec.Tasks[0].ID = "Base Types"
+				spec.Tasks[1].BlockedBy = nil
+			},
+			wantErr: "tasks[0].id must be lowercase kebab-case",
+		},
+		{
+			name: "task id too long",
+			mutate: func(spec *Spec) {
+				spec.Tasks[0].ID = strings.Repeat("a", naming.MaxSlugLength+1)
+				spec.Tasks[1].BlockedBy = nil
+			},
+			wantErr: "tasks[0].id length must be <= 80, got 81",
+		},
+		{
+			name: "missing task title",
+			mutate: func(spec *Spec) {
+				spec.Tasks[0].Title = "\t"
+			},
+			wantErr: "tasks[0].title is required",
+		},
+		{
+			name: "missing task briefing",
+			mutate: func(spec *Spec) {
+				spec.Tasks[0].Briefing = "\n"
+			},
+			wantErr: "tasks[0].briefing is required",
+		},
+		{
+			name: "invalid resolved task slug",
+			mutate: func(spec *Spec) {
+				spec.Tasks[0].Slug = "Base Types"
+			},
+			wantErr: "tasks[0].slug must be lowercase kebab-case",
+		},
+		{
+			name: "resolved task slug too long",
+			mutate: func(spec *Spec) {
+				spec.Tasks[0].Slug = strings.Repeat("a", naming.MaxSlugLength+1)
+			},
+			wantErr: "tasks[0].slug length must be <= 80, got 81",
+		},
+		{
+			name: "duplicate task id",
+			mutate: func(spec *Spec) {
+				spec.Tasks[1].ID = "base-types"
+				spec.Tasks[1].BlockedBy = nil
+			},
+			wantErr: `tasks[1].id "base-types" duplicates tasks[0].id`,
+		},
+		{
+			name: "duplicate resolved task slug",
+			mutate: func(spec *Spec) {
+				spec.Tasks[0].Slug = "shared-task"
+				spec.Tasks[1].Slug = "shared-task"
+			},
+			wantErr: `tasks[1].slug "shared-task" duplicates tasks[0].slug`,
+		},
+		{
+			name: "duplicate resolved task branch",
+			mutate: func(spec *Spec) {
+				spec.Tasks[0].Branch = "feat/shared"
+				spec.Tasks[1].Branch = "feat/shared"
+			},
+			wantErr: `tasks[1].branch "feat/shared" duplicates tasks[0].branch`,
+		},
+		{
+			name: "branch contains whitespace",
+			mutate: func(spec *Spec) {
+				spec.Tasks[0].Branch = "feat/base types"
+			},
+			wantErr: `tasks[0].branch must not contain whitespace`,
+		},
+		{
+			name: "blocked_by references unknown task",
+			mutate: func(spec *Spec) {
+				spec.Tasks[1].BlockedBy = []string{"missing-task"}
+			},
+			wantErr: `tasks[1].blocked_by[0] references unknown task "missing-task"`,
+		},
+		{
+			name: "blocked_by cycle",
+			mutate: func(spec *Spec) {
+				spec.Tasks[0].BlockedBy = []string{"api-client"}
+			},
+			wantErr: "blocked_by cycle detected: base-types -> api-client -> base-types",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			spec := validSpec()
+			if tc.mutate != nil {
+				tc.mutate(&spec)
+			}
+
+			err := Validate(spec)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Validate() error = %v, want nil", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("Validate() error = nil, want %q", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("Validate() error = %v, want substring %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestTaskResolvedDefaults(t *testing.T) {
+	tests := []struct {
+		name       string
+		task       Task
+		wantSlug   string
+		wantBranch string
+	}{
+		{
+			name:       "derives slug and branch",
+			task:       Task{ID: "api-client", Title: "Extract auth API client"},
+			wantSlug:   "extract-auth-api-client-api-client",
+			wantBranch: "fanout/extract-auth-api-client-api-client",
+		},
+		{
+			name:       "falls back when title slug is empty",
+			task:       Task{ID: "api-client", Title: "認証 API"},
+			wantSlug:   "api-api-client",
+			wantBranch: "fanout/api-api-client",
+		},
+		{
+			name:       "falls back when title has no slug characters",
+			task:       Task{ID: "api-client", Title: "認証"},
+			wantSlug:   "task-api-client",
+			wantBranch: "fanout/task-api-client",
+		},
+		{
+			name:       "clamps derived slug length",
+			task:       Task{ID: "api-client", Title: strings.Repeat("a", 200)},
+			wantSlug:   strings.Repeat("a", naming.MaxSlugLength-len("-api-client")) + "-api-client",
+			wantBranch: "fanout/" + strings.Repeat("a", naming.MaxSlugLength-len("-api-client")) + "-api-client",
+		},
+		{
+			name:       "honors explicit slug and branch",
+			task:       Task{ID: "api-client", Title: "Extract auth API client", Slug: "extract-auth-api", Branch: "feat/auth-api-client"},
+			wantSlug:   "extract-auth-api",
+			wantBranch: "feat/auth-api-client",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.task.ResolvedSlug(); got != tc.wantSlug {
+				t.Fatalf("ResolvedSlug() = %q, want %q", got, tc.wantSlug)
+			}
+			if got := tc.task.ResolvedBranch(); got != tc.wantBranch {
+				t.Fatalf("ResolvedBranch() = %q, want %q", got, tc.wantBranch)
+			}
+			if got := ResolveSlug(tc.task); got != tc.wantSlug {
+				t.Fatalf("ResolveSlug() = %q, want %q", got, tc.wantSlug)
+			}
+			if got := ResolveBranch(tc.task); got != tc.wantBranch {
+				t.Fatalf("ResolveBranch() = %q, want %q", got, tc.wantBranch)
+			}
+		})
+	}
+}
+
+func TestLoad(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		wantErr string
+	}{
+		{
+			name: "valid spec",
+			body: `{
+				"version": 1,
+				"plan": {"slug": "auth-refactor", "title": "Auth refactor"},
+				"tasks": [{"id": "api-client", "title": "Extract API client", "briefing": "## Goal\nExtract it"}]
+			}`,
+		},
+		{
+			name:    "invalid json",
+			body:    `{"version":`,
+			wantErr: "parse plan spec",
+		},
+		{
+			name: "invalid spec",
+			body: `{
+				"version": 2,
+				"plan": {"slug": "auth-refactor", "title": "Auth refactor"},
+				"tasks": [{"id": "api-client", "title": "Extract API client", "briefing": "## Goal\nExtract it"}]
+			}`,
+			wantErr: "validate plan spec",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "spec.json")
+			if err := os.WriteFile(path, []byte(tc.body), 0o600); err != nil {
+				t.Fatalf("write spec: %v", err)
+			}
+			spec, err := Load(path)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Load() error = %v, want nil", err)
+				}
+				if spec.Version != Version {
+					t.Fatalf("Load() version = %d, want %d", spec.Version, Version)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("Load() error = nil, want %q", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("Load() error = %v, want substring %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func validSpec() Spec {
+	return Spec{
+		Version: Version,
+		Plan: Plan{
+			Slug:  "auth-refactor",
+			Title: "Auth refactor",
+		},
+		Tasks: []Task{
+			{
+				ID:       "base-types",
+				Title:    "Define base types",
+				Briefing: "## Goal\nDefine the shared types",
+			},
+			{
+				ID:        "api-client",
+				Title:     "Extract auth API client",
+				Briefing:  "## Goal\nExtract the API client",
+				BlockedBy: []string{"base-types"},
+				Wave:      "2",
+			},
+		},
+	}
+}


### PR DESCRIPTION
## TL;DR
Adds `internal/planspec` for plan spec JSON loading, validation, and default task slug/branch resolution. Review effort: 2

## Why
Issue #212 asks for a pure package that defines the JSON spec consumed later by `fanout plan`, using parent issue #211's settled format as the source of truth. This change keeps CLI wiring out of scope and only adds the reusable spec contract and validation layer.

```mermaid
flowchart LR
  Load["Load(path)"] --> Spec["Spec"]
  Spec --> Plan["Plan"]
  Spec --> Task["Task"]
  Validate["Validate(Spec)"] --> Spec
  Task --> Slug["ResolvedSlug()"]
  Task --> Branch["ResolvedBranch()"]
```

## Changes by file
<details><summary>Changed files</summary>

| File | What changed | Why |
| --- | --- | --- |
| `internal/planspec/planspec.go` | Added `Spec`, `Plan`, and `Task` JSON types, `Load`, `Validate`, blocked_by reference/cycle checks, uniqueness checks, and resolved slug/branch helpers. | Provide the pure package contract consumed by later `fanout plan` CLI work. |
| `internal/planspec/planspec_test.go` | Added table-driven coverage for valid specs, validation failures, cycle errors, Load parse/validate behavior, and default slug/branch derivation. | Lock issue #212 acceptance criteria and review-gate fixes. |

</details>

## Risk
This package is not wired into CLI execution yet; integration behavior lands in a later child issue.

## Test plan
- `GOCACHE="$(pwd)/.cache/go-build" go test ./internal/planspec` — pass
- `GOCACHE="$(pwd)/.cache/go-build" go vet ./...` — pass
- `make lint` — pass (0 issues)
- `make test` — pass
- `codex review --uncommitted` — pass; no actionable correctness issues

Closes #212
