### PR TITLE
feat(state,ghissue): TaskID state 行と branch PR 解決を追加

### DIFF
--- a/internal/ghissue/ghissue.go
+++ b/internal/ghissue/ghissue.go
@@ -338,6 +338,27 @@ func (r Runner) IssueWithPRs(owner, repo string, num int) (state string, prs []P
 	return snapshot.State, snapshot.PRs, nil
 }
 
+func (r Runner) PRsForBranch(branch string) ([]PRRef, error) {
+	out, err := r.gh(
+		"pr", "list",
+		"--head", branch,
+		"--state", "all",
+		"--json", "number,state,mergedAt,isDraft,reviewDecision,statusCheckRollup",
+	)
+	if err != nil {
+		return nil, err
+	}
+	var refs []prListItem
+	if err := json.Unmarshal(out, &refs); err != nil {
+		return nil, fmt.Errorf("parse gh pr list --head %q: %w", branch, err)
+	}
+	prs := make([]PRRef, 0, len(refs))
+	for _, pr := range refs {
+		prs = append(prs, pr.ref())
+	}
+	return prs, nil
+}
+
 type prRefGraphQL struct {
 	Number         int     `json:"number"`
 	State          string  `json:"state"`
@@ -355,6 +376,15 @@ type prRefGraphQL struct {
 	} `json:"commits"`
 }
 
+type prListItem struct {
+	Number            int             `json:"number"`
+	State             string          `json:"state"`
+	MergedAt          *string         `json:"mergedAt"`
+	IsDraft           bool            `json:"isDraft"`
+	ReviewDecision    string          `json:"reviewDecision"`
+	StatusCheckRollup json.RawMessage `json:"statusCheckRollup"`
+}
+
 func (pr prRefGraphQL) ref() PRRef {
 	return PRRef{
 		Number:         pr.Number,
@@ -366,11 +396,74 @@ func (pr prRefGraphQL) ref() PRRef {
 	}
 }
 
+func (pr prListItem) ref() PRRef {
+	return PRRef{
+		Number:         pr.Number,
+		State:          pr.State,
+		MergedAt:       pr.MergedAt,
+		IsDraft:        pr.IsDraft,
+		ReviewDecision: pr.ReviewDecision,
+		CIStatus:       ciStatusFromStatusCheckRollup(pr.StatusCheckRollup),
+	}
+}
+
 func (pr prRefGraphQL) statusCheckRollupState() string {
 	if len(pr.Commits.Nodes) == 0 || pr.Commits.Nodes[0].Commit.StatusCheckRollup == nil {
 		return ""
 	}
 	return pr.Commits.Nodes[0].Commit.StatusCheckRollup.State
+}
+
+func ciStatusFromStatusCheckRollup(raw json.RawMessage) string {
+	trimmed := strings.TrimSpace(string(raw))
+	if trimmed == "" || trimmed == "null" {
+		return ""
+	}
+
+	var rollup struct {
+		State string `json:"state"`
+	}
+	if err := json.Unmarshal(raw, &rollup); err == nil && strings.TrimSpace(rollup.State) != "" {
+		return normalizeCIStatus(rollup.State)
+	}
+
+	var checks []struct {
+		State      string `json:"state"`
+		Conclusion string `json:"conclusion"`
+		Status     string `json:"status"`
+	}
+	if err := json.Unmarshal(raw, &checks); err != nil {
+		return ""
+	}
+
+	sawPass := false
+	sawPending := false
+	for _, check := range checks {
+		status := strings.ToUpper(strings.TrimSpace(check.Status))
+		if status != "" && status != "COMPLETED" {
+			sawPending = true
+			continue
+		}
+		state := check.State
+		if strings.TrimSpace(state) == "" {
+			state = check.Conclusion
+		}
+		switch normalizeCIStatus(state) {
+		case "fail":
+			return "fail"
+		case "pending":
+			sawPending = true
+		case "pass":
+			sawPass = true
+		}
+	}
+	if sawPending {
+		return "pending"
+	}
+	if sawPass {
+		return "pass"
+	}
+	return ""
 }
 
 func normalizeCIStatus(state string) string {
@@ -379,7 +472,7 @@ func normalizeCIStatus(state string) string {
 		return ""
 	case "SUCCESS":
 		return "pass"
-	case "ERROR", "FAILURE":
+	case "ACTION_REQUIRED", "CANCELLED", "CANCELED", "ERROR", "FAILURE", "STARTUP_FAILURE", "TIMED_OUT": //nolint:misspell // GitHub's CheckConclusionState enum spells this CANCELLED.
 		return "fail"
 	case "EXPECTED", "PENDING":
 		return "pending"

--- a/internal/ghissue/ghissue_test.go
+++ b/internal/ghissue/ghissue_test.go
@@ -1,6 +1,12 @@
 package ghissue
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
 
 func TestPRRefDisplayState(t *testing.T) {
 	mergedAt := "2026-06-09T00:00:00Z"
@@ -70,6 +76,87 @@ func TestSummarizeCI(t *testing.T) {
 	}
 }
 
+func TestPRsForBranchMapsListOutput(t *testing.T) {
+	mergedAt := "2026-06-13T01:02:03Z"
+	argsPath := installFakeGH(t, `[
+  {
+    "number": 10,
+    "state": "MERGED",
+    "mergedAt": "2026-06-13T01:02:03Z",
+    "isDraft": false,
+    "reviewDecision": "APPROVED",
+    "statusCheckRollup": {"state": "SUCCESS"}
+  },
+  {
+    "number": 11,
+    "state": "OPEN",
+    "mergedAt": null,
+    "isDraft": true,
+    "reviewDecision": "REVIEW_REQUIRED",
+    "statusCheckRollup": [{"status": "IN_PROGRESS"}]
+  },
+  {
+    "number": 12,
+    "state": "OPEN",
+    "mergedAt": null,
+    "isDraft": false,
+    "reviewDecision": "",
+    "statusCheckRollup": [
+      {"status": "COMPLETED", "conclusion": "SUCCESS"},
+      {"status": "COMPLETED", "conclusion": "TIMED_OUT"}
+    ]
+  }
+]`)
+
+	got, err := (Runner{}).PRsForBranch("fanout/taskid-state-pr-213")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []PRRef{
+		{
+			Number:         10,
+			State:          "MERGED",
+			MergedAt:       &mergedAt,
+			ReviewDecision: "APPROVED",
+			CIStatus:       "pass",
+		},
+		{
+			Number:         11,
+			State:          "OPEN",
+			IsDraft:        true,
+			ReviewDecision: "REVIEW_REQUIRED",
+			CIStatus:       "pending",
+		},
+		{
+			Number:   12,
+			State:    "OPEN",
+			CIStatus: "fail",
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("PRsForBranch() = %#v, want %#v", got, want)
+	}
+	assertFakeGHArgs(t, argsPath, []string{
+		"pr", "list",
+		"--head", "fanout/taskid-state-pr-213",
+		"--state", "all",
+		"--json", "number,state,mergedAt,isDraft,reviewDecision,statusCheckRollup",
+	})
+}
+
+func TestPRsForBranchReturnsEmptyList(t *testing.T) {
+	installFakeGH(t, `[]`)
+
+	got, err := (Runner{}).PRsForBranch("fanout/no-prs")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("PRsForBranch() = %#v, want empty", got)
+	}
+}
+
 func TestNormalizeCIStatus(t *testing.T) {
 	for _, tc := range []struct {
 		in   string
@@ -78,6 +165,10 @@ func TestNormalizeCIStatus(t *testing.T) {
 		{in: "SUCCESS", want: "pass"},
 		{in: "FAILURE", want: "fail"},
 		{in: "ERROR", want: "fail"},
+		{in: "CANCELLED", want: "fail"}, //nolint:misspell // GitHub's CheckConclusionState enum spells this CANCELLED.
+		{in: "TIMED_OUT", want: "fail"},
+		{in: "ACTION_REQUIRED", want: "fail"},
+		{in: "STARTUP_FAILURE", want: "fail"},
 		{in: "PENDING", want: "pending"},
 		{in: "EXPECTED", want: "pending"},
 		{in: "", want: ""},
@@ -85,6 +176,37 @@ func TestNormalizeCIStatus(t *testing.T) {
 		if got := normalizeCIStatus(tc.in); got != tc.want {
 			t.Fatalf("normalizeCIStatus(%q) = %q, want %q", tc.in, got, tc.want)
 		}
+	}
+}
+
+func installFakeGH(t *testing.T, output string) string {
+	t.Helper()
+	dir := t.TempDir()
+	argsPath := filepath.Join(dir, "args")
+	script := filepath.Join(dir, "gh")
+	body := `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$@" > "$GH_FAKE_ARGS"
+printf '%s' "$GH_FAKE_OUTPUT"
+`
+	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GH_FAKE_ARGS", argsPath)
+	t.Setenv("GH_FAKE_OUTPUT", output)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return argsPath
+}
+
+func assertFakeGHArgs(t *testing.T, argsPath string, want []string) {
+	t.Helper()
+	data, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := strings.Split(strings.TrimSuffix(string(data), "\n"), "\n")
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("gh args = %#v, want %#v", got, want)
 	}
 }
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -19,13 +19,15 @@ type Store struct {
 	Panes         []Pane `json:"panes"`
 }
 
-// Pane records one launched agent pane. Parent and IssueNum form the
+// Pane records one launched agent pane. Parent and IssueNum form the legacy
 // idempotency key: issue fanout uses the parent issue or Project ref plus the
 // GitHub issue number, while synthetic launches use a reserved parent such as
 // @manual with non-GitHub numbers that only need to be unique under that parent.
+// TaskID is an additive key for issue-less task rows.
 type Pane struct {
 	Parent     string `json:"parent"`
 	IssueNum   int    `json:"issueNum"`
+	TaskID     string `json:"taskId,omitempty"`
 	Slug       string `json:"slug"`
 	BranchName string `json:"branchName"`
 	// BaseBranch is the resolved base branch the worktree branched from
@@ -125,7 +127,7 @@ func (l *LockedStore) Unlock() error {
 }
 
 func (l *LockedStore) RecordPane(p Pane) error {
-	l.Upsert(p)
+	l.UpsertTask(p)
 	return save(l.path, l.Store)
 }
 
@@ -136,10 +138,17 @@ func (l *LockedStore) RemovePane(parent string, issueNum int) error {
 	return save(l.path, l.Store)
 }
 
+func (l *LockedStore) RemoveTaskPane(parent, taskID string) error {
+	if !l.removeTask(parent, taskID) {
+		return nil
+	}
+	return save(l.path, l.Store)
+}
+
 func (s Store) FannedNumbersForParent(parent string) map[int]bool {
 	out := map[int]bool{}
 	for _, pane := range s.Panes {
-		if parentMatches(pane.Parent, parent) {
+		if pane.IssueNum > 0 && parentMatches(pane.Parent, parent) {
 			out[pane.IssueNum] = true
 		}
 	}
@@ -149,8 +158,18 @@ func (s Store) FannedNumbersForParent(parent string) map[int]bool {
 func (s Store) FannedNumbersForOtherParents(parent string) map[int]bool {
 	out := map[int]bool{}
 	for _, pane := range s.Panes {
-		if !parentMatches(pane.Parent, parent) {
+		if pane.IssueNum > 0 && !parentMatches(pane.Parent, parent) {
 			out[pane.IssueNum] = true
+		}
+	}
+	return out
+}
+
+func (s Store) FannedTaskIDsForParent(parent string) map[string]bool {
+	out := map[string]bool{}
+	for _, pane := range s.Panes {
+		if pane.TaskID != "" && parentMatches(pane.Parent, parent) {
+			out[pane.TaskID] = true
 		}
 	}
 	return out
@@ -159,6 +178,18 @@ func (s Store) FannedNumbersForOtherParents(parent string) map[int]bool {
 func (s Store) Find(parent string, issueNum int) (Pane, bool) {
 	for _, pane := range s.Panes {
 		if pane.IssueNum == issueNum && parentMatches(pane.Parent, parent) {
+			return pane, true
+		}
+	}
+	return Pane{}, false
+}
+
+func (s Store) FindTask(parent, taskID string) (Pane, bool) {
+	if taskID == "" {
+		return Pane{}, false
+	}
+	for _, pane := range s.Panes {
+		if pane.TaskID == taskID && parentMatches(pane.Parent, parent) {
 			return pane, true
 		}
 	}
@@ -186,11 +217,39 @@ func (s *Store) Upsert(p Pane) {
 	s.Panes = append(s.Panes, p)
 }
 
+func (s *Store) UpsertTask(p Pane) {
+	s.normalize()
+	for i := range s.Panes {
+		if taskPaneMatches(s.Panes[i], p) {
+			s.Panes[i] = p
+			return
+		}
+	}
+	s.Panes = append(s.Panes, p)
+}
+
 func (s *Store) Remove(parent string, issueNum int) bool {
 	kept := s.Panes[:0]
 	removed := false
 	for _, pane := range s.Panes {
 		if pane.IssueNum == issueNum && parentMatches(pane.Parent, parent) {
+			removed = true
+			continue
+		}
+		kept = append(kept, pane)
+	}
+	s.Panes = kept
+	return removed
+}
+
+func (s *Store) removeTask(parent, taskID string) bool {
+	if taskID == "" {
+		return false
+	}
+	kept := s.Panes[:0]
+	removed := false
+	for _, pane := range s.Panes {
+		if pane.TaskID == taskID && parentMatches(pane.Parent, parent) {
 			removed = true
 			continue
 		}
@@ -232,4 +291,14 @@ func parentMatches(stored, filter string) bool {
 	storedNum, storedErr := strconv.Atoi(stored)
 	filterNum, filterErr := strconv.Atoi(filter)
 	return storedErr == nil && filterErr == nil && storedNum == filterNum
+}
+
+func taskPaneMatches(stored, incoming Pane) bool {
+	if !parentMatches(stored.Parent, incoming.Parent) {
+		return false
+	}
+	if stored.TaskID != "" && incoming.TaskID != "" {
+		return stored.TaskID == incoming.TaskID
+	}
+	return stored.IssueNum == incoming.IssueNum
 }

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -27,6 +27,8 @@ func TestFannedNumbersForParentDedupesByParentAndIssue(t *testing.T) {
 		{Parent: "0300", IssueNum: 502},
 		{Parent: "400", IssueNum: 601},
 		{Parent: "300", IssueNum: 501},
+		{Parent: "300", IssueNum: 0, TaskID: "task-a"},
+		{Parent: "300", IssueNum: -1},
 	}}
 
 	got := store.FannedNumbersForParent("300")
@@ -48,6 +50,7 @@ func TestFannedNumbersForOtherParents(t *testing.T) {
 		{Parent: "0300", IssueNum: 502},
 		{Parent: "400", IssueNum: 501},
 		{Parent: "500", IssueNum: 601},
+		{Parent: "400", IssueNum: 0, TaskID: "task-a"},
 	}}
 
 	got := store.FannedNumbersForOtherParents("300")
@@ -145,6 +148,51 @@ func TestLoadLegacyRowWithoutBaseBranchDefaultsToEmpty(t *testing.T) {
 	}
 }
 
+func TestLegacyStateRoundTripOmitsTaskID(t *testing.T) {
+	root := t.TempDir()
+	legacy := `{
+  "schemaVersion": 1,
+  "panes": [
+    {
+      "parent": "81",
+      "issueNum": 83,
+      "slug": "state-idempotency-83",
+      "branchName": "fanout/state-idempotency-83",
+      "paneId": "%42",
+      "agent": "codex",
+      "displayName": "State Idempotency",
+      "worktreePath": "/repo/.fanout/worktrees/state-idempotency-83",
+      "prompt": "p",
+      "createdAt": "2026-06-04T00:00:00Z"
+    }
+  ]
+}`
+	if err := os.MkdirAll(filepath.Dir(Path(root)), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(Path(root), []byte(legacy), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := LoadProject(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = save(Path(root), loaded); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(Path(root))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), `"taskId"`) {
+		t.Fatalf("legacy round-trip added taskId:\n%s", data)
+	}
+	if got, want := string(data), legacy+"\n"; got != want {
+		t.Fatalf("legacy round-trip changed bytes:\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+
 func TestAgentStatusRoundTripsAndOmitsWhenEmpty(t *testing.T) {
 	root := t.TempDir()
 	locked, err := LockProject(root)
@@ -212,6 +260,38 @@ func TestCodexPlanModeRoundTripsAndOmitsWhenFalse(t *testing.T) {
 	}
 }
 
+func TestTaskIDRoundTripsAndOmitsWhenEmpty(t *testing.T) {
+	root := t.TempDir()
+	locked, err := LockProject(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = locked.Unlock() })
+
+	if err = locked.RecordPane(Pane{Parent: "plan:alpha", IssueNum: 0, TaskID: "task-a", PaneID: "%1"}); err != nil {
+		t.Fatal(err)
+	}
+	if err = locked.RecordPane(Pane{Parent: "plan:alpha", IssueNum: 1, PaneID: "%2"}); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := LoadProject(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, ok := loaded.FindTask("plan:alpha", "task-a")
+	if !ok || got.PaneID != "%1" {
+		t.Fatalf("FindTask() = %+v (found=%v), want pane %%1", got, ok)
+	}
+	data, err := os.ReadFile(Path(root))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n := strings.Count(string(data), `"taskId"`); n != 1 {
+		t.Fatalf("taskId key appears %d times, want 1:\n%s", n, data)
+	}
+}
+
 func TestRecordPaneReplacesSameParentIssue(t *testing.T) {
 	root := t.TempDir()
 	locked, err := LockProject(root)
@@ -239,6 +319,47 @@ func TestRecordPaneReplacesSameParentIssue(t *testing.T) {
 	}
 }
 
+func TestUpsertTaskReplacesSameParentTaskID(t *testing.T) {
+	store := Store{}
+	store.UpsertTask(Pane{Parent: "211", IssueNum: 0, TaskID: "task-a", PaneID: "%1"})
+	store.UpsertTask(Pane{Parent: "0211", IssueNum: 0, TaskID: "task-b", PaneID: "%2"})
+	store.UpsertTask(Pane{Parent: "211", IssueNum: 99, TaskID: "task-a", PaneID: "%3"})
+
+	if len(store.Panes) != 2 {
+		t.Fatalf("pane count = %d, want 2: %+v", len(store.Panes), store.Panes)
+	}
+	got, ok := store.FindTask("211", "task-a")
+	if !ok || got.PaneID != "%3" || got.IssueNum != 99 {
+		t.Fatalf("FindTask(task-a) = %+v (found=%v), want pane %%3 issue #99", got, ok)
+	}
+	if _, ok := store.FindTask("211", "task-b"); !ok {
+		t.Fatalf("task-b was clobbered: %+v", store.Panes)
+	}
+	fanned := store.FannedTaskIDsForParent("211")
+	if !fanned["task-a"] || !fanned["task-b"] || len(fanned) != 2 {
+		t.Fatalf("FannedTaskIDsForParent() = %#v, want task-a and task-b", fanned)
+	}
+}
+
+func TestUpsertTaskFallsBackToIssueNumberWhenEitherSideLacksTaskID(t *testing.T) {
+	store := Store{Panes: []Pane{{Parent: "211", IssueNum: 42, PaneID: "%old"}}}
+	store.UpsertTask(Pane{Parent: "0211", IssueNum: 42, TaskID: "task-c", PaneID: "%new"})
+
+	if len(store.Panes) != 1 {
+		t.Fatalf("pane count after legacy replacement = %d, want 1: %+v", len(store.Panes), store.Panes)
+	}
+	got, ok := store.FindTask("211", "task-c")
+	if !ok || got.PaneID != "%new" {
+		t.Fatalf("legacy row was not replaced by task row: %+v (found=%v)", got, ok)
+	}
+
+	store.UpsertTask(Pane{Parent: "211", IssueNum: 42, PaneID: "%legacy"})
+	got, ok = store.Find("211", 42)
+	if len(store.Panes) != 1 || !ok || got.PaneID != "%legacy" || got.TaskID != "" {
+		t.Fatalf("issue fallback replacement = %+v (found=%v), panes=%+v", got, ok, store.Panes)
+	}
+}
+
 func TestRemoveDeletesAllSameParentIssueRows(t *testing.T) {
 	store := Store{Panes: []Pane{
 		{Parent: "84", IssueNum: 101, PaneID: "%1"},
@@ -258,5 +379,35 @@ func TestRemoveDeletesAllSameParentIssueRows(t *testing.T) {
 	}
 	if _, ok := store.Find("85", 101); !ok {
 		t.Fatalf("different parent same issue was removed: %+v", store.Panes)
+	}
+}
+
+func TestLockedStoreRemoveTaskPane(t *testing.T) {
+	root := t.TempDir()
+	locked, err := LockProject(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = locked.Unlock() })
+
+	if err = locked.RecordPane(Pane{Parent: "211", IssueNum: 0, TaskID: "task-a", PaneID: "%1"}); err != nil {
+		t.Fatal(err)
+	}
+	if err = locked.RecordPane(Pane{Parent: "211", IssueNum: 0, TaskID: "task-b", PaneID: "%2"}); err != nil {
+		t.Fatal(err)
+	}
+	if err = locked.RemoveTaskPane("0211", "task-a"); err != nil {
+		t.Fatal(err)
+	}
+
+	loaded, err := LoadProject(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := loaded.FindTask("211", "task-a"); ok {
+		t.Fatalf("task-a still present: %+v", loaded.Panes)
+	}
+	if got, ok := loaded.FindTask("211", "task-b"); !ok || got.PaneID != "%2" {
+		t.Fatalf("task-b = %+v (found=%v), want pane %%2", got, ok)
 	}
 }


### PR DESCRIPTION
**TL;DR** — Adds TaskID-aware state APIs for issue-less pane rows and a `gh pr list --head` resolver that maps branch PRs into `PRRef` with CI. Review effort: 2

**Why** — Issue #213 asks for package-level support for issue-less state rows keyed by `(parent, taskID)` and for resolving PRs for rows without issue numbers by head branch. CLI and sessionview wiring is intentionally left for follow-up issues.

**Changes by file**

<details><summary>Changed files</summary>

| File | What changed | Why |
| --- | --- | --- |
| `internal/state/state.go` | Added `Pane.TaskID`, TaskID lookup/list/upsert/remove helpers, and made `RecordPane` use TaskID-aware upsert while issue-number sets ignore non-positive synthetic rows. | Allows issue-less rows to persist without breaking existing issue-number status paths. |
| `internal/state/state_test.go` | Added legacy byte-compatible round-trip, TaskID round-trip, TaskID idempotency, fallback matching, task removal, and non-positive issue filtering coverage. | Locks the additive schema and mixed old/new state behavior. |
| `internal/ghissue/ghissue.go` | Added `Runner.PRsForBranch` using `gh pr list --head ... --state all`, maps results into `PRRef`, and normalizes object or CheckRun-array CI rollups. | Lets future issue-less rows resolve PR state by branch. |
| `internal/ghissue/ghissue_test.go` | Added fake-gh PR branch lookup coverage for merged/open/empty results and terminal failed check conclusions. | Verifies the command contract and PRRef/CI mapping without network. |

</details>

```mermaid
flowchart LR
  Pane["state.Pane taskId"] --> Upsert["UpsertTask / FindTask"]
  Upsert --> Rows["issue-less rows keyed by parent + taskId"]
  Branch["state.Pane BranchName"] --> Lookup["ghissue.Runner.PRsForBranch"]
  Lookup --> PRRef["PRRef CIStatus"]
```

**Risk**

> [!WARNING]
> Live `gh pr list --head ... --json statusCheckRollup` response shape was not verified because api.github.com was unreachable in this environment; unit tests cover the object rollup, CheckRun-array pending/fail, merged/open, and empty-list paths.

**Test plan**

- [x] `go test ./internal/state ./internal/ghissue` — pass
- [x] `go test ./...` — pass
- [x] `go vet ./...` — pass
- [x] `make lint` — pass
- [x] `make test` — pass
- [x] `codex review --uncommitted` — clean after fixes

Closes #213