### PR TITLE
feat(briefing): add issue-less task briefs

### DIFF
--- a/internal/briefing/briefing.go
+++ b/internal/briefing/briefing.go
@@ -1,5 +1,5 @@
-// Package briefing builds the per-issue task brief that fanout drops at
-// /tmp/fanout-<repo>-<N>.md and points the agent at via the one-line prompt.
+// Package briefing builds task briefs that fanout drops under /tmp and points
+// the agent at via the one-line prompt.
 //
 // The body is locked in by Tier 2 goldens (briefing size: NNN bytes) — both
 // the heredoc text and the trailing newline must match fanout:799-814 byte
@@ -19,6 +19,13 @@ import (
 func Path(projectRoot string, num int) string {
 	repo := filepath.Base(projectRoot)
 	return fmt.Sprintf("/tmp/fanout-%s-%d.md", repo, num)
+}
+
+// TaskPath returns /tmp/fanout-<repo_slug>-<planSlug>-<taskID>.md.
+// The single-hyphen shape is part of the plan-mode briefing contract.
+func TaskPath(projectRoot, planSlug, taskID string) string {
+	repo := filepath.Base(projectRoot)
+	return fmt.Sprintf("/tmp/fanout-%s-%s-%s.md", repo, planSlug, taskID)
 }
 
 // TeamSibling is one roster entry of a --team run: a child pane created
@@ -41,12 +48,95 @@ type TeamContext struct {
 // Render produces the brief body. Live mode writes it to Path(); dry-run uses
 // len(Render()) to compute the goldened "briefing size" without touching disk.
 // team is nil unless the run opted in with --team.
-func Render(num int, title, body, agent, baseBranch string, s settings.Settings, codexPlanMode bool, team *TeamContext) string {
+func Render(num int, title, body, agentName, baseBranch string, s settings.Settings, codexPlanMode bool, team *TeamContext) string {
 	if codexPlanMode {
 		return renderCodexPlanBriefing(num, title, body)
 	}
-	lines := []string{
-		fmt.Sprintf("You are assigned GitHub issue #%d in this repository.", num),
+	return renderWorkBriefing(workBriefing{
+		header:                     fmt.Sprintf("You are assigned GitHub issue #%d in this repository.", num),
+		title:                      title,
+		body:                       body,
+		scopeRequirement:           "- Make focused, minimal changes scoped to this single issue.",
+		autoPullRequestRequirement: fmt.Sprintf("- Open a pull request with \"Closes #%d\" in the body.", num),
+		ambiguityRequirement:       "- If the scope is ambiguous, stop and leave a comment on the issue instead of guessing.",
+		prFooter:                   issuePRFooter(num),
+		agentName:                  agentName,
+		baseBranch:                 baseBranch,
+		settings:                   s,
+		team:                       team,
+		teamIssueNum:               num,
+	})
+}
+
+// RenderTask produces an issue-less task brief. The task variant deliberately
+// avoids GitHub issue closing references because there is no issue to close.
+func RenderTask(planSlug, planTitle, taskID, title, body, agentName, baseBranch string, s settings.Settings) string {
+	footer := taskPRFooter(planSlug, taskID)
+	return renderWorkBriefing(workBriefing{
+		header:                     fmt.Sprintf("You are assigned task \"%s\" of plan \"%s\" (plan:%s) in this repository.", taskID, planTitle, planSlug),
+		title:                      title,
+		body:                       body,
+		scopeRequirement:           "- Make focused, minimal changes scoped to this single task.",
+		autoPullRequestRequirement: fmt.Sprintf("- Open a pull request and end the PR body with \"%s\"; do not add an issue-closing footer because this task has no corresponding GitHub issue.", footer.line),
+		ambiguityRequirement:       "- If the scope is ambiguous, stop and report the ambiguity in this pane instead of guessing.",
+		prFooter:                   footer,
+		agentName:                  agentName,
+		baseBranch:                 baseBranch,
+		settings:                   s,
+	})
+}
+
+type workBriefing struct {
+	header                     string
+	title                      string
+	body                       string
+	scopeRequirement           string
+	autoPullRequestRequirement string
+	ambiguityRequirement       string
+	prFooter                   prFooter
+	agentName                  string
+	baseBranch                 string
+	settings                   settings.Settings
+	team                       *TeamContext
+	teamIssueNum               int
+}
+
+func renderWorkBriefing(b workBriefing) string {
+	lines := baseRequirementLines(b.header, b.title, b.body, b.scopeRequirement)
+	if b.settings.AutoPullRequest {
+		lines = append(lines, b.autoPullRequestRequirement)
+	}
+	lines = append(lines, b.ambiguityRequirement)
+
+	base := strings.Join(lines, "\n") + "\n"
+	if b.settings.AutoPullRequest && b.settings.PRVisualization {
+		base += prVisualizationSection(b.prFooter, b.baseBranch)
+	}
+	if b.team != nil {
+		base += teamSection(b.teamIssueNum, b.team)
+	}
+	if b.agentName == "codex" {
+		return base + codexReviewSection(b.settings.AutoPullRequest)
+	}
+	if b.agentName != "claude" {
+		return base
+	}
+
+	if !b.settings.PRReviewGate {
+		base += reviewGateBypassSection
+	}
+	if b.settings.BriefingCodeReview {
+		base += codeReviewSection
+	}
+	if b.settings.AgentTeamsHint {
+		base += agentTeamsSection
+	}
+	return base
+}
+
+func baseRequirementLines(header, title, body, scopeRequirement string) []string {
+	return []string{
+		header,
 		"",
 		fmt.Sprintf("Title: %s", title),
 		"",
@@ -55,39 +145,10 @@ func Render(num int, title, body, agent, baseBranch string, s settings.Settings,
 		"",
 		"Requirements:",
 		"- You are working inside a git worktree that was prepared for this task. Do not create additional worktrees.",
-		"- Make focused, minimal changes scoped to this single issue.",
+		scopeRequirement,
 		"- Run the project's lint/test commands if they exist (inspect package.json / Makefile / pyproject.toml first).",
 		"- When implementation passes tests, commit and push the branch.",
 	}
-	if s.AutoPullRequest {
-		lines = append(lines, fmt.Sprintf("- Open a pull request with \"Closes #%d\" in the body.", num))
-	}
-	lines = append(lines, "- If the scope is ambiguous, stop and leave a comment on the issue instead of guessing.")
-
-	base := strings.Join(lines, "\n") + "\n"
-	if s.AutoPullRequest && s.PRVisualization {
-		base += prVisualizationSection(num, baseBranch)
-	}
-	if team != nil {
-		base += teamSection(num, team)
-	}
-	if agent == "codex" {
-		return base + codexReviewSection(s.AutoPullRequest)
-	}
-	if agent != "claude" {
-		return base
-	}
-
-	if !s.PRReviewGate {
-		base += reviewGateBypassSection
-	}
-	if s.BriefingCodeReview {
-		base += codeReviewSection
-	}
-	if s.AgentTeamsHint {
-		base += agentTeamsSection
-	}
-	return base
 }
 
 func renderCodexPlanBriefing(num int, title, body string) string {
@@ -122,7 +183,7 @@ When opening the PR, structure the PR body in this order:
 3. **Changes by file** — inside ` + "`<details><summary>Changed files</summary>`" + `, add a ` + "`File | What changed | Why`" + ` table that lists only files you actually touched.
 4. **Risk** — add a ` + "`> [!WARNING]`" + ` block only for real risks. Do not add filler such as "no risk".
 5. **Test plan** — list the lint/test commands you ran and their results.
-6. **Footer** — end with ` + "`Closes #%d`" + ` on its own line so GitHub closes the child issue on merge.
+6. **Footer** — end with ` + "`%s`" + ` on its own line%s.
 
 Ground every substantive claim in the branch diff and current worktree. Before
 opening the PR, compare the PR body with ` + "`git diff --name-only %s...HEAD`" + `
@@ -141,11 +202,30 @@ is dropped; omit the whole diagram if it does not carry review value. GitHub
 renders ` + "```mermaid" + ` directly, so do not use image-generation tools.
 `
 
-func prVisualizationSection(num int, baseBranch string) string {
+type prFooter struct {
+	line   string
+	suffix string
+}
+
+func issuePRFooter(num int) prFooter {
+	return prFooter{
+		line:   fmt.Sprintf("Closes #%d", num),
+		suffix: " so GitHub closes the child issue on merge",
+	}
+}
+
+func taskPRFooter(planSlug, taskID string) prFooter {
+	return prFooter{
+		line:   fmt.Sprintf("Plan: %s / Task: %s", planSlug, taskID),
+		suffix: " to identify the issue-less task",
+	}
+}
+
+func prVisualizationSection(footer prFooter, baseBranch string) string {
 	if baseBranch == "" {
 		baseBranch = "main"
 	}
-	return fmt.Sprintf(prVisualizationSectionTemplate, num, agent.ShellQuote(baseBranch))
+	return fmt.Sprintf(prVisualizationSectionTemplate, footer.line, footer.suffix, agent.ShellQuote(baseBranch))
 }
 
 func codexReviewSection(autoPullRequest bool) string {

--- a/internal/briefing/briefing.go
+++ b/internal/briefing/briefing.go
@@ -21,11 +21,21 @@ func Path(projectRoot string, num int) string {
 	return fmt.Sprintf("/tmp/fanout-%s-%d.md", repo, num)
 }
 
-// TaskPath returns /tmp/fanout-<repo_slug>-<planSlug>-<taskID>.md.
-// The single-hyphen shape is part of the plan-mode briefing contract.
+// TaskPath returns /tmp/fanout-<repo_slug>-<escaped-planSlug>-<escaped-taskID>.md.
 func TaskPath(projectRoot, planSlug, taskID string) string {
 	repo := filepath.Base(projectRoot)
-	return fmt.Sprintf("/tmp/fanout-%s-%s-%s.md", repo, planSlug, taskID)
+	return fmt.Sprintf("/tmp/fanout-%s-%s-%s.md", repo, taskPathComponent(planSlug), taskPathComponent(taskID))
+}
+
+var taskPathComponentReplacer = strings.NewReplacer(
+	"%", "%25",
+	"-", "%2D",
+	"/", "%2F",
+	"\\", "%5C",
+)
+
+func taskPathComponent(value string) string {
+	return taskPathComponentReplacer.Replace(value)
 }
 
 // TeamSibling is one roster entry of a --team run: a child pane created

--- a/internal/briefing/briefing_test.go
+++ b/internal/briefing/briefing_test.go
@@ -8,12 +8,16 @@ import (
 )
 
 func TestTaskPathUsesPlanTaskNamespace(t *testing.T) {
-	got := TaskPath("/repos/project_root", "plan-alpha", "task-001")
-	want := "/tmp/fanout-project_root-plan-alpha-task-001.md"
+	root := "/repos/project_root"
+	got := TaskPath(root, "plan-alpha", "task-001")
+	want := "/tmp/fanout-project_root-plan%2Dalpha-task%2D001.md"
 	if got != want {
 		t.Fatalf("TaskPath() = %q, want %q", got, want)
 	}
-	if got == Path("/repos/project_root", 214) {
+	if got == TaskPath(root, "plan", "alpha-task-001") {
+		t.Fatalf("TaskPath() collides across plan/task boundary: %q", got)
+	}
+	if got == Path(root, 214) {
 		t.Fatalf("TaskPath() collides with issue Path(): %q", got)
 	}
 }

--- a/internal/briefing/briefing_test.go
+++ b/internal/briefing/briefing_test.go
@@ -7,6 +7,17 @@ import (
 	"github.com/butaosuinu/fanout/internal/settings"
 )
 
+func TestTaskPathUsesPlanTaskNamespace(t *testing.T) {
+	got := TaskPath("/repos/project_root", "plan-alpha", "task-001")
+	want := "/tmp/fanout-project_root-plan-alpha-task-001.md"
+	if got != want {
+		t.Fatalf("TaskPath() = %q, want %q", got, want)
+	}
+	if got == Path("/repos/project_root", 214) {
+		t.Fatalf("TaskPath() collides with issue Path(): %q", got)
+	}
+}
+
 func TestPRVisualizationSectionHonorsSettings(t *testing.T) {
 	defaults := settings.Defaults()
 	for _, agent := range []string{"claude", "codex"} {
@@ -48,6 +59,121 @@ func TestPRVisualizationSectionQuotesBaseBranch(t *testing.T) {
 	want := "git diff --name-only 'foo;bar'...HEAD"
 	if !strings.Contains(got, want) {
 		t.Fatalf("Render(...) missing shell-quoted base branch command %q", want)
+	}
+}
+
+func TestRenderTaskDefaultsUsePlanTaskFooterAndSharedAgentSections(t *testing.T) {
+	defaults := settings.Defaults()
+	for _, tc := range []struct {
+		agent string
+		wants []string
+	}{
+		{
+			agent: "claude",
+			wants: []string{
+				"run the `/code-review` slash command",
+				"Optional: Agent Teams",
+			},
+		},
+		{
+			agent: "codex",
+			wants: []string{
+				"codex review --uncommitted",
+				"Only after the review loop is clean should you commit, push, and open the PR",
+			},
+		},
+	} {
+		got := RenderTask("plan-alpha", "Launch Plan", "task-001", "Task title", "Task body", tc.agent, "release/v1", defaults)
+		commonWants := []string{
+			`You are assigned task "task-001" of plan "Launch Plan" (plan:plan-alpha) in this repository.`,
+			"Title: Task title",
+			"Task body",
+			"Make focused, minimal changes scoped to this single task",
+			`Open a pull request and end the PR body with "Plan: plan-alpha / Task: task-001"`,
+			"do not add an issue-closing footer",
+			"stop and report the ambiguity in this pane",
+			"structure the PR body",
+			"`Plan: plan-alpha / Task: task-001`",
+			"git diff --name-only release/v1...HEAD",
+			"Diagram gate",
+		}
+		for _, want := range append(commonWants, tc.wants...) {
+			if !strings.Contains(got, want) {
+				t.Fatalf("RenderTask(..., %q) missing %q:\n%s", tc.agent, want, got)
+			}
+		}
+		assertIssueLessTaskBriefing(t, got)
+	}
+}
+
+func TestRenderTaskSettingsToggleCombinations(t *testing.T) {
+	defaults := settings.Defaults()
+
+	noAutoPR := defaults
+	noAutoPR.AutoPullRequest = false
+	got := RenderTask("plan-alpha", "Launch Plan", "task-001", "Task title", "Task body", "codex", "release/v1", noAutoPR)
+	for _, unwanted := range []string{
+		"Open a pull request",
+		"structure the PR body",
+		"Diagram gate",
+		"open the PR",
+	} {
+		if strings.Contains(got, unwanted) {
+			t.Fatalf("RenderTask(..., AutoPullRequest=false) contains %q:\n%s", unwanted, got)
+		}
+	}
+	if !strings.Contains(got, "Only after the review loop is clean should you commit and push the branch") {
+		t.Fatalf("RenderTask(..., AutoPullRequest=false) missing no-PR codex review gate:\n%s", got)
+	}
+	assertIssueLessTaskBriefing(t, got)
+
+	noVisualization := defaults
+	noVisualization.PRVisualization = false
+	got = RenderTask("plan-alpha", "Launch Plan", "task-001", "Task title", "Task body", "claude", "release/v1", noVisualization)
+	if !strings.Contains(got, `Open a pull request and end the PR body with "Plan: plan-alpha / Task: task-001"`) {
+		t.Fatalf("RenderTask(..., PRVisualization=false) missing auto-PR task requirement:\n%s", got)
+	}
+	for _, unwanted := range []string{"structure the PR body", "Diagram gate"} {
+		if strings.Contains(got, unwanted) {
+			t.Fatalf("RenderTask(..., PRVisualization=false) contains %q:\n%s", unwanted, got)
+		}
+	}
+	assertIssueLessTaskBriefing(t, got)
+
+	claudeToggles := defaults
+	claudeToggles.PRReviewGate = false
+	claudeToggles.BriefingCodeReview = false
+	claudeToggles.AgentTeamsHint = false
+	got = RenderTask("plan-alpha", "Launch Plan", "task-001", "Task title", "Task body", "claude", "release/v1", claudeToggles)
+	if !strings.Contains(got, "The PR review gate is disabled for this fanout run") {
+		t.Fatalf("RenderTask(..., PRReviewGate=false) missing bypass notice:\n%s", got)
+	}
+	for _, unwanted := range []string{
+		"run the `/code-review` slash command",
+		"Optional: Agent Teams",
+	} {
+		if strings.Contains(got, unwanted) {
+			t.Fatalf("RenderTask(..., disabled claude toggles) contains %q:\n%s", unwanted, got)
+		}
+	}
+	assertIssueLessTaskBriefing(t, got)
+}
+
+func TestRenderTaskPRVisualizationQuotesBaseBranch(t *testing.T) {
+	got := RenderTask("plan-alpha", "Launch Plan", "task-001", "Task title", "Task body", "codex", "foo;bar", settings.Defaults())
+	want := "git diff --name-only 'foo;bar'...HEAD"
+	if !strings.Contains(got, want) {
+		t.Fatalf("RenderTask(...) missing shell-quoted base branch command %q:\n%s", want, got)
+	}
+	assertIssueLessTaskBriefing(t, got)
+}
+
+func assertIssueLessTaskBriefing(t *testing.T, got string) {
+	t.Helper()
+	for _, unwanted := range []string{"Closes #", "GitHub issue #"} {
+		if strings.Contains(got, unwanted) {
+			t.Fatalf("issue-less task briefing contains %q:\n%s", unwanted, got)
+		}
 	}
 }
 


### PR DESCRIPTION
## TL;DR
Adds issue-less task briefing helpers for plan tasks while keeping the existing issue briefing output unchanged. Review effort: 2.

## Why
Issue #214 asks for plan task briefings that do not map to GitHub issues, so they need their own /tmp path and PR footer guidance without issue-closing semantics.

```mermaid
flowchart TD
  Render["Render(issue)"] --> Shared["renderWorkBriefing"]
  RenderTask["RenderTask(plan task)"] --> Shared
  Shared --> PRViz["prVisualizationSection"]
  PRViz --> IssueFooter["Closes #N"]
  PRViz --> TaskFooter["Plan slug / Task id"]
```

## Changes by file
<details><summary>Changed files</summary>

| File | What changed | Why |
| --- | --- | --- |
| internal/briefing/briefing.go | Added TaskPath at internal/briefing/briefing.go:24 and RenderTask at internal/briefing/briefing.go:71, then routed both issue and task variants through renderWorkBriefing. | Provides the issue-less task brief contract while preserving existing issue rendering. |
| internal/briefing/briefing.go | Parameterized PR visualization footers at internal/briefing/briefing.go:179 and added issue/task footer helpers at internal/briefing/briefing.go:210. | Keeps issue PRs ending with Closes #N while task PR guidance ends with Plan/Task metadata. |
| internal/briefing/briefing_test.go | Added TaskPath and RenderTask tests at internal/briefing/briefing_test.go:10 and internal/briefing/briefing_test.go:65, including toggle combinations and issue-less output assertions at internal/briefing/briefing_test.go:171. | Covers the new task behavior and guards against Closes # or GitHub issue # in task briefings. |

</details>

## Risk
The main risk is accidentally changing existing issue briefing text while factoring shared rendering; Tier 2 goldens and the full test suite cover that path.

## Test plan
- go test ./internal/briefing: passed.
- GOCACHE="$PWD/.cache/go-build" go vet ./...: passed.
- make lint: passed.
- make test: passed, including Tier 1 and Tier 2 Bats goldens.
- codex review --uncommitted: clean.

Closes #214