### PR TITLE
feat(dashboard,tui): show plan task rows by branch PR

### DIFF
--- a/internal/dashboard/poller.go
+++ b/internal/dashboard/poller.go
@@ -28,11 +28,13 @@ const (
 )
 
 // GHProvider is the GitHub fetch surface the poller throttles and caches:
-// per-issue PR state plus the per-parent wave/blocker graph (child set
-// included, so not-started children can render as synthetic rows).
+// per-issue PR state, per-branch PR refs for task rows, plus the per-parent
+// wave/blocker graph (child set included, so not-started children can render
+// as synthetic rows).
 // sessionview.GH satisfies it; tests inject a fake.
 type GHProvider interface {
 	IssuePRs(num int) (string, []ghissue.PRRef, error)
+	BranchPRs(branch string) ([]ghissue.PRRef, error)
 	Waves(parent string, recordedNums []int) (sessionview.WaveGraph, error)
 }
 
@@ -40,6 +42,11 @@ type ghCacheEntry struct {
 	state string
 	prs   []ghissue.PRRef
 	err   error
+}
+
+type branchPRCacheEntry struct {
+	prs []ghissue.PRRef
+	err error
 }
 
 // waveCacheEntry is one parent's cached wave graph. FetchWaveGraph keeps
@@ -87,9 +94,10 @@ type poller struct {
 	latestJSON []byte
 	lastKey    []byte
 
-	cacheMu   sync.Mutex
-	cache     map[int]ghCacheEntry
-	waveCache map[string]waveCacheEntry // keyed by normalized parent
+	cacheMu     sync.Mutex
+	cache       map[int]ghCacheEntry
+	branchCache map[string]branchPRCacheEntry
+	waveCache   map[string]waveCacheEntry // keyed by normalized parent
 }
 
 func newPollerBase(projectRoot string, h *hub) *poller {
@@ -100,6 +108,7 @@ func newPollerBase(projectRoot string, h *hub) *poller {
 		ghInterval:    defaultGHInterval,
 		waveInterval:  defaultWaveInterval,
 		cache:         map[int]ghCacheEntry{},
+		branchCache:   map[string]branchPRCacheEntry{},
 		waveCache:     map[string]waveCacheEntry{},
 	}
 }
@@ -213,6 +222,19 @@ func (p *poller) issuePRsFromCache(num int) (string, []ghissue.PRRef, error) {
 	return e.state, e.prs, e.err
 }
 
+func (p *poller) branchPRsFromCache(branch string) ([]ghissue.PRRef, error) {
+	if _, _, ghErr := p.ghIdentity(); ghErr != nil {
+		return nil, ghErr
+	}
+	p.cacheMu.Lock()
+	defer p.cacheMu.Unlock()
+	e, ok := p.branchCache[branch]
+	if !ok {
+		return nil, nil // cache miss: unknown, not degraded
+	}
+	return e.prs, e.err
+}
+
 // wavesFromCache mirrors issuePRsFromCache for the per-parent wave graph: a
 // sticky GitHub failure short-circuits to (zero, err), and a cache miss is
 // (zero, nil) — "not fetched yet", which Build renders as zero-valued wave
@@ -246,6 +268,7 @@ func (p *poller) refreshGH() {
 	// hourly GitHub API budget (the exact failure the wave throttle exists
 	// to prevent).
 	p.refreshIssuePRs(gh, distinctIssueNums(store))
+	p.refreshBranchPRs(gh, distinctTaskBranches(store))
 	// Phase 2: one wave-graph fetch per distinct normalized parent. The recorded
 	// issue numbers seed FetchWaveGraph's child set for @manual/Project parents
 	// and backfill unlinked children for numeric ones.
@@ -368,6 +391,15 @@ func (p *poller) refreshIssuePRs(gh GHProvider, nums []int) {
 	}
 }
 
+func (p *poller) refreshBranchPRs(gh GHProvider, branches []string) {
+	for _, branch := range branches {
+		prs, err := gh.BranchPRs(branch)
+		p.cacheMu.Lock()
+		p.branchCache[branch] = branchPRCacheEntry{prs: prs, err: err}
+		p.cacheMu.Unlock()
+	}
+}
+
 // mergeDegradedWaveGraph overlays a degraded wave fetch onto the previous
 // cache entry: the per-child info merges via mergeDegradedWaveInfos and the
 // child sets union by issue number, so previously discovered not-started
@@ -426,6 +458,7 @@ func (p *poller) build() sessionview.Snapshot {
 		LoadState:    sessionview.StateLoader(p.projectRoot),
 		LivePanes:    sessionview.LivePanes(),
 		IssuePRs:     p.issuePRsFromCache,
+		BranchPRs:    p.branchPRsFromCache,
 		Waves:        p.wavesFromCache,
 		WorktreeStat: sessionview.GitWorktreeStat(p.projectRoot),
 		Now:          time.Now,
@@ -488,6 +521,23 @@ func distinctIssueNums(store state.Store) []int {
 	}
 	slices.Sort(nums)
 	return nums
+}
+
+func distinctTaskBranches(store state.Store) []string {
+	seen := map[string]bool{}
+	var branches []string
+	for _, p := range store.Panes {
+		branch := strings.TrimSpace(p.BranchName)
+		if p.IssueNum > 0 || p.TaskID == "" || branch == "" {
+			continue
+		}
+		if !seen[branch] {
+			seen[branch] = true
+			branches = append(branches, branch)
+		}
+	}
+	slices.Sort(branches)
+	return branches
 }
 
 // recordedNumsByParent groups each distinct normalized parent in state to the

--- a/internal/dashboard/poller_test.go
+++ b/internal/dashboard/poller_test.go
@@ -16,12 +16,13 @@ import (
 )
 
 type countingGH struct {
-	mu        sync.Mutex
-	calls     map[int]int
-	waveCalls map[string]int
-	waveNums  map[string][]int // recordedNums passed per parent (last call)
-	waves     map[string]sessionview.WaveGraph
-	wavesErr  error
+	mu          sync.Mutex
+	calls       map[int]int
+	branchCalls map[string]int
+	waveCalls   map[string]int
+	waveNums    map[string][]int // recordedNums passed per parent (last call)
+	waves       map[string]sessionview.WaveGraph
+	wavesErr    error
 }
 
 func (g *countingGH) IssuePRs(num int) (string, []ghissue.PRRef, error) {
@@ -32,6 +33,16 @@ func (g *countingGH) IssuePRs(num int) (string, []ghissue.PRRef, error) {
 	}
 	g.calls[num]++
 	return "CLOSED", []ghissue.PRRef{{Number: 900 + num, State: "MERGED"}}, nil
+}
+
+func (g *countingGH) BranchPRs(branch string) ([]ghissue.PRRef, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if g.branchCalls == nil {
+		g.branchCalls = map[string]int{}
+	}
+	g.branchCalls[branch]++
+	return []ghissue.PRRef{{Number: 700, State: "MERGED"}}, nil
 }
 
 func (g *countingGH) Waves(parent string, recordedNums []int) (sessionview.WaveGraph, error) {
@@ -56,6 +67,36 @@ func writeState(t *testing.T, root, body string) {
 	}
 	if err := os.WriteFile(filepath.Join(root, ".fanout", "state.json"), []byte(body), 0o644); err != nil {
 		t.Fatal(err)
+	}
+}
+
+func TestPollerRefreshGHPopulatesBranchCacheAndBuildReadsIt(t *testing.T) {
+	root := t.TempDir()
+	writeState(t, root, `{"schemaVersion":1,"panes":[
+	  {"parent":"plan:alpha","issueNum":0,"taskId":"task-a","branchName":"fanout/task-a","slug":"a","paneId":"%1"},
+	  {"parent":"plan:alpha","issueNum":0,"taskId":"task-b","branchName":"fanout/task-a","slug":"b","paneId":"%2"}
+	]}`)
+
+	gh := &countingGH{}
+	p := newPoller("o/n", root, gh, nil, newHub())
+	p.refreshGH()
+	snap := p.build()
+
+	if len(gh.calls) != 0 {
+		t.Fatalf("IssuePRs calls = %v, want none for task-only rows", gh.calls)
+	}
+	if gh.branchCalls["fanout/task-a"] != 1 {
+		t.Fatalf("BranchPRs(fanout/task-a) calls = %d, want 1", gh.branchCalls["fanout/task-a"])
+	}
+	if len(snap.Sessions) != 1 || len(snap.Sessions[0].Panes) != 2 {
+		t.Fatalf("unexpected snapshot shape: %+v", snap.Sessions)
+	}
+	got := snap.Sessions[0].Panes[0]
+	if got.TaskID != "task-a" || got.IssueState != sessionview.IssueStateUnknown || !got.HasMergedPR {
+		t.Fatalf("task branch PR state should reach the snapshot, got %+v", got)
+	}
+	if snap.Degraded.GitHub {
+		t.Fatal("GitHub should not be degraded on branch PR success")
 	}
 }
 
@@ -234,6 +275,21 @@ func TestDistinctIssueNumsSkipsSyntheticManualPanes(t *testing.T) {
 		if got[i] != want[i] {
 			t.Fatalf("distinctIssueNums() = %#v, want %#v", got, want)
 		}
+	}
+}
+
+func TestDistinctTaskBranchesUsesIssueLessTaskRows(t *testing.T) {
+	got := distinctTaskBranches(state.Store{Panes: []state.Pane{
+		{Parent: "plan:a", IssueNum: 0, TaskID: "task-a", BranchName: " fanout/task-a "},
+		{Parent: "plan:a", IssueNum: 0, TaskID: "task-b", BranchName: "fanout/task-a"},
+		{Parent: "plan:a", IssueNum: 0, TaskID: "task-c", BranchName: "fanout/task-c"},
+		{Parent: "plan:a", IssueNum: 0, TaskID: "", BranchName: "fanout/no-task"},
+		{Parent: "100", IssueNum: 101, TaskID: "task-issue", BranchName: "fanout/issue"},
+	}})
+
+	want := []string{"fanout/task-a", "fanout/task-c"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("distinctTaskBranches() = %#v, want %#v", got, want)
 	}
 }
 

--- a/internal/dashboard/server_test.go
+++ b/internal/dashboard/server_test.go
@@ -17,6 +17,8 @@ type fakeGH struct{}
 
 func (fakeGH) IssuePRs(num int) (string, []ghissue.PRRef, error) { return "OPEN", nil, nil }
 
+func (fakeGH) BranchPRs(branch string) ([]ghissue.PRRef, error) { return nil, nil }
+
 func (fakeGH) Waves(parent string, recordedNums []int) (sessionview.WaveGraph, error) {
 	return sessionview.WaveGraph{}, nil
 }

--- a/internal/sessionview/aggregate.go
+++ b/internal/sessionview/aggregate.go
@@ -47,6 +47,10 @@ type Collectors struct {
 	// server restarts, so id-only matching would falsely revive stale rows.
 	LivePanes func() (map[string]LivePaneInfo, error)
 	IssuePRs  func(num int) (issueState string, prs []ghissue.PRRef, err error)
+	// BranchPRs mirrors IssuePRs for issue-less task rows keyed by head branch:
+	// a nil PR slice with nil error is a cache miss, while a non-nil error marks
+	// GitHub degraded.
+	BranchPRs func(branch string) ([]ghissue.PRRef, error)
 	// Waves follows the same three-outcome cache contract as IssuePRs, keyed by
 	// parent instead of issue number (the caller closes over the recorded issue
 	// numbers it passes to FetchWaveGraph):
@@ -95,12 +99,13 @@ func Build(repo, projectRoot string, c Collectors) Snapshot {
 		live = set
 	}
 
-	// One gh read per distinct issue number, cached across sessions.
+	// One gh read per distinct issue number or branch, cached across sessions.
 	prCache := map[int]struct {
 		state string
 		prs   []ghissue.PRRef
 	}{}
-	fetch := func(num int) (string, []ghissue.PRRef) {
+	branchPRCache := map[string][]ghissue.PRRef{}
+	fetchIssue := func(num int) (string, []ghissue.PRRef) {
 		if got, ok := prCache[num]; ok {
 			return got.state, got.prs
 		}
@@ -123,6 +128,36 @@ func Build(repo, projectRoot string, c Collectors) Snapshot {
 			prs   []ghissue.PRRef
 		}{st, prs}
 		return st, prs
+	}
+	fetchBranch := func(branch string) []ghissue.PRRef {
+		branch = strings.TrimSpace(branch)
+		if got, ok := branchPRCache[branch]; ok {
+			return got
+		}
+		prs := []ghissue.PRRef{}
+		if branch == "" {
+			branchPRCache[branch] = prs
+			return prs
+		}
+		if c.BranchPRs == nil {
+			snap.Degraded.GitHub = true
+		} else if gotPRs, err := c.BranchPRs(branch); err != nil {
+			snap.Degraded.GitHub = true
+			snap.Degraded.Reason = appendReason(snap.Degraded.Reason, "github: "+err.Error())
+		} else if gotPRs != nil {
+			prs = gotPRs
+		}
+		branchPRCache[branch] = prs
+		return prs
+	}
+	fetchPanePRs := func(p state.Pane) (string, []ghissue.PRRef) {
+		if p.IssueNum <= 0 && strings.TrimSpace(p.TaskID) != "" && strings.TrimSpace(p.BranchName) != "" {
+			return IssueStateUnknown, fetchBranch(p.BranchName)
+		}
+		if p.IssueNum <= 0 {
+			return IssueStateUnknown, []ghissue.PRRef{}
+		}
+		return fetchIssue(p.IssueNum)
 	}
 	// One waves read per distinct parent, cached across the Build call.
 	waveCache := map[string]WaveGraph{}
@@ -171,17 +206,23 @@ func Build(repo, projectRoot string, c Collectors) Snapshot {
 	syntheticEmitted := map[string]bool{}
 	for _, parent := range sortedParents(grouped) {
 		panes := grouped[parent]
-		slices.SortFunc(panes, func(a, b state.Pane) int { return cmp.Compare(a.IssueNum, b.IssueNum) })
+		slices.SortFunc(panes, func(a, b state.Pane) int {
+			if c := cmp.Compare(a.IssueNum, b.IssueNum); c != 0 {
+				return c
+			}
+			return strings.Compare(taskSortKey(a), taskSortKey(b))
+		})
 
 		session := Session{Parent: parent, Panes: make([]PaneView, 0, len(panes))}
 		graph := fetchWaves(parent)
 		for _, p := range panes {
-			issueState, prs := fetch(p.IssueNum)
+			issueState, prs := fetchPanePRs(p)
 			worktreeStat, worktreeErr := fetchWorktree(p.WorktreePath, p.BaseBranch)
 			alive := paneAlive(live, p.PaneID, p.WorktreePath)
 			wi := graph.Info[p.IssueNum]
 			pv := PaneView{
 				IssueNum:     p.IssueNum,
+				TaskID:       p.TaskID,
 				Slug:         p.Slug,
 				DisplayName:  p.DisplayName,
 				Agent:        p.Agent,
@@ -232,7 +273,7 @@ func Build(repo, projectRoot string, c Collectors) Snapshot {
 				if child.Number <= 0 || recorded[child.Number] {
 					continue
 				}
-				issueState, prs := fetch(child.Number)
+				issueState, prs := fetchIssue(child.Number)
 				closeUnconfirmed := false
 				if issueState == IssueStateUnknown && child.State != "" {
 					// PR キャッシュ未取得でも wave graph は issue 状態を知って
@@ -306,6 +347,16 @@ func groupByParent(panes []state.Pane) map[string][]state.Pane {
 		out[p.Parent] = append(out[p.Parent], p)
 	}
 	return out
+}
+
+func taskSortKey(p state.Pane) string {
+	if strings.TrimSpace(p.TaskID) != "" {
+		return p.TaskID
+	}
+	if strings.TrimSpace(p.BranchName) != "" {
+		return p.BranchName
+	}
+	return p.Slug
 }
 
 // sortedParents orders numeric parents (issue numbers) ascending and before any

--- a/internal/sessionview/aggregate_test.go
+++ b/internal/sessionview/aggregate_test.go
@@ -478,6 +478,84 @@ func TestBuildPlanModePassthrough(t *testing.T) {
 	}
 }
 
+func TestBuildTaskIDPaneUsesBranchPRs(t *testing.T) {
+	first := pane("plan:alpha", 0, "%1")
+	first.TaskID = "task-b"
+	first.BranchName = "fanout/task-branch"
+	second := pane("plan:alpha", 0, "%2")
+	second.TaskID = "task-a"
+	second.BranchName = "fanout/task-branch"
+
+	branchCalls := 0
+	c := Collectors{
+		Now:       fixedNow,
+		LoadState: storeOf(first, second),
+		LivePanes: livePanesAt(),
+		IssuePRs: func(num int) (string, []ghissue.PRRef, error) {
+			t.Fatalf("IssuePRs(%d) called for task row", num)
+			return "", nil, nil
+		},
+		BranchPRs: func(branch string) ([]ghissue.PRRef, error) {
+			branchCalls++
+			if branch != "fanout/task-branch" {
+				t.Fatalf("BranchPRs branch = %q, want fanout/task-branch", branch)
+			}
+			return mergedPR(701), nil
+		},
+		Waves: wavesNone,
+	}
+	snap := Build("o/n", "/root", c)
+
+	if branchCalls != 1 {
+		t.Fatalf("BranchPRs calls = %d, want one cached call for the shared branch", branchCalls)
+	}
+	panes := snap.Sessions[0].Panes
+	if len(panes) != 2 {
+		t.Fatalf("panes = %+v, want two task panes", panes)
+	}
+	if panes[0].TaskID != "task-a" || panes[1].TaskID != "task-b" {
+		t.Fatalf("task pane order = %q,%q want task-a,task-b", panes[0].TaskID, panes[1].TaskID)
+	}
+	for _, pv := range panes {
+		if pv.IssueState != IssueStateUnknown || !pv.HasMergedPR || len(pv.PRs) != 1 {
+			t.Fatalf("task pane should carry branch PR state and unknown issue state: %+v", pv)
+		}
+	}
+	if snap.Sessions[0].Rollup.Total != 2 || snap.Sessions[0].Rollup.Merged != 2 || !snap.Sessions[0].Rollup.AllMerged {
+		t.Fatalf("task rollup = %+v, want all merged", snap.Sessions[0].Rollup)
+	}
+	raw, err := json.Marshal(panes[0])
+	if err != nil {
+		t.Fatalf("marshal task pane: %v", err)
+	}
+	if !strings.Contains(string(raw), `"taskId":"task-a"`) {
+		t.Fatalf("task pane JSON should include taskId: %s", raw)
+	}
+}
+
+func TestBuildTaskIDBranchPRFailureDegradesGitHub(t *testing.T) {
+	task := pane("plan:alpha", 0, "%1")
+	task.TaskID = "task-a"
+	task.BranchName = "fanout/task-a"
+	c := Collectors{
+		Now:       fixedNow,
+		LoadState: storeOf(task),
+		LivePanes: livePanesAt(),
+		BranchPRs: func(branch string) ([]ghissue.PRRef, error) {
+			return nil, errors.New("gh pr list failed")
+		},
+		Waves: wavesNone,
+	}
+	snap := Build("o/n", "/root", c)
+	if !snap.Degraded.GitHub || !strings.Contains(snap.Degraded.Reason, "gh pr list failed") {
+		t.Fatalf("branch PR failure should degrade GitHub, got %+v", snap.Degraded)
+	}
+	pv := snap.Sessions[0].Panes[0]
+	if pv.IssueState != IssueStateUnknown || pv.PRs == nil || len(pv.PRs) != 0 {
+		t.Fatalf("failed task pane = %+v, want UNKNOWN and non-nil empty PRs", pv)
+	}
+}
+
 func TestBuildCIStatusFromPrimaryPR(t *testing.T) {
 	c := Collectors{
 		Now:       fixedNow,
@@ -858,5 +936,8 @@ func TestBuildBlockersMarshalAsEmptyArray(t *testing.T) {
 	}
 	if !strings.Contains(string(raw), `"blockers":[]`) {
 		t.Fatalf("pane view JSON should contain \"blockers\":[] — got %s", raw)
+	}
+	if strings.Contains(string(raw), `"taskId"`) {
+		t.Fatalf("issue pane JSON should omit empty taskId for wire compatibility — got %s", raw)
 	}
 }

--- a/internal/sessionview/collect.go
+++ b/internal/sessionview/collect.go
@@ -96,6 +96,11 @@ func (g GH) IssuePRs(num int) (string, []ghissue.PRRef, error) {
 	return g.runner.IssueWithPRs(g.owner, g.repo, num)
 }
 
+// BranchPRs fetches PR refs by head branch for issue-less task rows.
+func (g GH) BranchPRs(branch string) ([]ghissue.PRRef, error) {
+	return g.runner.PRsForBranch(branch)
+}
+
 // Waves fetches one parent's wave/blocker graph: the resolved child set plus
 // per-child wave/blocker info keyed by issue number. The Collectors.Waves
 // field takes only the parent — the poller closes over the recorded issue

--- a/internal/sessionview/model.go
+++ b/internal/sessionview/model.go
@@ -45,6 +45,7 @@ type WorktreeStat struct {
 // worktree status.
 type PaneView struct {
 	IssueNum     int             `json:"issueNum"`
+	TaskID       string          `json:"taskId,omitempty"`
 	Slug         string          `json:"slug"`
 	DisplayName  string          `json:"displayName"`
 	Agent        string          `json:"agent"`

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -57,6 +57,7 @@ type Options struct {
 type issueKey struct {
 	Parent string
 	Num    int
+	TaskID string
 }
 
 // LaunchRequest describes one manual pane launch requested from the TUI.
@@ -100,6 +101,7 @@ type issueTransitionSnapshot struct {
 type paneView struct {
 	Parent       string
 	IssueNum     int
+	TaskID       string
 	Name         string
 	PaneID       string
 	TmuxState    string
@@ -944,7 +946,7 @@ func (m model) detailContent() string {
 		return "No panes match the current filter."
 	}
 	lines := []string{
-		fmt.Sprintf("%s #%d  %s", pane.Parent, pane.IssueNum, pane.Name),
+		fmt.Sprintf("%s %s  %s", pane.Parent, pane.itemLabel(), pane.Name),
 		fmt.Sprintf("pane=%s tmux=%s title=%s agent=%s", dash(pane.PaneID), pane.TmuxState, dash(pane.TmuxTitle), dash(pane.Agent)),
 		fmt.Sprintf("issue=%s pr=%s ci=%s branch=%s", dash(pane.IssueState), dash(pane.PRSummary), dash(pane.CIStatus), dash(pane.BranchName)),
 		fmt.Sprintf("wave=%s blockers=%s", dash(pane.waveText()), dash(pane.Blockers)),
@@ -1111,8 +1113,9 @@ func loadIssueStatuses(projectRoot string) (map[issueKey]issueStatus, error) {
 		return nil, err
 	}
 	parents := recordedParents(store.Panes)
+	taskRows := recordedTaskRows(store.Panes)
 	statuses := map[issueKey]issueStatus{}
-	if len(parents) == 0 {
+	if len(parents) == 0 && len(taskRows) == 0 {
 		return statuses, nil
 	}
 
@@ -1127,6 +1130,7 @@ func loadIssueStatuses(projectRoot string) (map[issueKey]issueStatus, error) {
 	}
 
 	prCache := map[int]issueStatus{}
+	branchCache := map[string]branchStatus{}
 	var loadErr error
 	for _, parent := range parents {
 		graph, err := sessionview.FetchWaveGraph(gh, parent, recordedIssueNums(store.PanesForParent(parent)))
@@ -1155,7 +1159,32 @@ func loadIssueStatuses(projectRoot string) (map[issueKey]issueStatus, error) {
 			statuses[key] = cached
 		}
 	}
+	for _, task := range taskRows {
+		cached, ok := branchCache[task.BranchName]
+		if !ok {
+			prs, err := gh.PRsForBranch(task.BranchName)
+			if err != nil {
+				loadErr = errors.Join(loadErr, fmt.Errorf("branch %s: %w", task.BranchName, err))
+				continue
+			}
+			cached = branchStatus{PRs: prs}
+			branchCache[task.BranchName] = cached
+		}
+		statuses[task.key] = issueStatus{
+			State: sessionview.IssueStateUnknown,
+			PRs:   cached.PRs,
+		}
+	}
 	return statuses, loadErr
+}
+
+type taskStatusRow struct {
+	key        issueKey
+	BranchName string
+}
+
+type branchStatus struct {
+	PRs []ghissue.PRRef
 }
 
 func recordedIssueNums(panes []state.Pane) []int {
@@ -1175,6 +1204,9 @@ func detectIssueTransitions(previous map[issueKey]issueTransitionSnapshot, curre
 	keys := sortedIssueKeys(current)
 	events := []fanoutnotify.Event{}
 	for _, key := range keys {
+		if key.TaskID != "" {
+			continue
+		}
 		prev, ok := previous[key]
 		if !ok {
 			continue
@@ -1311,7 +1343,10 @@ func sortedIssueKeys(statuses map[issueKey]issueStatus) []issueKey {
 		if c := cmp.Compare(a.Parent, b.Parent); c != 0 {
 			return c
 		}
-		return cmp.Compare(a.Num, b.Num)
+		if c := cmp.Compare(a.Num, b.Num); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.TaskID, b.TaskID)
 	})
 	return keys
 }
@@ -1349,8 +1384,54 @@ func recordedParents(panes []state.Pane) []string {
 	return parents
 }
 
+func recordedTaskRows(panes []state.Pane) []taskStatusRow {
+	seen := map[issueKey]bool{}
+	var rows []taskStatusRow
+	for _, pane := range panes {
+		branch := strings.TrimSpace(pane.BranchName)
+		taskID := strings.TrimSpace(pane.TaskID)
+		if pane.Parent == "" || pane.IssueNum > 0 || taskID == "" || branch == "" {
+			continue
+		}
+		key := keyForTask(pane.Parent, taskID)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		rows = append(rows, taskStatusRow{key: key, BranchName: branch})
+	}
+	slices.SortFunc(rows, func(a, b taskStatusRow) int {
+		if c := cmp.Compare(a.key.Parent, b.key.Parent); c != 0 {
+			return c
+		}
+		if c := cmp.Compare(a.key.TaskID, b.key.TaskID); c != 0 {
+			return c
+		}
+		return cmp.Compare(a.BranchName, b.BranchName)
+	})
+	return rows
+}
+
 func keyForIssue(parent string, num int) issueKey {
 	return issueKey{Parent: normalizedParent(parent), Num: num}
+}
+
+func keyForPane(pane state.Pane) issueKey {
+	if pane.IssueNum <= 0 && strings.TrimSpace(pane.TaskID) != "" {
+		return keyForTask(pane.Parent, pane.TaskID)
+	}
+	return keyForIssue(pane.Parent, pane.IssueNum)
+}
+
+func keyForPaneView(pane paneView) issueKey {
+	if pane.IssueNum <= 0 && strings.TrimSpace(pane.TaskID) != "" {
+		return keyForTask(pane.Parent, pane.TaskID)
+	}
+	return keyForIssue(pane.Parent, pane.IssueNum)
+}
+
+func keyForTask(parent, taskID string) issueKey {
+	return issueKey{Parent: normalizedParent(parent), Num: 0, TaskID: strings.TrimSpace(taskID)}
 }
 
 func normalizedParent(parent string) string {
@@ -1369,12 +1450,13 @@ func buildPaneViews(projectRoot string, panes []state.Pane, tmuxPanes []tmuxrun.
 	out := make([]paneView, 0, len(panes))
 	seen := map[issueKey]bool{}
 	for _, pane := range panes {
-		key := keyForIssue(pane.Parent, pane.IssueNum)
+		key := keyForPane(pane)
 		status, hasStatus := issues[key]
 		seen[key] = true
 		view := paneView{
 			Parent:       pane.Parent,
 			IssueNum:     pane.IssueNum,
+			TaskID:       pane.TaskID,
 			Name:         paneName(pane),
 			PaneID:       pane.PaneID,
 			TmuxState:    tmuxState(pane.PaneID, tmuxByID, tmuxKnown),
@@ -1411,7 +1493,7 @@ func buildPaneViews(projectRoot string, panes []state.Pane, tmuxPanes []tmuxrun.
 		out = append(out, view)
 	}
 	for key, status := range issues {
-		if seen[key] {
+		if seen[key] || key.TaskID != "" {
 			continue
 		}
 		out = append(out, paneView{
@@ -1438,7 +1520,7 @@ func applyIssueStatuses(panes []paneView, issues map[issueKey]issueStatus) []pan
 	out := slices.Clone(panes)
 	seen := map[issueKey]bool{}
 	for i := range out {
-		key := keyForIssue(out[i].Parent, out[i].IssueNum)
+		key := keyForPaneView(out[i])
 		seen[key] = true
 		if status, ok := issues[key]; ok {
 			out[i].IssueState = dash(status.State)
@@ -1455,7 +1537,7 @@ func applyIssueStatuses(panes []paneView, issues map[issueKey]issueStatus) []pan
 		}
 	}
 	for key, status := range issues {
-		if seen[key] {
+		if seen[key] || key.TaskID != "" {
 			continue
 		}
 		out = append(out, paneView{
@@ -1486,7 +1568,10 @@ func sortPaneViews(panes []paneView) {
 		if c := cmp.Compare(a.Wave, b.Wave); c != 0 {
 			return c
 		}
-		return cmp.Compare(a.IssueNum, b.IssueNum)
+		if c := cmp.Compare(a.IssueNum, b.IssueNum); c != 0 {
+			return c
+		}
+		return strings.Compare(a.itemLabel(), b.itemLabel())
 	})
 }
 
@@ -1503,7 +1588,7 @@ func (p paneView) tableRow() table.Row {
 	}
 	return table.Row{
 		compactParent(p.Parent),
-		"#" + strconv.Itoa(p.IssueNum),
+		p.itemLabel(),
 		truncate(dash(p.waveCell()), 12),
 		truncate(dash(p.Blockers), 22),
 		truncate(p.Name, 28),
@@ -1663,6 +1748,8 @@ func (p paneView) matchesFilter(filter paneFilter) bool {
 	}
 	searchText := strings.ToLower(strings.Join([]string{
 		p.Parent,
+		p.TaskID,
+		p.itemLabel(),
 		"#" + strconv.Itoa(p.IssueNum),
 		strconv.Itoa(p.IssueNum),
 		p.Name,
@@ -1793,7 +1880,17 @@ func paneName(pane state.Pane) string {
 	if strings.TrimSpace(pane.Slug) != "" {
 		return pane.Slug
 	}
+	if strings.TrimSpace(pane.TaskID) != "" {
+		return pane.TaskID
+	}
 	return "#" + strconv.Itoa(pane.IssueNum)
+}
+
+func (p paneView) itemLabel() string {
+	if strings.TrimSpace(p.TaskID) != "" {
+		return p.TaskID
+	}
+	return "#" + strconv.Itoa(p.IssueNum)
 }
 
 func tmuxState(paneID string, panes map[string]tmuxrun.PaneInfo, known bool) string {

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -3,6 +3,8 @@ package tui
 import (
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -14,6 +16,7 @@ import (
 	"github.com/butaosuinu/fanout/internal/ghissue"
 	"github.com/butaosuinu/fanout/internal/lifecycle"
 	fanoutnotify "github.com/butaosuinu/fanout/internal/notify"
+	"github.com/butaosuinu/fanout/internal/sessionview"
 	"github.com/butaosuinu/fanout/internal/state"
 	"github.com/butaosuinu/fanout/internal/tmuxrun"
 )
@@ -106,6 +109,83 @@ func TestBuildPaneViewsMarksTmuxUnknownWhenListFails(t *testing.T) {
 	}
 	if got[0].TmuxState != "unknown" {
 		t.Fatalf("TmuxState = %q, want unknown", got[0].TmuxState)
+	}
+}
+
+func TestBuildPaneViewsTaskIDDisplayFallback(t *testing.T) {
+	mergedAt := "2026-06-13T00:00:00Z"
+	issues := map[issueKey]issueStatus{
+		keyForTask("plan:alpha", "task-a"): {
+			State: "UNKNOWN",
+			PRs: []ghissue.PRRef{{
+				Number:   42,
+				State:    "MERGED",
+				MergedAt: &mergedAt,
+				CIStatus: "pass",
+			}},
+		},
+	}
+	got := buildPaneViews("/repo", []state.Pane{
+		{Parent: "plan:alpha", IssueNum: 0, TaskID: "task-b", PaneID: "%2"},
+		{Parent: "plan:alpha", IssueNum: 0, TaskID: "task-a", PaneID: "%1"},
+	}, nil, true, issues, nil)
+
+	if len(got) != 2 {
+		t.Fatalf("buildPaneViews len = %d, want 2", len(got))
+	}
+	if got[0].TaskID != "task-a" || got[1].TaskID != "task-b" {
+		t.Fatalf("task order = %q,%q want task-a,task-b", got[0].TaskID, got[1].TaskID)
+	}
+	if got[0].Name != "task-a" {
+		t.Fatalf("Name = %q, want task id fallback", got[0].Name)
+	}
+	if row := got[0].tableRow(); row[1] != "task-a" {
+		t.Fatalf("issue column = %q, want task id", row[1])
+	}
+	if got[0].PRSummary != "#42 merged" || got[0].CIStatus != "pass" || !got[0].HasMergedPR {
+		t.Fatalf("task PR fields = pr:%q ci:%q merged:%v", got[0].PRSummary, got[0].CIStatus, got[0].HasMergedPR)
+	}
+	if filtered := filterPaneViews(got, "task-a"); len(filtered) != 1 || filtered[0].TaskID != "task-a" {
+		t.Fatalf("task id filter = %+v, want only task-a", filtered)
+	}
+}
+
+func TestLoadIssueStatusesFetchesTaskBranchPRs(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".fanout"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".fanout", "state.json"), []byte(`{"schemaVersion":1,"panes":[
+	  {"parent":"plan:alpha","issueNum":0,"taskId":"task-a","branchName":"fanout/task-a","paneId":"%1"}
+	]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	argsPath := installTUIFakeGH(t, `[{
+	  "number":42,
+	  "state":"MERGED",
+	  "mergedAt":"2026-06-13T00:00:00Z",
+	  "isDraft":false,
+	  "reviewDecision":"APPROVED",
+	  "statusCheckRollup":{"state":"SUCCESS"}
+	}]`)
+
+	statuses, err := loadIssueStatuses(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	status, ok := statuses[keyForTask("plan:alpha", "task-a")]
+	if !ok {
+		t.Fatalf("missing task status in %#v", statuses)
+	}
+	if status.State != sessionview.IssueStateUnknown || len(status.PRs) != 1 || status.PRs[0].Number != 42 || status.PRs[0].CIStatus != "pass" {
+		t.Fatalf("task branch status = %+v", status)
+	}
+	args, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(args), "pr list --head fanout/task-a --state all") {
+		t.Fatalf("fake gh args did not include branch PR lookup:\n%s", args)
 	}
 }
 
@@ -1035,6 +1115,34 @@ func (f *fakeLifecycleRunner) Cleanup(opts lifecycle.Options, parent string, lg 
 	f.cleanupParent = parent
 	fmt.Fprintf(lg.Stderr(), "[ ok ] fake cleanup\n")
 	return f.code
+}
+
+func installTUIFakeGH(t *testing.T, prListOutput string) string {
+	t.Helper()
+	dir := t.TempDir()
+	argsPath := filepath.Join(dir, "args")
+	script := filepath.Join(dir, "gh")
+	body := `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$GH_FAKE_ARGS"
+if [[ "$1 $2" == "repo view" ]]; then
+  printf 'o/n'
+  exit 0
+fi
+if [[ "$1 $2" == "pr list" ]]; then
+  printf '%s' "$GH_FAKE_PR_LIST"
+  exit 0
+fi
+printf 'unexpected gh command: %s\n' "$*" >&2
+exit 1
+`
+	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GH_FAKE_ARGS", argsPath)
+	t.Setenv("GH_FAKE_PR_LIST", prListOutput)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return argsPath
 }
 
 func keyRunes(s string) tea.KeyMsg {

--- a/web/src/components/Drawer.tsx
+++ b/web/src/components/Drawer.tsx
@@ -4,7 +4,7 @@ import { usePeek } from "../hooks/usePeek";
 import { usePlan } from "../hooks/usePlan";
 import { fmtCreated } from "../lib/format";
 import { issueUrl } from "../lib/github";
-import { blockerLabel, fmtWave, notStartedNote } from "../lib/pane";
+import { blockerLabel, fmtWave, notStartedNote, paneLabel } from "../lib/pane";
 import type { PaneView } from "../lib/types";
 import { AgentStateTag, DirtyTag, GhLink, IssueStateTag, PrPill, Tag } from "./ui";
 
@@ -165,7 +165,7 @@ export function Drawer({
       <header className="drawer-head">
         <h3>
           <span className="d-issue" id="d-issue">
-            <GhLink url={issueUrl(repo, pane.issueNum)}>#{pane.issueNum}</GhLink>
+            <GhLink url={issueUrl(repo, pane.issueNum)}>{paneLabel(pane)}</GhLink>
           </span>
           <span id="d-name">{pane.displayName || pane.slug || "—"}</span>
         </h3>

--- a/web/src/components/SessionSection.tsx
+++ b/web/src/components/SessionSection.tsx
@@ -7,6 +7,7 @@ import {
   fmtWave,
   openBlockerCount,
   paneCI,
+  paneLabel,
   prPrimary,
   rowKey,
 } from "../lib/pane";
@@ -62,7 +63,7 @@ function PaneRow({
   return (
     <tr className={cls} tabIndex={0} ref={registerRow} onClick={onClick} onKeyDown={onKeyDown}>
       <td className="c-issue">
-        <GhLink url={issueUrl(repo, pane.issueNum)}>#{pane.issueNum}</GhLink>
+        <GhLink url={issueUrl(repo, pane.issueNum)}>{paneLabel(pane)}</GhLink>
       </td>
       <td className="c-name" title={pane.slug}>
         {pane.displayName || pane.slug || "—"}

--- a/web/src/lib/filter.test.ts
+++ b/web/src/lib/filter.test.ts
@@ -94,6 +94,15 @@ describe("matches", () => {
   it("issue: は完全一致", () => {
     expect(matches(makePane({ issueNum: 12 }), q("issue:12"))).toBe(true);
     expect(matches(makePane({ issueNum: 123 }), q("issue:12"))).toBe(false);
+    expect(matches(makePane({ issueNum: 0, taskId: "plan-lint" }), q("issue:plan-lint"))).toBe(
+      true,
+    );
+  });
+
+  it("taskId は自由語検索の対象になる", () => {
+    const p = makePane({ issueNum: 0, taskId: "plan-dashboard" });
+    expect(matches(p, q("dashboard"))).toBe(true);
+    expect(matches(p, q("plan-review"))).toBe(false);
   });
 
   it("pr: は primary PR の状態、無ければ none", () => {

--- a/web/src/lib/filter.ts
+++ b/web/src/lib/filter.ts
@@ -36,6 +36,7 @@ export function parseQuery(str: string): Term[] {
 export function matches(p: PaneView, terms: Term[]): boolean {
   const hay = [
     p.issueNum,
+    p.taskId,
     p.displayName,
     p.slug,
     p.agent,
@@ -94,7 +95,8 @@ export function matches(p: PaneView, terms: Term[]): boolean {
         if ((t.value === "yes") !== !!p.alive) return false;
         break;
       case "issue":
-        if (String(p.issueNum) !== t.value) return false;
+        if (String(p.issueNum) !== t.value && String(p.taskId ?? "").toLowerCase() !== t.value)
+          return false;
         break;
       case "pr":
         if ((pr?.state ?? "none").toLowerCase() !== t.value) return false;

--- a/web/src/lib/pane.ts
+++ b/web/src/lib/pane.ts
@@ -56,9 +56,14 @@ export function blockersAllClosed(p: PaneView): boolean {
   return !!p.blockers && p.blockers.length > 0 && p.blockers.every((b) => b.state === "CLOSED");
 }
 
+export function paneLabel(p: PaneView): string {
+  return p.taskId || `#${p.issueNum}`;
+}
+
 /* 行の安定キー。tmux 再起動後は pane id (%N) が別 issue の古い行と重複しうる
- * ので、選択は parent#issueNum で識別し、paneId は capture 対象にだけ使う。 */
+ * ので、選択は parent + issueNum/taskId で識別し、paneId は capture 対象にだけ使う。 */
 export function rowKey(parent: string, p: PaneView): string {
+  if (p.taskId) return `${parent}@${p.taskId}`;
   return `${parent}#${p.issueNum}`;
 }
 

--- a/web/src/lib/sort.test.ts
+++ b/web/src/lib/sort.test.ts
@@ -3,6 +3,7 @@ import { makePane } from "../test/fixtures";
 import { sortPanes } from "./sort";
 
 const nums = (ps: { issueNum: number }[]) => ps.map((p) => p.issueNum);
+const taskIds = (ps: { taskId?: string }[]) => ps.map((p) => p.taskId);
 
 describe("sortPanes", () => {
   it("diff は +X/-Y の総量、パース不能は -1(先頭)", () => {
@@ -34,6 +35,12 @@ describe("sortPanes", () => {
     const c = makePane({ issueNum: 2, agent: "codex" });
     expect(nums(sortPanes([a, b, c], "agent", 1))).toEqual([1, 3, 2]);
     expect(nums(sortPanes([a, b, c], "agent", -1))).toEqual([2, 1, 3]);
+  });
+
+  it("issueNum が同じ task 行は taskId で安定ソートする", () => {
+    const b = makePane({ issueNum: 0, taskId: "task-b", agent: "codex" });
+    const a = makePane({ issueNum: 0, taskId: "task-a", agent: "codex" });
+    expect(taskIds(sortPanes([b, a], "agent", 1))).toEqual(["task-a", "task-b"]);
   });
 
   it("dir 反転で順序が逆になる", () => {

--- a/web/src/lib/sort.ts
+++ b/web/src/lib/sort.ts
@@ -7,7 +7,7 @@ type SortKeyFn = (p: PaneView) => number | string;
 
 export const SORTS: Record<string, SortKeyFn> = {
   issueNum: (p) => p.issueNum ?? 0,
-  name: (p) => String(p.displayName || p.slug || "").toLowerCase(),
+  name: (p) => String(p.displayName || p.slug || p.taskId || "").toLowerCase(),
   agent: (p) => String(p.agent ?? "").toLowerCase(),
   wave: (p) => p.wave || 99,
   blockers: (p) => (p.blockers ?? []).filter((b) => b.state === "OPEN").length,
@@ -41,7 +41,18 @@ export const COLS: ReadonlyArray<readonly [key: string, label: string]> = [
   ["pr", "pr"],
 ];
 
-/* 非破壊ソート。一次キーが同値なら issueNum 昇順の安定二次ソート。 */
+function tieKey(p: PaneView): string {
+  return String(p.taskId || p.issueNum).toLowerCase();
+}
+
+function tieCompare(a: PaneView, b: PaneView): number {
+  if ((a.issueNum ?? 0) > 0 && (b.issueNum ?? 0) > 0) {
+    return (a.issueNum ?? 0) - (b.issueNum ?? 0);
+  }
+  return tieKey(a).localeCompare(tieKey(b));
+}
+
+/* 非破壊ソート。一次キーが同値なら issueNum/taskId 昇順の安定二次ソート。 */
 export function sortPanes(panes: PaneView[], sortKey: string, dir: SortDir): PaneView[] {
   const fn = SORTS[sortKey] ?? SORTS["issueNum"]!;
   return [...panes].sort((a, b) => {
@@ -49,6 +60,6 @@ export function sortPanes(panes: PaneView[], sortKey: string, dir: SortDir): Pan
     const kb = fn(b);
     if (ka < kb) return -dir;
     if (ka > kb) return dir;
-    return (a.issueNum ?? 0) - (b.issueNum ?? 0);
+    return tieCompare(a, b);
   });
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -22,6 +22,7 @@ export interface Session {
 
 export interface PaneView {
   issueNum: number;
+  taskId?: string;
   slug: string;
   displayName: string;
   agent: string;

--- a/web/src/test/app.test.tsx
+++ b/web/src/test/app.test.tsx
@@ -116,6 +116,20 @@ describe("snapshot 描画", () => {
     expect(screen.getByText("#101")).toBeInTheDocument(); // 素テキストには落ちる
   });
 
+  it("plan 行は #0 ではなく taskId を表示する", () => {
+    render(<App />);
+    streamSnapshot(
+      makeSnapshot([
+        makeSession("plan:alpha", [
+          makePane({ issueNum: 0, taskId: "plan-lint", displayName: "Lint plan" }),
+        ]),
+      ]),
+    );
+    expect(screen.getByText("plan-lint")).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: "plan-lint" })).not.toBeInTheDocument();
+    expect(screen.queryByText("#0")).not.toBeInTheDocument();
+  });
+
   it("degraded フラグで banner を表示し、正常時は隠す", () => {
     render(<App />);
     streamSnapshot(makeSnapshot([], { degraded: { tmux: true, github: true } }));


### PR DESCRIPTION
## TL;DR
Plan task rows now render by `taskId` instead of `#0`, and read paths fetch PR/CI state by head branch for issue-less task rows.
Review effort: 3

## Why
Issue-less plan sessions record `Parent=plan:<slug>`, `TaskID`, and `IssueNum=0`, but the read layer still assumed positive issue numbers. That made dashboard/TUI displays show numeric placeholders and miss the PR state attached to the task branch.

```mermaid
flowchart LR
  S[state.json plan row] --> A[sessionview Build]
  A -->|IssueNum > 0| I[IssuePRs]
  A -->|TaskID + branch| B[BranchPRs]
  B --> D[dashboard/TUI PR + CI]
  A --> W[web taskId labels + filters]
```

## Changes by file
<details><summary>Changed files</summary>

| File | Change |
| --- | --- |
| `internal/dashboard/poller.go` | Adds branch-key PR cache and refreshes distinct task branches before building snapshots. |
| `internal/dashboard/poller_test.go` | Covers task branch PR cache population and distinct task branch selection. |
| `internal/dashboard/server_test.go` | Extends the fake GitHub provider with branch PR lookup. |
| `internal/sessionview/aggregate.go` | Adds task-aware PR fetch routing, task sorting fallback, and task IDs in pane views. |
| `internal/sessionview/aggregate_test.go` | Covers branch PRs for task rows, degraded branch lookup, and JSON task ID behavior. |
| `internal/sessionview/collect.go` | Wires `GH.BranchPRs` to `ghissue.Runner.PRsForBranch`. |
| `internal/sessionview/model.go` | Adds optional `taskId` to the snapshot wire model. |
| `internal/tui/tui.go` | Uses task-aware status keys, fetches branch PRs for task rows, and avoids issue-only synthetic/status handling for tasks. |
| `internal/tui/tui_test.go` | Covers task row display fallback and TUI branch PR loading. |
| `web/src/components/Drawer.tsx` | Displays task labels without issue links for issue-less rows. |
| `web/src/components/SessionSection.tsx` | Displays task labels in table issue cells. |
| `web/src/lib/filter.test.ts` | Covers task ID structured and free-text search. |
| `web/src/lib/filter.ts` | Includes task ID in search and `issue:` matching. |
| `web/src/lib/pane.ts` | Adds task-aware pane labels and stable row keys. |
| `web/src/lib/sort.test.ts` | Covers task ID tie-break sorting. |
| `web/src/lib/sort.ts` | Uses task ID as name fallback and issue/task tie-breaker. |
| `web/src/lib/types.ts` | Adds optional `taskId` to `PaneView`. |
| `web/src/test/app.test.tsx` | Covers plan rows rendering task ID instead of `#0`. |

</details>

## Risk
Low: the new branch PR reads are additive and cached per distinct task branch; GitHub failures degrade the display path like existing issue PR failures.

## Test plan
- `make lint` passed.
- `make test` passed.
- `make lint-web` passed.
- `codex review --uncommitted` completed with no findings.
- `./fanout-go msg inbox` checked sibling notes before publish.

Closes #216
