### PR TITLE
docs: document issue-less plan fan-out

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,8 @@ Build the binary with `make build-go` and validate with `make test`.
   inside tmux.
 - Verify changes without creating worktrees or panes:
   `./fanout-go <parent-issue> --agent claude --dry-run`.
+- Verify issue-less plan tasks without creating worktrees or panes:
+  `./fanout-go plan <spec.json|plan-slug> --agent claude --dry-run`.
 - Settings (`--auto-pr` / `--no-auto-pr`, `--pr-review-gate` /
   `--no-pr-review-gate`, `--briefing-code-review` /
   `--no-briefing-code-review`, `--agent-teams-hint` /
@@ -63,6 +65,12 @@ Build the binary with `make build-go` and validate with `make test`.
 - `cmd/fanout/main.go` handles parse dispatch, dependency checks, runtime
   resolution, child loading, state loading/locking, and the fail-fast
   `executePlan` loop.
+- `cmd/fanout/plancmd.go` is the issue-less `fanout plan` entrypoint
+  dispatched before normal `cliflags.Parse`. It loads a local plan spec or
+  `.fanout/plans/<slug>.json`, resolves the base branch, builds task rows,
+  applies `--only` / `--skip` / `--limit` / `--unblocked-only`, copies live
+  specs into `.fanout/plans/`, and wires plan `--status`, `--close`, `--merge`,
+  and `--cleanup`.
 - `cmd/fanout/pane.go` is the creation orchestration: briefing render, naming,
   worktree planning/preparation, tmux split/title/layout, state recording,
   metadata write, and agent launch.
@@ -114,7 +122,12 @@ Build the binary with `make build-go` and validate with `make test`.
   commands and validates installed CLIs for live mode.
 - `internal/state` owns `.fanout/state.json` plus `.fanout/state.json.lock`.
   The coarse lock covers planning and launching so two fanout invocations do
-  not race on the same `(parent, issueNum)` idempotency key.
+  not race on the same `(parent, issueNum)` idempotency key. Issue-less plan
+  rows use parent `plan:<slug>`, `issueNum: 0`, and `taskId`; `taskId` is an
+  additive key used by plan idempotency and task lifecycle.
+- `internal/planspec` owns the pure JSON schema for `fanout plan`: `version`,
+  `plan` metadata, task validation, deterministic task slug/branch defaults,
+  duplicate/collision checks, and `blocked_by` dependency cycle detection.
 - `internal/naming` deterministically generates slugs and branch names.
   `--name` may override slug, display name, and branch. The skills generate
   these flags from issue context; the CLI does not call an LLM.
@@ -143,7 +156,11 @@ Build the binary with `make build-go` and validate with `make test`.
 - `internal/ghissue`, `internal/blockers`, `internal/briefing`,
   `internal/settings`, `internal/displayname`, `internal/atomicfs`,
   `internal/log`, `internal/tty`, and `internal/exitcode` hold the remaining
-  reusable pieces.
+  reusable pieces. Plan status and blocked-task completion use
+  `ghissue.Runner.PRsForBranch` (`gh pr list --head <branch>`) because plan
+  tasks have no issue closed-by graph. `briefing.RenderTask` is the plan-task
+  briefing variant; it removes issue-closing footers and asks PR bodies to end
+  with `Plan: <slug> / Task: <id>`.
 
 ## Behavior Boundaries
 
@@ -151,12 +168,18 @@ Build the binary with `make build-go` and validate with `make test`.
   rows. Project mode uses Project items instead. Prose scanning (`Closes #N`,
   `Depends on #N`, Japanese child-reference idioms) belongs in the Claude/Codex
   skills, which forward accepted candidates through `--include`.
+- `fanout plan` is a separate issue-less lane. It must not overload the
+  issue-mode `Plan` / child enumeration path, must not invent GitHub issue
+  numbers, and must keep task selection keyed by task IDs. Task dependencies
+  are local `blocked_by` IDs whose completion is inferred from merged PRs on
+  task branches.
 - `--unblocked-only` parses blockers from the child body's `## Blocked by`
   section, the parent task-list row trailer `(blocked by #X, #Y)`, and the
   `blocked` label as a weak signal.
 - `--status`, `--close`, `--merge`, and `--cleanup` do not inspect old pane
   prompts or external config. They operate on `.fanout/state.json` or
-  `FANOUT_STATE_PATH`.
+  `FANOUT_STATE_PATH`. The plan variants load the spec first and then operate
+  on `plan:<slug>` task rows.
 - `fanout dashboard --web` is the one HTTP surface, and it is deliberately
   carved out: a read-only, `127.0.0.1`-bound, GET-only, token-gated localhost
   server that only ever reads state/tmux/gh and never mutates repo or GitHub
@@ -188,13 +211,20 @@ Build the binary with `make build-go` and validate with `make test`.
   user-facing `fanout tui` compatibility path.
 - Keep the state lock close to live launch behavior. Moving exclude setup or
   lock acquisition can leave dirty `.fanout/state.json.lock` artifacts or
-  reintroduce launch races.
+  reintroduce launch races. Plan live runs also rely on the same lock while
+  copying specs and checking `(plan:<slug>, taskId)` idempotency.
 - `tmux split-window -P` returns the new pane id synchronously; do not add
   polling around pane creation unless a future tmux path stops returning an id.
 - Preserve fail-fast behavior in `executePlan`: stop after the first failed
   child launch.
 - When changing dry-run output, update and inspect Tier 2 goldens before
-  committing.
+  committing. Plan changes usually touch both dry-run and status fixtures /
+  goldens (`scenario-plan-*`); regenerate with `FANOUT_GOLDEN_UPDATE=1 make
+  test-tier2` and review the exact diff.
+- Keep plan branch-derived PR lookups aligned across status, cleanup, and
+  `--unblocked-only`. If branch generation, task `branch` overrides, or
+  `--branch-prefix` behavior changes, update the plan status fixtures and
+  docs together.
 - `gh pr create` is gated by the repo's `PreToolUse(Bash)` hook registered in
   `.claude/settings.json`. Run `/post-work-review` before creating a PR, or use
   `FANOUT_SKIP_PR_REVIEW=1` only when the documented escape hatch is intended.

--- a/README.ja.md
+++ b/README.ja.md
@@ -149,10 +149,12 @@ curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh |
 - `$CLAUDE_DIR/commands/pr-watch.md`（既定は `~/.claude/commands/pr-watch.md`）
 - `$CLAUDE_DIR/skills/fanout/`（既定は `~/.claude/skills/fanout/`）
 - `$CLAUDE_DIR/skills/fanout-issues/`（既定は `~/.claude/skills/fanout-issues/`）
+- `$CLAUDE_DIR/skills/fanout-plan/`（既定は `~/.claude/skills/fanout-plan/`）
 - `$CLAUDE_DIR/skills/post-work-review/`（既定は `~/.claude/skills/post-work-review/`）
 - `$CLAUDE_DIR/skills/pr-watch/`（既定は `~/.claude/skills/pr-watch/`）
 - `$CODEX_DIR/skills/fanout/`（既定は `~/.codex/skills/fanout/`）
 - `$CODEX_DIR/skills/fanout-issues/`（既定は `~/.codex/skills/fanout-issues/`）
+- `$CODEX_DIR/skills/fanout-plan/`（既定は `~/.codex/skills/fanout-plan/`）
 - `$CODEX_DIR/skills/post-work-review/`（既定は `~/.codex/skills/post-work-review/`）
 - `$CODEX_DIR/skills/pr-watch/`（既定は `~/.codex/skills/pr-watch/`）
 
@@ -306,6 +308,14 @@ fanout <parent-issue|project-url>  # 一括 pane 作成; tmux 内から実行
        [--codex-plan-mode|--no-codex-plan-mode]
        [--pr-visualization|--no-pr-visualization]
        [--team]
+fanout plan <spec.json|plan-slug> [--agent <name>] [--dry-run]
+       [--limit <N>] [--only <task-id[,id...]>] [--skip <task-id[,id...]>]
+       [--unblocked-only] [--base-branch <branch>] [--branch-prefix <prefix>]
+       [--no-refresh] [--session <tmux-session>] [--sleep <seconds>]
+fanout plan <spec.json|plan-slug> --status [--format json|table]
+fanout plan <spec.json|plan-slug> --merge <task-id>
+fanout plan <spec.json|plan-slug> --close <task-id>
+fanout plan <spec.json|plan-slug> --cleanup
 fanout <parent-issue> --status [--format json|table] [--post-dashboard]
                                       # 状態を読み、任意で dashboard を投稿
 fanout <parent-issue> --merge <NUM> # 記録済み子 branch を ff-only merge
@@ -323,6 +333,101 @@ Projects v2 URL（Project モード、上記参照）のいずれか。`--projec
 は Project モードでのみ意味を持ち、issue モードでは無視されます。
 `--popup-timeout` は旧ランタイム互換の deprecated flag で、direct tmux path
 では受け付けるだけで無視されます。
+
+### Plan fan-out (issue-less)
+
+`fanout plan <spec.json|plan-slug>` は、GitHub child issue ではなくローカル
+JSON spec から task pane を起動する lane です。実装計画がすでにローカル task に
+分解されていて、issue ツリーを作るとノイズになる場合に使います。path または
+`*.json` 引数はそのまま読み、bare slug は
+`<git-root>/.fanout/plans/<slug>.json` を読みます。live run は元 spec をそこへ
+コピーするため、以後は slug だけで再実行できます。
+
+spec フォーマットのリファレンス:
+
+```json
+{
+  "version": 1,
+  "plan": {
+    "slug": "launch-plan",
+    "title": "Launch plan",
+    "source": "docs/launch.md",
+    "base_branch": "main"
+  },
+  "tasks": [
+    {
+      "id": "base-types",
+      "title": "Define base types",
+      "briefing": "## Goal\nDefine the shared types.",
+      "display_name": "Base types",
+      "wave": "1"
+    },
+    {
+      "id": "api-client",
+      "title": "Extract API client",
+      "briefing": "## Goal\nExtract the API client.",
+      "blocked_by": ["base-types"],
+      "wave": "2"
+    }
+  ]
+}
+```
+
+必須 field は `version: 1`、`plan.slug`、`plan.title`、そして kebab-case
+`id`、`title`、空でない `briefing` を持つ task 1 件以上です。任意 field は
+`plan.source`、`plan.base_branch`、task ごとの `slug`、`display_name`、
+`branch`、`wave`、`blocked_by` です。既定の worktree slug は plan 名で
+qualify されます（上例なら `launch-plan-define-base-types-base-types`）。
+生成 branch は `fanout/<slug>` で、task の `branch` があればそれをそのまま使います。
+
+```bash
+# 生成される worktree、branch、tmux command、task briefing を確認
+fanout plan /tmp/fanout-plan-launch-plan.json --agent claude --dry-run
+
+# 現時点で unblock されている task を起動
+fanout plan /tmp/fanout-plan-launch-plan.json --agent claude --unblocked-only
+
+# 保存済み plan を slug で再実行し、この wave を 2 件に制限
+fanout plan launch-plan --agent claude --unblocked-only --limit 2
+
+# task の PR 状態を確認。既定は JSON、table は PR state / CI / type /
+# files / diff bar / link を追加
+fanout plan launch-plan --status
+fanout plan launch-plan --status --format table
+
+# lifecycle は issue 番号ではなく task ID を指定
+fanout plan launch-plan --merge base-types
+fanout plan launch-plan --close base-types
+fanout plan launch-plan --cleanup
+```
+
+`--only` と `--skip` は issue 番号ではなく task ID を受け取ります。
+`--unblocked-only` は各 task の `blocked_by` を、依存 task の明示 branch または
+生成 branch に merge 済み PR があるかで判定します。依存に merge 済み PR がまだ
+無い task は `deferred (blocked)` と報告され、その run では pane を作りません。
+`--status` は plan task に GitHub issue 番号が無いため、issue closed-by ではなく
+`gh pr list --head <branch>` を使います。Plan task の row は
+`.fanout/state.json` に parent `plan:<slug>`、`taskId`、`issueNum: 0` で記録され、
+再実行時は state または `.fanout/worktrees/` に既にある row をスキップします。
+
+Plan task briefing は標準の fanout briefing と同じですが、issue-closing footer は
+要求しません。auto-PR guidance は、GitHub issue が無くても task を識別できるよう、
+PR body の末尾を `Plan: <slug> / Task: <id>` にするよう指示します。
+
+同梱の agent 連携を使う場合、Claude Code の `/fanout plan ...` は
+`~/.claude/skills/fanout-plan/` へ、Codex の `$fanout-plan` または "fanout plan"
+依頼は `~/.codex/skills/fanout-plan/` へ routing されます。skill は spec を
+作成または選択し、まず dry-run を実行し、task / wave / branch を要約してから、
+wrapper で確認スキップを明示されていない限り確認後に live command を実行します。
+
+exit code は既存 lane に従います。通常 / dry-run の `fanout plan` は、成功または
+何もすることが無い場合 `0`、環境・spec・filter・preflight・launch の失敗で `1`、
+不正な呼び出しで `2` を返します。`fanout plan <spec> --status` は、status 出力で
+`0`、`git` や `gh` などの必須 dependency が無い場合 `1`、不正な呼び出し・
+読めない / 壊れた spec/state・使えない project root で `2`、GitHub PR lookup
+失敗で `3` です。Plan `--close` / `--merge` / `--cleanup` は、成功（cleanup
+対象無しを含む）で `0`、環境・git・cleanup 失敗で `1`、記録済み task target が
+不正な場合 `2`、cleanup が branch PR 状態を取得できない場合 `3` を返します。
 
 ### Codex Plan Mode
 
@@ -674,6 +779,19 @@ fanout 123 --agent codex
 # Codex 子ペインを app-server Plan Mode + interactive TUI で開始する
 fanout 123 --agent codex --codex-plan-mode
 
+# agent wrapper から issue-less な実装計画を分解して起動する。
+# Claude Code は /fanout plan、Codex は $fanout-plan または "fanout plan"
+# 依頼を使う。どちらも live 起動前に fanout plan --dry-run で preview する。
+/fanout plan /tmp/implementation-plan.md
+
+# 既存 spec から CLI を直接使い、blocked_by 依存は前提 task branch の PR が
+# merge されるまで deferred にする
+fanout plan /tmp/fanout-plan-launch-plan.json --agent claude --dry-run
+fanout plan /tmp/fanout-plan-launch-plan.json --agent claude --unblocked-only
+fanout plan launch-plan --status --format table
+fanout plan launch-plan --merge base-types
+fanout plan launch-plan --cleanup
+
 # この run だけ、子 briefing から PR 自動作成指示を外す
 fanout 123 --no-auto-pr
 
@@ -747,6 +865,11 @@ Claude Code 向けの推奨連携 — これらのアセットはこのリポジ
   同一リポジトリ内の子 issue を作成し、GitHub Sub-issues と親本文のタスクリストの
   両方へ反映し、`fanout --unblocked-only` が読める `## Blocked by` /
   `(blocked by #N)` 形式で依存関係の wave も記録します。
+- **plan fan-out スキル** → `claude/skills/fanout-plan/SKILL.md` が
+  `~/.claude/skills/fanout-plan/SKILL.md` にインストールされ、`/fanout plan`
+  を支えます。承認済みまたはローカルの実装計画を `fanout plan` spec に変換し、
+  dry-run preview を実行して task / wave を要約し、確認後に issue-less task pane
+  を起動します。
 
 Codex CLI 向けの推奨連携 — スキルはこのリポジトリの `codex/` 配下に同梱され、
 `make install` で配置されます:
@@ -764,6 +887,11 @@ Codex CLI 向けの推奨連携 — スキルはこのリポジトリの `codex/
   `fanout --unblocked-only` 用の blocker wave 作成を依頼したときに使います。
   Claude 版と同じく、同一リポジトリ内の子 issue、GitHub Sub-issues のリンク、
   親本文のタスクリスト、`## Blocked by` 注記を揃えます。
+- **plan fan-out スキル** → `codex/skills/fanout-plan/SKILL.md` が
+  `~/.codex/skills/fanout-plan/SKILL.md` にインストールされます。`$fanout-plan`
+  または `fanout plan` の依頼で使います。ローカル spec を作成または選択し、
+  `fanout plan ... --dry-run` を preview してから、確認後に live の issue-less
+  task fan-out を実行します（確認スキップが明示された場合を除く）。
 - **post-work review スキル** → `codex/skills/post-work-review/SKILL.md` が
   `~/.codex/skills/post-work-review/SKILL.md` にインストールされます。Codex に
   コミット前・PR前の最終レビューを依頼したときに使い、明示 scope 付きの

--- a/README.md
+++ b/README.md
@@ -162,10 +162,12 @@ Installed paths:
 - `$CLAUDE_DIR/commands/pr-watch.md` (default `~/.claude/commands/pr-watch.md`)
 - `$CLAUDE_DIR/skills/fanout/` (default `~/.claude/skills/fanout/`)
 - `$CLAUDE_DIR/skills/fanout-issues/` (default `~/.claude/skills/fanout-issues/`)
+- `$CLAUDE_DIR/skills/fanout-plan/` (default `~/.claude/skills/fanout-plan/`)
 - `$CLAUDE_DIR/skills/post-work-review/` (default `~/.claude/skills/post-work-review/`)
 - `$CLAUDE_DIR/skills/pr-watch/` (default `~/.claude/skills/pr-watch/`)
 - `$CODEX_DIR/skills/fanout/` (default `~/.codex/skills/fanout/`)
 - `$CODEX_DIR/skills/fanout-issues/` (default `~/.codex/skills/fanout-issues/`)
+- `$CODEX_DIR/skills/fanout-plan/` (default `~/.codex/skills/fanout-plan/`)
 - `$CODEX_DIR/skills/post-work-review/` (default `~/.codex/skills/post-work-review/`)
 - `$CODEX_DIR/skills/pr-watch/` (default `~/.codex/skills/pr-watch/`)
 
@@ -319,6 +321,14 @@ fanout <parent-issue|project-url>  # batch pane creation; run from inside tmux
        [--codex-plan-mode|--no-codex-plan-mode]
        [--pr-visualization|--no-pr-visualization]
        [--team]
+fanout plan <spec.json|plan-slug> [--agent <name>] [--dry-run]
+       [--limit <N>] [--only <task-id[,id...]>] [--skip <task-id[,id...]>]
+       [--unblocked-only] [--base-branch <branch>] [--branch-prefix <prefix>]
+       [--no-refresh] [--session <tmux-session>] [--sleep <seconds>]
+fanout plan <spec.json|plan-slug> --status [--format json|table]
+fanout plan <spec.json|plan-slug> --merge <task-id>
+fanout plan <spec.json|plan-slug> --close <task-id>
+fanout plan <spec.json|plan-slug> --cleanup
 fanout <parent-issue> --status [--format json|table] [--post-dashboard]
                                       # status of fanned children; optionally post dashboard
 fanout <parent-issue> --merge <NUM> # fast-forward merge a recorded child branch
@@ -336,6 +346,106 @@ task-list mode) or a Projects v2 URL (Project mode; see above).
 `--project-status` only applies to Project mode and is ignored otherwise.
 `--popup-timeout` is a deprecated compatibility flag from the old runtime and
 is accepted but ignored by the direct tmux path.
+
+### Plan fan-out (issue-less)
+
+`fanout plan <spec.json|plan-slug>` launches task panes from a local JSON spec
+instead of GitHub child issues. Use it when an implementation plan is already
+split into local tasks and creating issue trees would add noise. A path or
+`*.json` argument is loaded directly; a bare slug loads
+`<git-root>/.fanout/plans/<slug>.json`. Live runs copy the source spec there,
+so later runs can use the shorter slug.
+
+Spec format reference:
+
+```json
+{
+  "version": 1,
+  "plan": {
+    "slug": "launch-plan",
+    "title": "Launch plan",
+    "source": "docs/launch.md",
+    "base_branch": "main"
+  },
+  "tasks": [
+    {
+      "id": "base-types",
+      "title": "Define base types",
+      "briefing": "## Goal\nDefine the shared types.",
+      "display_name": "Base types",
+      "wave": "1"
+    },
+    {
+      "id": "api-client",
+      "title": "Extract API client",
+      "briefing": "## Goal\nExtract the API client.",
+      "blocked_by": ["base-types"],
+      "wave": "2"
+    }
+  ]
+}
+```
+
+Required fields are `version: 1`, `plan.slug`, `plan.title`, and at least one
+task with kebab-case `id`, `title`, and non-empty `briefing`. Optional fields
+are `plan.source`, `plan.base_branch`, and per-task `slug`, `display_name`,
+`branch`, `wave`, and `blocked_by`. Default worktree slugs are plan-qualified
+(`launch-plan-define-base-types-base-types` in the example), generated branches
+use `fanout/<slug>`, and explicit task `branch` values are honored exactly.
+
+```bash
+# Preview the generated worktrees, branches, tmux commands, and task briefings.
+fanout plan /tmp/fanout-plan-launch-plan.json --agent claude --dry-run
+
+# Launch the currently unblocked tasks.
+fanout plan /tmp/fanout-plan-launch-plan.json --agent claude --unblocked-only
+
+# Rerun a saved plan by slug and cap this wave.
+fanout plan launch-plan --agent claude --unblocked-only --limit 2
+
+# Inspect task PR state. JSON is default; table adds PR state, CI, type, files,
+# diff bars, and links.
+fanout plan launch-plan --status
+fanout plan launch-plan --status --format table
+
+# Lifecycle commands address task IDs, not issue numbers.
+fanout plan launch-plan --merge base-types
+fanout plan launch-plan --close base-types
+fanout plan launch-plan --cleanup
+```
+
+`--only` and `--skip` take task IDs, not issue numbers. `--unblocked-only`
+checks each task's `blocked_by` list against merged PRs on the dependency
+task's explicit or generated branch. Tasks whose dependencies do not yet have a
+merged PR are reported as `deferred (blocked)` and no pane is created for them.
+`--status` uses `gh pr list --head <branch>` rather than issue closed-by data,
+because plan tasks have no GitHub issue number. Plan task rows are recorded in
+`.fanout/state.json` under parent `plan:<slug>` with `taskId` and
+`issueNum: 0`, so reruns skip rows already recorded or already present under
+`.fanout/worktrees/`.
+
+Plan task briefings are the same standard fanout briefings except they do not
+ask for an issue-closing footer. Auto-PR guidance tells agents to end the PR
+body with `Plan: <slug> / Task: <id>` so the task can be identified without a
+GitHub issue.
+
+When using the bundled agent integrations, `/fanout plan ...` in Claude Code
+routes to `~/.claude/skills/fanout-plan/`, and `$fanout-plan` or "fanout plan"
+requests in Codex route to `~/.codex/skills/fanout-plan/`. The skill writes or
+selects the spec, runs the dry-run first, summarizes the tasks/waves/branches,
+and only runs the live command after confirmation unless the wrapper was asked
+to skip confirmation.
+
+Exit codes follow the existing lanes: normal and dry-run `fanout plan` return
+`0` for success or nothing to do, `1` for environment/spec/filter/preflight or
+launch failures, and `2` for bad invocation. `fanout plan <spec> --status`
+returns `0` when status is emitted, `1` when required dependencies such as
+`git` or `gh` are missing, `2` for invalid invocation, unreadable or invalid
+spec/state, or unusable project root, and `3` for GitHub PR lookup failures.
+Plan `--close`, `--merge`, and `--cleanup` return `0` for success
+(including no eligible cleanup rows), `1` for environment/git/cleanup failures,
+`2` for invalid recorded-task targets, and `3` when cleanup cannot query branch
+PR state.
 
 ### Codex Plan Mode
 
@@ -761,6 +871,19 @@ fanout 123 --agent codex
 # Start Codex children as app-server Plan Mode sessions with interactive TUI.
 fanout 123 --agent codex --codex-plan-mode
 
+# Decompose and launch an issue-less implementation plan from an agent wrapper.
+# Claude Code uses /fanout plan; Codex uses $fanout-plan or a "fanout plan"
+# request. Both preview with fanout plan --dry-run before live launch.
+/fanout plan /tmp/implementation-plan.md
+
+# Run the CLI directly from an existing spec, deferring blocked_by dependencies
+# until their prerequisite task branches have merged PRs.
+fanout plan /tmp/fanout-plan-launch-plan.json --agent claude --dry-run
+fanout plan /tmp/fanout-plan-launch-plan.json --agent claude --unblocked-only
+fanout plan launch-plan --status --format table
+fanout plan launch-plan --merge base-types
+fanout plan launch-plan --cleanup
+
 # Remove the automatic PR-opening requirement from child briefings for one run
 fanout 123 --no-auto-pr
 
@@ -837,6 +960,11 @@ repo under `claude/` and get placed by `make install`:
   GitHub Sub-issues, mirrors them in the parent task list, and records
   blocker waves in the `## Blocked by` / `(blocked by #N)` shapes that
   `fanout --unblocked-only` understands.
+- **Plan fan-out skill** → `claude/skills/fanout-plan/SKILL.md` is installed
+  to `~/.claude/skills/fanout-plan/SKILL.md` and backs `/fanout plan`. It
+  turns an approved/local implementation plan into a `fanout plan` spec, runs
+  the dry-run preview, summarizes tasks and waves, then launches the issue-less
+  task panes after confirmation.
 
 Recommended integration for Codex CLI — the skills are bundled under
 `codex/` and get placed by `make install`:
@@ -854,6 +982,11 @@ Recommended integration for Codex CLI — the skills are bundled under
   parent/child issues, or prepare blocker waves for `fanout --unblocked-only`.
   It mirrors the Claude issue-creation skill: same-repo children, GitHub
   Sub-issues links, parent task-list rows, and `## Blocked by` annotations.
+- **Plan fan-out skill** → `codex/skills/fanout-plan/SKILL.md` is installed to
+  `~/.codex/skills/fanout-plan/SKILL.md`. Use it with `$fanout-plan` or by
+  asking Codex for `fanout plan`. It writes/selects a local spec, previews
+  `fanout plan ... --dry-run`, then runs the live issue-less task fan-out after
+  confirmation unless explicitly told to skip confirmation.
 - **Post-work review skill** → `codex/skills/post-work-review/SKILL.md` is
   installed to `~/.codex/skills/post-work-review/SKILL.md`. Use it by asking
   Codex to run a final review loop before commit or PR; it runs

--- a/claude/skills/fanout-plan/SKILL.md
+++ b/claude/skills/fanout-plan/SKILL.md
@@ -93,9 +93,11 @@ otherwise let fanout resolve the repository default branch or let the user pass
 
 ## CLI Surface
 
-Run from the target repository worktree. `fanout plan` needs `git` and `tmux`;
-`gh` is needed only for `--unblocked-only` blocker completion checks. Use
-`--agent claude` unless the user supplied `--agent` or `FANOUT_AGENT`.
+Run from the target repository worktree. Task creation and dry-run modes need
+`git` and `tmux`; `gh` is additionally needed for `--unblocked-only` blocker
+completion checks. Read/lifecycle action modes need `git` but not tmux;
+`--status` and `--cleanup` also need `gh`. Use `--agent claude` unless the user
+supplied `--agent` or `FANOUT_AGENT`.
 
 Forward only the flags supported by the current `fanout plan` implementation:
 
@@ -127,10 +129,18 @@ blockers are complete. Omit it only when the user explicitly asks to launch all
 waves together.
 
 Do not forward issue/project-mode-only flags to `fanout plan`: `--include`,
-`--name`, `--project-status`, `--format`, `--post-dashboard`, `--team`,
-`--popup-timeout`, `--codex-plan-mode`, `--status`, `--close`, `--merge`, or
-`--cleanup`. Names belong in the spec (`slug`, `display_name`, `branch`), and
-dependencies belong in `blocked_by`.
+`--name`, `--project-status`, `--post-dashboard`, `--team`,
+`--popup-timeout`, or `--codex-plan-mode`. Names belong in the spec (`slug`,
+`display_name`, `branch`), and dependencies belong in `blocked_by`.
+
+Use read/lifecycle flags only when the user explicitly asks for plan task
+status or cleanup, not during initial plan generation:
+
+- `--status`
+- `--format <json|table>` (only with `--status`)
+- `--close <task-id>`
+- `--merge <task-id>`
+- `--cleanup`
 
 ## Run
 
@@ -154,19 +164,35 @@ dependencies belong in `blocked_by`.
 
 After a live run, fanout copies the spec to `.fanout/plans/<slug>.json`; later
 runs can re-address it as `fanout plan <slug> ...`. Use `--only <task-id>` or
-`--skip <task-id>` for partial reruns. In the current plan surface, task
-lifecycle flags are not implemented on `fanout plan`; for read-only visibility
-use the no-argument `fanout` TUI or dashboard, and do not invent
-`fanout plan --status` / `--cleanup` unless the CLI has been updated.
+`--skip <task-id>` for partial reruns. For read-only visibility, use
+`fanout plan <slug> --status [--format table]`; for task lifecycle, use
+`fanout plan <slug> --merge <task-id>`, `--close <task-id>`, or `--cleanup`.
+These task modes address task IDs, not issue numbers.
+
+## Status and Lifecycle
+
+`fanout plan <spec-or-slug> --status` loads the spec and state, then looks up
+PRs by branch with `gh pr list --head <branch>` because issue-less tasks have
+no GitHub issue closed-by graph. JSON is the default output; `--format table`
+adds PR state, CI, type, changed-file count, diff bars, and links.
+
+`--merge <task-id>` fast-forwards the recorded task branch into the project
+checkout. `--close <task-id>` removes the recorded task worktree, pane, and
+state row. `--cleanup` removes recorded plan task panes whose head branch has a
+merged PR. These modes honor `FANOUT_STATE_PATH`.
 
 ## Failure Mapping
 
 - Exit 0: success, dry-run success, or nothing to do.
 - Exit 1: environment/preflight, unreadable or invalid spec JSON, invalid
   filter values, missing dependencies, agent/runtime setup, worktree creation,
-  or failed pane launch.
+  failed pane launch, git merge failure, worktree cleanup failure, or state
+  update failure.
 - Exit 2: bad invocation such as missing spec, unknown plan option, or extra
-  positional arguments.
+  positional arguments. For `--status`, missing `git`/`gh` preflight
+  dependencies return 1, while unreadable spec/state and unusable project root
+  return 2; for task lifecycle, an unrecorded task ID returns 2.
+- Exit 3: GitHub PR lookup failure in plan `--status` or `--cleanup`.
 
 For common runtime errors: `fanout must be run inside tmux` means batch pane
 creation needs tmux; `agent is required` means pass `--agent claude` or another

--- a/codex/skills/fanout-plan/SKILL.md
+++ b/codex/skills/fanout-plan/SKILL.md
@@ -95,9 +95,11 @@ otherwise let fanout resolve the repository default branch or let the user pass
 
 ## CLI Surface
 
-Run from the target repository worktree. `fanout plan` needs `git` and `tmux`;
-`gh` is needed only for `--unblocked-only` blocker completion checks. Use
-`--agent codex` unless the user supplied `--agent` or `FANOUT_AGENT`.
+Run from the target repository worktree. Task creation and dry-run modes need
+`git` and `tmux`; `gh` is additionally needed for `--unblocked-only` blocker
+completion checks. Read/lifecycle action modes need `git` but not tmux;
+`--status` and `--cleanup` also need `gh`. Use `--agent codex` unless the user
+supplied `--agent` or `FANOUT_AGENT`.
 
 Forward only the flags supported by the current `fanout plan` implementation:
 
@@ -129,10 +131,18 @@ blockers are complete. Omit it only when the user explicitly asks to launch all
 waves together.
 
 Do not forward issue/project-mode-only flags to `fanout plan`: `--include`,
-`--name`, `--project-status`, `--format`, `--post-dashboard`, `--team`,
-`--popup-timeout`, `--codex-plan-mode`, `--status`, `--close`, `--merge`, or
-`--cleanup`. Names belong in the spec (`slug`, `display_name`, `branch`), and
-dependencies belong in `blocked_by`.
+`--name`, `--project-status`, `--post-dashboard`, `--team`, `--popup-timeout`,
+or `--codex-plan-mode`. Names belong in the spec (`slug`, `display_name`,
+`branch`), and dependencies belong in `blocked_by`.
+
+Use read/lifecycle flags only when the user explicitly asks for plan task
+status or cleanup, not during initial plan generation:
+
+- `--status`
+- `--format <json|table>` (only with `--status`)
+- `--close <task-id>`
+- `--merge <task-id>`
+- `--cleanup`
 
 ## Run
 
@@ -156,19 +166,35 @@ dependencies belong in `blocked_by`.
 
 After a live run, fanout copies the spec to `.fanout/plans/<slug>.json`; later
 runs can re-address it as `fanout plan <slug> ...`. Use `--only <task-id>` or
-`--skip <task-id>` for partial reruns. In the current plan surface, task
-lifecycle flags are not implemented on `fanout plan`; for read-only visibility
-use the no-argument `fanout` TUI or dashboard, and do not invent
-`fanout plan --status` / `--cleanup` unless the CLI has been updated.
+`--skip <task-id>` for partial reruns. For read-only visibility, use
+`fanout plan <slug> --status [--format table]`; for task lifecycle, use
+`fanout plan <slug> --merge <task-id>`, `--close <task-id>`, or `--cleanup`.
+These task modes address task IDs, not issue numbers.
+
+## Status and Lifecycle
+
+`fanout plan <spec-or-slug> --status` loads the spec and state, then looks up
+PRs by branch with `gh pr list --head <branch>` because issue-less tasks have
+no GitHub issue closed-by graph. JSON is the default output; `--format table`
+adds PR state, CI, type, changed-file count, diff bars, and links.
+
+`--merge <task-id>` fast-forwards the recorded task branch into the project
+checkout. `--close <task-id>` removes the recorded task worktree, pane, and
+state row. `--cleanup` removes recorded plan task panes whose head branch has a
+merged PR. These modes honor `FANOUT_STATE_PATH`.
 
 ## Failure Mapping
 
 - Exit 0: success, dry-run success, or nothing to do.
 - Exit 1: environment/preflight, unreadable or invalid spec JSON, invalid
   filter values, missing dependencies, agent/runtime setup, worktree creation,
-  or failed pane launch.
+  failed pane launch, git merge failure, worktree cleanup failure, or state
+  update failure.
 - Exit 2: bad invocation such as missing spec, unknown plan option, or extra
-  positional arguments.
+  positional arguments. For `--status`, missing `git`/`gh` preflight
+  dependencies return 1, while unreadable spec/state and unusable project root
+  return 2; for task lifecycle, an unrecorded task ID returns 2.
+- Exit 3: GitHub PR lookup failure in plan `--status` or `--cleanup`.
 
 For common runtime errors: `fanout must be run inside tmux` means batch pane
 creation needs tmux; `agent is required` means pass `--agent codex` or another

--- a/site/content/docs/agents.ja.md
+++ b/site/content/docs/agents.ja.md
@@ -35,6 +35,12 @@ skill は `--name` フラグ(slug / display name / branch)も issue のタイト
 
 `~/.claude/skills/fanout-issues/` は、計画を fanout-ready な GitHub 親 issue + リンクされた子 issue 群へ変換する場面で agent を導きます。同一 repo 内の子 issue を作成し、GitHub Sub-issues でリンクし、親本文のタスクリストにミラーし、`fanout --unblocked-only` が読める `## Blocked by` / `(blocked by #N)` 形式で blocker wave も記録します。
 
+### `fanout-plan` skill
+
+`~/.claude/skills/fanout-plan/` は `/fanout plan` を支えます。承認済みまたは
+ローカルの実装計画を `fanout plan` JSON spec に変換し、dry-run preview を実行して
+task / wave / branch を要約し、確認後に issue-less task pane を起動します。
+
 ### レビューと PR follow-up skill
 
 `~/.claude/skills/post-work-review/` はローカルの PR review gate を支え、最終レビュー
@@ -44,11 +50,16 @@ loop を回して reviewed HEAD marker を記録します。`~/.claude/commands/
 
 ## Codex CLI
 
-Codex 版の skill は `~/.codex/skills/fanout/`、`~/.codex/skills/fanout-issues/`、`~/.codex/skills/post-work-review/`、`~/.codex/skills/pr-watch/` に配置されます。skill のインストールや更新の後、実行中の Codex セッションがある場合は再起動すると新しいファイルを認識します。
+Codex 版の skill は `~/.codex/skills/fanout/`、`~/.codex/skills/fanout-issues/`、`~/.codex/skills/fanout-plan/`、`~/.codex/skills/post-work-review/`、`~/.codex/skills/pr-watch/` に配置されます。skill のインストールや更新の後、実行中の Codex セッションがある場合は再起動すると新しいファイルを認識します。
 
 fanout skill は、Codex に「#123 を fan out して」のように依頼するか、明示的に `$fanout` を指定すると起動します。Claude のコマンドと同じ安全フロー — まず dry-run、ターゲットを確認、それから本実行 — に従い、暗黙の子参照のスキャンと `--name` 生成も同様に行います。
 
 `fanout-issues` skill も Claude 版をミラーします: fanout-ready な GitHub issue ツリーの作成、計画の親子 issue 化、`fanout --unblocked-only` 用の blocker wave の準備を Codex に依頼したときに使われ、同一 repo の子 issue、GitHub Sub-issues のリンク、親本文のタスクリスト、`## Blocked by` 注記を同じように揃えます。
+
+GitHub child issue を作らずローカル実装計画を fan out したい場合は、`$fanout-plan`
+または `fanout plan` の依頼を使います。spec を作成または選択し、
+`fanout plan ... --dry-run` を preview してから、確認後に live 実行します
+（確認スキップが明示された場合を除く）。
 
 `$post-work-review` は、Codex にコミット前・PR前の最終レビュー loop を依頼するときに使います。明示 scope 付きの `codex review` を実行し、actionable な指摘を修正し、clean になるまで再レビューします。HEAD が clean な場合は Claude PR gate と同じ marker も記録します。
 

--- a/site/content/docs/agents.md
+++ b/site/content/docs/agents.md
@@ -35,17 +35,29 @@ The skill also generates the `--name` flags (slug / display name / branch) from 
 
 `~/.claude/skills/fanout-issues/` guides the agent when turning a plan into a fanout-ready GitHub parent issue plus linked child issues. It creates same-repo children, links them through GitHub Sub-issues, mirrors them in the parent task list, and records blocker waves in the `## Blocked by` / `(blocked by #N)` shapes that `fanout --unblocked-only` understands.
 
+### The `fanout-plan` skill
+
+`~/.claude/skills/fanout-plan/` backs `/fanout plan`. It turns an approved or
+local implementation plan into a `fanout plan` JSON spec, runs the dry-run
+preview, summarizes tasks/waves/branches, then launches issue-less task panes
+after confirmation.
+
 ### Review and PR follow-up skills
 
 `~/.claude/skills/post-work-review/` backs the local PR review gate: it runs a final review loop and records the reviewed HEAD marker. `~/.claude/commands/pr-watch.md` and `~/.claude/skills/pr-watch/` watch an existing PR after creation and handle safe conflict, CI, and review-comment follow-up.
 
 ## Codex CLI
 
-The Codex skills are installed to `~/.codex/skills/fanout/`, `~/.codex/skills/fanout-issues/`, `~/.codex/skills/post-work-review/`, and `~/.codex/skills/pr-watch/`. Restart any running Codex session after installing or updating the skills so it picks up the new files.
+The Codex skills are installed to `~/.codex/skills/fanout/`, `~/.codex/skills/fanout-issues/`, `~/.codex/skills/fanout-plan/`, `~/.codex/skills/post-work-review/`, and `~/.codex/skills/pr-watch/`. Restart any running Codex session after installing or updating the skills so it picks up the new files.
 
 Invoke the fanout skill by asking Codex to fan out a parent issue (for example, "fan out #123") or explicitly with `$fanout`. It follows the same safety flow as the Claude command — dry-run first, confirm targets, then run the real command — and it also performs the implicit-child scan and `--name` generation.
 
 The `fanout-issues` skill mirrors the Claude version: ask Codex to create a fanout-ready GitHub issue tree, decompose a plan into parent/child issues, or prepare blocker waves for `fanout --unblocked-only`, and it produces the same same-repo children, GitHub Sub-issues links, parent task-list rows, and `## Blocked by` annotations.
+
+Use `$fanout-plan` or ask Codex for `fanout plan` when you want to fan out a
+local implementation plan without creating GitHub child issues. It writes or
+selects the plan spec, previews `fanout plan ... --dry-run`, and runs live
+after confirmation unless confirmation was explicitly skipped.
 
 Use `$post-work-review` when you want Codex to run a final pre-commit or pre-PR review loop. It invokes `codex review` with an explicit scope, fixes actionable findings, reruns until clean, and records the same marker used by the Claude PR gate when HEAD is clean.
 

--- a/site/content/docs/cli.ja.md
+++ b/site/content/docs/cli.ja.md
@@ -23,6 +23,14 @@ fanout <parent-issue|project-url>
        [--agent-teams-hint|--no-agent-teams-hint]
        [--codex-plan-mode|--no-codex-plan-mode]
        [--pr-visualization|--no-pr-visualization]
+fanout plan <spec.json|plan-slug> [--agent <name>] [--dry-run]
+       [--limit <N>] [--only <task-id[,id...]>] [--skip <task-id[,id...]>]
+       [--unblocked-only] [--base-branch <branch>] [--branch-prefix <prefix>]
+       [--no-refresh] [--session <tmux-session>] [--sleep <seconds>]
+fanout plan <spec.json|plan-slug> --status [--format json|table]
+fanout plan <spec.json|plan-slug> --merge <task-id>
+fanout plan <spec.json|plan-slug> --close <task-id>
+fanout plan <spec.json|plan-slug> --cleanup
 fanout <parent-issue> --status [--format json|table] [--post-dashboard]
                                       # status of fanned children; optionally post dashboard
 fanout <parent-issue> --merge <NUM> # fast-forward merge a recorded child branch
@@ -84,6 +92,104 @@ fanout 123 --base-branch release/v2 --branch-prefix fanout/release/
 | `--sleep` | `<seconds>` | 子の作成成功ごとに挟む待機秒数。既定: `4`。launch 間の rate limit であり、retry 用ノブではない。 |
 | `--dry-run` | — | git worktree、tmux split-window、agent 起動のコマンド列を実行せずに表示する。 |
 | `--debug` | — | 追加の診断ログを有効化する。 |
+
+## Plan fan-out (issue-less)
+
+`fanout plan <spec.json|plan-slug>` は、GitHub child issue ではなくローカル JSON
+spec から task pane を起動します。path または `*.json` 引数はそのまま読み、
+bare slug は `<git-root>/.fanout/plans/<slug>.json` を読みます。live run は元 spec
+をそこへコピーするため、以後は短い slug で再実行できます。
+
+spec フォーマット:
+
+```json
+{
+  "version": 1,
+  "plan": {
+    "slug": "launch-plan",
+    "title": "Launch plan",
+    "source": "docs/launch.md",
+    "base_branch": "main"
+  },
+  "tasks": [
+    {
+      "id": "base-types",
+      "title": "Define base types",
+      "briefing": "## Goal\nDefine the shared types.",
+      "display_name": "Base types",
+      "wave": "1"
+    },
+    {
+      "id": "api-client",
+      "title": "Extract API client",
+      "briefing": "## Goal\nExtract the API client.",
+      "blocked_by": ["base-types"],
+      "wave": "2"
+    }
+  ]
+}
+```
+
+必須 field は `version: 1`、`plan.slug`、`plan.title`、そして kebab-case
+`id`、`title`、空でない `briefing` を持つ task 1 件以上です。任意 field は
+`plan.source`、`plan.base_branch`、task ごとの `slug`、`display_name`、
+`branch`、`wave`、`blocked_by` です。既定 task slug は plan 名で qualify され、
+生成 branch は task が `branch` を持たない限り `fanout/<slug>` になります。
+
+| フラグ | 引数 | 説明 |
+|---|---|---|
+| `--only` | `<task-id[,id...]>` | 対象を task ID に絞る。存在しない ID は警告して無視する。`--skip` とは併用不可。 |
+| `--skip` | `<task-id[,id...]>` | 指定 task ID を除外する。`--only` とは併用不可。 |
+| `--limit` | `<N>` | 作成する task pane を N 件までに制限し、残りは task ID の再実行 hint として表示する。 |
+| `--unblocked-only` | — | `blocked_by` 依存 task の明示 branch または生成 branch に merge 済み PR がまだ無い task を deferred にする。 |
+| `--base-branch` | `<branch>` | `plan.base_branch` を上書きする。どちらも無い場合は repository default branch を解決する。 |
+| `--branch-prefix` | `<prefix>` | 生成 task branch 名の prefix。 |
+| `--no-refresh` | — | task worktree 作成前の base branch refresh をスキップする。 |
+
+```bash
+fanout plan /tmp/fanout-plan-launch-plan.json --agent claude --dry-run
+fanout plan /tmp/fanout-plan-launch-plan.json --agent claude --unblocked-only
+fanout plan launch-plan --agent claude --unblocked-only --limit 2
+```
+
+Plan row は parent `plan:<slug>`、`taskId`、`issueNum: 0` として記録されます。
+Task briefing は issue-closing footer を避け、PR body 末尾を
+`Plan: <slug> / Task: <id>` にするよう指示します。
+
+### Plan status と lifecycle
+
+`fanout plan <spec|slug> --status` は spec と `.fanout/state.json` を読み、
+plan task には issue 番号が無いため `gh pr list --head <branch>` で branch ごとの
+PR を照会します。
+
+```bash
+fanout plan launch-plan --status
+fanout plan launch-plan --status --format table
+```
+
+JSON 出力は `plan`、`tasks[]`（`id`、`branch`、`prs`、`has_merged_pr`、
+`blocked`）、`summary`（`total`、`merged`、`pending`、`blocked`、
+`all_merged`）を含みます。table 形式は PR state、CI、Conventional Commit type、
+変更ファイル数、diff bar、link を追加します。
+
+lifecycle コマンドは task ID を指定します:
+
+```bash
+fanout plan launch-plan --merge base-types
+fanout plan launch-plan --close base-types
+fanout plan launch-plan --cleanup
+```
+
+`--merge <task-id>` は記録済み task branch を project checkout へ fast-forward
+します。`--close <task-id>` は記録済み task worktree、pane、state row を削除します。
+`--cleanup` は head branch に merge 済み PR がある記録済み plan task pane を閉じます。
+これらの mode は `FANOUT_STATE_PATH` を尊重します。
+
+agent wrapper は同梱 skill 経由で plan fan-out へ routing します。Claude Code は
+`/fanout plan ...` と `~/.claude/skills/fanout-plan/`、Codex は `$fanout-plan` または
+`fanout plan` 依頼と `~/.codex/skills/fanout-plan/` を使います。skill は spec を
+作成または選択し、`fanout plan ... --dry-run` を実行して task / wave / branch を
+要約し、確認スキップが明示されていない限り確認後に live 実行します。
 
 ## settings 系フラグ
 
@@ -187,7 +293,7 @@ bool の settings 変数は `1/true/yes/on` と `0/false/no/off` を受け付け
 
 ## Exit codes
 
-既定の fan-out フローは、成功（「子が無く、何もすることが無い」を含む）で `0`、前提条件 / 環境の問題で `1`、不正な呼び出しで `2` を返します。次の 3 つのモードは独立した exit code 体系を持ちます:
+既定の fan-out フローは、成功（「子が無く、何もすることが無い」を含む）で `0`、前提条件 / 環境の問題で `1`、不正な呼び出しで `2` を返します。`fanout plan` の live / dry-run task 作成も同じ lane を使い、成功または何もすることが無い場合 `0`、環境・spec・filter・preflight・launch の失敗で `1`、不正な呼び出しで `2` です。読み取り・lifecycle 系 mode は独立した exit code 体系を持ちます:
 
 ### `--status`
 
@@ -196,6 +302,24 @@ bool の settings 変数は `1/true/yes/on` と `0/false/no/off` を受け付け
 | `0` | status を出力した — 実際の状態は JSON mode の `summary.all_merged` で確認する |
 | `2` | 列挙不能: 不正な呼び出し、読めない / 壊れた state file、使えない project root、Projects v2 URL を parent に指定。state file が無い場合は空の state として扱う |
 | `3` | `gh` API 呼び出しが失敗した（認証、ネットワーク、存在しない issue など） |
+
+### `fanout plan --status`
+
+| Exit code | 意味 |
+|---|---|
+| `0` | plan status を出力した — 実際の状態は JSON mode の `summary.all_merged` で確認する |
+| `1` | status preflight で `git` や `gh` などの必須 dependency が見つからない |
+| `2` | 不正な呼び出し、読めない / 壊れた spec/state、または使えない project root |
+| `3` | task PR 状態を解決する `gh pr list --head <branch>` が失敗した |
+
+### `fanout plan --close` / `--merge` / `--cleanup`
+
+| Exit code | 意味 |
+|---|---|
+| `0` | lifecycle が完了した。cleanup 対象 row が無い場合も含む |
+| `1` | 環境、git merge、worktree 削除、pane cleanup、state 更新のいずれかが失敗した |
+| `2` | 指定 task ID がその plan に記録されていない |
+| `3` | cleanup が branch PR 状態を取得できなかった |
 
 ### `--check-update`
 

--- a/site/content/docs/cli.md
+++ b/site/content/docs/cli.md
@@ -23,6 +23,14 @@ fanout <parent-issue|project-url>
        [--agent-teams-hint|--no-agent-teams-hint]
        [--codex-plan-mode|--no-codex-plan-mode]
        [--pr-visualization|--no-pr-visualization]
+fanout plan <spec.json|plan-slug> [--agent <name>] [--dry-run]
+       [--limit <N>] [--only <task-id[,id...]>] [--skip <task-id[,id...]>]
+       [--unblocked-only] [--base-branch <branch>] [--branch-prefix <prefix>]
+       [--no-refresh] [--session <tmux-session>] [--sleep <seconds>]
+fanout plan <spec.json|plan-slug> --status [--format json|table]
+fanout plan <spec.json|plan-slug> --merge <task-id>
+fanout plan <spec.json|plan-slug> --close <task-id>
+fanout plan <spec.json|plan-slug> --cleanup
 fanout <parent-issue> --status [--format json|table] [--post-dashboard]
                                       # status of fanned children; optionally post dashboard
 fanout <parent-issue> --merge <NUM> # fast-forward merge a recorded child branch
@@ -84,6 +92,105 @@ fanout 123 --base-branch release/v2 --branch-prefix fanout/release/
 | `--sleep` | `<seconds>` | Pause between successful pane creations. Default: `4`. A rate limit between launches, not a retry knob. |
 | `--dry-run` | — | Print the git worktree, tmux split-window and agent launch commands without executing them. |
 | `--debug` | — | Enable extra diagnostic logging. |
+
+## Plan fan-out (issue-less)
+
+`fanout plan <spec.json|plan-slug>` launches task panes from a local JSON spec
+instead of GitHub child issues. A path or `*.json` argument is loaded directly;
+a bare slug loads `<git-root>/.fanout/plans/<slug>.json`. Live runs copy the
+source spec there for shorter reruns.
+
+Spec format:
+
+```json
+{
+  "version": 1,
+  "plan": {
+    "slug": "launch-plan",
+    "title": "Launch plan",
+    "source": "docs/launch.md",
+    "base_branch": "main"
+  },
+  "tasks": [
+    {
+      "id": "base-types",
+      "title": "Define base types",
+      "briefing": "## Goal\nDefine the shared types.",
+      "display_name": "Base types",
+      "wave": "1"
+    },
+    {
+      "id": "api-client",
+      "title": "Extract API client",
+      "briefing": "## Goal\nExtract the API client.",
+      "blocked_by": ["base-types"],
+      "wave": "2"
+    }
+  ]
+}
+```
+
+Required fields are `version: 1`, `plan.slug`, `plan.title`, and one or more
+tasks with kebab-case `id`, `title`, and non-empty `briefing`. Optional fields
+are `plan.source`, `plan.base_branch`, and per-task `slug`, `display_name`,
+`branch`, `wave`, and `blocked_by`. Default task slugs are plan-qualified, and
+generated branches use `fanout/<slug>` unless the task supplies `branch`.
+
+| Flag | Argument | Description |
+|---|---|---|
+| `--only` | `<task-id[,id...]>` | Restrict this run to task IDs. Missing IDs are warned and ignored. Cannot be combined with `--skip`. |
+| `--skip` | `<task-id[,id...]>` | Exclude task IDs. Cannot be combined with `--only`. |
+| `--limit` | `<N>` | Create at most N task panes and print a task-ID rerun hint for the rest. |
+| `--unblocked-only` | — | Defer tasks whose `blocked_by` dependencies do not yet have a merged PR on their explicit or generated branch. |
+| `--base-branch` | `<branch>` | Override `plan.base_branch`; if neither is set, fanout resolves the repository default branch. |
+| `--branch-prefix` | `<prefix>` | Prefix generated task branch names. |
+| `--no-refresh` | — | Skip base-branch refresh before creating task worktrees. |
+
+```bash
+fanout plan /tmp/fanout-plan-launch-plan.json --agent claude --dry-run
+fanout plan /tmp/fanout-plan-launch-plan.json --agent claude --unblocked-only
+fanout plan launch-plan --agent claude --unblocked-only --limit 2
+```
+
+Plan rows are recorded under parent `plan:<slug>` with `taskId` and
+`issueNum: 0`. Task briefings avoid issue-closing footers and ask PR bodies to
+end with `Plan: <slug> / Task: <id>`.
+
+### Plan status and lifecycle
+
+`fanout plan <spec|slug> --status` reads the spec plus `.fanout/state.json`,
+then queries PRs by branch with `gh pr list --head <branch>` because plan tasks
+do not have issue numbers.
+
+```bash
+fanout plan launch-plan --status
+fanout plan launch-plan --status --format table
+```
+
+JSON output contains `plan`, `tasks[]` (`id`, `branch`, `prs`,
+`has_merged_pr`, `blocked`), and `summary` (`total`, `merged`, `pending`,
+`blocked`, `all_merged`). The table format adds PR state, CI, Conventional
+Commit type, changed-file counts, diff bars, and links.
+
+Lifecycle commands address task IDs:
+
+```bash
+fanout plan launch-plan --merge base-types
+fanout plan launch-plan --close base-types
+fanout plan launch-plan --cleanup
+```
+
+`--merge <task-id>` fast-forwards the recorded task branch into the project
+checkout. `--close <task-id>` removes the recorded task worktree, pane, and
+state row. `--cleanup` closes recorded plan task panes whose head branch has a
+merged PR. These modes honor `FANOUT_STATE_PATH`.
+
+Agent wrappers route plan fan-out through the bundled skills: Claude Code uses
+`/fanout plan ...` and `~/.claude/skills/fanout-plan/`; Codex uses
+`$fanout-plan` or a `fanout plan` request and `~/.codex/skills/fanout-plan/`.
+The skill writes or selects a spec, runs `fanout plan ... --dry-run`, summarizes
+tasks/waves/branches, and runs live after confirmation unless confirmation was
+explicitly skipped.
 
 ## Settings flags
 
@@ -187,7 +294,7 @@ The boolean settings variables accept `1/true/yes/on` and `0/false/no/off`, case
 
 ## Exit codes
 
-The default fan-out flow exits `0` on success (including "no children, nothing to do"), `1` on a prerequisite or environment problem, and `2` on bad invocation. Three modes have their own exit-code lanes:
+The default fan-out flow exits `0` on success (including "no children, nothing to do"), `1` on a prerequisite or environment problem, and `2` on bad invocation. `fanout plan` uses the same default lane for live and dry-run task creation: `0` for success or nothing to do, `1` for environment/spec/filter/preflight or launch failures, and `2` for bad invocation. Read and lifecycle modes have their own exit-code lanes:
 
 ### `--status`
 
@@ -196,6 +303,24 @@ The default fan-out flow exits `0` on success (including "no children, nothing t
 | `0` | status emitted — check `summary.all_merged` in JSON mode for the actual state |
 | `2` | cannot enumerate: bad invocation, unreadable or malformed state file, unusable project root, or a Projects v2 URL as parent. A missing state file is treated as an empty state |
 | `3` | `gh` API call failed (auth, network, non-existent issue, etc.) |
+
+### `fanout plan --status`
+
+| Exit code | Meaning |
+|---|---|
+| `0` | plan status emitted — check `summary.all_merged` in JSON mode for the actual state |
+| `1` | required dependencies such as `git` or `gh` are missing during status preflight |
+| `2` | bad invocation, unreadable or invalid spec/state, or unusable project root |
+| `3` | `gh pr list --head <branch>` failed while resolving task PR state |
+
+### `fanout plan --close` / `--merge` / `--cleanup`
+
+| Exit code | Meaning |
+|---|---|
+| `0` | lifecycle completed, including cleanup with no eligible rows |
+| `1` | environment, git merge, worktree removal, pane cleanup, or state update failed |
+| `2` | the requested task ID is not recorded for the plan |
+| `3` | cleanup could not query branch PR state |
 
 ### `--check-update`
 

--- a/site/content/docs/installation.ja.md
+++ b/site/content/docs/installation.ja.md
@@ -46,10 +46,12 @@ curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh |
 - `$CLAUDE_DIR/commands/pr-watch.md`(既定は `~/.claude/commands/pr-watch.md`)
 - `$CLAUDE_DIR/skills/fanout/`(既定は `~/.claude/skills/fanout/`)
 - `$CLAUDE_DIR/skills/fanout-issues/`(既定は `~/.claude/skills/fanout-issues/`)
+- `$CLAUDE_DIR/skills/fanout-plan/`(既定は `~/.claude/skills/fanout-plan/`)
 - `$CLAUDE_DIR/skills/post-work-review/`(既定は `~/.claude/skills/post-work-review/` — PR レビューゲートを支える skill。同名 skill を上書きするので、自前のものがあればバックアップを)
 - `$CLAUDE_DIR/skills/pr-watch/`(既定は `~/.claude/skills/pr-watch/`)
 - `$CODEX_DIR/skills/fanout/`(既定は `~/.codex/skills/fanout/`)
 - `$CODEX_DIR/skills/fanout-issues/`(既定は `~/.codex/skills/fanout-issues/`)
+- `$CODEX_DIR/skills/fanout-plan/`(既定は `~/.codex/skills/fanout-plan/`)
 - `$CODEX_DIR/skills/post-work-review/`(既定は `~/.codex/skills/post-work-review/`)
 - `$CODEX_DIR/skills/pr-watch/`(既定は `~/.codex/skills/pr-watch/`)
 

--- a/site/content/docs/installation.md
+++ b/site/content/docs/installation.md
@@ -46,10 +46,12 @@ curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh |
 - `$CLAUDE_DIR/commands/pr-watch.md` (default `~/.claude/commands/pr-watch.md`)
 - `$CLAUDE_DIR/skills/fanout/` (default `~/.claude/skills/fanout/`)
 - `$CLAUDE_DIR/skills/fanout-issues/` (default `~/.claude/skills/fanout-issues/`)
+- `$CLAUDE_DIR/skills/fanout-plan/` (default `~/.claude/skills/fanout-plan/`)
 - `$CLAUDE_DIR/skills/post-work-review/` (default `~/.claude/skills/post-work-review/` — backs the PR review gate; overwrites a same-named skill, so back yours up)
 - `$CLAUDE_DIR/skills/pr-watch/` (default `~/.claude/skills/pr-watch/`)
 - `$CODEX_DIR/skills/fanout/` (default `~/.codex/skills/fanout/`)
 - `$CODEX_DIR/skills/fanout-issues/` (default `~/.codex/skills/fanout-issues/`)
+- `$CODEX_DIR/skills/fanout-plan/` (default `~/.codex/skills/fanout-plan/`)
 - `$CODEX_DIR/skills/post-work-review/` (default `~/.codex/skills/post-work-review/`)
 - `$CODEX_DIR/skills/pr-watch/` (default `~/.codex/skills/pr-watch/`)
 

--- a/site/content/docs/workflow.ja.md
+++ b/site/content/docs/workflow.ja.md
@@ -76,6 +76,43 @@ fanout 123 --unblocked-only --limit 3
 
 2 つ目の形は、fanout に次の unblocked バッチを選ばせつつ、各 wave の件数を制限します。
 
+## issue-less plan fan-out
+
+作業がローカルで既に分解されていて、GitHub child issue を作りたくない場合は
+`fanout plan` を使います。ループ自体は同じですが、source of truth は issue tree
+ではなく JSON spec です:
+
+1. `version: 1`、`plan.slug`、`plan.title`、`tasks[]` entry（`id`、`title`、
+   `briefing`、任意の `wave`、`blocked_by`、`branch`、`display_name`、`slug`）
+   を持つ plan spec を書く、または選択する。
+2. まず `fanout plan <spec> --dry-run --agent <agent>` で preview する。
+3. live run は `fanout plan <spec> --agent <agent>`。task に `blocked_by` がある
+   場合は通常 `--unblocked-only` も付ける。
+4. TUI / dashboard、または `fanout plan <slug> --status [--format table]` で見る。
+5. task ID を指定して取り込み / 後始末する:
+   `fanout plan <slug> --merge <task-id>`、`--close <task-id>`、`--cleanup`。
+6. 次 wave は保存済み slug で再実行する。
+
+```bash
+fanout plan /tmp/fanout-plan-launch-plan.json --agent claude --dry-run
+fanout plan /tmp/fanout-plan-launch-plan.json --agent claude --unblocked-only
+fanout plan launch-plan --status --format table
+fanout plan launch-plan --merge base-types
+fanout plan launch-plan --cleanup
+```
+
+live run は spec を `.fanout/plans/<slug>.json` に保存します。row は
+`.fanout/state.json` に parent `plan:<slug>`、`taskId`、`issueNum: 0` として
+記録されます。`blocked_by` 依存は、依存 task の明示 branch または生成 branch に
+merge 済み PR ができたときだけ complete とみなされます。Plan task briefing は
+GitHub issue-closing footer を避け、PR body 末尾を
+`Plan: <slug> / Task: <id>` にするよう agent に伝えます。
+
+同梱の agent wrapper は spec 作成も支援できます。Claude Code では
+`/fanout plan <path-or-plan>` が `fanout-plan` skill へ routing されます。Codex では
+`$fanout-plan`、または `fanout plan` の依頼を使います。skill は live launch 前に
+dry-run を要約します（確認スキップが明示された場合を除く）。
+
 ## 命名とブランチ
 
 既定では、各子の worktree slug は `slugify(title)-<issueNum>`、branch は `fanout/<slug>` です。これを 3 つの flag で上書きできます:

--- a/site/content/docs/workflow.md
+++ b/site/content/docs/workflow.md
@@ -76,6 +76,45 @@ fanout 123 --unblocked-only --limit 3
 
 The second form caps each wave while letting fanout pick the next unblocked batch.
 
+## Issue-less plan fan-out
+
+Use `fanout plan` when the work is already decomposed locally and you do not
+want to create GitHub child issues. The workflow is the same loop, but the
+source of truth is a JSON spec instead of an issue tree:
+
+1. Write or select a plan spec with `version: 1`, `plan.slug`, `plan.title`, and
+   `tasks[]` entries (`id`, `title`, `briefing`, optional `wave`,
+   `blocked_by`, `branch`, `display_name`, and `slug`).
+2. Preview first with `fanout plan <spec> --dry-run --agent <agent>`.
+3. Run live with `fanout plan <spec> --agent <agent>`, usually adding
+   `--unblocked-only` when any task has `blocked_by`.
+4. Monitor with the TUI/dashboard or `fanout plan <slug> --status
+   [--format table]`.
+5. Merge or fold away tasks with task IDs:
+   `fanout plan <slug> --merge <task-id>`, `--close <task-id>`, or
+   `--cleanup`.
+6. Rerun the saved slug for the next wave.
+
+```bash
+fanout plan /tmp/fanout-plan-launch-plan.json --agent claude --dry-run
+fanout plan /tmp/fanout-plan-launch-plan.json --agent claude --unblocked-only
+fanout plan launch-plan --status --format table
+fanout plan launch-plan --merge base-types
+fanout plan launch-plan --cleanup
+```
+
+Live runs save the spec to `.fanout/plans/<slug>.json`; rows are stored in
+`.fanout/state.json` under parent `plan:<slug>` with `taskId` and `issueNum: 0`.
+`blocked_by` dependencies are considered complete only after the dependency
+task's explicit or generated branch has a merged PR. Plan task briefings avoid
+GitHub issue-closing footers and tell agents to end PR bodies with
+`Plan: <slug> / Task: <id>`.
+
+The bundled agent wrappers can create the spec for you. In Claude Code,
+`/fanout plan <path-or-plan>` routes to the `fanout-plan` skill; in Codex, use
+`$fanout-plan` or ask for `fanout plan`. The skill summarizes the dry-run
+before live launch unless confirmation was explicitly skipped.
+
 ## Naming and branches
 
 By default each child gets the worktree slug `slugify(title)-<issueNum>` and the branch `fanout/<slug>`. Three flags override this:


### PR DESCRIPTION
**TL;DR**

Documents the issue-less `fanout plan` workflow across README, site docs, bundled skills, and maintainer notes. Review effort: 2

**Why**

Issue #219 asks for the newly added plan fan-out surface to be reflected in user-facing docs and agent guidance: spec shape, dry-run/live usage, unblocked waves, status/lifecycle commands, exit codes, and the `/fanout plan` / `$fanout-plan` skill flow.

**Changes by file**

<details><summary>Changed files</summary>

| File | What changed | Why |
|---|---|---|
| `README.md` | Added `fanout plan` command forms, issue-less plan fan-out reference, examples, installed skill paths, skill integration notes, and plan exit-code contract. | Make the primary English README describe the complete plan fan-out workflow. |
| `README.ja.md` | Mirrored the README updates in Japanese. | Keep the Japanese primary docs in sync with the English surface. |
| `site/content/docs/cli.md` | Added plan command synopsis, spec reference, flags, status/lifecycle usage, and plan-specific exit-code tables. | Expose the full plan CLI contract on the generated docs site. |
| `site/content/docs/cli.ja.md` | Mirrored the CLI site docs in Japanese. | Keep the Japanese CLI reference aligned. |
| `site/content/docs/workflow.md` | Added an issue-less plan fan-out workflow section. | Show how plan specs fit into the normal fanout loop. |
| `site/content/docs/workflow.ja.md` | Mirrored the workflow section in Japanese. | Keep the Japanese workflow guide aligned. |
| `site/content/docs/agents.md` | Added `fanout-plan` skill coverage for Claude and Codex. | Document the wrapper path for `/fanout plan` and `$fanout-plan`. |
| `site/content/docs/agents.ja.md` | Mirrored the agent docs in Japanese. | Keep Japanese agent integration docs aligned. |
| `site/content/docs/installation.md` | Added the installed `fanout-plan` skill directories. | Make installation output expectations complete. |
| `site/content/docs/installation.ja.md` | Mirrored the installation path additions in Japanese. | Keep Japanese installation docs aligned. |
| `CLAUDE.md` | Added architecture and caution notes for `cmd/fanout/plancmd.go`, `internal/planspec`, plan state keys, task briefings, branch PR lookup, and plan goldens. | Give future maintainers the plan-specific boundaries and fixtures to preserve. |
| `claude/skills/fanout-plan/SKILL.md` | Updated stale lifecycle guidance and dependency/exit-code mappings for plan status, merge, close, and cleanup. | Keep Claude's bundled skill aligned with the current CLI. |
| `codex/skills/fanout-plan/SKILL.md` | Mirrored the lifecycle, dependency, and exit-code updates for Codex. | Keep Codex's bundled skill aligned with the current CLI. |

</details>

**Risk**

Docs-only change. The main review risk is cross-surface consistency between README, site docs, and the two bundled skill copies.

**Test plan**

- `go test ./...` - passed.
- `make test` - passed.
- `make lint` - passed.
- `hugo --source site --destination /tmp/fanout-site-build-219` - passed.
- `git diff --check` - passed.
- `codex review --uncommitted` - clean after follow-up fixes.

Closes #219
