### PR TITLE
[codex] add Codex review follow-up skills

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,10 +16,9 @@ a shellcheck of the test shims. `make fmt` formats (gofumpt/goimports),
 
 Source-of-truth integration files:
 
-- Claude Code: `claude/commands/fanout.md` and
-  `claude/skills/fanout/SKILL.md`, installed under `~/.claude/`.
-- Codex CLI: `codex/skills/fanout/SKILL.md`, installed under
-  `~/.codex/skills/fanout/`.
+- Claude Code: `claude/commands/*.md` and `claude/skills/*/SKILL.md`,
+  installed under `~/.claude/`.
+- Codex CLI: `codex/skills/*/SKILL.md`, installed under `~/.codex/skills/`.
 
 Do not edit installed copies under home directories directly. Edit the repo
 versions and rerun `make install` or `make link`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,11 +22,11 @@ shellcheck of the test shims (Node-free on purpose; the web lint is
 `go fix` idiom updates (run `make test` after applying), and `make vuln` runs
 govulncheck (network; deliberately not part of `lint`).
 
-The Claude Code integration files (`claude/commands/fanout.md` slash command
-and `claude/skills/fanout/SKILL.md` skill) and Codex CLI integration file
-(`codex/skills/fanout/SKILL.md`) are bundled in the repo as the source of
-truth. `make install` places them under `~/.claude/` and `~/.codex/`. Do not
-edit installed copies directly.
+The Claude Code integration files (`claude/commands/*.md` slash commands and
+`claude/skills/*/SKILL.md` skills) and Codex CLI integration files
+(`codex/skills/*/SKILL.md`) are bundled in the repo as the source of truth.
+`make install` places them under `~/.claude/` and `~/.codex/`. Do not edit
+installed copies directly.
 
 The user-facing surface is in `README.md` and `README.ja.md`. Read those before
 changing behavior; this file covers repo-local architecture and maintenance

--- a/README.ja.md
+++ b/README.ja.md
@@ -122,10 +122,15 @@ curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh |
 
 - `$BIN_DIR/fanout`（既定は `~/.local/bin/fanout`）
 - `$CLAUDE_DIR/commands/fanout.md`（既定は `~/.claude/commands/fanout.md`）
+- `$CLAUDE_DIR/commands/pr-watch.md`（既定は `~/.claude/commands/pr-watch.md`）
 - `$CLAUDE_DIR/skills/fanout/`（既定は `~/.claude/skills/fanout/`）
 - `$CLAUDE_DIR/skills/fanout-issues/`（既定は `~/.claude/skills/fanout-issues/`）
+- `$CLAUDE_DIR/skills/post-work-review/`（既定は `~/.claude/skills/post-work-review/`）
+- `$CLAUDE_DIR/skills/pr-watch/`（既定は `~/.claude/skills/pr-watch/`）
 - `$CODEX_DIR/skills/fanout/`（既定は `~/.codex/skills/fanout/`）
 - `$CODEX_DIR/skills/fanout-issues/`（既定は `~/.codex/skills/fanout-issues/`）
+- `$CODEX_DIR/skills/post-work-review/`（既定は `~/.codex/skills/post-work-review/`）
+- `$CODEX_DIR/skills/pr-watch/`（既定は `~/.codex/skills/pr-watch/`）
 
 `install.sh` は macOS/Linux と amd64/arm64 を自動判定し、最新 GitHub Release
 （または `FANOUT_VERSION` で指定した tag）から
@@ -735,6 +740,16 @@ Codex CLI 向けの推奨連携 — スキルはこのリポジトリの `codex/
   `fanout --unblocked-only` 用の blocker wave 作成を依頼したときに使います。
   Claude 版と同じく、同一リポジトリ内の子 issue、GitHub Sub-issues のリンク、
   親本文のタスクリスト、`## Blocked by` 注記を揃えます。
+- **post-work review スキル** → `codex/skills/post-work-review/SKILL.md` が
+  `~/.codex/skills/post-work-review/SKILL.md` にインストールされます。Codex に
+  コミット前・PR前の最終レビューを依頼したときに使い、明示 scope 付きの
+  `codex review` を回し、actionable な指摘を直し、clean になるまで再レビューします。
+  reviewed HEAD が clean な場合は Claude の PR gate と同じ marker も記録します。
+- **PR watch スキル** → `codex/skills/pr-watch/SKILL.md` が
+  `~/.codex/skills/pr-watch/SKILL.md` にインストールされます。PR 作成後に
+  mergeability、失敗 CI、レビューコメントを確認し、安全に直せるものを修正し、
+  guarded `--force-with-lease` で push して、green / reviewer 待ち / blocked の
+  状態を報告します。
 
 上記の CLI 前提条件はそのまま適用されます: TUI は対象リポジトリの worktree から
 起動し、一括 pane 作成では tmux 内で実行し、agent 名を明示してください。詳しくは
@@ -835,8 +850,9 @@ fanout settings で `prReviewGate=false` になっている場合、子 Claude b
   `sh -c "<文字列>"` のような間接実行や、コミットメッセージ・PR コメントの本文に
   シェル演算子と一緒に `gh pr create` という文字列を書いた場合などは取りこぼし／過検知
   し得ます。その場合は `FANOUT_SKIP_PR_REVIEW=1` で回避してください。
-- `make install` は同名のグローバル `post-work-review` skill を上書きします。独自に
-  管理しているコピーがある場合は事前にバックアップしてください。
+- `make install` は Claude / Codex 配下の同名グローバル `post-work-review` /
+  `pr-watch` skill を上書きします。独自に管理しているコピーがある場合は事前に
+  バックアップしてください。
 
 ## 設計メモ
 

--- a/README.md
+++ b/README.md
@@ -133,10 +133,15 @@ Installed paths:
 
 - `$BIN_DIR/fanout` (default `~/.local/bin/fanout`)
 - `$CLAUDE_DIR/commands/fanout.md` (default `~/.claude/commands/fanout.md`)
+- `$CLAUDE_DIR/commands/pr-watch.md` (default `~/.claude/commands/pr-watch.md`)
 - `$CLAUDE_DIR/skills/fanout/` (default `~/.claude/skills/fanout/`)
 - `$CLAUDE_DIR/skills/fanout-issues/` (default `~/.claude/skills/fanout-issues/`)
+- `$CLAUDE_DIR/skills/post-work-review/` (default `~/.claude/skills/post-work-review/`)
+- `$CLAUDE_DIR/skills/pr-watch/` (default `~/.claude/skills/pr-watch/`)
 - `$CODEX_DIR/skills/fanout/` (default `~/.codex/skills/fanout/`)
 - `$CODEX_DIR/skills/fanout-issues/` (default `~/.codex/skills/fanout-issues/`)
+- `$CODEX_DIR/skills/post-work-review/` (default `~/.codex/skills/post-work-review/`)
+- `$CODEX_DIR/skills/pr-watch/` (default `~/.codex/skills/pr-watch/`)
 
 `install.sh` detects macOS/Linux and amd64/arm64, downloads
 `fanout_<os>_<arch>.tar.gz` from the latest GitHub Release (or
@@ -807,8 +812,8 @@ repo under `claude/` and get placed by `make install`:
   blocker waves in the `## Blocked by` / `(blocked by #N)` shapes that
   `fanout --unblocked-only` understands.
 
-Recommended integration for Codex CLI — the skill is bundled under
-`codex/` and gets placed by `make install`:
+Recommended integration for Codex CLI — the skills are bundled under
+`codex/` and get placed by `make install`:
 
 - **Skill** → `codex/skills/fanout/SKILL.md` is installed to
   `~/.codex/skills/fanout/SKILL.md`. Restart any running Codex session after
@@ -823,6 +828,17 @@ Recommended integration for Codex CLI — the skill is bundled under
   parent/child issues, or prepare blocker waves for `fanout --unblocked-only`.
   It mirrors the Claude issue-creation skill: same-repo children, GitHub
   Sub-issues links, parent task-list rows, and `## Blocked by` annotations.
+- **Post-work review skill** → `codex/skills/post-work-review/SKILL.md` is
+  installed to `~/.codex/skills/post-work-review/SKILL.md`. Use it by asking
+  Codex to run a final review loop before commit or PR; it runs
+  `codex review` with an explicit scope, fixes actionable findings, reruns
+  until clean, and records the same review marker used by the Claude PR gate
+  when the reviewed HEAD is clean.
+- **PR watch skill** → `codex/skills/pr-watch/SKILL.md` is installed to
+  `~/.codex/skills/pr-watch/SKILL.md`. Use it after opening a PR when you want
+  Codex to inspect mergeability, failing CI, and review comments, fix what is
+  safe to fix, push with guarded `--force-with-lease`, and report when the PR
+  is green, reviewer-waiting, or blocked.
 
 The CLI prerequisites above still apply: start the TUI from the target
 repository worktree, and for batch pane creation run from inside tmux, pass
@@ -933,8 +949,8 @@ Notes:
 - Detection is a simple regex on the command string. Contorted forms (`... &&
   gh pr create`, `xargs gh pr create`) can slip through — acceptable for
   fanout's normal flow.
-- `make install` overwrites a same-named global `post-work-review` skill; back
-  it up first if you maintain your own copy.
+- `make install` overwrites same-named global `post-work-review` and
+  `pr-watch` skills under Claude and Codex; back up any custom copies first.
 
 ## Design notes
 

--- a/codex/skills/post-work-review/SKILL.md
+++ b/codex/skills/post-work-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: post-work-review
-description: Use from Codex CLI to run a finish-review loop on current git work before commit or PR: inspect the diff, run codex review with an explicit scope, fix actionable findings, rerun until clean, and record the review marker when the reviewed commit is clean. Use when the user says review して仕上げて, post-review, finalize, コミット前に確認, 二重チェック, codex review もかけて, or asks for a final pre-PR review pass.
+description: "Use from Codex CLI to run a finish-review loop on current git work before commit or PR: inspect the diff, run codex review with an explicit scope, fix actionable findings, rerun until clean, and record the review marker when the reviewed commit is clean. Use when the user says review して仕上げて, post-review, finalize, コミット前に確認, 二重チェック, codex review もかけて, or asks for a final pre-PR review pass."
 metadata:
   short-description: Run a final Codex review loop before PR
 ---

--- a/codex/skills/post-work-review/SKILL.md
+++ b/codex/skills/post-work-review/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: post-work-review
+description: Use from Codex CLI to run a finish-review loop on current git work before commit or PR: inspect the diff, run codex review with an explicit scope, fix actionable findings, rerun until clean, and record the review marker when the reviewed commit is clean. Use when the user says review して仕上げて, post-review, finalize, コミット前に確認, 二重チェック, codex review もかけて, or asks for a final pre-PR review pass.
+metadata:
+  short-description: Run a final Codex review loop before PR
+---
+
+# post-work-review
+
+Codex で実装後の差分を仕上げるためのレビュー・修正ループ。
+
+Claude 版の `post-work-review` は Claude の `code-review` plugin と Codex
+companion を組み合わせるが、Codex 版ではそれらを使わない。Codex CLI の
+native review を明示スコープ付きで実行し、指摘を修正して、指摘なしになるまで
+同じ作業ツリーで回す。
+
+## Scope
+
+- 対象は現在の git リポジトリの作業ツリー、HEAD、または現在ブランチの差分。
+- git リポジトリ外なら、`post-work-review` は使えないと伝えて終了する。
+- レビュー対象が空なら、レビュー対象がないと伝えて終了する。
+- PR 作成、push、merge はこの skill の責任外。ユーザーが別途明示したときだけ行う。
+
+## Preflight
+
+1. `git rev-parse --is-inside-work-tree` で git リポジトリ内か確認する。
+2. `git status --porcelain` と `git diff --stat` を確認する。
+3. clean tree で branch diff を見る必要があるときは default branch を解決する。
+   まず `gh repo view --json defaultBranchRef -q .defaultBranchRef.name` を使い、
+   失敗したら `origin/HEAD`、最後に `main` を候補にする。
+
+## Review Target
+
+`codex review` は必ず明示スコープ付きで呼ぶ。裸の `codex review` は使わない。
+
+- 未コミット変更をレビューする: `codex review --uncommitted`
+- clean tree の現在コミットだけを見る: `codex review --commit HEAD`
+- clean tree のブランチ差分を見る: `codex review --base <default-branch>`
+
+未コミット変更があるときは、まず `--uncommitted` を使う。clean tree で、直前に
+レビュー済みとして marker を書く目的なら `--commit HEAD` を使う。PR 全体相当の
+差分を見たい依頼なら `--base` を使う。
+
+## Review Loop
+
+1. レビュー対象とコマンドを 1 文でユーザーに伝える。
+2. `codex review ...` を実行する。
+3. 出力を findings として読む。重大度、ファイル、行、指摘内容を保持する。
+4. actionable な指摘だけ修正する。明らかな bug、規約違反、セキュリティ問題、
+   テスト不整合を優先する。単なる好みの提案は理由を添えて見送ってよい。
+5. 修正したら、必要な focused test や formatting check を実行する。
+6. 同じスコープで `codex review ...` を再実行する。
+7. clean 判定まで 2-6 を繰り返す。
+
+### Clean 判定
+
+次の両方を満たすときだけ clean と見なす。
+
+- 肯定的な verdict がある: `approved`, `looks good`, `no issues`,
+  `no findings`, `0 findings`, `指摘なし`, `問題なし`, `修正不要` など。
+- 否定表現や残 findings がない: `not approved`, `cannot approve`,
+  `request changes`, `要修正`, `approve できない` などがあれば clean ではない。
+
+肯定語と否定語が混在する、findings があるのに approve 風の文面がある、などの
+曖昧な出力なら勝手に終了せず、ユーザーに clean と扱ってよいか確認する。
+
+### Oscillation Safety
+
+同じ指摘集合が 2 回連続で返ったら、自動修正を続けない。各 finding を
+`path:line:summary` に正規化して比較し、同一なら次を短く報告してユーザー判断を
+仰ぐ。
+
+- 繰り返している指摘
+- 直した内容
+- まだ残っている理由の仮説
+
+同一ではなくても、3 回連続で同じファイル群に同種の指摘が出る場合も停止して
+相談する。
+
+## Marker
+
+レビュー済み marker は、レビューが実質的に成功し、かつ working tree が clean
+なときだけ書く。dirty tree では書かない。未コミットの修正が PR に乗らないのに
+HEAD だけをレビュー済み扱いにするのを防ぐため。
+
+```bash
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "git repository not found: marker not written"
+elif [ -n "$(git status --porcelain)" ]; then
+  echo "working tree is dirty: marker not written"
+else
+  git rev-parse HEAD > "$(git rev-parse --git-dir)/post-work-review-passed"
+  echo "marker recorded: $(git rev-parse HEAD)"
+fi
+```
+
+この marker はこのリポジトリの Claude PR gate も読む。Codex 自体は
+`.claude/hooks` を実行しないが、同じ worktree を Claude Code から PR 作成に使う
+場合に一貫した signal になる。
+
+## Finish Report
+
+最後に 2-4 文で報告する。
+
+- どの scope をレビューしたか
+- 何回 `codex review` を回し、何件修正したか
+- 実行したテストやチェック
+- clean 判定で終えたか、ユーザー判断で止めたか
+- marker を書いたか、書かなかった場合は理由

--- a/codex/skills/post-work-review/SKILL.md
+++ b/codex/skills/post-work-review/SKILL.md
@@ -38,8 +38,12 @@ native review を明示スコープ付きで実行し、指摘を修正して、
 - clean tree のブランチ差分を見る: `codex review --base <default-branch>`
 
 未コミット変更があるときは、まず `--uncommitted` を使う。clean tree で、直前に
-レビュー済みとして marker を書く目的なら `--commit HEAD` を使う。PR 全体相当の
-差分を見たい依頼なら `--base` を使う。
+レビュー済みとして marker を書く目的なら、原則として `--base <default-branch>` を使い、
+PR 全体相当の branch diff をレビューする。`--commit HEAD` だけで marker を書いてよい
+のは、HEAD が base からの唯一の未レビュー commit だと確認できる場合、またはユーザーが
+単一 commit の再レビューだけを明示した場合に限る。複数 commit の feature branch で
+`--commit HEAD` だけを通して marker を書くと、古い commit が未レビューのまま PR gate を
+通す可能性がある。
 
 ## Review Loop
 
@@ -81,7 +85,9 @@ native review を明示スコープ付きで実行し、指摘を修正して、
 
 レビュー済み marker は、レビューが実質的に成功し、かつ working tree が clean
 なときだけ書く。dirty tree では書かない。未コミットの修正が PR に乗らないのに
-HEAD だけをレビュー済み扱いにするのを防ぐため。
+HEAD だけをレビュー済み扱いにするのを防ぐため。さらに、marker 前の成功レビューは
+PR 全体相当の branch/base scope であることを確認する。`--commit HEAD` の成功だけを
+根拠に marker を書くのは、base からの差分がその commit だけだと確認できる場合に限る。
 
 ```bash
 if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then

--- a/codex/skills/post-work-review/agents/openai.yaml
+++ b/codex/skills/post-work-review/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "post-work-review"
+  short_description: "Run a final Codex review loop"
+  default_prompt: "Use $post-work-review to run a final Codex review loop before a PR."
+
+policy:
+  allow_implicit_invocation: true

--- a/codex/skills/pr-watch/SKILL.md
+++ b/codex/skills/pr-watch/SKILL.md
@@ -75,7 +75,7 @@ gh pr view ${pr:+"$pr"} --json number,state,isDraft,mergeable,mergeStateStatus,r
    actionable な修正依頼が来ることがあるため、thread だけで未対応 0 と判定しない。
    `gh pr view --json comments` は先頭 100 件に制限される。完了判定や blocked 判定で
    トップレベルコメントを使う前に、コメントが多い PR では GraphQL の
-   `issueComments(first:100, after:$endCursor)` を全ページ取得し、後続ページの
+   `pullRequest.comments(first:100, after:$endCursor)` を全ページ取得し、後続ページの
    actionable request を取りこぼさない。
 
 ### B. 終了判定

--- a/codex/skills/pr-watch/SKILL.md
+++ b/codex/skills/pr-watch/SKILL.md
@@ -1,0 +1,196 @@
+---
+name: pr-watch
+description: Use from Codex CLI to monitor an existing pull request after creation and autonomously address merge conflicts, failing CI, and review comments until it is mergeable, green, and approved or genuinely blocked. Use when the user says PR を見張って, コンフリクト直して, CI 直して, レビュー対応して, PR がマージできる状態まで, babysit this PR, or after PR creation says あとよろしく.
+metadata:
+  short-description: Watch and repair an existing PR
+---
+
+# pr-watch
+
+PR 作成後に起きるマージコンフリクト、CI 失敗、レビューコメントを検知し、
+安全に自動対応する Codex 用 workflow。
+
+Claude 版の `pr-watch` は `/loop` と `ScheduleWakeup` を前提にする。Codex 版では
+バックグラウンド監視を装わない。通常は 1 pass を実行して現状と対応結果を報告する。
+ユーザーが「継続して見張って」と明示した場合だけ、同じセッション内で短い polling
+loop を回す。人間レビュー待ちなど長時間アイドルになる状態では、何を待っているかを
+報告して止まる。
+
+## Preconditions
+
+- git リポジトリ内で実行する。外なら終了する。
+- `gh auth status` が通ること。失敗したら `gh auth login` を案内して終了する。
+- 対象は現在ブランチに紐づく PR、またはユーザーが渡した PR 番号 / URL。
+- この skill は PR を作らない。PR が見つからなければ、先に PR を作るよう伝える。
+- 操作対象は自分が作成し、push 権限がある head topic branch だけ。
+
+## Target PR
+
+引数なしなら現在ブランチの PR を対象にする。PR 番号または URL がある場合だけ
+位置引数として渡す。空文字を渡してはいけない。
+
+```bash
+gh pr view ${pr:+"$pr"} --json number,state,isDraft,mergeable,mergeStateStatus,reviewDecision,reviewRequests,headRefName,baseRefName,author,headRepository,headRepositoryOwner,isCrossRepository,maintainerCanModify,url,title,statusCheckRollup
+```
+
+`headRefName` が現在のローカルブランチ名と一致することを確認する。不一致なら
+修正や push に入らず、対象 PR の head branch を checkout してから続けるか、
+ユーザーに確認する。別ブランチの HEAD で PR head を上書きしてはいけない。
+
+## One Pass
+
+各ステップの前に、何を確認または修正するかを 1 文でユーザーへ伝える。
+
+### A. 状態取得
+
+1. `gh pr view` で PR 状態を取得する。
+2. CI を取得する。`gh pr checks` は pending や failing で非 0 を返すことがあるので、
+   exit code ではなく JSON の `bucket` を読む。
+
+   ```bash
+   gh pr checks ${pr:+"$pr"} --json name,state,bucket,link,workflow || true
+   ```
+
+3. 未解決 review thread を GraphQL で全ページ取得する。`isResolved=false` の thread、
+   top-level comment の本文、latest comment の author/body を読む。
+
+   ```bash
+   gh api graphql --paginate -f query='
+     query($owner:String!,$repo:String!,$num:Int!,$endCursor:String){
+       repository(owner:$owner,name:$repo){
+         pullRequest(number:$num){
+           reviewThreads(first:100, after:$endCursor){
+             pageInfo{ hasNextPage endCursor }
+             nodes{ isResolved path line originalLine diffSide
+               topLevel: comments(first:1){ nodes{ fullDatabaseId body diffHunk } }
+               latest: comments(last:1){ nodes{ author{login} createdAt body } }
+             }
+           }
+         }
+       }
+     }' -F owner="$owner" -F repo="$repo" -F num="$num"
+   ```
+
+4. `latestReviews` とトップレベル `comments` も読む。レビュー本文や PR コメントだけで
+   actionable な修正依頼が来ることがあるため、thread だけで未対応 0 と判定しない。
+
+### B. 終了判定
+
+対処前に終了済みか確認する。
+
+- `state` が `MERGED` または `CLOSED` なら完了。
+- OPEN かつ draft でなく、mergeable、CI が pass/skipping、未対応 review thread と
+  actionable top-level 指摘が 0、承認済みまたはレビュー不要なら完了。
+- `mergeable=UNKNOWN` は GitHub 計算中として短い待ち候補にする。
+- draft、reviewer 待ち、CI pending は完了扱いにしない。対処対象がなければ何を
+  待っているか報告する。
+
+`mergeStateStatus=BEHIND` は、base branch の up-to-date が必須なら rebase 対象。
+必須でない repo では `mergeable=MERGEABLE` と green CI を優先し、無駄な rebase を
+避ける。
+
+### C. Push Remote と Force Push 認可
+
+rebase、CI 修正、レビュー修正で push する前に必ず解決する。
+
+- `me=$(gh api user -q .login)` を取得する。
+- force push してよいのは、PR author が自分で、head branch に push 権限がある場合のみ。
+- 同一リポジトリ PR は author が自分なら push 可。fork PR は head repository owner が
+  自分のときだけ push 可。
+- `maintainerCanModify=true` は履歴 rewrite の認可根拠にしない。
+- local remote は PR の `headRepository.nameWithOwner` に実際に一致するものを使う。
+  一致 remote がなければ URL を解決し、remote を追加して fetch してから使う。
+- push は常に明示 refspec を使う。
+
+```bash
+git push --force-with-lease "<head-remote>" HEAD:"$head"
+```
+
+無印 `--force`、refspec なしの `git push --force-with-lease`、保護ブランチや他者 PR
+への force push は使わない。
+
+### D. コンフリクトと Base Drift
+
+`mergeable=CONFLICTING`、`mergeStateStatus=DIRTY`、または strict required checks で
+`BEHIND` の場合に対応する。
+
+1. dirty tree なら、勝手に捨てず、commit するか stash するかを判断する。
+2. PR の base repository に一致する remote から base branch を fetch する。fork や
+   triangular clone があるので `origin/main` 決め打ちはしない。
+3. `git rebase FETCH_HEAD` で今 fetch した base に rebase する。
+4. import 併合など確信できる hunk だけ自動解決する。意味的判断が必要な衝突は
+   `git rebase --abort` して、具体的な hunk と理由を添えてエスカレーションする。
+5. rebase 完了後に `git push --force-with-lease "<head-remote>" HEAD:"$head"`。
+6. push したら、その pass では古い CI/log/thread を使わず終了する。必要なら次 pass で
+   状態を取り直す。
+
+### E. CI 失敗
+
+`gh pr checks` の `bucket` が `fail` または `cancel` のものを拾う。
+
+- GitHub Actions なら run id を取り、対象 repo を `-R` で明示して失敗ログだけ読む。
+
+  ```bash
+  gh run view -R "$owner/$repo" <run-id> --log-failed
+  ```
+
+- 外部 CI は `gh run` で読めない。link を確認し、自動アクセスできなければユーザーに
+  エスカレーションする。
+- 原因を特定してから修正する。CI を通すためにテスト削除、workflow 緩和、skip 追加を
+  してはいけない。
+- 修正後は focused test を実行し、commit して、明示 refspec で push する。
+- flaky やインフラ起因なら 1 回だけ再実行を促す。再現するならコードを無理に触らず
+  エスカレーションする。
+
+### F. レビューコメント対応
+
+未対応のインライン thread、review summary、トップレベル PR コメントを対象にする。
+
+- `latest` comment が自分の返信で、その後レビュアー反応がなければ対応済みとして
+  skip する。
+- 新しいレビュアー返信があれば、top-level comment ではなく latest comment の要求を読む。
+- 仕様判断や方針確認が必要な指摘は無理に直さず、判断点を整理してユーザーに確認する。
+- 修正したら test、commit、push の順に進める。
+- 返信は push 後に行う。インライン返信は top-level comment の `fullDatabaseId` を使う。
+- thread resolve は基本的にレビュアーへ委ねる。自分で resolve するのは確信がある場合のみ。
+
+## Continuous Watching
+
+ユーザーが継続監視を明示した場合だけ、pass の後に状態に応じて待つ。
+
+- CI 実行中、push 直後、`mergeable=UNKNOWN`: 数分待って再 pass。
+- 人間レビュー待ちで CI green、衝突なし、未対応指摘なし: 長時間待ちになるため、
+  状態を報告して停止する。
+
+Codex セッションを終了すると監視は続かない。バックグラウンドで見張っているように
+表現しない。
+
+## Oscillation Safety
+
+直前 pass の対処対象を正規化して覚える。
+
+- conflict: 衝突ファイル集合
+- CI: failing workflow/job 集合
+- review: path と指摘要旨の集合
+
+同じ集合が 2 pass 連続で残り、進捗がないなら自動修正を止める。3 pass 連続で
+同じファイル群に同種の問題が残る場合も止める。残っている問題、試した修正、
+次に必要な判断を短く整理してユーザーに渡す。
+
+## Do Not
+
+- PR を新規作成しない。
+- 明示指示なしに auto-merge しない。
+- 他者 PR、保護ブランチ、push 権限が曖昧な fork に force push しない。
+- CI を通すためにテストや必須チェックを弱めない。
+- GitHub の古い thread や push 前の CI log を根拠に、push 後も同じ pass で修正を続けない。
+
+## Finish Report
+
+2-4 文で報告する。
+
+- 何 pass 回したか
+- conflict、CI、review をそれぞれ何件処理したか
+- push や返信をしたか
+- 最終状態が merged/closed、mergeable+green、reviewer 待ち、CI 待ち、blocked のどれか
+- 残課題がある場合は箇条書き

--- a/codex/skills/pr-watch/SKILL.md
+++ b/codex/skills/pr-watch/SKILL.md
@@ -73,6 +73,10 @@ gh pr view ${pr:+"$pr"} --json number,state,isDraft,mergeable,mergeStateStatus,r
 
 4. `latestReviews` とトップレベル `comments` も読む。レビュー本文や PR コメントだけで
    actionable な修正依頼が来ることがあるため、thread だけで未対応 0 と判定しない。
+   `gh pr view --json comments` は先頭 100 件に制限される。完了判定や blocked 判定で
+   トップレベルコメントを使う前に、コメントが多い PR では GraphQL の
+   `issueComments(first:100, after:$endCursor)` を全ページ取得し、後続ページの
+   actionable request を取りこぼさない。
 
 ### B. 終了判定
 
@@ -101,6 +105,16 @@ rebase、CI 修正、レビュー修正で push する前に必ず解決する�
 - local remote は PR の `headRepository.nameWithOwner` に実際に一致するものを使う。
   一致 remote がなければ URL を解決し、remote を追加して fetch してから使う。
 - push は常に明示 refspec を使う。
+- `--force-with-lease` は ancestry check ではない。fetch や background fetch で lease が
+  更新されると、remote-only commit を含まないローカル HEAD でも上書きできてしまう。
+  force-with-lease push の直前に必ず head branch を fetch し、remote PR head が現在
+  HEAD の祖先であることを確認する。false なら push せず、remote-only commit を取り込むか
+  ユーザーにエスカレーションする。
+
+```bash
+git fetch "<head-remote>" "$head"
+git merge-base --is-ancestor FETCH_HEAD HEAD
+```
 
 ```bash
 git push --force-with-lease "<head-remote>" HEAD:"$head"

--- a/codex/skills/pr-watch/SKILL.md
+++ b/codex/skills/pr-watch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-watch
-description: Use from Codex CLI to monitor an existing pull request after creation and autonomously address merge conflicts, failing CI, and review comments until it is mergeable, green, and approved or genuinely blocked. Use when the user says PR を見張って, コンフリクト直して, CI 直して, レビュー対応して, PR がマージできる状態まで, babysit this PR, or after PR creation says あとよろしく.
+description: "Use from Codex CLI to monitor an existing pull request after creation and autonomously address merge conflicts, failing CI, and review comments until it is mergeable, green, and approved or genuinely blocked. Use when the user says PR を見張って, コンフリクト直して, CI 直して, レビュー対応して, PR がマージできる状態まで, babysit this PR, or after PR creation says あとよろしく."
 metadata:
   short-description: Watch and repair an existing PR
 ---

--- a/codex/skills/pr-watch/SKILL.md
+++ b/codex/skills/pr-watch/SKILL.md
@@ -107,17 +107,24 @@ rebase、CI 修正、レビュー修正で push する前に必ず解決する�
 - push は常に明示 refspec を使う。
 - `--force-with-lease` は ancestry check ではない。fetch や background fetch で lease が
   更新されると、remote-only commit を含まないローカル HEAD でも上書きできてしまう。
-  force-with-lease push の直前に必ず head branch を fetch し、remote PR head が現在
-  HEAD の祖先であることを確認する。false なら push せず、remote-only commit を取り込むか
-  ユーザーにエスカレーションする。
+  rebase などの履歴 rewrite や追加 commit を始める前に必ず head branch を fetch し、
+  remote PR head が現在 HEAD の祖先であることを確認して、その SHA を保存する。false なら
+  作業を進めず、remote-only commit を取り込むかユーザーにエスカレーションする。
+- push 直前には head branch を再 fetch し、remote tip が保存した SHA から動いていないことを
+  確認する。remote が動いていたら push せず、取り込みまたはエスカレーションする。
+  rebase 後は古い PR tip が新しい HEAD の祖先とは限らないため、rebase 後に ancestry check を
+  再実行して判断しない。
 
 ```bash
 git fetch "<head-remote>" "$head"
-git merge-base --is-ancestor FETCH_HEAD HEAD
+pr_head_before_work=$(git rev-parse FETCH_HEAD)
+git merge-base --is-ancestor "$pr_head_before_work" HEAD
 ```
 
 ```bash
-git push --force-with-lease "<head-remote>" HEAD:"$head"
+git fetch "<head-remote>" "$head"
+test "$(git rev-parse FETCH_HEAD)" = "$pr_head_before_work"
+git push --force-with-lease="refs/heads/$head:$pr_head_before_work" "<head-remote>" HEAD:"$head"
 ```
 
 無印 `--force`、refspec なしの `git push --force-with-lease`、保護ブランチや他者 PR
@@ -129,13 +136,15 @@ git push --force-with-lease "<head-remote>" HEAD:"$head"
 `BEHIND` の場合に対応する。
 
 1. dirty tree なら、勝手に捨てず、commit するか stash するかを判断する。
-2. PR の base repository に一致する remote から base branch を fetch する。fork や
+2. C の PR head guard を rebase 前に実行し、`pr_head_before_work` を保存する。
+3. PR の base repository に一致する remote から base branch を fetch する。fork や
    triangular clone があるので `origin/main` 決め打ちはしない。
-3. `git rebase FETCH_HEAD` で今 fetch した base に rebase する。
-4. import 併合など確信できる hunk だけ自動解決する。意味的判断が必要な衝突は
+4. `git rebase FETCH_HEAD` で今 fetch した base に rebase する。
+5. import 併合など確信できる hunk だけ自動解決する。意味的判断が必要な衝突は
    `git rebase --abort` して、具体的な hunk と理由を添えてエスカレーションする。
-5. rebase 完了後に `git push --force-with-lease "<head-remote>" HEAD:"$head"`。
-6. push したら、その pass では古い CI/log/thread を使わず終了する。必要なら次 pass で
+6. rebase 完了後、push 直前に remote tip が `pr_head_before_work` から動いていないことを
+   確認し、保存した SHA を期待値にした `--force-with-lease` で push する。
+7. push したら、その pass では古い CI/log/thread を使わず終了する。必要なら次 pass で
    状態を取り直す。
 
 ### E. CI 失敗

--- a/codex/skills/pr-watch/agents/openai.yaml
+++ b/codex/skills/pr-watch/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "pr-watch"
+  short_description: "Watch and repair an existing PR"
+  default_prompt: "Use $pr-watch to monitor an existing PR and fix conflicts, CI, or review comments."
+
+policy:
+  allow_implicit_invocation: true

--- a/install.sh
+++ b/install.sh
@@ -111,7 +111,8 @@ remove_integrations() {
   rm -f "$claude_dir/commands/fanout.md" "$claude_dir/commands/pr-watch.md"
   rm -rf "$claude_dir/skills/fanout" "$claude_dir/skills/fanout-issues" \
     "$claude_dir/skills/post-work-review" "$claude_dir/skills/pr-watch"
-  rm -rf "$codex_dir/skills/fanout" "$codex_dir/skills/fanout-issues"
+  rm -rf "$codex_dir/skills/fanout" "$codex_dir/skills/fanout-issues" \
+    "$codex_dir/skills/post-work-review" "$codex_dir/skills/pr-watch"
 }
 
 copy_skill_dirs() {

--- a/site/content/docs/agents.ja.md
+++ b/site/content/docs/agents.ja.md
@@ -1,7 +1,7 @@
 ---
 title: Claude Code・Codex 連携
 linkTitle: エージェント連携
-description: "Claude Code / Codex 向けの /fanout スラッシュコマンドと fanout・fanout-issues skill、そして Codex Plan Mode。"
+description: "Claude Code / Codex 向けの同梱 skill と /fanout スラッシュコマンド、そして Codex Plan Mode。"
 weight: 70
 kanji: 連
 yomi: agents
@@ -35,13 +35,24 @@ skill は `--name` フラグ(slug / display name / branch)も issue のタイト
 
 `~/.claude/skills/fanout-issues/` は、計画を fanout-ready な GitHub 親 issue + リンクされた子 issue 群へ変換する場面で agent を導きます。同一 repo 内の子 issue を作成し、GitHub Sub-issues でリンクし、親本文のタスクリストにミラーし、`fanout --unblocked-only` が読める `## Blocked by` / `(blocked by #N)` 形式で blocker wave も記録します。
 
+### レビューと PR follow-up skill
+
+`~/.claude/skills/post-work-review/` はローカルの PR review gate を支え、最終レビュー
+loop を回して reviewed HEAD marker を記録します。`~/.claude/commands/pr-watch.md` と
+`~/.claude/skills/pr-watch/` は、PR 作成後のコンフリクト、CI、レビューコメント対応を
+安全に見張って処理します。
+
 ## Codex CLI
 
-Codex 版の skill は `~/.codex/skills/fanout/` と `~/.codex/skills/fanout-issues/` に配置されます。skill のインストールや更新の後、実行中の Codex セッションがある場合は再起動すると新しいファイルを認識します。
+Codex 版の skill は `~/.codex/skills/fanout/`、`~/.codex/skills/fanout-issues/`、`~/.codex/skills/post-work-review/`、`~/.codex/skills/pr-watch/` に配置されます。skill のインストールや更新の後、実行中の Codex セッションがある場合は再起動すると新しいファイルを認識します。
 
 fanout skill は、Codex に「#123 を fan out して」のように依頼するか、明示的に `$fanout` を指定すると起動します。Claude のコマンドと同じ安全フロー — まず dry-run、ターゲットを確認、それから本実行 — に従い、暗黙の子参照のスキャンと `--name` 生成も同様に行います。
 
 `fanout-issues` skill も Claude 版をミラーします: fanout-ready な GitHub issue ツリーの作成、計画の親子 issue 化、`fanout --unblocked-only` 用の blocker wave の準備を Codex に依頼したときに使われ、同一 repo の子 issue、GitHub Sub-issues のリンク、親本文のタスクリスト、`## Blocked by` 注記を同じように揃えます。
+
+`$post-work-review` は、Codex にコミット前・PR前の最終レビュー loop を依頼するときに使います。明示 scope 付きの `codex review` を実行し、actionable な指摘を修正し、clean になるまで再レビューします。HEAD が clean な場合は Claude PR gate と同じ marker も記録します。
+
+`$pr-watch` は、PR 作成後に mergeability、失敗 CI、レビューコメントを Codex に確認・修正させたいときに使います。Codex は background scheduler を持たないため、green、reviewer 待ち、CI 待ち、blocked のどの状態かを報告して止まります。
 
 ## Codex Plan Mode
 

--- a/site/content/docs/agents.md
+++ b/site/content/docs/agents.md
@@ -1,7 +1,7 @@
 ---
 title: Agent Integrations
 linkTitle: Agent Integrations
-description: "The /fanout slash command, the fanout and fanout-issues skills for Claude Code and Codex, and Codex Plan Mode."
+description: "The /fanout slash command, bundled Claude Code and Codex skills, and Codex Plan Mode."
 weight: 70
 kanji: 連
 yomi: agents
@@ -35,13 +35,21 @@ The skill also generates the `--name` flags (slug / display name / branch) from 
 
 `~/.claude/skills/fanout-issues/` guides the agent when turning a plan into a fanout-ready GitHub parent issue plus linked child issues. It creates same-repo children, links them through GitHub Sub-issues, mirrors them in the parent task list, and records blocker waves in the `## Blocked by` / `(blocked by #N)` shapes that `fanout --unblocked-only` understands.
 
+### Review and PR follow-up skills
+
+`~/.claude/skills/post-work-review/` backs the local PR review gate: it runs a final review loop and records the reviewed HEAD marker. `~/.claude/commands/pr-watch.md` and `~/.claude/skills/pr-watch/` watch an existing PR after creation and handle safe conflict, CI, and review-comment follow-up.
+
 ## Codex CLI
 
-The Codex skills are installed to `~/.codex/skills/fanout/` and `~/.codex/skills/fanout-issues/`. Restart any running Codex session after installing or updating the skills so it picks up the new files.
+The Codex skills are installed to `~/.codex/skills/fanout/`, `~/.codex/skills/fanout-issues/`, `~/.codex/skills/post-work-review/`, and `~/.codex/skills/pr-watch/`. Restart any running Codex session after installing or updating the skills so it picks up the new files.
 
 Invoke the fanout skill by asking Codex to fan out a parent issue (for example, "fan out #123") or explicitly with `$fanout`. It follows the same safety flow as the Claude command — dry-run first, confirm targets, then run the real command — and it also performs the implicit-child scan and `--name` generation.
 
 The `fanout-issues` skill mirrors the Claude version: ask Codex to create a fanout-ready GitHub issue tree, decompose a plan into parent/child issues, or prepare blocker waves for `fanout --unblocked-only`, and it produces the same same-repo children, GitHub Sub-issues links, parent task-list rows, and `## Blocked by` annotations.
+
+Use `$post-work-review` when you want Codex to run a final pre-commit or pre-PR review loop. It invokes `codex review` with an explicit scope, fixes actionable findings, reruns until clean, and records the same marker used by the Claude PR gate when HEAD is clean.
+
+Use `$pr-watch` after opening a PR when you want Codex to inspect mergeability, failing CI, and review comments, then safely fix and push the items it can handle. Codex does not run a background scheduler, so the skill reports when it is green, reviewer-waiting, CI-waiting, or blocked.
 
 ## Codex Plan Mode
 

--- a/site/content/docs/installation.ja.md
+++ b/site/content/docs/installation.ja.md
@@ -43,11 +43,15 @@ curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh |
 
 - `$BIN_DIR/fanout`(既定は `~/.local/bin/fanout`)
 - `$CLAUDE_DIR/commands/fanout.md`(既定は `~/.claude/commands/fanout.md`)
+- `$CLAUDE_DIR/commands/pr-watch.md`(既定は `~/.claude/commands/pr-watch.md`)
 - `$CLAUDE_DIR/skills/fanout/`(既定は `~/.claude/skills/fanout/`)
 - `$CLAUDE_DIR/skills/fanout-issues/`(既定は `~/.claude/skills/fanout-issues/`)
 - `$CLAUDE_DIR/skills/post-work-review/`(既定は `~/.claude/skills/post-work-review/` — PR レビューゲートを支える skill。同名 skill を上書きするので、自前のものがあればバックアップを)
+- `$CLAUDE_DIR/skills/pr-watch/`(既定は `~/.claude/skills/pr-watch/`)
 - `$CODEX_DIR/skills/fanout/`(既定は `~/.codex/skills/fanout/`)
 - `$CODEX_DIR/skills/fanout-issues/`(既定は `~/.codex/skills/fanout-issues/`)
+- `$CODEX_DIR/skills/post-work-review/`(既定は `~/.codex/skills/post-work-review/`)
+- `$CODEX_DIR/skills/pr-watch/`(既定は `~/.codex/skills/pr-watch/`)
 
 `~/.local/bin` が `PATH` に入っていることを確認してください:
 

--- a/site/content/docs/installation.md
+++ b/site/content/docs/installation.md
@@ -43,11 +43,15 @@ curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh |
 
 - `$BIN_DIR/fanout` (default `~/.local/bin/fanout`)
 - `$CLAUDE_DIR/commands/fanout.md` (default `~/.claude/commands/fanout.md`)
+- `$CLAUDE_DIR/commands/pr-watch.md` (default `~/.claude/commands/pr-watch.md`)
 - `$CLAUDE_DIR/skills/fanout/` (default `~/.claude/skills/fanout/`)
 - `$CLAUDE_DIR/skills/fanout-issues/` (default `~/.claude/skills/fanout-issues/`)
 - `$CLAUDE_DIR/skills/post-work-review/` (default `~/.claude/skills/post-work-review/` — backs the PR review gate; overwrites a same-named skill, so back yours up)
+- `$CLAUDE_DIR/skills/pr-watch/` (default `~/.claude/skills/pr-watch/`)
 - `$CODEX_DIR/skills/fanout/` (default `~/.codex/skills/fanout/`)
 - `$CODEX_DIR/skills/fanout-issues/` (default `~/.codex/skills/fanout-issues/`)
+- `$CODEX_DIR/skills/post-work-review/` (default `~/.codex/skills/post-work-review/`)
+- `$CODEX_DIR/skills/pr-watch/` (default `~/.codex/skills/pr-watch/`)
 
 Confirm `~/.local/bin` is on your `PATH`:
 

--- a/site/content/docs/troubleshooting.ja.md
+++ b/site/content/docs/troubleshooting.ja.md
@@ -81,7 +81,7 @@ fanout settings で `prReviewGate=false` になっている場合、子 Claude b
 - ゲートは HEAD に固定されます。新しいコミットを積むと再武装されるので、PR の前にもう一度レビューしてください。marker は worktree ローカルなので、fanout の並列ペイン同士が干渉することはありません。
 - 検出はシェルトークナイザ(Python 製のコンパニオンパーサ)を通します。コマンド語と引用された引数値を区別するので、コミットメッセージに `gh pr create` と書いただけでは引っかかりません。`eval` / `xargs` / `sh -c "<文字列>"` のような間接実行はすり抜けることがありますが、fanout の通常フローでは許容範囲としています。
 - `python3` が無い環境では fail-closed になり、PR 作成らしきコマンドを粗い判定で deny します。`python3` をインストールするか、`export FANOUT_SKIP_PR_REVIEW=1` してください。
-- `make install` は同名のグローバル `post-work-review` skill を上書きします。独自に管理しているコピーがある場合は事前にバックアップしてください。
+- `make install` は Claude / Codex 配下の同名グローバル `post-work-review` / `pr-watch` skill を上書きします。独自に管理しているコピーがある場合は事前にバックアップしてください。
 
 ## Project モードで items が取れない
 

--- a/site/content/docs/troubleshooting.md
+++ b/site/content/docs/troubleshooting.md
@@ -81,7 +81,7 @@ Notes:
 - The gate is HEAD-pinned: any new commit re-arms it, so review again before the PR. The marker is worktree-local, so fanout's parallel panes don't interfere with each other.
 - Detection runs through a shell tokenizer (a Python companion parser), so command words are distinguished from quoted argument values — a commit message that merely mentions `gh pr create` does not trip it. Indirect forms (`eval`, `xargs`, `sh -c "<string>"`) can still slip through; that is accepted for fanout's normal flow.
 - Without `python3` the hook fails closed: it denies anything that coarsely looks like PR creation. Install `python3`, or `export FANOUT_SKIP_PR_REVIEW=1`.
-- `make install` overwrites a same-named global `post-work-review` skill; back it up first if you maintain your own copy.
+- `make install` overwrites same-named global `post-work-review` and `pr-watch` skills under Claude and Codex; back up any custom copies first.
 
 ## Project mode returns no items
 


### PR DESCRIPTION
## Summary
- add Codex versions of `post-work-review` and `pr-watch` with Codex-native review and PR follow-up workflows
- add `agents/openai.yaml` metadata for the new Codex skills
- update install/uninstall paths plus README and docs site references so Claude and Codex integrations stay aligned

## Impact
Codex users now get the same follow-up workflows that previously existed only for Claude, without relying on Claude-only slash commands, companion scripts, or background loop primitives.

## Validation
- `make lint`
- `make test`
- `git diff --check`
- `sh -n install.sh`
- frontmatter validation equivalent for the two new Codex skills
- `CLAUDE_DIR=/private/tmp/... CODEX_DIR=/private/tmp/... make install-integrations` smoke test confirmed both new Codex skills are copied