### PR TITLE
feat(skills): add fanout plan skill

### DIFF
--- a/claude/commands/fanout.md
+++ b/claude/commands/fanout.md
@@ -1,12 +1,13 @@
 ---
-description: Start the fanout TUI console, or fan out a parent GitHub issue's OPEN sub-issues / GitHub Projects v2 board items into parallel tmux panes via the fanout CLI.
-argument-hint: "[parent-issue | project-url | dashboard] [--go] [extra fanout flags]"
+description: Start the fanout TUI console, fan out a parent GitHub issue / GitHub Projects v2 board, or route an implementation plan through fanout plan.
+argument-hint: "[parent-issue | project-url | dashboard | plan [path]] [--go] [extra fanout flags]"
 ---
 
-Invoke the `fanout` CLI to start the persistent TUI console, or to spawn one
-tmux pane per OPEN sub-issue of a parent GitHub issue / OPEN item of a GitHub
-Projects v2 board. See the `fanout` skill
-(`~/.claude/skills/fanout/SKILL.md`) for context on when and why to use this.
+Invoke the `fanout` CLI to start the persistent TUI console, to spawn one tmux
+pane per OPEN sub-issue of a parent GitHub issue / OPEN item of a GitHub
+Projects v2 board, or to route an implementation plan into `fanout plan`. See
+the `fanout` skill (`~/.claude/skills/fanout/SKILL.md`) for context on when and
+why to use this.
 
 Arguments: `$ARGUMENTS`
 
@@ -23,9 +24,9 @@ prompt-based agent pane from the console.
 
 ## Steps
 
-0. **TUI / dashboard short-circuit (before any target resolution).** If
+0. **TUI / dashboard / plan short-circuit (before any target resolution).** If
    `$ARGUMENTS` is empty, run `fanout` with no arguments from the target
-   repository worktree and stop. For dashboard detection only, look at
+   repository worktree and stop. For dashboard/plan detection, look at
    `$ARGUMENTS` with the wrapper-only flags `--go`/`--wait` ignored — but do NOT
    mutate `$ARGUMENTS` itself; Steps 2/3 still need to see `--go`/`--wait` for
    non-dashboard calls. If, ignoring those wrapper flags, the first token is
@@ -34,8 +35,14 @@ prompt-based agent pane from the console.
    path. Forward the dashboard arguments with `--go`/`--wait` stripped (e.g.
    `fanout dashboard --web --open`) — the `dashboard` parser rejects unknown
    flags like `--go`/`--wait` — and stop here; it starts the standalone
-   read-only localhost web dashboard, which takes no parent argument. Otherwise,
-   leave `$ARGUMENTS` untouched and continue to Step 1.
+   read-only localhost web dashboard, which takes no parent argument. If,
+   ignoring wrapper flags, the first token is `plan` (`/fanout plan [path]`,
+   `/fanout --go plan ...`, etc.), do NOT resolve a parent target, scan issue
+   bodies, add generated `--name` flags, or run issue/project dry-runs. Invoke
+   the `fanout-plan` skill (`~/.claude/skills/fanout-plan/SKILL.md`) with the
+   `plan` token removed, keep `--go` as that skill's confirmation bypass, and
+   strip/warn on `--wait` because wait-and-continue is issue-mode only. Then
+   stop here. Otherwise, leave `$ARGUMENTS` untouched and continue to Step 1.
 
 1. **Resolve the parent target** from `$ARGUMENTS`. Two input shapes are accepted; the first matching token wins:
    - **Issue mode** — first token matching `^#?\d+$` → that integer is `N`. **Strip the leading `#` if present** before invoking `fanout`; the CLI only accepts bare digits in issue mode and rejects `#42`.
@@ -107,6 +114,8 @@ prompt-based agent pane from the console.
 - `/fanout 123 --team` — fan out with sibling-pane peer messaging: each child briefing gets a coordination section and the panes are seeded into the parent's peer registry. Children then coordinate with `fanout msg` from inside their own panes.
 - `/fanout 123 --only 4,7,8,10` — fan out only these four children. `--skip 6,9` is the opposite form (deny-list).
 - `/fanout 123 --unblocked-only` — only children whose blockers are all CLOSED. Great for periodic reruns that walk Wave 1 → 2 → ... automatically.
+- `/fanout plan /tmp/implementation-plan.md` — decompose a local implementation plan into a `fanout plan` spec, preview it, then run after confirmation.
+- `/fanout plan --go` — use the best available approved plan candidate and run the plan fan-out after the dry-run summary without a second confirmation.
 - `/fanout https://github.com/users/butaosuinu/projects/3` — project mode (default). Fans out only the Status=Todo column of the user Project.
 - `/fanout https://github.com/users/butaosuinu/projects/3/views/1` — canonical board-URL form (works the same as the bare project URL; `/views/N` is preserved verbatim and the CLI ignores it).
 - `/fanout https://github.com/users/butaosuinu/projects/3 --project-status all` — project mode, disable the Status filter, fan out every OPEN item.

--- a/claude/skills/fanout-plan/SKILL.md
+++ b/claude/skills/fanout-plan/SKILL.md
@@ -14,7 +14,12 @@ worktrees and panes.
 
 Find the source plan in this order:
 
-1. An explicit path argument from `/fanout plan <path>` or the user's message.
+1. An explicit argument from `/fanout plan <arg>` or the user's message. If
+   `<arg>` is a file path, use that file. Otherwise, check whether
+   `.fanout/plans/<arg>.json` exists in the target repository; if it does, use
+   `<arg>` as the saved plan slug and skip spec authoring. If the explicit
+   argument resolves to neither a file nor a saved plan slug, stop and report
+   the missing path/slug instead of rediscovering another source plan.
 2. The newest `~/.claude/plans/*.md` file by modification time.
 3. The current conversation's approved implementation plan.
 
@@ -41,10 +46,12 @@ Use these naming rules:
 - `plan.slug`: lowercase kebab-case, 2-4 words when possible.
 - `task.id`: required lowercase kebab-case, 2-4 words, stable across reruns.
 - `task.display_name`: optional readable pane title, 40 characters or fewer.
-- `task.slug`: optional final worktree slug. Prefer omitting it unless the
-  default from title + id is unclear. If set, use the same policy as fanout's
-  `--name` slug hints: 2-4 lowercase kebab words, starts with alnum, contains
-  only `[a-z0-9-]`, and is unique in the plan.
+- `task.slug`: optional final worktree slug. Prefer omitting it; default slugs
+  are plan-qualified. If set, fanout uses it exactly, so it must be globally
+  unique under `.fanout/worktrees`, not merely unique within this plan. Use the
+  same policy as fanout's `--name` slug hints: 2-4 lowercase kebab words,
+  starts with alnum, and contains only `[a-z0-9-]`. Prefix it with `plan.slug`
+  when that helps avoid collisions, for example `launch-plan-base-types`.
 
 ## Spec JSON
 
@@ -114,6 +121,11 @@ Forward only the flags supported by the current `fanout plan` implementation:
 Use `--dry-run` for preview. Strip `/fanout`'s wrapper-only `--go` before
 calling the CLI; it means "skip confirmation", not a fanout flag.
 
+If the spec contains any non-empty `blocked_by` lists, include
+`--unblocked-only` by default so dependent tasks are deferred until their
+blockers are complete. Omit it only when the user explicitly asks to launch all
+waves together.
+
 Do not forward issue/project-mode-only flags to `fanout plan`: `--include`,
 `--name`, `--project-status`, `--format`, `--post-dashboard`, `--team`,
 `--popup-timeout`, `--codex-plan-mode`, `--status`, `--close`, `--merge`, or
@@ -122,10 +134,12 @@ dependencies belong in `blocked_by`.
 
 ## Run
 
-1. Write `/tmp/fanout-plan-<slug>.json`.
+1. If using a saved plan slug from `.fanout/plans/<slug>.json`, keep that slug
+   as the command argument and skip writing a new spec. Otherwise, write
+   `/tmp/fanout-plan-<slug>.json`.
 2. Run:
    ```bash
-   fanout plan /tmp/fanout-plan-<slug>.json --dry-run --agent claude <flags>
+   fanout plan <spec-or-slug> --dry-run --agent claude <flags>
    ```
 3. Summarize the dry-run: plan slug/title, task count, task ids/titles,
    waves, `blocked_by`, generated worktree paths, branch names, and deferred
@@ -134,7 +148,7 @@ dependencies belong in `blocked_by`.
    immediate execution. If the user passed `--dry-run`, stop after the preview.
 5. Run the live command without `--dry-run`:
    ```bash
-   fanout plan /tmp/fanout-plan-<slug>.json --agent claude <flags>
+   fanout plan <spec-or-slug> --agent claude <flags>
    ```
 6. Return the created/skipped/deferred/failed summary.
 

--- a/claude/skills/fanout-plan/SKILL.md
+++ b/claude/skills/fanout-plan/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: fanout-plan
+description: "Generate and run fanout plan specs from implementation plans. Use when the user invokes `/fanout plan`, asks to fan out a local plan instead of GitHub child issues, or wants an approved plan decomposed into issue-less fanout tasks for `fanout plan`."
+---
+
+# fanout-plan
+
+Turn an implementation plan into an issue-less `fanout plan` spec and run it.
+The Go CLI does not call an LLM: all decomposition, task naming, and spec JSON
+authoring happens in this skill before `fanout plan` deterministically creates
+worktrees and panes.
+
+## Plan Discovery
+
+Find the source plan in this order:
+
+1. An explicit path argument from `/fanout plan <path>` or the user's message.
+2. The newest `~/.claude/plans/*.md` file by modification time.
+3. The current conversation's approved implementation plan.
+
+If more than one candidate is plausible, list the candidates with short labels
+and ask the user which one to use. If no plan is available, stop and ask for a
+path or an approved plan.
+
+## Decompose
+
+Create tasks that can run in parallel panes:
+
+- Give every task a bounded deliverable and put an acceptance checklist in
+  `briefing`.
+- Split dependencies into waves. If task B needs task A, set
+  `blocked_by: ["task-a"]`; do not rely on task order or `wave` alone.
+- Avoid parallel tasks that edit the same files. If two tasks need the same
+  file, make one block on the other or combine the work into one bounded task.
+- Do not create a catch-all integration task unless there is real integration
+  work that cannot stay with the parent/human follow-up.
+- Make task titles concrete enough to become pane titles.
+
+Use these naming rules:
+
+- `plan.slug`: lowercase kebab-case, 2-4 words when possible.
+- `task.id`: required lowercase kebab-case, 2-4 words, stable across reruns.
+- `task.display_name`: optional readable pane title, 40 characters or fewer.
+- `task.slug`: optional final worktree slug. Prefer omitting it unless the
+  default from title + id is unclear. If set, use the same policy as fanout's
+  `--name` slug hints: 2-4 lowercase kebab words, starts with alnum, contains
+  only `[a-z0-9-]`, and is unique in the plan.
+
+## Spec JSON
+
+Write the spec to `/tmp/fanout-plan-<plan.slug>.json` with the available file
+editing tool. Do not use shell heredocs, `echo >`, or ad-hoc shell redirection
+to create the JSON; long briefings and quoting are too fragile.
+
+Schema:
+
+```json
+{
+  "version": 1,
+  "plan": {
+    "slug": "launch-plan",
+    "title": "Launch plan",
+    "source": "path-or-conversation-label",
+    "base_branch": "main"
+  },
+  "tasks": [
+    {
+      "id": "base-types",
+      "title": "Define base types",
+      "briefing": "## Goal\n...\n\n## Scope\n- ...\n\n## Acceptance checklist\n- [ ] ...",
+      "slug": "launch-plan-base-types",
+      "display_name": "Base types",
+      "branch": "feat/base-types",
+      "wave": "1",
+      "blocked_by": []
+    }
+  ]
+}
+```
+
+`source`, `base_branch`, `slug`, `display_name`, `branch`, `wave`, and
+`blocked_by` are optional except when the dependency graph requires
+`blocked_by`. Prefer `plan.base_branch` when the source plan names a base;
+otherwise let fanout resolve the repository default branch or let the user pass
+`--base-branch`.
+
+## CLI Surface
+
+Run from the target repository worktree. `fanout plan` needs `git` and `tmux`;
+`gh` is needed only for `--unblocked-only` blocker completion checks. Use
+`--agent claude` unless the user supplied `--agent` or `FANOUT_AGENT`.
+
+Forward only the flags supported by the current `fanout plan` implementation:
+
+- `--agent <name>`
+- `--dry-run`
+- `--limit <N>`
+- `--only <task-id[,id...]>`
+- `--skip <task-id[,id...]>`
+- `--unblocked-only`
+- `--base-branch <branch>`
+- `--branch-prefix <prefix>`
+- `--no-refresh`
+- `--session <tmux-session>`
+- `--sleep <seconds>`
+- `--debug`
+- `--auto-pr` / `--no-auto-pr`
+- `--pr-review-gate` / `--no-pr-review-gate`
+- `--briefing-code-review` / `--no-briefing-code-review`
+- `--agent-teams-hint` / `--no-agent-teams-hint`
+- `--pr-visualization` / `--no-pr-visualization`
+- `--dashboard-keybind` / `--no-dashboard-keybind`
+
+Use `--dry-run` for preview. Strip `/fanout`'s wrapper-only `--go` before
+calling the CLI; it means "skip confirmation", not a fanout flag.
+
+Do not forward issue/project-mode-only flags to `fanout plan`: `--include`,
+`--name`, `--project-status`, `--format`, `--post-dashboard`, `--team`,
+`--popup-timeout`, `--codex-plan-mode`, `--status`, `--close`, `--merge`, or
+`--cleanup`. Names belong in the spec (`slug`, `display_name`, `branch`), and
+dependencies belong in `blocked_by`.
+
+## Run
+
+1. Write `/tmp/fanout-plan-<slug>.json`.
+2. Run:
+   ```bash
+   fanout plan /tmp/fanout-plan-<slug>.json --dry-run --agent claude <flags>
+   ```
+3. Summarize the dry-run: plan slug/title, task count, task ids/titles,
+   waves, `blocked_by`, generated worktree paths, branch names, and deferred
+   rows.
+4. Ask for confirmation unless the user passed `--go` or explicitly requested
+   immediate execution. If the user passed `--dry-run`, stop after the preview.
+5. Run the live command without `--dry-run`:
+   ```bash
+   fanout plan /tmp/fanout-plan-<slug>.json --agent claude <flags>
+   ```
+6. Return the created/skipped/deferred/failed summary.
+
+After a live run, fanout copies the spec to `.fanout/plans/<slug>.json`; later
+runs can re-address it as `fanout plan <slug> ...`. Use `--only <task-id>` or
+`--skip <task-id>` for partial reruns. In the current plan surface, task
+lifecycle flags are not implemented on `fanout plan`; for read-only visibility
+use the no-argument `fanout` TUI or dashboard, and do not invent
+`fanout plan --status` / `--cleanup` unless the CLI has been updated.
+
+## Failure Mapping
+
+- Exit 0: success, dry-run success, or nothing to do.
+- Exit 1: environment/preflight, unreadable or invalid spec JSON, invalid
+  filter values, missing dependencies, agent/runtime setup, worktree creation,
+  or failed pane launch.
+- Exit 2: bad invocation such as missing spec, unknown plan option, or extra
+  positional arguments.
+
+For common runtime errors: `fanout must be run inside tmux` means batch pane
+creation needs tmux; `agent is required` means pass `--agent claude` or another
+supported agent; `unknown plan option` means the flag belongs to another
+fanout mode; spec validation errors should be fixed in the JSON and retried.

--- a/claude/skills/fanout/SKILL.md
+++ b/claude/skills/fanout/SKILL.md
@@ -28,12 +28,19 @@ fanout <parent-issue> --merge <NUM> # fast-forward merge a recorded child branch
 fanout <parent-issue> --close <NUM> # remove a recorded child worktree/pane
 fanout <parent-issue> --cleanup     # remove merged/closed recorded children
 fanout dashboard --web              # read-only localhost web dashboard (Session view); no parent arg
+fanout plan <spec.json|plan-slug>   # issue-less local plan task fan-out (see fanout-plan)
 fanout msg <verb> [options] [body...]  # peer messaging between sibling panes (see "Sibling coordination")
 fanout --check-update               # Read-only version comparison
 fanout update                       # Replace fanout via install.sh
 ```
 
 `fanout dashboard --web` is a standalone subcommand (no parent argument): it starts a read-only, 127.0.0.1-bound web dashboard that visualizes all fanned-out Sessions live (pane liveness, issue/PR state). It is human-facing — surface it to the user when they ask to "watch"/"monitor" parallel panes, but do not run it as part of the fan-out flow. After a live fan-out, fanout also binds `prefix + D` in tmux to open it; launched panes record their owner project root so the key still opens the right dashboard from agent TUIs such as Codex when tmux reports a stale `pane_current_path`. Pass `--no-dashboard-keybind` to suppress that.
+
+`fanout plan <spec.json|plan-slug>` is the issue-less plan-task lane. If the
+user asks to fan out an implementation plan, route through the `fanout-plan`
+skill (`~/.claude/skills/fanout-plan/SKILL.md`) so the agent decomposes the
+plan and writes the spec JSON before invoking the deterministic CLI. The CLI
+does not call an LLM and does not infer tasks from prose.
 
 **Do not run `fanout --help`, `fanout -h`, or `which fanout`.** This SKILL.md is the source-of-truth for the CLI surface — every flag above is documented under "Running" below, and the binary path is `/Users/butaosuinu/.local/bin/fanout` (also stated in the next paragraph). Probing the CLI directly wastes a tool call and adds nothing.
 
@@ -55,6 +62,7 @@ Good fits:
 - The user asks whether the installed `fanout` binary is up to date; in that case use `fanout --check-update`, not the pane-creation workflow.
 - The user asks to update fanout itself; in that case run `fanout update` immediately.
 - The user asks to start the fanout console / TUI; in that case run `fanout` with no arguments directly from the target repository worktree, skipping parent resolution, dry-run, pane naming, and agent selection.
+- The user asks to fan out an implementation plan or invokes `/fanout plan`; use the `fanout-plan` skill instead of the issue/Project workflow below.
 - The user types `/fanout` or mentions "fan out" / "並列展開".
 
 Do not invoke unprompted just because an issue has sub-issues. Pane creation is visible and the user has to close each pane manually if they change their mind — suggest first, wait for a "yes", and prefer routing through the `/fanout` slash command so there is one consistent entry point.

--- a/codex/skills/fanout-plan/SKILL.md
+++ b/codex/skills/fanout-plan/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: fanout-plan
+description: "Use from Codex CLI to generate and run fanout plan specs from implementation plans. Use when the user asks for `$fanout-plan`, `fanout plan`, `/fanout plan`, issue-less plan fan-out, or decomposing an approved/proposed plan into `fanout plan` tasks."
+---
+
+# fanout-plan
+
+Turn an implementation plan into an issue-less `fanout plan` spec and run it.
+The Go CLI does not call an LLM: all decomposition, task naming, and spec JSON
+authoring happens in this skill before `fanout plan` deterministically creates
+worktrees and panes.
+
+## Plan Discovery
+
+Find the source plan in this order:
+
+1. An explicit path argument from `$fanout-plan <path>`, `/fanout plan <path>`,
+   or the user's message.
+2. The newest `~/.claude/plans/*.md` file by modification time.
+3. The current conversation's approved implementation plan.
+4. The newest `<proposed_plan>...</proposed_plan>` block in the current
+   conversation.
+
+If more than one candidate is plausible, list the candidates with short labels
+and ask the user which one to use. If no plan is available, stop and ask for a
+path or an approved/proposed plan.
+
+## Decompose
+
+Create tasks that can run in parallel panes:
+
+- Give every task a bounded deliverable and put an acceptance checklist in
+  `briefing`.
+- Split dependencies into waves. If task B needs task A, set
+  `blocked_by: ["task-a"]`; do not rely on task order or `wave` alone.
+- Avoid parallel tasks that edit the same files. If two tasks need the same
+  file, make one block on the other or combine the work into one bounded task.
+- Do not create a catch-all integration task unless there is real integration
+  work that cannot stay with the parent/human follow-up.
+- Make task titles concrete enough to become pane titles.
+
+Use these naming rules:
+
+- `plan.slug`: lowercase kebab-case, 2-4 words when possible.
+- `task.id`: required lowercase kebab-case, 2-4 words, stable across reruns.
+- `task.display_name`: optional readable pane title, 40 characters or fewer.
+- `task.slug`: optional final worktree slug. Prefer omitting it unless the
+  default from title + id is unclear. If set, use the same policy as fanout's
+  `--name` slug hints: 2-4 lowercase kebab words, starts with alnum, contains
+  only `[a-z0-9-]`, and is unique in the plan.
+
+## Spec JSON
+
+Write the spec to `/tmp/fanout-plan-<plan.slug>.json` with the available file
+editing tool. Do not use shell heredocs, `echo >`, or ad-hoc shell redirection
+to create the JSON; long briefings and quoting are too fragile.
+
+Schema:
+
+```json
+{
+  "version": 1,
+  "plan": {
+    "slug": "launch-plan",
+    "title": "Launch plan",
+    "source": "path-or-conversation-label",
+    "base_branch": "main"
+  },
+  "tasks": [
+    {
+      "id": "base-types",
+      "title": "Define base types",
+      "briefing": "## Goal\n...\n\n## Scope\n- ...\n\n## Acceptance checklist\n- [ ] ...",
+      "slug": "launch-plan-base-types",
+      "display_name": "Base types",
+      "branch": "feat/base-types",
+      "wave": "1",
+      "blocked_by": []
+    }
+  ]
+}
+```
+
+`source`, `base_branch`, `slug`, `display_name`, `branch`, `wave`, and
+`blocked_by` are optional except when the dependency graph requires
+`blocked_by`. Prefer `plan.base_branch` when the source plan names a base;
+otherwise let fanout resolve the repository default branch or let the user pass
+`--base-branch`.
+
+## CLI Surface
+
+Run from the target repository worktree. `fanout plan` needs `git` and `tmux`;
+`gh` is needed only for `--unblocked-only` blocker completion checks. Use
+`--agent codex` unless the user supplied `--agent` or `FANOUT_AGENT`.
+
+Forward only the flags supported by the current `fanout plan` implementation:
+
+- `--agent <name>`
+- `--dry-run`
+- `--limit <N>`
+- `--only <task-id[,id...]>`
+- `--skip <task-id[,id...]>`
+- `--unblocked-only`
+- `--base-branch <branch>`
+- `--branch-prefix <prefix>`
+- `--no-refresh`
+- `--session <tmux-session>`
+- `--sleep <seconds>`
+- `--debug`
+- `--auto-pr` / `--no-auto-pr`
+- `--pr-review-gate` / `--no-pr-review-gate`
+- `--briefing-code-review` / `--no-briefing-code-review`
+- `--agent-teams-hint` / `--no-agent-teams-hint`
+- `--pr-visualization` / `--no-pr-visualization`
+- `--dashboard-keybind` / `--no-dashboard-keybind`
+
+Use `--dry-run` for preview. Strip wrapper-only `--go` before calling the CLI;
+it means "skip confirmation", not a fanout flag.
+
+Do not forward issue/project-mode-only flags to `fanout plan`: `--include`,
+`--name`, `--project-status`, `--format`, `--post-dashboard`, `--team`,
+`--popup-timeout`, `--codex-plan-mode`, `--status`, `--close`, `--merge`, or
+`--cleanup`. Names belong in the spec (`slug`, `display_name`, `branch`), and
+dependencies belong in `blocked_by`.
+
+## Run
+
+1. Write `/tmp/fanout-plan-<slug>.json`.
+2. Run:
+   ```bash
+   fanout plan /tmp/fanout-plan-<slug>.json --dry-run --agent codex <flags>
+   ```
+3. Summarize the dry-run: plan slug/title, task count, task ids/titles,
+   waves, `blocked_by`, generated worktree paths, branch names, and deferred
+   rows.
+4. Ask for confirmation unless the user passed `--go` or explicitly requested
+   immediate execution. If the user passed `--dry-run`, stop after the preview.
+5. Run the live command without `--dry-run`:
+   ```bash
+   fanout plan /tmp/fanout-plan-<slug>.json --agent codex <flags>
+   ```
+6. Return the created/skipped/deferred/failed summary.
+
+After a live run, fanout copies the spec to `.fanout/plans/<slug>.json`; later
+runs can re-address it as `fanout plan <slug> ...`. Use `--only <task-id>` or
+`--skip <task-id>` for partial reruns. In the current plan surface, task
+lifecycle flags are not implemented on `fanout plan`; for read-only visibility
+use the no-argument `fanout` TUI or dashboard, and do not invent
+`fanout plan --status` / `--cleanup` unless the CLI has been updated.
+
+## Failure Mapping
+
+- Exit 0: success, dry-run success, or nothing to do.
+- Exit 1: environment/preflight, unreadable or invalid spec JSON, invalid
+  filter values, missing dependencies, agent/runtime setup, worktree creation,
+  or failed pane launch.
+- Exit 2: bad invocation such as missing spec, unknown plan option, or extra
+  positional arguments.
+
+For common runtime errors: `fanout must be run inside tmux` means batch pane
+creation needs tmux; `agent is required` means pass `--agent codex` or another
+supported agent; `unknown plan option` means the flag belongs to another
+fanout mode; spec validation errors should be fixed in the JSON and retried.

--- a/codex/skills/fanout-plan/SKILL.md
+++ b/codex/skills/fanout-plan/SKILL.md
@@ -14,8 +14,12 @@ worktrees and panes.
 
 Find the source plan in this order:
 
-1. An explicit path argument from `$fanout-plan <path>`, `/fanout plan <path>`,
-   or the user's message.
+1. An explicit argument from `$fanout-plan <arg>`, `/fanout plan <arg>`, or the
+   user's message. If `<arg>` is a file path, use that file. Otherwise, check
+   whether `.fanout/plans/<arg>.json` exists in the target repository; if it
+   does, use `<arg>` as the saved plan slug and skip spec authoring. If the
+   explicit argument resolves to neither a file nor a saved plan slug, stop and
+   report the missing path/slug instead of rediscovering another source plan.
 2. The newest `~/.claude/plans/*.md` file by modification time.
 3. The current conversation's approved implementation plan.
 4. The newest `<proposed_plan>...</proposed_plan>` block in the current
@@ -44,10 +48,12 @@ Use these naming rules:
 - `plan.slug`: lowercase kebab-case, 2-4 words when possible.
 - `task.id`: required lowercase kebab-case, 2-4 words, stable across reruns.
 - `task.display_name`: optional readable pane title, 40 characters or fewer.
-- `task.slug`: optional final worktree slug. Prefer omitting it unless the
-  default from title + id is unclear. If set, use the same policy as fanout's
-  `--name` slug hints: 2-4 lowercase kebab words, starts with alnum, contains
-  only `[a-z0-9-]`, and is unique in the plan.
+- `task.slug`: optional final worktree slug. Prefer omitting it; default slugs
+  are plan-qualified. If set, fanout uses it exactly, so it must be globally
+  unique under `.fanout/worktrees`, not merely unique within this plan. Use the
+  same policy as fanout's `--name` slug hints: 2-4 lowercase kebab words,
+  starts with alnum, and contains only `[a-z0-9-]`. Prefix it with `plan.slug`
+  when that helps avoid collisions, for example `launch-plan-base-types`.
 
 ## Spec JSON
 
@@ -117,6 +123,11 @@ Forward only the flags supported by the current `fanout plan` implementation:
 Use `--dry-run` for preview. Strip wrapper-only `--go` before calling the CLI;
 it means "skip confirmation", not a fanout flag.
 
+If the spec contains any non-empty `blocked_by` lists, include
+`--unblocked-only` by default so dependent tasks are deferred until their
+blockers are complete. Omit it only when the user explicitly asks to launch all
+waves together.
+
 Do not forward issue/project-mode-only flags to `fanout plan`: `--include`,
 `--name`, `--project-status`, `--format`, `--post-dashboard`, `--team`,
 `--popup-timeout`, `--codex-plan-mode`, `--status`, `--close`, `--merge`, or
@@ -125,10 +136,12 @@ dependencies belong in `blocked_by`.
 
 ## Run
 
-1. Write `/tmp/fanout-plan-<slug>.json`.
+1. If using a saved plan slug from `.fanout/plans/<slug>.json`, keep that slug
+   as the command argument and skip writing a new spec. Otherwise, write
+   `/tmp/fanout-plan-<slug>.json`.
 2. Run:
    ```bash
-   fanout plan /tmp/fanout-plan-<slug>.json --dry-run --agent codex <flags>
+   fanout plan <spec-or-slug> --dry-run --agent codex <flags>
    ```
 3. Summarize the dry-run: plan slug/title, task count, task ids/titles,
    waves, `blocked_by`, generated worktree paths, branch names, and deferred
@@ -137,7 +150,7 @@ dependencies belong in `blocked_by`.
    immediate execution. If the user passed `--dry-run`, stop after the preview.
 5. Run the live command without `--dry-run`:
    ```bash
-   fanout plan /tmp/fanout-plan-<slug>.json --agent codex <flags>
+   fanout plan <spec-or-slug> --agent codex <flags>
    ```
 6. Return the created/skipped/deferred/failed summary.
 

--- a/codex/skills/fanout/SKILL.md
+++ b/codex/skills/fanout/SKILL.md
@@ -30,12 +30,19 @@ fanout <parent-issue> --merge <NUM> # fast-forward merge a recorded child branch
 fanout <parent-issue> --close <NUM> # remove a recorded child worktree/pane
 fanout <parent-issue> --cleanup     # remove merged/closed recorded children
 fanout dashboard --web              # read-only localhost web dashboard (Session view); no parent arg
+fanout plan <spec.json|plan-slug>   # issue-less local plan task fan-out (see fanout-plan)
 fanout msg <verb> [options] [body...]  # peer messaging between sibling panes (see Notes)
 fanout --check-update               # Read-only version comparison
 fanout update                       # Replace fanout via install.sh
 ```
 
 `fanout dashboard --web` is a standalone subcommand (no parent argument): a read-only, 127.0.0.1-bound web dashboard that visualizes all fanned-out Sessions live (pane liveness, issue/PR state). It is human-facing — surface it when the user wants to watch/monitor parallel panes, not as part of the fan-out flow. After a live fan-out, fanout also binds `prefix + D` in tmux to open it; launched panes record their owner project root so the key still opens the right dashboard from agent TUIs such as Codex when tmux reports a stale `pane_current_path`. `--no-dashboard-keybind` suppresses the binding.
+
+`fanout plan <spec.json|plan-slug>` is the issue-less plan-task lane. If the
+user asks to fan out an implementation plan, use the `fanout-plan` skill
+(`~/.codex/skills/fanout-plan/SKILL.md`) so Codex decomposes the plan and
+writes the spec JSON before invoking the deterministic CLI. The CLI does not
+call an LLM and does not infer tasks from prose.
 
 **Do not probe the CLI** with `fanout --help`, `fanout -h`, or
 `which fanout`. This SKILL.md is the source-of-truth for the CLI surface —
@@ -89,6 +96,8 @@ user asks to update fanout itself, run `fanout update` immediately.
 If the user asks to start the fanout console / TUI, run `fanout` with no
 arguments directly from the target repository worktree; skip parent resolution,
 dry-run, pane naming, and agent selection.
+If the user asks to fan out an implementation plan, run `$fanout-plan` instead
+of the issue/Project workflow below.
 Do not invoke fanout just because an issue has sub-issues; pane creation is
 visible and the user has to close unwanted panes manually.
 

--- a/install.sh
+++ b/install.sh
@@ -110,9 +110,11 @@ install_data() {
 remove_integrations() {
   rm -f "$claude_dir/commands/fanout.md" "$claude_dir/commands/pr-watch.md"
   rm -rf "$claude_dir/skills/fanout" "$claude_dir/skills/fanout-issues" \
-    "$claude_dir/skills/post-work-review" "$claude_dir/skills/pr-watch"
+    "$claude_dir/skills/fanout-plan" "$claude_dir/skills/post-work-review" \
+    "$claude_dir/skills/pr-watch"
   rm -rf "$codex_dir/skills/fanout" "$codex_dir/skills/fanout-issues" \
-    "$codex_dir/skills/post-work-review" "$codex_dir/skills/pr-watch"
+    "$codex_dir/skills/fanout-plan" "$codex_dir/skills/post-work-review" \
+    "$codex_dir/skills/pr-watch"
 }
 
 copy_skill_dirs() {


### PR DESCRIPTION
## TL;DR
Add Claude and Codex `fanout-plan` skills plus `/fanout plan` routing so agents can turn implementation plans into `fanout plan` specs and runs. Review effort: 2

## Why
Issue #218 asks for the agent-side entrypoint for issue-less plan fan-out: discover a plan, decompose it into bounded tasks, write the spec JSON, and invoke the already-implemented #215 `fanout plan` CLI surface without adding Go code.

## Changes by file
<details><summary>Changed files</summary>

| File | What changed | Why |
| --- | --- | --- |
| `claude/skills/fanout-plan/SKILL.md` | Added the Claude workflow for plan discovery, task decomposition, spec JSON output, #215 flag forwarding, dry-run/live execution, rerun guidance, and failure mapping. | Provides the new Claude-side entrypoint requested by #218. |
| `codex/skills/fanout-plan/SKILL.md` | Added the Codex variant with `<proposed_plan>` discovery and Codex default agent guidance. | Provides the new Codex-side entrypoint requested by #218. |
| `claude/commands/fanout.md` | Added a `/fanout plan` short-circuit before parent/Project resolution and examples for plan input. | Routes slash-command plan input to the new skill instead of the issue/Project workflow. |
| `claude/skills/fanout/SKILL.md` | Added a `fanout plan` synopsis line and cross-reference to `fanout-plan`. | Keeps the general fanout skill aligned with the new plan lane. |
| `codex/skills/fanout/SKILL.md` | Added a `fanout plan` synopsis line and cross-reference to `$fanout-plan`. | Keeps the Codex fanout skill aligned with the new plan lane. |

</details>

## Risk
> [!WARNING]
> `fanout plan --status` / `--cleanup` are intentionally documented as unavailable in the current #215 surface because task lifecycle support is tracked separately in #217. These skill docs will need a follow-up once #217 lands.

## Test plan
- `ruby -ryaml -e ... claude/skills/fanout-plan/SKILL.md codex/skills/fanout-plan/SKILL.md claude/commands/fanout.md claude/skills/fanout/SKILL.md codex/skills/fanout/SKILL.md` passed
- `make -n install-integrations` confirmed `fanout-plan` is included for both Claude and Codex wildcard installs
- `make test` passed
- `make lint` passed
- `codex review --uncommitted` reported no issues

Closes #218