### PR TITLE
[codex] fix dashboard session root resolution

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -364,7 +364,9 @@ fanout dashboard --web [--port N] [--open] [--no-token] [--no-keybind]
   を押すだけで開けます。ライブ fan-out 後（およびダッシュボード起動時）に fanout が
   この tmux キーバインドを自動登録するため、どのペインからでも呼び出せます。キーは
   detached な `fanout-dashboard` ウィンドウでサーバを起動するのでキー押下後も生き続け、
-  2 回目以降は既存 URL を開き直すだけです。自動登録は
+  2 回目以降は既存 URL を開き直すだけです。fanout は起動したペインに owner
+  project root を記録するため、Codex などの agent TUI で tmux の
+  `pane_current_path` が stale でも正しい dashboard を開けます。自動登録は
   `--no-dashboard-keybind`（fan-out）/ `--no-keybind`（dashboard）・設定キー
   `dashboardKeybind`・`FANOUT_DASHBOARD_KEYBIND=0` で無効化できます。
 - **Session テーブル + HUD。** 各ペイン行に issue・agent・wave と未解決

--- a/README.md
+++ b/README.md
@@ -434,9 +434,11 @@ fanout dashboard --web [--port N] [--open] [--no-token] [--no-keybind]
   itself starts) fanout registers that tmux keybinding for you, so any pane can
   pop the dashboard. The key launches the server in a detached
   `fanout-dashboard` window, so it outlives the keypress; a second press just
-  reopens the existing URL. Disable the auto-binding with `--no-dashboard-keybind`
-  (fan-out) / `--no-keybind` (dashboard), the `dashboardKeybind` config key, or
-  `FANOUT_DASHBOARD_KEYBIND=0`.
+  reopens the existing URL. fanout records the owning project root on launched
+  panes, so the key keeps working from agent TUIs such as Codex even when tmux
+  reports a stale `pane_current_path`. Disable the auto-binding with
+  `--no-dashboard-keybind` (fan-out) / `--no-keybind` (dashboard), the
+  `dashboardKeybind` config key, or `FANOUT_DASHBOARD_KEYBIND=0`.
 - **Session table + HUD.** Each pane row shows issue, agent, wave and open
   blockers (from the parent issue graph), branch, diff/dirty, CI status, tmux
   liveness with the current pane title and a `running` / `done` agent-state

--- a/claude/skills/fanout/SKILL.md
+++ b/claude/skills/fanout/SKILL.md
@@ -33,7 +33,7 @@ fanout --check-update               # Read-only version comparison
 fanout update                       # Replace fanout via install.sh
 ```
 
-`fanout dashboard --web` is a standalone subcommand (no parent argument): it starts a read-only, 127.0.0.1-bound web dashboard that visualizes all fanned-out Sessions live (pane liveness, issue/PR state). It is human-facing — surface it to the user when they ask to "watch"/"monitor" parallel panes, but do not run it as part of the fan-out flow. After a live fan-out, fanout also binds `prefix + D` in tmux to open it; pass `--no-dashboard-keybind` to suppress that.
+`fanout dashboard --web` is a standalone subcommand (no parent argument): it starts a read-only, 127.0.0.1-bound web dashboard that visualizes all fanned-out Sessions live (pane liveness, issue/PR state). It is human-facing — surface it to the user when they ask to "watch"/"monitor" parallel panes, but do not run it as part of the fan-out flow. After a live fan-out, fanout also binds `prefix + D` in tmux to open it; launched panes record their owner project root so the key still opens the right dashboard from agent TUIs such as Codex when tmux reports a stale `pane_current_path`. Pass `--no-dashboard-keybind` to suppress that.
 
 **Do not run `fanout --help`, `fanout -h`, or `which fanout`.** This SKILL.md is the source-of-truth for the CLI surface — every flag above is documented under "Running" below, and the binary path is `/Users/butaosuinu/.local/bin/fanout` (also stated in the next paragraph). Probing the CLI directly wastes a tool call and adds nothing.
 

--- a/cmd/fanout/dashboard.go
+++ b/cmd/fanout/dashboard.go
@@ -259,7 +259,8 @@ func bindDashboardKey(lg *log.Logger, enabled bool) {
 		return
 	}
 	// The binding resolves the repo from the pressing pane at keypress time
-	// (#{pane_current_path}) and cmdDashboard maps that to the main worktree, so
+	// (@fanout_project_root when fanout recorded it, otherwise
+	// #{pane_current_path}) and cmdDashboard maps that to the main worktree, so
 	// no repo root needs to be baked in here.
 	if err := tmuxrun.BindDashboardKey(defaultDashboardKey, bin); err != nil {
 		lg.Debug("dashboard keybind: %v (not in tmux?)", err)
@@ -277,13 +278,7 @@ func bindDashboardKey(lg *log.Logger, enabled bool) {
 // — it never escapes into an unrelated ancestor checkout that merely happens to
 // have its own .fanout/state.json. A never-fanned worktree falls back to itself.
 func dashboardProjectRoot() (string, error) {
-	top, err := gitToplevelFromCwd()
-	if err != nil {
-		return "", err
-	}
-	return resolveRootFromTop(top, func(dir string) bool {
-		return fileExists(filepath.Join(dir, ".fanout", "state.json"))
-	}), nil
+	return resolveDisplayProjectRoot()
 }
 
 func resolveRootFromTop(top string, hasState func(string) bool) string {

--- a/cmd/fanout/dashboard_test.go
+++ b/cmd/fanout/dashboard_test.go
@@ -102,6 +102,47 @@ func TestResolveRootFromTop(t *testing.T) {
 	}
 }
 
+func TestResolveDisplayProjectRootFromFallsBackToTmuxPaneState(t *testing.T) {
+	has := func(roots ...string) func(string) bool {
+		set := map[string]bool{}
+		for _, r := range roots {
+			set[r] = true
+		}
+		return func(dir string) bool { return set[dir] }
+	}
+
+	tmuxTop := func(root string) func() (string, error) {
+		return func() (string, error) { return root, nil }
+	}
+
+	// Codex/dmux can execute commands with a process cwd in a helper worktree
+	// while tmux still reports the visible pane path in the repo that owns the
+	// fanout state. Display commands should show the state-owning root instead
+	// of silently rendering an empty Session list from the helper worktree.
+	if got := resolveDisplayProjectRootFrom("/repo/.dmux/worktrees/codex", tmuxTop("/repo"), has("/repo")); got != "/repo" {
+		t.Fatalf("tmux fallback root = %q want /repo", got)
+	}
+
+	// The process cwd still wins when it already has fanout state; this keeps a
+	// normal checked-out worktree from being hijacked by a stale tmux cwd.
+	if got := resolveDisplayProjectRootFrom("/worktree", tmuxTop("/repo"), has("/worktree", "/repo")); got != "/worktree" {
+		t.Fatalf("cwd-owned root = %q want /worktree", got)
+	}
+
+	// A tmux pane that is itself in a fanned child worktree should resolve to
+	// the owner checkout that holds .fanout/state.json.
+	child := "/repo/.fanout/worktrees/child-1"
+	if got := resolveDisplayProjectRootFrom("/empty", tmuxTop(child), has("/repo")); got != "/repo" {
+		t.Fatalf("tmux child fallback root = %q want /repo", got)
+	}
+
+	// If neither side has fanout state, stay with the command cwd rather than
+	// guessing an unrelated tmux location.
+	if got := resolveDisplayProjectRootFrom("/empty", tmuxTop("/repo"), has()); got != "/empty" {
+		t.Fatalf("no-state fallback root = %q want /empty", got)
+	}
+}
+
 func TestRandomTokenIsHexAndUnique(t *testing.T) {
 	a, err := randomToken()
 	if err != nil {

--- a/cmd/fanout/main.go
+++ b/cmd/fanout/main.go
@@ -19,6 +19,7 @@ import (
 	fanoutruntime "github.com/butaosuinu/fanout/internal/runtime"
 	"github.com/butaosuinu/fanout/internal/settings"
 	"github.com/butaosuinu/fanout/internal/state"
+	"github.com/butaosuinu/fanout/internal/tmuxrun"
 	"github.com/butaosuinu/fanout/internal/worktree"
 )
 
@@ -279,10 +280,23 @@ func resolveRuntime(cfg *cliflags.Config, lg *log.Logger) (*runtimeInfo, exitcod
 		lg.Err("project root %s is not a git work tree; cannot resolve GitHub repo", info.ProjectRoot)
 		return nil, exitcode.Env
 	}
+	if !cfg.DryRun {
+		markCurrentPaneProjectRoot(info.ProjectRoot, lg)
+	}
 	return &runtimeInfo{
 		info: info,
 		gh:   ghissue.Runner{Cwd: info.ProjectRoot},
 	}, exitcode.OK
+}
+
+func markCurrentPaneProjectRoot(projectRoot string, lg *log.Logger) {
+	paneID := strings.TrimSpace(os.Getenv("TMUX_PANE"))
+	if paneID == "" {
+		return
+	}
+	if err := tmuxrun.SetPaneProjectRoot(paneID, projectRoot); err != nil {
+		lg.Debug("dashboard project root hint: %v", err)
+	}
 }
 
 type childLoadResult struct {

--- a/cmd/fanout/pane.go
+++ b/cmd/fanout/pane.go
@@ -122,6 +122,9 @@ func createPane(cfg *cliflags.Config, lg *log.Logger, info *fanoutruntime.Info, 
 	if err := tmuxrun.SetPaneTitle(paneID, paneTitle(req)); err != nil {
 		lg.Warn("#%d: %v", req.Number, err)
 	}
+	if err := tmuxrun.SetPaneProjectRoot(paneID, info.ProjectRoot); err != nil {
+		lg.Warn("#%d: dashboard project root hint: %v", req.Number, err)
+	}
 	if err := tmuxrun.SelectTiled(info.Target); err != nil {
 		lg.Warn("#%d: %v", req.Number, err)
 	}

--- a/cmd/fanout/state_runtime.go
+++ b/cmd/fanout/state_runtime.go
@@ -49,6 +49,67 @@ func resolveStateRuntime() (fanoutStateRuntime, error) {
 	return fanoutStateRuntime{projectRoot: root, statePath: state.Path(root)}, nil
 }
 
+// resolveDisplayProjectRoot resolves the project root whose fanout Session
+// state should be displayed by dashboard-style surfaces (the resident TUI and
+// web dashboard). Unlike action/status modes, display commands are often launched
+// from Codex/dmux wrappers whose process cwd can differ from the tmux pane's
+// visible current path. Prefer a conventional FANOUT_STATE_PATH
+// (<root>/.fanout/state.json), then the cwd root when it already owns state,
+// then the tmux pane path when that is the only state-owning root available.
+func resolveDisplayProjectRoot() (string, error) {
+	if raw := os.Getenv(fanoutStatePathEnv); raw != "" {
+		path, err := filepath.Abs(raw)
+		if err != nil {
+			path = raw
+		}
+		return inferProjectRootFromStatePath(path), nil
+	}
+	top, err := gitToplevelFromCwd()
+	if err != nil {
+		return "", err
+	}
+	return resolveDisplayProjectRootFrom(top, tmuxPaneGitToplevel, projectHasState), nil
+}
+
+func resolveDisplayProjectRootFrom(cwdTop string, tmuxTop func() (string, error), hasState func(string) bool) string {
+	cwdRoot := resolveRootFromTop(cwdTop, hasState)
+	if hasState(cwdRoot) {
+		return cwdRoot
+	}
+	if tmuxTop == nil {
+		return cwdRoot
+	}
+	top, err := tmuxTop()
+	if err != nil || strings.TrimSpace(top) == "" {
+		return cwdRoot
+	}
+	tmuxRoot := resolveRootFromTop(top, hasState)
+	if hasState(tmuxRoot) {
+		return tmuxRoot
+	}
+	return cwdRoot
+}
+
+func projectHasState(dir string) bool {
+	return fileExists(state.Path(dir))
+}
+
+func tmuxPaneGitToplevel() (string, error) {
+	pane := strings.TrimSpace(os.Getenv("TMUX_PANE"))
+	if pane == "" {
+		return "", fmt.Errorf("not inside a tmux pane")
+	}
+	out, err := exec.Command("tmux", "display-message", "-p", "-t", pane, "#{pane_current_path}").Output()
+	if err != nil {
+		return "", fmt.Errorf("tmux display-message pane_current_path: %w", err)
+	}
+	path := strings.TrimSpace(string(out))
+	if path == "" {
+		return "", fmt.Errorf("tmux pane current path is empty")
+	}
+	return gitToplevelAt(path)
+}
+
 func inferProjectRootFromStatePath(path string) string {
 	stateDir := filepath.Dir(path)
 	if filepath.Base(stateDir) == ".fanout" {
@@ -61,7 +122,15 @@ func inferProjectRootFromStatePath(path string) string {
 }
 
 func gitToplevelFromCwd() (string, error) {
-	out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	return gitToplevelAt("")
+}
+
+func gitToplevelAt(dir string) (string, error) {
+	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	if strings.TrimSpace(dir) != "" {
+		cmd.Dir = dir
+	}
+	out, err := cmd.Output()
 	if err != nil {
 		return "", fmt.Errorf("current directory is not inside a git work tree")
 	}

--- a/cmd/fanout/tui.go
+++ b/cmd/fanout/tui.go
@@ -6,7 +6,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -56,7 +55,7 @@ func cmdTUI(commandName string, lg *log.Logger) exitcode.Code {
 		lg.Err("notifications: %v", err)
 		return exitcode.Env
 	}
-	restoreTitle := markTUIRunning()
+	restoreTitle := markTUIRunning(projectRoot)
 	defer restoreTitle()
 	if err := fanouttui.Run(fanouttui.Options{
 		ProjectRoot:   projectRoot,
@@ -239,11 +238,12 @@ func enterTUISession(projectRoot, commandName string, lg *log.Logger) exitcode.C
 	return exitcode.OK
 }
 
-func markTUIRunning() func() {
+func markTUIRunning(projectRoot string) func() {
 	paneID := strings.TrimSpace(os.Getenv("TMUX_PANE"))
 	if paneID == "" {
 		return func() {}
 	}
+	_ = tmuxrun.SetPaneProjectRoot(paneID, projectRoot) // Best-effort dashboard keybinding hint.
 	originalTitle, err := tmuxrun.PaneTitle(paneID)
 	if err != nil {
 		originalTitle = "fanout"
@@ -279,15 +279,7 @@ func firstSessionPane(session string) (tmuxrun.PaneInfo, error) {
 }
 
 func tuiProjectRoot() (string, error) {
-	out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
-	if err != nil {
-		return "", fmt.Errorf("current directory is not inside a git work tree")
-	}
-	root := strings.TrimSpace(string(out))
-	if root == "" {
-		return "", fmt.Errorf("git rev-parse --show-toplevel returned an empty path")
-	}
-	return root, nil
+	return resolveDisplayProjectRoot()
 }
 
 func fanoutTUISessionName(projectRoot string) string {

--- a/codex/skills/fanout/SKILL.md
+++ b/codex/skills/fanout/SKILL.md
@@ -35,7 +35,7 @@ fanout --check-update               # Read-only version comparison
 fanout update                       # Replace fanout via install.sh
 ```
 
-`fanout dashboard --web` is a standalone subcommand (no parent argument): a read-only, 127.0.0.1-bound web dashboard that visualizes all fanned-out Sessions live (pane liveness, issue/PR state). It is human-facing — surface it when the user wants to watch/monitor parallel panes, not as part of the fan-out flow. After a live fan-out, fanout also binds `prefix + D` in tmux to open it; `--no-dashboard-keybind` suppresses that.
+`fanout dashboard --web` is a standalone subcommand (no parent argument): a read-only, 127.0.0.1-bound web dashboard that visualizes all fanned-out Sessions live (pane liveness, issue/PR state). It is human-facing — surface it when the user wants to watch/monitor parallel panes, not as part of the fan-out flow. After a live fan-out, fanout also binds `prefix + D` in tmux to open it; launched panes record their owner project root so the key still opens the right dashboard from agent TUIs such as Codex when tmux reports a stale `pane_current_path`. `--no-dashboard-keybind` suppresses the binding.
 
 **Do not probe the CLI** with `fanout --help`, `fanout -h`, or
 `which fanout`. This SKILL.md is the source-of-truth for the CLI surface —

--- a/internal/tmuxrun/tmuxrun.go
+++ b/internal/tmuxrun/tmuxrun.go
@@ -24,6 +24,7 @@ const (
 	// tmux 3.6a/macOS; Linux resolves the foreground pgrp leader the same way).
 	// Pane user options die with the pane, matching the liveness boundary.
 	agentStateOption         = "@fanout_agent_state"
+	projectRootOption        = "@fanout_project_root"
 	livePaneAgentStateFormat = "#{pane_id}\t#{" + agentStateOption + "}"
 	paneAlternateFormat      = "#{alternate_on}"
 )
@@ -250,11 +251,14 @@ func parseLivePaneField(out string) map[string]string {
 // opens the read-only web dashboard. It binds the key directly to `new-window`
 // (not run-shell), so:
 //
-//   - tmux expands `#{pane_current_path}` to the *active pane's* cwd at keypress
-//     time, making a single global key open the dashboard for whichever repo the
-//     pressing pane belongs to (multi-repo / multi-session safe). cmdDashboard
-//     then resolves that cwd to the main working tree, so pressing from a child
-//     worktree pane still reads the parent `.fanout/state.json`.
+//   - tmux expands @fanout_project_root (when fanout recorded it on the pane)
+//     or `#{pane_current_path}` at keypress time, making a single global key
+//     open the dashboard for whichever repo the pressing pane belongs to
+//     (multi-repo / multi-session safe). The explicit pane option covers agent
+//     TUIs such as Codex where tmux's current-path signal can remain stuck on
+//     the parent shell's cwd. cmdDashboard then resolves that cwd to the main
+//     working tree, so pressing from a child worktree pane still reads the
+//     parent `.fanout/state.json`.
 //   - The command runs through exactly one shell (new-window's), so the binary
 //     path needs a single level of quoting — handling install paths with spaces
 //     without the fragile double-quoting a run-shell wrapper would require.
@@ -271,12 +275,29 @@ func BindDashboardKey(key, fanoutBin string) error {
 		return fmt.Errorf("tmux bind-key: key and fanout binary path are required")
 	}
 	launch := shellQuote(fanoutBin) + " dashboard --web --open"
+	startDir := "#{?@fanout_project_root,#{@fanout_project_root},#{pane_current_path}}"
 	args := []string{
 		"bind-key", key, "new-window", "-d", "-n", "fanout-dashboard",
-		"-c", "#{pane_current_path}", launch,
+		"-c", startDir, launch,
 	}
 	if err := exec.Command("tmux", args...).Run(); err != nil {
 		return fmt.Errorf("tmux bind-key %s: %w", key, err)
+	}
+	return nil
+}
+
+// SetPaneProjectRoot records the fanout state owner on a pane. The dashboard
+// keybinding prefers this over #{pane_current_path}, which can be stale inside
+// agent TUIs such as Codex that do not update tmux's foreground cwd signal.
+func SetPaneProjectRoot(paneID, projectRoot string) error {
+	if strings.TrimSpace(paneID) == "" {
+		return fmt.Errorf("pane id is required")
+	}
+	if strings.TrimSpace(projectRoot) == "" {
+		return fmt.Errorf("project root is required")
+	}
+	if err := exec.Command("tmux", "set-option", "-p", "-t", paneID, projectRootOption, projectRoot).Run(); err != nil {
+		return fmt.Errorf("tmux set-option %s: %w", projectRootOption, err)
 	}
 	return nil
 }

--- a/internal/tmuxrun/tmuxrun_test.go
+++ b/internal/tmuxrun/tmuxrun_test.go
@@ -365,8 +365,12 @@ printf '%s\n' "$@" > "$TMUXRUN_ARGS"
 	}
 	got := strings.Split(strings.TrimRight(string(body), "\n"), "\n")
 	// Each tmux argv on its own line: bind-key D new-window -d -n
-	// fanout-dashboard -c #{pane_current_path} <launch>.
-	want := []string{"bind-key", "D", "new-window", "-d", "-n", "fanout-dashboard", "-c", "#{pane_current_path}", "/abs/path/fanout dashboard --web --open"}
+	// fanout-dashboard -c <root-or-current-path> <launch>.
+	want := []string{
+		"bind-key", "D", "new-window", "-d", "-n", "fanout-dashboard",
+		"-c", "#{?@fanout_project_root,#{@fanout_project_root},#{pane_current_path}}",
+		"/abs/path/fanout dashboard --web --open",
+	}
 	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
 		t.Fatalf("tmux args = %#v, want %#v", got, want)
 	}
@@ -408,6 +412,19 @@ func TestBindDashboardKeyRejectsEmptyArgs(t *testing.T) {
 	if err := BindDashboardKey("D", ""); err == nil {
 		t.Fatal("BindDashboardKey(empty bin) should error")
 	}
+}
+
+func TestSetPaneProjectRoot(t *testing.T) {
+	argsPath := installTmuxShim(t, `printf '%s\n' "$@" > "$TMUXRUN_ARGS"
+`)
+
+	if err := SetPaneProjectRoot("%42", "/tmp/My Repo"); err != nil {
+		t.Fatalf("SetPaneProjectRoot() failed: %v", err)
+	}
+
+	assertTmuxArgs(t, argsPath, []string{
+		"set-option", "-p", "-t", "%42", "@fanout_project_root", "/tmp/My Repo",
+	})
 }
 
 func TestBuildPaneLaunchCommandUsesUserShellAndKeepsPaneOpen(t *testing.T) {


### PR DESCRIPTION
## Summary
- TUI / Web dashboard の Session 表示で使う project root 解決を共通化
- Codex/dmux のように process cwd と tmux pane path がずれる環境で、state を持つ owner root を選べるように修正
- launched pane / TUI pane / fanout 実行元 pane に `@fanout_project_root` を記録し、`prefix + D` dashboard keybind がそれを優先するように変更
- README / README.ja / bundled Claude・Codex skill の dashboard keybind 説明を更新

## Root Cause
Codex 上で fanout を実行すると、プロセスの cwd、tmux の `pane_current_path`、実際に `.fanout/state.json` を持つ owner worktree が一致しないことがある。TUI と Web dashboard が cwd または stale な `pane_current_path` を基準に state を読んだ結果、Session リストが空または別 checkout の state になっていた。

## Validation
- `go test ./cmd/fanout`
- `go test ./internal/tmuxrun`
- `go test ./...`
- `make build-go`
- `make test`
- `make lint`
- `git diff --check`