### PR TITLE
[codex] Share dashboard session view logic

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -43,7 +43,9 @@ agent 側の instrumentation なしで未 commit 作業の有無を確認でき�
 継続します。記録済みの issue 親については親の子一覧も再読込し、
 `--unblocked-only` と同じ `## Blocked by` / `(blocked by #N)` から wave / blocker
 列を表示します。まだ fanout されていない blocked 子は `deferred` 行で表示され、
-CLOSED blocker は resolved として区別されます。ヘッダーには `total` / `merged` /
+CLOSED blocker は resolved として区別されます。TUI と Web dashboard は同じ
+Session snapshot model を読むため、label、filter 語彙、PR/CI summary、synthetic 行の
+state が両 surface で揃います。ヘッダーには `total` / `merged` /
 `pending` / `blocked` の集約 count を表示します。`n` で必須 prompt、`claude` / `codex`
 の agent 選択、任意 slug を指定して manual agent pane を作成できます。manual pane
 は synthetic な `@manual` state entry として記録され、起動後に一覧へ表示されます。

--- a/README.md
+++ b/README.md
@@ -49,8 +49,11 @@ filter is active. For recorded issue parents it also reloads the parent child
 set and shows wave / blocker columns using the same `## Blocked by` and
 `(blocked by #N)` sources as `--unblocked-only`; blocked children that have not
 been fanned yet appear as `deferred` rows, and CLOSED blockers are shown as
-resolved. Its header shows `total` / `merged` / `pending` / `blocked` rollup
-counts. Press `n` to create a manual agent pane from a required prompt, selectable
+resolved. The TUI and web dashboard consume the same Session snapshot model, so
+labels, filtering terms, PR/CI summaries, and synthetic row states stay aligned
+across both dashboard surfaces. Its header shows `total` / `merged` /
+`pending` / `blocked` rollup counts. Press `n` to create a manual agent pane
+from a required prompt, selectable
 `claude` / `codex` agent, and optional slug. Manual panes use synthetic
 `@manual` state entries and appear in the list after launch. Press `Enter` or
 `o` on a live row to focus that pane, and press `p` to refresh the read-only

--- a/internal/sessionview/aggregate.go
+++ b/internal/sessionview/aggregate.go
@@ -2,6 +2,7 @@ package sessionview
 
 import (
 	"cmp"
+	"fmt"
 	"path/filepath"
 	"slices"
 	"strconv"
@@ -257,6 +258,7 @@ func Build(repo, projectRoot string, c Collectors) Snapshot {
 				// tmux 列が stale を伝えるので空のままにする。
 				pv.AgentState = normalizeAgentState(p.AgentStatus)
 			}
+			pv.Derived = DerivePane(projectRoot, parent, pv)
 			session.Panes = append(session.Panes, pv)
 			accumulate(&session.Rollup, pv)
 		}
@@ -301,6 +303,7 @@ func Build(repo, projectRoot string, c Collectors) Snapshot {
 					NotStarted:       true,
 					closeUnconfirmed: closeUnconfirmed,
 				}
+				pv.Derived = DerivePane(projectRoot, parent, pv)
 				session.Panes = append(session.Panes, pv)
 				if countsInRollup(pv) {
 					accumulate(&session.Rollup, pv)
@@ -589,4 +592,302 @@ func appendReason(existing, add string) string {
 		return existing // collapse repeated identical reasons (e.g. one per issue)
 	}
 	return existing + "; " + add
+}
+
+// DerivePane computes display/filter/sort helper values from the canonical
+// PaneView fields. parent is passed separately because PaneView deliberately
+// does not repeat its containing Session parent on the public wire shape.
+func DerivePane(projectRoot, parent string, pv PaneView) PaneDerived {
+	name := paneName(pv)
+	prSummary, prNum, prState := summarizePR(pv.PRs)
+	ci := paneCI(pv)
+	waveBadge := WaveBadge(pv.Wave, pv.Blocked)
+	waveText := WaveText(pv.WaveLabel, waveBadge)
+	dependencyWave := DependencyWaveText(pv.Wave)
+	blockersText := BlockersText(pv.Blockers)
+	openBlockers := OpenBlockerCount(pv.Blockers)
+	diffTotal, diffParsed := ParseDiffTotal(pv.DiffSummary)
+	relWorktree := RelativePath(projectRoot, pv.WorktreePath)
+
+	filterValues := map[string]string{
+		"state": strings.ToLower(strings.TrimSpace(firstMatchingState(pv.TmuxState, pv.IssueState))),
+		"run":   strings.ToLower(strings.TrimSpace(pv.AgentState)),
+		"agent": strings.ToLower(strings.TrimSpace(pv.Agent)),
+		"wave":  strings.ToLower(strings.TrimSpace(firstNonEmpty(strconv.Itoa(pv.Wave), pv.WaveLabel, dependencyWave))),
+		"ci":    strings.ToLower(strings.TrimSpace(ci)),
+		"dirty": yesNo(pv.DirtyState == "dirty"),
+		"live":  yesNo(pv.Alive),
+		"issue": issueFilterValue(pv),
+		"pr":    strings.ToLower(firstNonEmpty(prState, "none")),
+	}
+	if pv.Wave <= 0 {
+		filterValues["wave"] = strings.ToLower(strings.TrimSpace(firstNonEmpty(pv.WaveLabel, dependencyWave)))
+	}
+
+	filterText := strings.ToLower(strings.Join([]string{
+		parent,
+		pv.TaskID,
+		"#" + strconv.Itoa(pv.IssueNum),
+		strconv.Itoa(pv.IssueNum),
+		name,
+		pv.Slug,
+		pv.PaneID,
+		pv.TmuxState,
+		pv.TmuxTitle,
+		pv.AgentState,
+		pv.IssueState,
+		prSummary,
+		ci,
+		pv.BranchName,
+		pv.WorktreePath,
+		relWorktree,
+		pv.DiffSummary,
+		pv.DirtyState,
+		pv.WorktreeErr,
+		pv.Agent,
+		pv.WaveLabel,
+		waveBadge,
+		waveText,
+		blockersText,
+		dependencyWave,
+		pv.CreatedAt,
+		pv.Prompt,
+	}, "\n"))
+
+	canFocus := canFocusPane(pv.PaneID, pv.TmuxState)
+	return PaneDerived{
+		Name:             name,
+		PRSummary:        prSummary,
+		PrimaryPRNumber:  prNum,
+		PrimaryPRState:   prState,
+		CI:               ci,
+		WaveBadge:        waveBadge,
+		WaveText:         waveText,
+		DependencyWave:   dependencyWave,
+		BlockersText:     blockersText,
+		OpenBlockers:     openBlockers,
+		DiffTotal:        diffTotal,
+		DiffParsed:       diffParsed,
+		FilterText:       filterText,
+		FilterValues:     filterValues,
+		CanFocus:         canFocus,
+		CanPeek:          canFocus,
+		WorktreeRelative: relWorktree,
+		Sort: PaneSortKeys{
+			IssueNum: pv.IssueNum,
+			Name:     strings.ToLower(name),
+			Agent:    strings.ToLower(pv.Agent),
+			Wave:     waveSortKey(pv.Wave),
+			Blockers: openBlockers,
+			Branch:   strings.ToLower(pv.BranchName),
+			Diff:     diffSortKey(diffTotal, diffParsed),
+			Dirty:    dirtyRank(pv.DirtyState),
+			CI:       ciRank(ci),
+			Tmux:     tmuxRank(pv),
+			State:    strings.ToLower(pv.IssueState),
+			PR:       prRank(prState),
+		},
+	}
+}
+
+func paneName(pv PaneView) string {
+	return firstNonEmpty(pv.DisplayName, pv.Slug, pv.TaskID, "#"+strconv.Itoa(pv.IssueNum))
+}
+
+func issueFilterValue(pv PaneView) string {
+	if pv.IssueNum <= 0 && strings.TrimSpace(pv.TaskID) != "" {
+		return strings.ToLower(strings.TrimSpace(pv.TaskID))
+	}
+	return strconv.Itoa(pv.IssueNum)
+}
+
+func summarizePR(prs []ghissue.PRRef) (summary string, number int, state string) {
+	pr, ok := ghissue.PrimaryPR(prs)
+	if !ok {
+		return "-", 0, "none"
+	}
+	return "#" + strconv.Itoa(pr.Number) + " " + dash(pr.DisplayState()), pr.Number, strings.ToLower(pr.State)
+}
+
+func paneCI(pv PaneView) string {
+	if strings.TrimSpace(pv.CIStatus) == "" || pv.CIStatus == "-" {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(pv.CIStatus))
+}
+
+// WaveBadge returns the compact TUI wave badge: WN ready / WN blocked.
+func WaveBadge(wave int, blocked bool) string {
+	if wave <= 0 {
+		return "-"
+	}
+	state := "ready"
+	if blocked {
+		state = "blocked"
+	}
+	return fmt.Sprintf("W%d %s", wave, state)
+}
+
+// WaveText joins the human label and computed badge without duplicate dashes.
+func WaveText(label, badge string) string {
+	parts := nonDashStrings(label, badge)
+	if len(parts) == 0 {
+		return "-"
+	}
+	return strings.Join(parts, " ")
+}
+
+func DependencyWaveText(wave int) string {
+	if wave <= 0 {
+		return ""
+	}
+	return fmt.Sprintf("wave%d", wave)
+}
+
+func BlockersText(rows []blockers.Status) string {
+	if len(rows) == 0 {
+		return "-"
+	}
+	return blockers.FormatStatuses(rows)
+}
+
+func OpenBlockerCount(rows []blockers.Status) int {
+	n := 0
+	for _, row := range rows {
+		if row.State == "OPEN" {
+			n++
+		}
+	}
+	return n
+}
+
+func ParseDiffTotal(summary string) (int, bool) {
+	s := strings.TrimSpace(summary)
+	if !strings.HasPrefix(s, "+") {
+		return 0, false
+	}
+	addPart, delPart, ok := strings.Cut(s[1:], "/-")
+	if !ok {
+		return 0, false
+	}
+	add, errA := strconv.Atoi(addPart)
+	del, errD := strconv.Atoi(delPart)
+	if errA != nil || errD != nil {
+		return 0, false
+	}
+	return add + del, true
+}
+
+func RelativePath(root, path string) string {
+	if root == "" || path == "" {
+		return path
+	}
+	rel, err := filepath.Rel(root, path)
+	if err != nil || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
+		return path
+	}
+	return rel
+}
+
+func firstMatchingState(tmuxState, issueState string) string {
+	if strings.TrimSpace(tmuxState) != "" && tmuxState != "-" {
+		return tmuxState
+	}
+	return issueState
+}
+
+func yesNo(v bool) string {
+	if v {
+		return "yes"
+	}
+	return "no"
+}
+
+func waveSortKey(wave int) int {
+	if wave <= 0 {
+		return 99
+	}
+	return wave
+}
+
+func diffSortKey(total int, parsed bool) int {
+	if !parsed {
+		return -1
+	}
+	return total
+}
+
+func dirtyRank(state string) int {
+	switch state {
+	case "clean":
+		return 0
+	case "dirty":
+		return 1
+	case "unknown":
+		return 2
+	default:
+		return 3
+	}
+}
+
+func ciRank(ci string) int {
+	switch ci {
+	case "fail":
+		return 0
+	case "pending":
+		return 1
+	case "pass":
+		return 2
+	default:
+		return 3
+	}
+}
+
+func tmuxRank(pv PaneView) int {
+	switch {
+	case pv.Alive:
+		return 0
+	case pv.NotStarted:
+		return 2
+	default:
+		return 1
+	}
+}
+
+func prRank(state string) int {
+	switch strings.ToUpper(state) {
+	case "MERGED":
+		return 0
+	case "OPEN":
+		return 1
+	case "CLOSED":
+		return 2
+	default:
+		return 3
+	}
+}
+
+func canFocusPane(paneID, tmuxState string) bool {
+	return strings.TrimSpace(paneID) != "" && tmuxState != "stale" && tmuxState != "-"
+}
+
+func nonDashStrings(values ...string) []string {
+	out := make([]string, 0, len(values))
+	seen := map[string]bool{}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" || value == "-" || seen[value] {
+			continue
+		}
+		out = append(out, value)
+		seen[value] = true
+	}
+	return out
+}
+
+func dash(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return "-"
+	}
+	return s
 }

--- a/internal/sessionview/aggregate_test.go
+++ b/internal/sessionview/aggregate_test.go
@@ -145,6 +145,44 @@ func TestBuildGroupsByParentSortedAndComputesRollups(t *testing.T) {
 	}
 }
 
+func TestBuildAddsDerivedDisplayFilterAndSortFields(t *testing.T) {
+	c := Collectors{
+		Now:       fixedNow,
+		LoadState: storeOf(state.Pane{Parent: "100", IssueNum: 101, Slug: "child", DisplayName: "Child work", PaneID: "%1", Agent: "codex", BranchName: "feat/child", WorktreePath: "/repo/.fanout/worktrees/child"}),
+		LivePanes: livePanesWith(map[string]LivePaneInfo{"%1": {Path: "/repo/.fanout/worktrees/child", Title: "child title", AgentState: "running"}}),
+		IssuePRs: func(num int) (string, []ghissue.PRRef, error) {
+			return "OPEN", []ghissue.PRRef{{Number: 501, State: "OPEN", CIStatus: "fail"}}, nil
+		},
+		Waves: wavesOf(map[int]WaveInfo{
+			101: {Wave: 2, WaveLabel: "wave2", Blocked: true, Blockers: []blockers.Status{{Num: 99, State: "OPEN"}}},
+		}, nil),
+		WorktreeStat: func(path, baseRef string) (WorktreeStat, error) {
+			return WorktreeStat{DiffSummary: "+12/-3", DirtyState: "dirty"}, nil
+		},
+	}
+
+	pv := Build("o/n", "/repo", c).Sessions[0].Panes[0]
+	d := pv.Derived
+	if d.Name != "Child work" || d.PRSummary != "#501 open" || d.CI != "fail" {
+		t.Fatalf("derived display = %+v", d)
+	}
+	if d.WaveBadge != "W2 blocked" || d.WaveText != "wave2 W2 blocked" || d.BlockersText != "OPEN #99" {
+		t.Fatalf("derived wave/blockers = %+v", d)
+	}
+	if d.DiffTotal != 15 || !d.DiffParsed || d.Sort.Diff != 15 || d.Sort.CI != 0 {
+		t.Fatalf("derived sort/diff = %+v", d)
+	}
+	if d.FilterValues["run"] != "running" || d.FilterValues["dirty"] != "yes" || d.FilterValues["pr"] != "open" {
+		t.Fatalf("derived filter values = %+v", d.FilterValues)
+	}
+	if !strings.Contains(d.FilterText, "child title") || !strings.Contains(d.FilterText, "+12/-3") {
+		t.Fatalf("derived filter text = %q", d.FilterText)
+	}
+	if d.WorktreeRelative != ".fanout/worktrees/child" || !d.CanFocus || !d.CanPeek {
+		t.Fatalf("derived path/focus = %+v", d)
+	}
+}
+
 func TestBuildPerSessionAllMerged(t *testing.T) {
 	c := Collectors{
 		Now:       fixedNow,

--- a/internal/sessionview/model.go
+++ b/internal/sessionview/model.go
@@ -87,6 +87,48 @@ type PaneView struct {
 	// フラグ。一時的な gh 失敗で session が 100%/AllMerged に見えないよう、
 	// こうした行は rollup に残す。JSON には出さない(非エクスポート)。
 	closeUnconfirmed bool
+	Derived          PaneDerived `json:"derived"`
+}
+
+// PaneDerived holds display/filter/sort-friendly values computed from the
+// canonical PaneView fields. It is additive JSON: older UIs can ignore it, while
+// the TUI and bundled web UI use it to avoid duplicating domain decisions.
+type PaneDerived struct {
+	Name             string            `json:"name,omitempty"`
+	PRSummary        string            `json:"prSummary,omitempty"`
+	PrimaryPRNumber  int               `json:"primaryPrNumber,omitempty"`
+	PrimaryPRState   string            `json:"primaryPrState,omitempty"`
+	CI               string            `json:"ci,omitempty"`
+	WaveBadge        string            `json:"waveBadge,omitempty"`
+	WaveText         string            `json:"waveText,omitempty"`
+	DependencyWave   string            `json:"dependencyWave,omitempty"`
+	BlockersText     string            `json:"blockersText,omitempty"`
+	OpenBlockers     int               `json:"openBlockers,omitempty"`
+	DiffTotal        int               `json:"diffTotal,omitempty"`
+	DiffParsed       bool              `json:"diffParsed,omitempty"`
+	FilterText       string            `json:"filterText,omitempty"`
+	FilterValues     map[string]string `json:"filterValues,omitempty"`
+	Sort             PaneSortKeys      `json:"sort"`
+	CanFocus         bool              `json:"canFocus"`
+	CanPeek          bool              `json:"canPeek"`
+	WorktreeRelative string            `json:"worktreeRelative,omitempty"`
+}
+
+// PaneSortKeys is the shared ranking surface used by the web dashboard while
+// keeping browser-side sorting interactive.
+type PaneSortKeys struct {
+	IssueNum int    `json:"issueNum"`
+	Name     string `json:"name,omitempty"`
+	Agent    string `json:"agent,omitempty"`
+	Wave     int    `json:"wave,omitempty"`
+	Blockers int    `json:"blockers,omitempty"`
+	Branch   string `json:"branch,omitempty"`
+	Diff     int    `json:"diff,omitempty"`
+	Dirty    int    `json:"dirty,omitempty"`
+	CI       int    `json:"ci,omitempty"`
+	Tmux     int    `json:"tmux,omitempty"`
+	State    string `json:"state,omitempty"`
+	PR       int    `json:"pr,omitempty"`
 }
 
 // Rollup is an aggregate count band, mirroring --status's summary plus liveness.

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"io"
 	"maps"
-	"path/filepath"
 	"slices"
 	"strconv"
 	"strings"
@@ -23,7 +22,6 @@ import (
 	"github.com/butaosuinu/fanout/internal/blockers"
 	"github.com/butaosuinu/fanout/internal/exitcode"
 	"github.com/butaosuinu/fanout/internal/ghissue"
-	"github.com/butaosuinu/fanout/internal/gitstat"
 	"github.com/butaosuinu/fanout/internal/lifecycle"
 	fanoutnotify "github.com/butaosuinu/fanout/internal/notify"
 	"github.com/butaosuinu/fanout/internal/sessionview"
@@ -77,6 +75,7 @@ type issueStatus struct {
 	Wave            int
 	WaveLabel       string
 	Blockers        string
+	BlockerRows     []blockers.Status
 	HasOpenBlockers bool
 	// WaveDegraded marks rows whose body hydration failed in this refresh:
 	// the wave/blocker fields were computed without the child's body, so an
@@ -106,6 +105,7 @@ type paneView struct {
 	PaneID       string
 	TmuxState    string
 	TmuxTitle    string
+	AgentState   string
 	IssueState   string
 	PRSummary    string
 	HasMergedPR  bool
@@ -123,6 +123,7 @@ type paneView struct {
 	Agent        string
 	CreatedAt    string
 	Prompt       string
+	Derived      sessionview.PaneDerived
 }
 
 type hudSummary struct {
@@ -190,6 +191,12 @@ type paneFilter struct {
 	states []string
 	agents []string
 	waves  []string
+	runs   []string
+	cis    []string
+	dirty  []string
+	live   []string
+	issues []string
+	prs    []string
 }
 
 type stateLoadedMsg struct {
@@ -919,7 +926,7 @@ func (m model) formInputWidth() int {
 }
 
 func (m *model) refreshRows() {
-	m.allPanes = applyIssueStatuses(m.allPanes, m.issues)
+	m.allPanes = applyIssueStatuses(m.opts.ProjectRoot, m.allPanes, m.issues)
 	m.panes = filterPaneViews(m.allPanes, m.filterQuery)
 	rows := make([]table.Row, 0, len(m.panes))
 	for _, pane := range m.panes {
@@ -1097,14 +1104,28 @@ func (m model) notifyEventsCmd(events []fanoutnotify.Event) tea.Cmd {
 }
 
 func loadPaneViews(projectRoot string, issues map[issueKey]issueStatus) ([]paneView, error) {
-	store, err := state.LoadProject(projectRoot)
-	if err != nil {
-		return nil, err
+	var stateErr error
+	loadState := func() (state.Store, error) {
+		store, err := state.LoadProject(projectRoot)
+		stateErr = err
+		return store, err
 	}
-	tmuxPanes, err := tmuxrun.ListAllPanes()
-	tmuxKnown := err == nil
-	worktrees := loadWorktreeStats(store.Panes)
-	return buildPaneViews(projectRoot, store.Panes, tmuxPanes, tmuxKnown, issues, worktrees), err
+	var tmuxErr error
+	livePanes := sessionview.LivePanes()
+	live := func() (map[string]sessionview.LivePaneInfo, error) {
+		panes, err := livePanes()
+		tmuxErr = err
+		return panes, err
+	}
+	snap := sessionview.Build("", projectRoot, sessionview.Collectors{
+		LoadState:    loadState,
+		LivePanes:    live,
+		IssuePRs:     issuePRCollector(issues),
+		Waves:        waveCollector(issues),
+		WorktreeStat: sessionview.GitWorktreeStat(projectRoot),
+		Now:          time.Now,
+	})
+	return paneViewsFromSnapshot(projectRoot, snap), errors.Join(stateErr, tmuxErr)
 }
 
 func loadIssueStatuses(projectRoot string) (map[issueKey]issueStatus, error) {
@@ -1154,6 +1175,7 @@ func loadIssueStatuses(projectRoot string) (map[issueKey]issueStatus, error) {
 			cached.Wave = info.Wave
 			cached.WaveLabel = info.WaveLabel
 			cached.Blockers = blockers.FormatStatuses(info.Blockers)
+			cached.BlockerRows = info.Blockers
 			cached.HasOpenBlockers = info.Blocked
 			cached.WaveDegraded = info.Degraded
 			statuses[key] = cached
@@ -1195,6 +1217,81 @@ func recordedIssueNums(panes []state.Pane) []int {
 		}
 	}
 	return nums
+}
+
+func issuePRCollector(issues map[issueKey]issueStatus) func(int) (string, []ghissue.PRRef, error) {
+	byNum := map[int]issueStatus{}
+	for key, status := range issues {
+		if key.Num > 0 {
+			byNum[key.Num] = status
+		}
+	}
+	return func(num int) (string, []ghissue.PRRef, error) {
+		status, ok := byNum[num]
+		if !ok {
+			return "", nil, nil
+		}
+		return status.State, status.PRs, nil
+	}
+}
+
+func waveCollector(issues map[issueKey]issueStatus) func(string) (sessionview.WaveGraph, error) {
+	return func(parent string) (sessionview.WaveGraph, error) {
+		return waveGraphFromStatuses(parent, issues), nil
+	}
+}
+
+func waveGraphFromStatuses(parent string, issues map[issueKey]issueStatus) sessionview.WaveGraph {
+	parent = sessionview.NormalizeParent(parent)
+	graph := sessionview.WaveGraph{Info: map[int]sessionview.WaveInfo{}}
+	for key, status := range issues {
+		if key.Parent != parent || key.Num <= 0 {
+			continue
+		}
+		graph.Children = append(graph.Children, ghissue.Issue{
+			Number: key.Num,
+			Title:  status.Title,
+			State:  status.State,
+		})
+		rows := status.BlockerRows
+		if rows == nil {
+			rows = parseFormattedBlockers(status.Blockers)
+		}
+		graph.Info[key.Num] = sessionview.WaveInfo{
+			Wave:      status.Wave,
+			WaveLabel: status.WaveLabel,
+			Blockers:  rows,
+			Blocked:   status.HasOpenBlockers,
+			Degraded:  status.WaveDegraded,
+		}
+	}
+	slices.SortFunc(graph.Children, func(a, b ghissue.Issue) int { return cmp.Compare(a.Number, b.Number) })
+	return graph
+}
+
+func parseFormattedBlockers(text string) []blockers.Status {
+	text = strings.TrimSpace(text)
+	if text == "" || text == "-" {
+		return nil
+	}
+	rows := []blockers.Status{}
+	for part := range strings.SplitSeq(text, ",") {
+		fields := strings.Fields(strings.TrimSpace(part))
+		if len(fields) < 2 {
+			continue
+		}
+		numText := strings.TrimPrefix(fields[len(fields)-1], "#")
+		num, err := strconv.Atoi(numText)
+		if err != nil {
+			continue
+		}
+		stateName := fields[0]
+		if stateName == "resolved" {
+			stateName = "CLOSED"
+		}
+		rows = append(rows, blockers.Status{Num: num, State: strings.ToUpper(stateName)})
+	}
+	return rows
 }
 
 func detectIssueTransitions(previous map[issueKey]issueTransitionSnapshot, current map[issueKey]issueStatus) []fanoutnotify.Event {
@@ -1282,6 +1379,7 @@ func mergeDegradedIssueStatus(previous, current issueStatus) issueStatus {
 		return current // previous carries nothing better to preserve
 	}
 	current.Blockers = previous.Blockers
+	current.BlockerRows = previous.BlockerRows
 	current.HasOpenBlockers = previous.HasOpenBlockers
 	current.Wave = previous.Wave
 	current.WaveLabel = previous.WaveLabel
@@ -1416,13 +1514,6 @@ func keyForIssue(parent string, num int) issueKey {
 	return issueKey{Parent: normalizedParent(parent), Num: num}
 }
 
-func keyForPane(pane state.Pane) issueKey {
-	if pane.IssueNum <= 0 && strings.TrimSpace(pane.TaskID) != "" {
-		return keyForTask(pane.Parent, pane.TaskID)
-	}
-	return keyForIssue(pane.Parent, pane.IssueNum)
-}
-
 func keyForPaneView(pane paneView) issueKey {
 	if pane.IssueNum <= 0 && strings.TrimSpace(pane.TaskID) != "" {
 		return keyForTask(pane.Parent, pane.TaskID)
@@ -1442,81 +1533,94 @@ func normalizedParent(parent string) string {
 	return strconv.Itoa(parentNum)
 }
 
-func buildPaneViews(projectRoot string, panes []state.Pane, tmuxPanes []tmuxrun.PaneInfo, tmuxKnown bool, issues map[issueKey]issueStatus, worktrees map[string]worktreeStatView) []paneView {
-	tmuxByID := map[string]tmuxrun.PaneInfo{}
+func buildPaneViews(panes []state.Pane, tmuxPanes []tmuxrun.PaneInfo, tmuxKnown bool, issues map[issueKey]issueStatus, worktrees map[string]worktreeStatView) []paneView {
+	const projectRoot = "/repo"
+	live := map[string]sessionview.LivePaneInfo{}
 	for _, pane := range tmuxPanes {
-		tmuxByID[pane.ID] = pane
+		live[pane.ID] = sessionview.LivePaneInfo{Path: matchingWorktreePath(pane.ID, panes), Title: pane.Title}
 	}
-	out := make([]paneView, 0, len(panes))
-	seen := map[issueKey]bool{}
+	liveCollector := func() (map[string]sessionview.LivePaneInfo, error) {
+		if !tmuxKnown {
+			return nil, errors.New("tmux unavailable")
+		}
+		return live, nil
+	}
+	worktreeCollector := func(path, baseRef string) (sessionview.WorktreeStat, error) {
+		if stat, ok := worktrees[path]; ok {
+			return sessionview.WorktreeStat{DiffSummary: stat.Diff, DirtyState: stat.Dirty}, errFromString(stat.Err)
+		}
+		return sessionview.WorktreeStat{DiffSummary: "-", DirtyState: "unknown"}, nil
+	}
+	snap := sessionview.Build("", projectRoot, sessionview.Collectors{
+		LoadState:    func() (state.Store, error) { return state.Store{SchemaVersion: 1, Panes: panes}, nil },
+		LivePanes:    liveCollector,
+		IssuePRs:     issuePRCollector(issues),
+		Waves:        waveCollector(issues),
+		WorktreeStat: worktreeCollector,
+		Now:          time.Now,
+	})
+	return applyIssueStatuses(projectRoot, paneViewsFromSnapshot(projectRoot, snap), issues)
+}
+
+func matchingWorktreePath(paneID string, panes []state.Pane) string {
 	for _, pane := range panes {
-		key := keyForPane(pane)
-		status, hasStatus := issues[key]
-		seen[key] = true
-		view := paneView{
-			Parent:       pane.Parent,
-			IssueNum:     pane.IssueNum,
-			TaskID:       pane.TaskID,
-			Name:         paneName(pane),
-			PaneID:       pane.PaneID,
-			TmuxState:    tmuxState(pane.PaneID, tmuxByID, tmuxKnown),
-			IssueState:   "-",
-			PRSummary:    "-",
-			Wave:         status.Wave,
-			WaveLabel:    firstNonEmpty(pane.Wave, status.WaveLabel),
-			WaveBadge:    waveBadge(status.Wave, status.HasOpenBlockers),
-			Blockers:     dash(status.Blockers),
-			Blocked:      status.HasOpenBlockers,
-			CIStatus:     "-",
-			DiffSummary:  "-",
-			DirtyState:   "-",
-			BranchName:   pane.BranchName,
-			WorktreePath: relativePath(projectRoot, pane.WorktreePath),
-			Agent:        pane.Agent,
-			CreatedAt:    pane.CreatedAt,
-			Prompt:       pane.Prompt,
+		if pane.PaneID == paneID {
+			return pane.WorktreePath
 		}
-		if tmuxPane, ok := tmuxByID[pane.PaneID]; ok {
-			view.TmuxTitle = tmuxPane.Title
-		}
-		if hasStatus {
-			view.IssueState = dash(status.State)
-			view.PRSummary = summarizePRs(status.PRs)
-			view.HasMergedPR = hasMergedPR(status.PRs)
-			view.CIStatus = ghissue.SummarizeCI(status.PRs)
-		}
-		if stat, ok := worktrees[pane.WorktreePath]; ok {
-			view.DiffSummary = stat.Diff
-			view.DirtyState = stat.Dirty
-			view.WorktreeErr = stat.Err
-		}
-		out = append(out, view)
 	}
-	for key, status := range issues {
-		if seen[key] || key.TaskID != "" {
-			continue
-		}
-		out = append(out, paneView{
-			Parent:      key.Parent,
-			IssueNum:    key.Num,
-			Name:        issueTitle(status, key.Num),
-			TmuxState:   syntheticTmuxState(status),
-			IssueState:  dash(status.State),
-			PRSummary:   summarizePRs(status.PRs),
-			HasMergedPR: hasMergedPR(status.PRs),
-			CIStatus:    ghissue.SummarizeCI(status.PRs),
-			Wave:        status.Wave,
-			WaveLabel:   status.WaveLabel,
-			WaveBadge:   waveBadge(status.Wave, status.HasOpenBlockers),
-			Blockers:    dash(status.Blockers),
-			Blocked:     status.HasOpenBlockers,
-		})
+	return ""
+}
+
+func errFromString(s string) error {
+	if strings.TrimSpace(s) == "" {
+		return nil
 	}
-	sortPaneViews(out)
+	return errors.New(s)
+}
+
+func paneViewsFromSnapshot(projectRoot string, snap sessionview.Snapshot) []paneView {
+	out := []paneView{}
+	for _, session := range snap.Sessions {
+		parent := session.Parent
+		for _, pv := range session.Panes {
+			derived := pv.Derived
+			if derived.Name == "" && derived.PRSummary == "" {
+				derived = sessionview.DerivePane(projectRoot, parent, pv)
+			}
+			out = append(out, paneView{
+				Parent:       parent,
+				IssueNum:     pv.IssueNum,
+				TaskID:       pv.TaskID,
+				Name:         derived.Name,
+				PaneID:       pv.PaneID,
+				TmuxState:    pv.TmuxState,
+				TmuxTitle:    pv.TmuxTitle,
+				AgentState:   pv.AgentState,
+				IssueState:   dash(pv.IssueState),
+				PRSummary:    dash(derived.PRSummary),
+				HasMergedPR:  pv.HasMergedPR,
+				Wave:         pv.Wave,
+				WaveLabel:    pv.WaveLabel,
+				WaveBadge:    derived.WaveBadge,
+				Blockers:     dash(derived.BlockersText),
+				Blocked:      pv.Blocked,
+				CIStatus:     dash(pv.CIStatus),
+				DiffSummary:  pv.DiffSummary,
+				DirtyState:   pv.DirtyState,
+				WorktreeErr:  pv.WorktreeErr,
+				BranchName:   pv.BranchName,
+				WorktreePath: firstNonEmpty(derived.WorktreeRelative, sessionview.RelativePath(projectRoot, pv.WorktreePath)),
+				Agent:        pv.Agent,
+				CreatedAt:    pv.CreatedAt,
+				Prompt:       pv.Prompt,
+				Derived:      derived,
+			})
+		}
+	}
 	return out
 }
 
-func applyIssueStatuses(panes []paneView, issues map[issueKey]issueStatus) []paneView {
+func applyIssueStatuses(projectRoot string, panes []paneView, issues map[issueKey]issueStatus) []paneView {
 	out := slices.Clone(panes)
 	seen := map[issueKey]bool{}
 	for i := range out {
@@ -1534,13 +1638,14 @@ func applyIssueStatuses(panes []paneView, issues map[issueKey]issueStatus) []pan
 			out[i].Blockers = dash(status.Blockers)
 			out[i].Blocked = status.HasOpenBlockers
 			out[i].CIStatus = ghissue.SummarizeCI(status.PRs)
+			out[i].Derived = derivePaneView(projectRoot, out[i], status.PRs, status.BlockerRows)
 		}
 	}
 	for key, status := range issues {
 		if seen[key] || key.TaskID != "" {
 			continue
 		}
-		out = append(out, paneView{
+		view := paneView{
 			Parent:      key.Parent,
 			IssueNum:    key.Num,
 			Name:        issueTitle(status, key.Num),
@@ -1554,10 +1659,44 @@ func applyIssueStatuses(panes []paneView, issues map[issueKey]issueStatus) []pan
 			WaveBadge:   waveBadge(status.Wave, status.HasOpenBlockers),
 			Blockers:    dash(status.Blockers),
 			Blocked:     status.HasOpenBlockers,
-		})
+		}
+		view.Derived = derivePaneView(projectRoot, view, status.PRs, status.BlockerRows)
+		out = append(out, view)
 	}
 	sortPaneViews(out)
 	return out
+}
+
+func derivePaneView(projectRoot string, view paneView, prs []ghissue.PRRef, blockerRows []blockers.Status) sessionview.PaneDerived {
+	if blockerRows == nil {
+		blockerRows = parseFormattedBlockers(view.Blockers)
+	}
+	return sessionview.DerivePane(projectRoot, view.Parent, sessionview.PaneView{
+		IssueNum:     view.IssueNum,
+		TaskID:       view.TaskID,
+		DisplayName:  view.Name,
+		Agent:        view.Agent,
+		BranchName:   view.BranchName,
+		PaneID:       view.PaneID,
+		WorktreePath: view.WorktreePath,
+		CreatedAt:    view.CreatedAt,
+		Alive:        view.TmuxState == "live",
+		IssueState:   view.IssueState,
+		PRs:          prs,
+		HasMergedPR:  view.HasMergedPR,
+		DiffSummary:  view.DiffSummary,
+		DirtyState:   view.DirtyState,
+		WorktreeErr:  view.WorktreeErr,
+		TmuxState:    view.TmuxState,
+		TmuxTitle:    view.TmuxTitle,
+		AgentState:   view.AgentState,
+		Prompt:       view.Prompt,
+		CIStatus:     strings.ToLower(strings.TrimSpace(view.CIStatus)),
+		Wave:         view.Wave,
+		WaveLabel:    view.WaveLabel,
+		Blockers:     blockerRows,
+		Blocked:      view.Blocked,
+	})
 }
 
 func sortPaneViews(panes []paneView) {
@@ -1634,37 +1773,6 @@ func columnsForWidth(width int) []table.Column {
 	}
 }
 
-func loadWorktreeStats(panes []state.Pane) map[string]worktreeStatView {
-	runner := gitstat.Runner{}
-	stats := map[string]worktreeStatView{}
-	for _, pane := range panes {
-		path := strings.TrimSpace(pane.WorktreePath)
-		if path == "" {
-			continue
-		}
-		if _, ok := stats[path]; ok {
-			continue
-		}
-		stats[path] = worktreeStatForPath(runner, path, pane.BaseBranch)
-	}
-	return stats
-}
-
-func worktreeStatForPath(runner gitstat.Runner, path, baseRef string) worktreeStatView {
-	stat, err := runner.Worktree(path, baseRef)
-	if err != nil {
-		return worktreeStatView{Diff: "-", Dirty: "unknown", Err: err.Error()}
-	}
-	dirty := "clean"
-	if stat.Dirty {
-		dirty = "dirty"
-	}
-	return worktreeStatView{
-		Diff:  fmt.Sprintf("+%d/-%d", stat.Additions, stat.Deletions),
-		Dirty: dirty,
-	}
-}
-
 func (m model) footerText() string {
 	parts := []string{"q quit", "n new", "j/k move", "/ filter", "enter/o focus", "p peek", "c close", "m merge", "x cleanup"}
 	if m.filterEditing {
@@ -1706,6 +1814,18 @@ func parsePaneFilter(query string) paneFilter {
 			filter.agents = append(filter.agents, value)
 		case "wave", "w":
 			filter.waves = append(filter.waves, value)
+		case "run":
+			filter.runs = append(filter.runs, value)
+		case "ci":
+			filter.cis = append(filter.cis, value)
+		case "dirty":
+			filter.dirty = append(filter.dirty, value)
+		case "live":
+			filter.live = append(filter.live, value)
+		case "issue":
+			filter.issues = append(filter.issues, value)
+		case "pr":
+			filter.prs = append(filter.prs, value)
 		default:
 			filter.terms = append(filter.terms, token)
 		}
@@ -1727,7 +1847,9 @@ func splitFilterToken(token string) (string, string, bool) {
 }
 
 func (f paneFilter) empty() bool {
-	return len(f.terms) == 0 && len(f.states) == 0 && len(f.agents) == 0 && len(f.waves) == 0
+	return len(f.terms) == 0 && len(f.states) == 0 && len(f.agents) == 0 && len(f.waves) == 0 &&
+		len(f.runs) == 0 && len(f.cis) == 0 && len(f.dirty) == 0 && len(f.live) == 0 &&
+		len(f.issues) == 0 && len(f.prs) == 0
 }
 
 func (p paneView) matchesFilter(filter paneFilter) bool {
@@ -1746,6 +1868,43 @@ func (p paneView) matchesFilter(filter paneFilter) bool {
 			return false
 		}
 	}
+	for _, run := range filter.runs {
+		if !equalFold(run, p.AgentState) {
+			return false
+		}
+	}
+	for _, ci := range filter.cis {
+		if !equalFold(ci, p.paneCI()) {
+			return false
+		}
+	}
+	for _, dirty := range filter.dirty {
+		if !equalFold(dirty, yesNo(p.DirtyState == "dirty")) {
+			return false
+		}
+	}
+	for _, live := range filter.live {
+		if !equalFold(live, yesNo(p.TmuxState == "live")) {
+			return false
+		}
+	}
+	for _, issue := range filter.issues {
+		value := strings.TrimSpace(p.Derived.FilterValues["issue"])
+		if value == "" {
+			value = strconv.Itoa(p.IssueNum)
+			if p.IssueNum <= 0 && strings.TrimSpace(p.TaskID) != "" {
+				value = strings.ToLower(strings.TrimSpace(p.TaskID))
+			}
+		}
+		if !equalFold(issue, value) {
+			return false
+		}
+	}
+	for _, pr := range filter.prs {
+		if !equalFold(pr, p.primaryPRState()) {
+			return false
+		}
+	}
 	searchText := strings.ToLower(strings.Join([]string{
 		p.Parent,
 		p.TaskID,
@@ -1756,6 +1915,7 @@ func (p paneView) matchesFilter(filter paneFilter) bool {
 		p.PaneID,
 		p.TmuxState,
 		p.TmuxTitle,
+		p.AgentState,
 		p.IssueState,
 		p.PRSummary,
 		p.CIStatus,
@@ -1772,12 +1932,47 @@ func (p paneView) matchesFilter(filter paneFilter) bool {
 		p.CreatedAt,
 		p.Prompt,
 	}, "\n"))
+	if strings.TrimSpace(p.Derived.FilterText) != "" {
+		searchText += "\n" + p.Derived.FilterText
+	}
 	for _, term := range filter.terms {
 		if !strings.Contains(searchText, term) {
 			return false
 		}
 	}
 	return true
+}
+
+func (p paneView) paneCI() string {
+	if strings.TrimSpace(p.Derived.CI) != "" {
+		return p.Derived.CI
+	}
+	if p.CIStatus == "-" {
+		return ""
+	}
+	return strings.ToLower(strings.TrimSpace(p.CIStatus))
+}
+
+func (p paneView) primaryPRState() string {
+	if strings.TrimSpace(p.Derived.PrimaryPRState) != "" {
+		return p.Derived.PrimaryPRState
+	}
+	fields := strings.Fields(p.PRSummary)
+	if len(fields) >= 2 {
+		return strings.ToLower(fields[1])
+	}
+	return "none"
+}
+
+func equalFold(a, b string) bool {
+	return strings.EqualFold(strings.TrimSpace(a), strings.TrimSpace(b))
+}
+
+func yesNo(v bool) string {
+	if v {
+		return "yes"
+	}
+	return "no"
 }
 
 func containsFold(needle string, values ...string) bool {
@@ -1873,37 +2068,11 @@ func hasMergedPR(prs []ghissue.PRRef) bool {
 	return false
 }
 
-func paneName(pane state.Pane) string {
-	if strings.TrimSpace(pane.DisplayName) != "" {
-		return pane.DisplayName
-	}
-	if strings.TrimSpace(pane.Slug) != "" {
-		return pane.Slug
-	}
-	if strings.TrimSpace(pane.TaskID) != "" {
-		return pane.TaskID
-	}
-	return "#" + strconv.Itoa(pane.IssueNum)
-}
-
 func (p paneView) itemLabel() string {
 	if strings.TrimSpace(p.TaskID) != "" {
 		return p.TaskID
 	}
 	return "#" + strconv.Itoa(p.IssueNum)
-}
-
-func tmuxState(paneID string, panes map[string]tmuxrun.PaneInfo, known bool) string {
-	if strings.TrimSpace(paneID) == "" {
-		return "-"
-	}
-	if !known {
-		return "unknown"
-	}
-	if _, ok := panes[paneID]; ok {
-		return "live"
-	}
-	return "stale"
 }
 
 func compactParent(parent string) string {
@@ -1918,17 +2087,6 @@ func compactParent(parent string) string {
 		}
 	}
 	return truncate(parent, 10)
-}
-
-func relativePath(root, path string) string {
-	if root == "" || path == "" {
-		return path
-	}
-	rel, err := filepath.Rel(root, path)
-	if err != nil || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
-		return path
-	}
-	return rel
 }
 
 func cloneIssueStatuses(in map[issueKey]issueStatus) map[issueKey]issueStatus {

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -24,7 +24,6 @@ import (
 var errBoom = errors.New("boom")
 
 func TestBuildPaneViewsMergesStateTmuxAndIssueStatuses(t *testing.T) {
-	projectRoot := "/repo"
 	panes := []state.Pane{
 		{
 			Parent:       "200",
@@ -64,7 +63,7 @@ func TestBuildPaneViewsMergesStateTmuxAndIssueStatuses(t *testing.T) {
 		"/repo/.fanout/worktrees/second": {Diff: "+12/-3", Dirty: "dirty"},
 	}
 
-	got := buildPaneViews(projectRoot, panes, tmuxPanes, true, issues, worktrees)
+	got := buildPaneViews(panes, tmuxPanes, true, issues, worktrees)
 
 	if len(got) != 2 {
 		t.Fatalf("buildPaneViews len = %d, want 2", len(got))
@@ -103,7 +102,7 @@ func TestBuildPaneViewsMergesStateTmuxAndIssueStatuses(t *testing.T) {
 }
 
 func TestBuildPaneViewsMarksTmuxUnknownWhenListFails(t *testing.T) {
-	got := buildPaneViews("/repo", []state.Pane{{IssueNum: 3, PaneID: "%3"}}, nil, false, nil, nil)
+	got := buildPaneViews([]state.Pane{{IssueNum: 3, PaneID: "%3"}}, nil, false, nil, nil)
 	if len(got) != 1 {
 		t.Fatalf("buildPaneViews len = %d, want 1", len(got))
 	}
@@ -125,7 +124,7 @@ func TestBuildPaneViewsTaskIDDisplayFallback(t *testing.T) {
 			}},
 		},
 	}
-	got := buildPaneViews("/repo", []state.Pane{
+	got := buildPaneViews([]state.Pane{
 		{Parent: "plan:alpha", IssueNum: 0, TaskID: "task-b", PaneID: "%2"},
 		{Parent: "plan:alpha", IssueNum: 0, TaskID: "task-a", PaneID: "%1"},
 	}, nil, true, issues, nil)
@@ -196,7 +195,7 @@ func TestBuildPaneViewsAddsDeferredIssueRows(t *testing.T) {
 		{Parent: "100", Num: 3}: {Title: "closed child", State: "CLOSED", Wave: 1, Blockers: "-"},
 	}
 
-	got := buildPaneViews("/repo", []state.Pane{{Parent: "100", IssueNum: 1, Slug: "ready-child-1"}}, nil, true, issues, nil)
+	got := buildPaneViews([]state.Pane{{Parent: "100", IssueNum: 1, Slug: "ready-child-1"}}, nil, true, issues, nil)
 
 	if len(got) != 3 {
 		t.Fatalf("buildPaneViews len = %d, want recorded pane plus deferred issue", len(got))
@@ -219,7 +218,7 @@ func TestBuildPaneViewsMatchesNormalizedNumericParents(t *testing.T) {
 		{Parent: "300", Num: 501}: {Title: "child", State: "OPEN", Wave: 1},
 	}
 
-	got := buildPaneViews("/repo", []state.Pane{{Parent: "0300", IssueNum: 501, Slug: "child"}}, nil, true, issues, nil)
+	got := buildPaneViews([]state.Pane{{Parent: "0300", IssueNum: 501, Slug: "child"}}, nil, true, issues, nil)
 
 	if len(got) != 1 {
 		t.Fatalf("buildPaneViews len = %d, want one real pane without synthetic duplicate", len(got))
@@ -266,11 +265,15 @@ func TestUpdateKeepsPartialGHResultsOnError(t *testing.T) {
 func TestMergeDegradedIssueStatuses(t *testing.T) {
 	key := issueKey{Parent: "100", Num: 101}
 	blocked := issueStatus{Title: "child", State: "OPEN", Wave: 2, WaveLabel: "wave2", Blockers: "OPEN #99", HasOpenBlockers: true}
+	blockedRows := blocked
+	blockedRows.BlockerRows = parseFormattedBlockers("OPEN #99")
 	degraded := issueStatus{Title: "child", State: "OPEN", Wave: 1, WaveLabel: "wave1", Blockers: "-", HasOpenBlockers: false, WaveDegraded: true}
 	unblocked := issueStatus{Title: "child", State: "OPEN", Wave: 2, WaveLabel: "wave2", Blockers: "resolved #99", HasOpenBlockers: false}
 	cleared := issueStatus{Title: "child", State: "OPEN", Wave: 1, WaveLabel: "wave1", Blockers: "-", HasOpenBlockers: false}
 	restored := blocked
 	restored.WaveDegraded = true
+	restoredRows := blockedRows
+	restoredRows.WaveDegraded = true
 
 	tests := []struct {
 		name     string
@@ -301,6 +304,12 @@ func TestMergeDegradedIssueStatuses(t *testing.T) {
 			previous: map[issueKey]issueStatus{key: blocked},
 			current:  map[issueKey]issueStatus{key: {Title: "child", State: "OPEN", Wave: 1, Blockers: "OPEN #7", HasOpenBlockers: true, WaveDegraded: true}},
 			want:     map[issueKey]issueStatus{key: restored},
+		},
+		{
+			name:     "degraded entry restores previous structured blocker rows",
+			previous: map[issueKey]issueStatus{key: blockedRows},
+			current:  map[issueKey]issueStatus{key: {Title: "child", State: "OPEN", Wave: 1, Blockers: "OPEN #7", BlockerRows: parseFormattedBlockers("OPEN #7"), HasOpenBlockers: true, WaveDegraded: true}},
+			want:     map[issueKey]issueStatus{key: restoredRows},
 		},
 		{
 			name:     "fresh blocker data replaces old entry",
@@ -604,7 +613,7 @@ func TestViewRendersHUDCounts(t *testing.T) {
 		{Parent: "200", Num: 202}: {State: "OPEN"},
 		{Parent: "200", Num: 203}: {State: "OPEN", HasOpenBlockers: true},
 	}
-	m.panes = applyIssueStatuses(m.panes, m.issues)
+	m.panes = applyIssueStatuses("/repo", m.panes, m.issues)
 	m.refreshRows()
 
 	got := m.View()

--- a/web/src/components/Drawer.tsx
+++ b/web/src/components/Drawer.tsx
@@ -167,7 +167,7 @@ export function Drawer({
           <span className="d-issue" id="d-issue">
             <GhLink url={issueUrl(repo, pane.issueNum)}>{paneLabel(pane)}</GhLink>
           </span>
-          <span id="d-name">{pane.displayName || pane.slug || "—"}</span>
+          <span id="d-name">{pane.derived?.name || pane.displayName || pane.slug || "—"}</span>
         </h3>
         <button id="drawer-close" type="button" aria-label="詳細を閉じる" onClick={onClose}>
           ✕
@@ -227,7 +227,8 @@ export function Drawer({
             <dl className="d-kv">
               <dt>path</dt>
               <dd id="d-path">
-                {(pane.worktreePath || "—") + (pane.worktreeErr ? ` (${pane.worktreeErr})` : "")}
+                {(pane.derived?.worktreeRelative || pane.worktreePath || "—") +
+                  (pane.worktreeErr ? ` (${pane.worktreeErr})` : "")}
               </dd>
               <dt>branch</dt>
               <dd id="d-branch">{pane.branchName || "—"}</dd>

--- a/web/src/components/SessionSection.tsx
+++ b/web/src/components/SessionSection.tsx
@@ -66,7 +66,7 @@ function PaneRow({
         <GhLink url={issueUrl(repo, pane.issueNum)}>{paneLabel(pane)}</GhLink>
       </td>
       <td className="c-name" title={pane.slug}>
-        {pane.displayName || pane.slug || "—"}
+        {pane.derived?.name || pane.displayName || pane.slug || "—"}
       </td>
       <td>{pane.agent || "—"}</td>
       <td>{wave || <span className="muted">—</span>}</td>

--- a/web/src/lib/filter.test.ts
+++ b/web/src/lib/filter.test.ts
@@ -71,6 +71,11 @@ describe("matches", () => {
     expect(matches(labeled, q("wave:w1*"))).toBe(true);
   });
 
+  it("derived waveText が full label のときも compact wN alias で一致する", () => {
+    const p = makePane({ wave: 2, derived: { waveText: "W2 ready", dependencyWave: "wave2" } });
+    expect(matches(p, q("wave:w2"))).toBe(true);
+  });
+
   it("ci: は paneCI(primary-PR の ciStatus、'-' は CI なし)を見る", () => {
     expect(matches(makePane({ ciStatus: "fail" }), q("ci:fail"))).toBe(true);
     expect(matches(makePane({ ciStatus: "-" }), q("ci:fail"))).toBe(false);
@@ -120,6 +125,20 @@ describe("matches", () => {
     const p = makePane({ agent: "claude", dirtyState: "dirty" });
     expect(matches(p, q("agent:claude dirty:yes"))).toBe(true);
     expect(matches(p, q("agent:claude dirty:no"))).toBe(false);
+  });
+
+  it("derived の filterText / filterValues を優先する", () => {
+    const p = makePane({
+      displayName: "fallback",
+      agentState: "",
+      dirtyState: "clean",
+      derived: {
+        filterText: "shared haystack",
+        filterValues: { run: "running", dirty: "yes", live: "no", issue: "777", pr: "merged" },
+      },
+    });
+    expect(matches(p, q("shared run:running dirty:yes live:no issue:777 pr:merged"))).toBe(true);
+    expect(matches(p, q("fallback"))).toBe(false);
   });
 });
 

--- a/web/src/lib/filter.ts
+++ b/web/src/lib/filter.ts
@@ -1,4 +1,4 @@
-import { fmtBlockers, fmtWave, paneCI, prPrimary } from "./pane";
+import { compactWave, fmtBlockers, fmtWave, paneCI, prPrimary } from "./pane";
 import type { PaneView } from "./types";
 
 /* 構造化フィルタ: key:value + 自由語、すべて AND。未知キーは自由語に降格。
@@ -34,23 +34,25 @@ export function parseQuery(str: string): Term[] {
 }
 
 export function matches(p: PaneView, terms: Term[]): boolean {
-  const hay = [
-    p.issueNum,
-    p.taskId,
-    p.displayName,
-    p.slug,
-    p.agent,
-    p.branchName,
-    p.diffSummary,
-    p.dirtyState,
-    p.issueState,
-    p.tmuxTitle,
-    p.agentState,
-    fmtWave(p),
-    fmtBlockers(p),
-  ]
-    .join(" ")
-    .toLowerCase();
+  const hay =
+    p.derived?.filterText ||
+    [
+      p.issueNum,
+      p.taskId,
+      p.displayName,
+      p.slug,
+      p.agent,
+      p.branchName,
+      p.diffSummary,
+      p.dirtyState,
+      p.issueState,
+      p.tmuxTitle,
+      p.agentState,
+      fmtWave(p),
+      fmtBlockers(p),
+    ]
+      .join(" ")
+      .toLowerCase();
   for (const t of terms) {
     if (t.kind === "word") {
       if (!hay.includes(t.word)) return false;
@@ -67,7 +69,7 @@ export function matches(p: PaneView, terms: Term[]): boolean {
           return false;
         break;
       case "run":
-        if ((p.agentState ?? "") !== t.value) return false;
+        if ((p.derived?.filterValues?.run ?? p.agentState ?? "") !== t.value) return false;
         break;
       case "agent":
         if (
@@ -81,6 +83,9 @@ export function matches(p: PaneView, terms: Term[]): boolean {
         if (
           String(p.wave ?? "") !== t.value &&
           (p.waveLabel ?? "").toLowerCase() !== t.value &&
+          (p.derived?.dependencyWave ?? "").toLowerCase() !== t.value &&
+          (p.derived?.waveText ?? "").toLowerCase() !== t.value &&
+          compactWave(p).toLowerCase() !== t.value &&
           fmtWave(p).toLowerCase() !== t.value
         )
           return false;
@@ -89,17 +94,25 @@ export function matches(p: PaneView, terms: Term[]): boolean {
         if (paneCI(p) !== t.value) return false;
         break;
       case "dirty":
-        if ((t.value === "yes") !== (p.dirtyState === "dirty")) return false;
+        if (
+          (p.derived?.filterValues?.dirty ?? (p.dirtyState === "dirty" ? "yes" : "no")) !== t.value
+        )
+          return false;
         break;
       case "live":
-        if ((t.value === "yes") !== !!p.alive) return false;
+        if ((p.derived?.filterValues?.live ?? (p.alive ? "yes" : "no")) !== t.value) return false;
         break;
       case "issue":
-        if (String(p.issueNum) !== t.value && String(p.taskId ?? "").toLowerCase() !== t.value)
+        if (
+          (p.derived?.filterValues?.issue ?? String(p.issueNum)) !== t.value &&
+          String(p.issueNum) !== t.value &&
+          String(p.taskId ?? "").toLowerCase() !== t.value
+        )
           return false;
         break;
       case "pr":
-        if ((pr?.state ?? "none").toLowerCase() !== t.value) return false;
+        if ((p.derived?.filterValues?.pr ?? pr?.state ?? "none").toLowerCase() !== t.value)
+          return false;
         break;
     }
   }

--- a/web/src/lib/pane.ts
+++ b/web/src/lib/pane.ts
@@ -25,6 +25,7 @@ export function ciWorst(prs: PRRef[] | null | undefined): string {
  * non-primary PR's failure. The fallback is only for snapshots predating the
  * field entirely. */
 export function paneCI(p: PaneView): string {
+  if (p.derived?.ci != null) return p.derived.ci;
   if (p.ciStatus == null || p.ciStatus === "") return ciWorst(p.prs);
   return p.ciStatus === "-" ? "" : p.ciStatus;
 }
@@ -38,15 +39,22 @@ export function blockerLabel(b: BlockerStatus): string {
 }
 
 export function fmtBlockers(p: PaneView): string {
+  if (p.derived?.blockersText) return p.derived.blockersText;
   if (!p.blockers || !p.blockers.length) return "-";
   return p.blockers.map((b) => `${blockerLabel(b)} #${b.num}`).join(", ");
 }
 
 export function fmtWave(p: PaneView): string {
-  return p.waveLabel || (p.wave ? `w${p.wave}` : "");
+  if (p.derived?.waveText && p.derived.waveText !== "-") return p.derived.waveText;
+  return p.waveLabel || compactWave(p);
+}
+
+export function compactWave(p: PaneView): string {
+  return p.wave ? `w${p.wave}` : "";
 }
 
 export function openBlockerCount(p: PaneView): number {
+  if (p.derived?.openBlockers != null) return p.derived.openBlockers;
   return (p.blockers ?? []).filter((b) => b.state === "OPEN").length;
 }
 

--- a/web/src/lib/sort.test.ts
+++ b/web/src/lib/sort.test.ts
@@ -54,4 +54,18 @@ describe("sortPanes", () => {
     const none = makePane({ issueNum: 2 });
     expect(nums(sortPanes([none, w1], "wave", 1))).toEqual([1, 2]);
   });
+
+  it("derived sort keys を優先する", () => {
+    const highDiff = makePane({
+      issueNum: 1,
+      diffSummary: "+999/-0",
+      derived: { sort: { diff: 1 } },
+    });
+    const lowDiff = makePane({
+      issueNum: 2,
+      diffSummary: "+1/-0",
+      derived: { sort: { diff: 999 } },
+    });
+    expect(nums(sortPanes([lowDiff, highDiff], "diff", 1))).toEqual([1, 2]);
+  });
 });

--- a/web/src/lib/sort.ts
+++ b/web/src/lib/sort.ts
@@ -6,21 +6,25 @@ export type SortDir = 1 | -1;
 type SortKeyFn = (p: PaneView) => number | string;
 
 export const SORTS: Record<string, SortKeyFn> = {
-  issueNum: (p) => p.issueNum ?? 0,
-  name: (p) => String(p.displayName || p.slug || p.taskId || "").toLowerCase(),
-  agent: (p) => String(p.agent ?? "").toLowerCase(),
-  wave: (p) => p.wave || 99,
-  blockers: (p) => (p.blockers ?? []).filter((b) => b.state === "OPEN").length,
-  branch: (p) => String(p.branchName ?? "").toLowerCase(),
+  issueNum: (p) => p.derived?.sort?.issueNum ?? p.issueNum ?? 0,
+  name: (p) =>
+    p.derived?.sort?.name ?? String(p.displayName || p.slug || p.taskId || "").toLowerCase(),
+  agent: (p) => p.derived?.sort?.agent ?? String(p.agent ?? "").toLowerCase(),
+  wave: (p) => (p.derived?.sort?.wave ?? p.wave) || 99,
+  blockers: (p) =>
+    p.derived?.sort?.blockers ?? (p.blockers ?? []).filter((b) => b.state === "OPEN").length,
+  branch: (p) => p.derived?.sort?.branch ?? String(p.branchName ?? "").toLowerCase(),
   diff: (p) => {
+    if (p.derived?.sort?.diff != null) return p.derived.sort.diff;
     const m = /\+(\d+)\/-(\d+)/.exec(p.diffSummary ?? "");
     return m ? +m[1]! + +m[2]! : -1;
   },
-  dirty: (p) => ({ clean: 0, dirty: 1, unknown: 2 })[p.dirtyState] ?? 3,
-  ci: (p) => ({ fail: 0, pending: 1, pass: 2 })[paneCI(p)] ?? 3,
-  tmux: (p) => (p.alive ? 0 : p.notStarted ? 2 : 1), // alive < stale < 未開始(synthetic)
-  state: (p) => String(p.issueState ?? "").toLowerCase(),
+  dirty: (p) => p.derived?.sort?.dirty ?? { clean: 0, dirty: 1, unknown: 2 }[p.dirtyState] ?? 3,
+  ci: (p) => p.derived?.sort?.ci ?? { fail: 0, pending: 1, pass: 2 }[paneCI(p)] ?? 3,
+  tmux: (p) => p.derived?.sort?.tmux ?? (p.alive ? 0 : p.notStarted ? 2 : 1), // alive < stale < 未開始(synthetic)
+  state: (p) => p.derived?.sort?.state ?? String(p.issueState ?? "").toLowerCase(),
   pr: (p) => {
+    if (p.derived?.sort?.pr != null) return p.derived.sort.pr;
     const pr = prPrimary(p.prs);
     return { MERGED: 0, OPEN: 1, CLOSED: 2 }[pr?.state ?? ""] ?? 3;
   },

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -50,6 +50,43 @@ export interface PaneView {
   /* 記録 pane の無い「未開始」子 issue の synthetic 行。pane 由来フィールドは
    * zero、tmuxState は closed / deferred / queued / unknown(TUI と同一文字列) */
   notStarted?: boolean;
+  derived?: PaneDerived;
+}
+
+export interface PaneDerived {
+  name?: string;
+  prSummary?: string;
+  primaryPrNumber?: number;
+  primaryPrState?: string;
+  ci?: string;
+  waveBadge?: string;
+  waveText?: string;
+  dependencyWave?: string;
+  blockersText?: string;
+  openBlockers?: number;
+  diffTotal?: number;
+  diffParsed?: boolean;
+  filterText?: string;
+  filterValues?: Record<string, string>;
+  sort?: PaneSortKeys;
+  canFocus?: boolean;
+  canPeek?: boolean;
+  worktreeRelative?: string;
+}
+
+export interface PaneSortKeys {
+  issueNum?: number;
+  name?: string;
+  agent?: string;
+  wave?: number;
+  blockers?: number;
+  branch?: string;
+  diff?: number;
+  dirty?: number;
+  ci?: number;
+  tmux?: number;
+  state?: string;
+  pr?: number;
 }
 
 export interface Rollup {


### PR DESCRIPTION
## Summary
- add shared `sessionview` derived display/filter/sort fields for dashboard panes
- move the resident TUI row construction onto the same `sessionview.Build` snapshot model used by the web dashboard
- make the web dashboard prefer server-derived labels, filter values, and sort keys while preserving fallback behavior for older snapshots
- document that the TUI and web dashboard share the same Session snapshot model

## Validation
- `go test ./internal/sessionview ./internal/tui ./internal/dashboard`
- `make test-web`
- `make lint-web`
- `go test ./...`
- `make lint`
- `make test`
- `git diff --check`

Note: the first sandboxed `make test-web` attempt could not resolve `registry.npmjs.org`; rerunning with approved network access installed the missing pnpm packages and passed.