### PR TITLE
docs: sync site + README to latest main for release

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -13,6 +13,10 @@
 cleanup を行えます。既存の `fanout <parent-issue|project-url>` レーンでは、
 既知の親 issue / Project を子ごとに 1 つの tmux ペインへファンアウトし、各ペインに
 独立した git worktree と issue ごとの briefing file を渡した agent CLI を起動します。
+さらに `fanout plan <spec|slug>` はローカルの plan spec から GitHub issue を作らずに
+task pane を起動する issue-less レーンを、`--team` と `fanout msg` は per-parent の
+SQLite バス上で兄弟ペイン同士が連絡を取り合う peer messaging を提供します（いずれも
+下部に専用節があります）。
 
 ## 常駐 TUI コンソール
 
@@ -139,7 +143,7 @@ curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh |
 
 # 配置先や Release tag を指定
 curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh | BIN_DIR=/usr/local/bin sh
-curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh | FANOUT_VERSION=v0.1.0 sh
+curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh | FANOUT_VERSION=v0.2.0 sh
 ```
 
 配置パス:
@@ -522,7 +526,7 @@ fanout dashboard --web [--port N] [--open] [--no-token] [--no-keybind]
   して取得できないことがあり、その場合は未検出の旨を表示します。
 - **構造化フィルタ。** フィルタ欄は自由語と
   `state:` / `run:` / `agent:` / `wave:` / `ci:` / `dirty:` / `live:` /
-  `issue:` / `pr:` の各 term を AND で組み合わせます — 例:
+  `issue:` / `task:` / `pr:` の各 term を AND で組み合わせます — 例:
   `agent:claude wave:2 ci:fail run:running`。フィルタ欄の隣のドロップダウンは
   同じ token を書き込み、適用中の term はクリックで外せるチップとして並びます。
 - **ライト / ダークテーマ。** docs サイトと揃えた PAPER BREEZE デザインで、
@@ -595,10 +599,14 @@ fanout msg send --to 42 "auth.go を触る前に feat/login を base に rebase 
 fanout msg post --kind heads-up "go.mod を編集中 — lockfile の編集は控えて"
 fanout msg mark-read --all            # inbox を drain しボードカーソルを進める
 fanout msg register                   # このペインを roster に（再）登録
+fanout msg nudge 42                   # best-effort: agent が running なら peer #42 のペインを ping
 ```
 
+`nudge` は DB を触らない通知専用 verb です。対象の agent が running でない（ペイン消失 / 状態不明 / done）
+ときは何もせず success（no-op）で返します。
+
 verb 共通のオプション: `--json`（機械可読出力）、`--self <N>` と `--parent <ref>`
-（ペイン検出を上書き）、`--dry-run`（write verb のみ —— `# would ...` の書き込み
+（ペイン検出を上書き）、`--dry-run`（write・notify verb のみ —— `# would ...` の書き込み
 内容を表示し何も触らない。`--json` とは併用不可）。exit code: `0` 成功、`2` 不正な
 呼び出し、`4` SQLite バックエンド失敗。
 
@@ -870,6 +878,18 @@ Claude Code 向けの推奨連携 — これらのアセットはこのリポジ
   を支えます。承認済みまたはローカルの実装計画を `fanout plan` spec に変換し、
   dry-run preview を実行して task / wave を要約し、確認後に issue-less task pane
   を起動します。
+- **PR watch スラッシュコマンド** → `claude/commands/pr-watch.md` が
+  `~/.claude/commands/pr-watch.md` にインストールされ、`/pr-watch [pr-number|pr-url]`
+  として呼び出せます。pr-watch スキルを呼び出します。
+- **post-work review スキル** → `claude/skills/post-work-review/SKILL.md` が
+  `~/.claude/skills/post-work-review/SKILL.md` にインストールされ、ローカルの
+  PR review gate を支えます。最終レビュー loop（code-review プラグイン → codex:review
+  ループ）を回し、`.claude/hooks/pre-pr-review-gate.sh` が読む reviewed HEAD marker を
+  記録します。
+- **PR watch スキル** → `claude/skills/pr-watch/SKILL.md` が
+  `~/.claude/skills/pr-watch/SKILL.md` にインストールされます。PR 作成後に
+  mergeability・失敗 CI・レビューコメントを見張り、安全に直せるものを修正 / push
+  します。`/loop /pr-watch` で `ScheduleWakeup` self-pacing しながら回す前提です。
 
 Codex CLI 向けの推奨連携 — スキルはこのリポジトリの `codex/` 配下に同梱され、
 `make install` で配置されます:
@@ -998,10 +1018,14 @@ fanout settings で `prReviewGate=false` になっている場合、子 Claude b
 - ゲートは HEAD に固定されます。新しいコミットを積むと再武装されるので、PR の前に
   もう一度レビューしてください。marker は worktree ローカルなので、fanout の並列ペイン
   同士が干渉することはありません。
-- 検出はコマンド文字列に対する正規表現ベースのベストエフォートです。`eval` / `xargs` /
-  `sh -c "<文字列>"` のような間接実行や、コミットメッセージ・PR コメントの本文に
-  シェル演算子と一緒に `gh pr create` という文字列を書いた場合などは取りこぼし／過検知
-  し得ます。その場合は `FANOUT_SKIP_PR_REVIEW=1` で回避してください。
+- 検出はシェルトークナイザ（Python 製のコンパニオンパーサ `pre-pr-review-gate.py`）を
+  通します。コマンド語と引用された引数値を区別するので、コミットメッセージに
+  `gh pr create` と書いただけでは引っかかりません。`eval` / `xargs` /
+  `sh -c "<文字列>"` のような間接実行はすり抜けることがありますが、fanout の通常
+  フローでは許容範囲としています。
+- `python3` が無い環境では fail-closed になり、PR 作成らしきコマンドを粗い判定で
+  deny します。`python3` をインストールするか、`export FANOUT_SKIP_PR_REVIEW=1` して
+  ください。
 - `make install` は Claude / Codex 配下の同名グローバル `post-work-review` /
   `pr-watch` skill を上書きします。独自に管理しているコピーがある場合は事前に
   バックアップしてください。

--- a/README.md
+++ b/README.md
@@ -13,14 +13,17 @@ current repository; from there you can create manual agent panes, focus existing
 child panes, and run close / merge / cleanup actions. The existing
 `fanout <parent-issue|project-url>` lane still fans a known target out into one
 tmux pane per child, with each pane getting its own git worktree and an agent
-CLI launched from a per-issue briefing file.
+CLI launched from a per-issue briefing file. Two further top-level lanes round
+this out (both documented below): `fanout plan <spec|slug>` fans out an
+issue-less local plan spec instead of GitHub child issues, and `--team` plus
+`fanout msg` give sibling panes SQLite-backed peer messaging.
 
 ## Persistent TUI console
 
 Run `fanout` with no arguments to start the persistent console. From a plain
-shell it creates a deterministic fanout-managed tmux session for the current
-repository, starts the console in that session, and attaches to it. From inside
-tmux it turns the current pane into the console.
+shell it creates (or attaches to an existing) deterministic fanout-managed tmux
+session for the current repository, starts the console in that session, and
+attaches to it. From inside tmux it turns the current pane into the console.
 
 Typical single-tool flow:
 
@@ -507,6 +510,7 @@ the repository checkout; otherwise fanout reads `<git-root>/.fanout/state.json`.
     "total":      2,
     "merged":     1,
     "pending":    1,
+    "blocked":    0,
     "all_merged": false
   }
 }
@@ -599,7 +603,7 @@ fanout dashboard --web [--port N] [--open] [--no-token] [--no-keybind]
   screen, in which case the section reports that no plan was found.
 - **Structured filtering.** The filter box ANDs free words with
   `state:` / `run:` / `agent:` / `wave:` / `ci:` / `dirty:` / `live:` /
-  `issue:` / `pr:` terms — e.g. `agent:claude wave:2 ci:fail run:running`.
+  `issue:` / `task:` / `pr:` terms — e.g. `agent:claude wave:2 ci:fail run:running`.
   The dropdowns next to the box write the same tokens for you, and active
   terms appear as removable chips.
 - **Light/dark themes.** The PAPER BREEZE UI matches the docs site; the header
@@ -675,11 +679,16 @@ fanout msg send --to 42 "rebase off feat/login before you touch auth.go"
 fanout msg post --kind heads-up "editing go.mod — hold lockfile edits"
 fanout msg mark-read --all            # drain your inbox + advance the board cursor
 fanout msg register                   # (re-)register this pane in the roster
+fanout msg nudge 42                   # best-effort: ping peer #42's pane if its agent is running
 ```
 
+`nudge` is a notify verb, not a message: it never touches the DB and is a
+no-op success when the peer's agent is not running (pane gone, state unknown,
+or done) — an idle-but-running pane is still nudged.
+
 Common options across verbs: `--json` (machine-readable output), `--self <N>`
-and `--parent <ref>` (override pane detection), and `--dry-run` (write verbs
-only — prints the `# would ...` writes and touches nothing; not combinable with
+and `--parent <ref>` (override pane detection), and `--dry-run` (write/notify
+verbs only — prints the `# would ...` writes and touches nothing; not combinable with
 `--json`). Exit codes: `0` success, `2` invalid invocation, `4` SQLite backend
 failure.
 
@@ -965,6 +974,19 @@ repo under `claude/` and get placed by `make install`:
   turns an approved/local implementation plan into a `fanout plan` spec, runs
   the dry-run preview, summarizes tasks and waves, then launches the issue-less
   task panes after confirmation.
+- **PR watch slash command** → `claude/commands/pr-watch.md` is installed to
+  `~/.claude/commands/pr-watch.md` and invoked as `/pr-watch [pr-number|pr-url]`.
+  It backs the pr-watch skill.
+- **Post-work review skill** → `claude/skills/post-work-review/SKILL.md` is
+  installed to `~/.claude/skills/post-work-review/SKILL.md` and backs the local
+  PR review gate: it runs a final review loop (code-review plugin then a
+  codex:review loop) and records the reviewed HEAD marker that
+  `.claude/hooks/pre-pr-review-gate.sh` reads.
+- **PR watch skill** → `claude/skills/pr-watch/SKILL.md` is installed to
+  `~/.claude/skills/pr-watch/SKILL.md`. After a PR is opened it watches
+  mergeability, failing CI, and review comments and safely fixes/pushes what it
+  can; it is designed to run under `/loop /pr-watch` with `ScheduleWakeup`
+  self-pacing.
 
 Recommended integration for Codex CLI — the skills are bundled under
 `codex/` and get placed by `make install`:
@@ -1105,9 +1127,13 @@ Notes:
 - The gate is HEAD-pinned: any new commit re-arms it, so review again before
   the PR. The marker is worktree-local, so fanout's parallel panes don't
   interfere with each other.
-- Detection is a simple regex on the command string. Contorted forms (`... &&
-  gh pr create`, `xargs gh pr create`) can slip through — acceptable for
-  fanout's normal flow.
+- Detection runs through a shell tokenizer (a Python companion parser,
+  `pre-pr-review-gate.py`), so command words are distinguished from quoted
+  argument values; a commit message that merely mentions `gh pr create` does
+  not trip it. Indirect forms (`eval`, `xargs`, `sh -c "<string>"`) can still
+  slip through, which is accepted for fanout's normal flow.
+- Without `python3` the hook fails closed: it denies anything that coarsely
+  looks like PR creation. Install `python3`, or `export FANOUT_SKIP_PR_REVIEW=1`.
 - `make install` overwrites same-named global `post-work-review` and
   `pr-watch` skills under Claude and Codex; back up any custom copies first.
 

--- a/site/content/_index.ja.md
+++ b/site/content/_index.ja.md
@@ -64,7 +64,7 @@ workflow:
       chip: "--status → --merge → --cleanup"
 cli:
   title: "覚えるのは、これだけ。"
-  lede: "フラグは少なく、出力は静かに。日々触るのはこの七手。"
+  lede: "フラグは少なく、出力は静かに。日々触るのはこの八手。"
   more: "CLI リファレンスの全文へ"
   rows:
     - cmd: "fanout 123 --agent claude"
@@ -73,6 +73,8 @@ cli:
       desc: "blocker が解けた子だけを、次の wave として展開する"
     - cmd: "fanout 123 --dry-run"
       desc: "worktree もペインも作らず、計画だけを表示する"
+    - cmd: "fanout plan spec.json --agent claude"
+      desc: "GitHub の子 issue ではなく、ローカルの plan spec を扇状に展開する"
     - cmd: "fanout"
       desc: "常駐 TUI コンソールを起動(フォーカス・ピーク・ライフサイクル操作)"
     - cmd: "fanout 123 --status"

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -64,7 +64,7 @@ workflow:
       chip: "--status → --merge → --cleanup"
 cli:
   title: "All you need to remember."
-  lede: "Few flags, quiet output. These seven are the daily moves."
+  lede: "Few flags, quiet output. These eight are the daily moves."
   more: "Full CLI reference"
   rows:
     - cmd: "fanout 123 --agent claude"
@@ -73,6 +73,8 @@ cli:
       desc: "Fan out only children whose blockers are closed &mdash; the next wave"
     - cmd: "fanout 123 --dry-run"
       desc: "Print the plan without touching git or tmux"
+    - cmd: "fanout plan spec.json --agent claude"
+      desc: "Fan out a local plan spec instead of GitHub child issues"
     - cmd: "fanout"
       desc: "Start the persistent TUI console (focus, peek, lifecycle keys)"
     - cmd: "fanout 123 --status"

--- a/site/content/docs/cli.ja.md
+++ b/site/content/docs/cli.ja.md
@@ -23,6 +23,7 @@ fanout <parent-issue|project-url>
        [--agent-teams-hint|--no-agent-teams-hint]
        [--codex-plan-mode|--no-codex-plan-mode]
        [--pr-visualization|--no-pr-visualization]
+       [--team]
 fanout plan <spec.json|plan-slug> [--agent <name>] [--dry-run]
        [--limit <N>] [--only <task-id[,id...]>] [--skip <task-id[,id...]>]
        [--unblocked-only] [--base-branch <branch>] [--branch-prefix <prefix>]
@@ -37,6 +38,7 @@ fanout <parent-issue> --merge <NUM> # fast-forward merge a recorded child branch
 fanout <parent-issue> --close <NUM> # remove a recorded child worktree/pane
 fanout <parent-issue> --cleanup     # remove merged/closed recorded children
 fanout dashboard --web              # read-only localhost web dashboard (Session view)
+fanout msg <verb> [options] [body...]  # 兄弟ペイン間の peer messaging
 fanout --check-update               # Compare this binary with the latest release
 fanout update                       # Replace this binary + integrations via install.sh
 fanout --help
@@ -90,6 +92,7 @@ fanout 123 --base-branch release/v2 --branch-prefix fanout/release/
 | `--agent` | `<name>` | 子ペインで起動する agent CLI: `claude` または `codex`。`FANOUT_AGENT` 未設定なら必須。未知の agent はペイン作成前に失敗し、live 実行では agent CLI のインストールも確認する。 |
 | `--session` | `<tmux-session>` | 起動元 pane ではなく指定した tmux セッション名を target にする。fanout 自体は引き続き tmux 内から実行する必要がある。 |
 | `--sleep` | `<seconds>` | 子の作成成功ごとに挟む待機秒数。既定: `4`。launch 間の rate limit であり、retry 用ノブではない。 |
+| `--team` | — | その run を兄弟協調に opt-in する。各子の通常 briefing に「Coordinating with your sibling panes」roster 節を付け、作成済みペインを親の peer レジストリ（[`fanout msg`](#fanout-msg) サブコマンドが読む parent ごとの SQLite バス）に seed する。`--codex-plan-mode` の子はレジストリには seed されるが最小限の Plan-Mode briefing を受け取るため、roster 節は付かない。どちらも best-effort で、レジストリの失敗が fan-out を止めることはない。既定: off。 |
 | `--dry-run` | — | git worktree、tmux split-window、agent 起動のコマンド列を実行せずに表示する。 |
 | `--debug` | — | 追加の診断ログを有効化する。 |
 
@@ -258,6 +261,37 @@ fanout dashboard --web [--port N] [--open] [--no-token] [--no-keybind]
 
 全フラグは `fanout dashboard --help` を参照してください。
 
+### `fanout msg`
+
+```text
+fanout msg <verb> [options] [body...]
+```
+
+parent ごとの SQLite メッセージバス上での兄弟協調です。fanout したペイン内で実行すると、`fanout msg` は自分がどの子か（tmux pane と `.fanout/state.json` から）・どの親に属すかを自動検出します。ペインは fan-out 時に [`--team`](#実行制御フラグ) で opt-in しますが、後から任意のペインが自分で `register` することもできます。Claude Code の Agent Teams との違い、および協調のワークフローは[ワークフロー]({{< relref "/docs/workflow" >}})を参照してください。
+
+| verb | 説明 |
+|---|---|
+| `peers` | この親に登録済みの兄弟を一覧する。 |
+| `inbox` | `[--all] [--mark-read]` —— 未読の 1:1 メッセージと未読の共有ボード投稿。`--all` は既読も含め、`--mark-read` は表示分を drain する。 |
+| `board` | `[--all]` —— 共有ボード（全兄弟へのブロードキャスト）。cursor ベース。`--all` は既読の投稿も含める。 |
+| `send` | `--to <N> [--kind K] <body...>` —— 子 issue `<N>` 宛に 1:1 メッセージを送る。末尾の語が body になる。 |
+| `post` | `[--kind K] <body...>` —— `<body...>` を共有ボードに投稿する。 |
+| `mark-read` | `[--id <N> ... \| --all]` —— 1:1 メッセージを id 指定（繰り返し可）で既読にするか、`--all` で全件を既読にしてボードカーソルを進める。 |
+| `register` | このペインを peers テーブルに upsert する（`--team` が自動で行う。再 join に使う）。 |
+| `nudge` | `<N>` —— best-effort: peer `#N` の agent が running のときだけ、tmux 経由でそのペインに inbox の hint を送る。メッセージではなく通知専用 verb で、DB は触らない。対象の agent が running でない（ペイン消失 / 状態不明 / done）ときは何もせず success（no-op）。 |
+
+verb 共通のオプション: `--json`（機械可読出力）、`--self <N>` と `--parent <ref>`（ペイン検出を上書き）、`--dry-run`（write / notify verb のみ —— `# would ...` の書き込み内容を表示し何も触らない。`--json` とは併用不可）。
+
+データベースは `/tmp/fanout-<repo>-<parent>.db` に置かれ、`FANOUT_DB_PATH` で上書きできます。協調は **pull ベース**です: メッセージは DB に永続し、兄弟は自分のチェックポイントで読みます —— `fanout msg` は忙しいペインに割り込みません。pure-Go の SQLite ドライバが同梱されているため、外部 `sqlite3` は不要です。
+
+| Exit code | 意味 |
+|---|---|
+| `0` | 成功（対象の agent が running でないときの best-effort `nudge` no-op を含む） |
+| `2` | 不正な呼び出し |
+| `4` | SQLite バックエンドの失敗 |
+
+全サーフェスは `fanout msg --help` を参照してください。
+
 ### `fanout update`
 
 ```text
@@ -287,6 +321,10 @@ fanout check-update
 | `FANOUT_AGENT_TEAMS_HINT` | Claude Agent Teams ヒント（`agentTeamsHint`）の環境変数レイヤ。 |
 | `FANOUT_PR_VISUALIZATION` | 構造化 PR 本文とゲート付き Mermaid 指示（`prVisualization`）の環境変数レイヤ。 |
 | `FANOUT_DASHBOARD_KEYBIND` | ダッシュボード `prefix + D` tmux キーバインド（`dashboardKeybind`）の環境変数レイヤ。 |
+| `FANOUT_NOTIFICATIONS` | TUI 遷移通知チャネル（`notifications`）の環境変数レイヤ。[設定]({{< relref "/docs/settings" >}})を参照。 |
+| `FANOUT_NTFY_URL` | ntfy POST URL（`ntfyURL`）の環境変数レイヤ。 |
+| `FANOUT_SLACK_WEBHOOK_URL` | Slack webhook POST URL（`slackWebhookURL`）の環境変数レイヤ。 |
+| `FANOUT_DB_PATH` | `--team` と `fanout msg` が使う parent ごとの peer messaging SQLite パスを上書きする。既定: `/tmp/fanout-<repo>-<parent>.db`。 |
 | `FANOUT_SKIP_PR_REVIEW` | PR レビューゲート hook の 1 回限りのバイパス: `gh pr create` の先頭に `FANOUT_SKIP_PR_REVIEW=1` を付ける。[トラブルシューティング]({{< relref "/docs/troubleshooting" >}})を参照。 |
 
 bool の settings 変数は `1/true/yes/on` と `0/false/no/off` を受け付けます（大小文字は無視）。不正な値は warn して無視されます。settings の解決順序では CLI flag と設定ファイルの間に位置します。

--- a/site/content/docs/cli.md
+++ b/site/content/docs/cli.md
@@ -23,6 +23,7 @@ fanout <parent-issue|project-url>
        [--agent-teams-hint|--no-agent-teams-hint]
        [--codex-plan-mode|--no-codex-plan-mode]
        [--pr-visualization|--no-pr-visualization]
+       [--team]
 fanout plan <spec.json|plan-slug> [--agent <name>] [--dry-run]
        [--limit <N>] [--only <task-id[,id...]>] [--skip <task-id[,id...]>]
        [--unblocked-only] [--base-branch <branch>] [--branch-prefix <prefix>]
@@ -37,6 +38,7 @@ fanout <parent-issue> --merge <NUM> # fast-forward merge a recorded child branch
 fanout <parent-issue> --close <NUM> # remove a recorded child worktree/pane
 fanout <parent-issue> --cleanup     # remove merged/closed recorded children
 fanout dashboard --web              # read-only localhost web dashboard (Session view)
+fanout msg <verb> [options] [body...]  # peer messaging between sibling panes
 fanout --check-update               # Compare this binary with the latest release
 fanout update                       # Replace this binary + integrations via install.sh
 fanout --help
@@ -90,6 +92,7 @@ fanout 123 --base-branch release/v2 --branch-prefix fanout/release/
 | `--agent` | `<name>` | Agent CLI to launch in child panes: `claude` or `codex`. Required unless `FANOUT_AGENT` is set. Unknown agents fail before pane creation; live mode also checks that the agent CLI is installed. |
 | `--session` | `<tmux-session>` | Target a named tmux session instead of the invoking pane. fanout itself must still be invoked from inside tmux. |
 | `--sleep` | `<seconds>` | Pause between successful pane creations. Default: `4`. A rate limit between launches, not a retry knob. |
+| `--team` | — | Opt the run into sibling coordination: append a "Coordinating with your sibling panes" roster section to each child's standard briefing and seed the created panes into the parent's peer registry (the per-parent SQLite bus the [`fanout msg`](#fanout-msg) subcommand reads). `--codex-plan-mode` children are seeded into the registry but receive the minimal Plan-Mode briefing, so the roster section is not added to them. Both effects are best-effort; a registry failure never fails the fan-out. Off by default. |
 | `--dry-run` | — | Print the git worktree, tmux split-window and agent launch commands without executing them. |
 | `--debug` | — | Enable extra diagnostic logging. |
 
@@ -259,6 +262,37 @@ Starts the read-only localhost web dashboard: bound to `127.0.0.1`, GET-only, to
 
 Run `fanout dashboard --help` for the full flag list.
 
+### `fanout msg`
+
+```text
+fanout msg <verb> [options] [body...]
+```
+
+Sibling coordination over a per-parent SQLite message bus. Run from inside a fanned pane: `fanout msg` auto-detects which child you are (from the tmux pane and `.fanout/state.json`) and which parent you belong to. Panes opt in with [`--team`](#run-control-flags) at fan-out time, but any pane can `register` itself afterward. How this differs from Claude Code Agent Teams, and the coordination workflow, are covered in [Workflow]({{< relref "/docs/workflow" >}}).
+
+| Verb | Description |
+|---|---|
+| `peers` | List the registered siblings of this parent. |
+| `inbox` | `[--all] [--mark-read]` — unread 1:1 messages plus unread shared-board posts. `--all` includes read ones; `--mark-read` drains what is shown. |
+| `board` | `[--all]` — the shared board (broadcast to all siblings), cursor-based. `--all` includes already-read posts. |
+| `send` | `--to <N> [--kind K] <body...>` — send a 1:1 message to child issue `<N>`. Trailing words form the body. |
+| `post` | `[--kind K] <body...>` — post `<body...>` to the shared board. |
+| `mark-read` | `[--id <N> ... \| --all]` — mark 1:1 messages read by id (repeatable), or `--all` to mark everything and advance the board cursor. |
+| `register` | Upsert this pane into the peers table (auto-done by `--team`; use it to (re-)join). |
+| `nudge` | `<N>` — best-effort: drop an inbox hint into peer `#N`'s pane via tmux only when its agent is running. A notify verb, not a message: it never touches the DB and is a no-op success when the peer's agent is not running (pane gone, state unknown, or done). |
+
+Common options across verbs: `--json` (machine-readable output), `--self <N>` and `--parent <ref>` (override pane detection), and `--dry-run` (write/notify verbs only — prints the `# would ...` writes and touches nothing; not combinable with `--json`).
+
+The database lives at `/tmp/fanout-<repo>-<parent>.db` and is overridable with `FANOUT_DB_PATH`. Coordination is **pull-based**: messages persist in the DB and a sibling reads them at its own checkpoints — `fanout msg` does not interrupt a busy pane. The pure-Go SQLite driver is embedded, so no external `sqlite3` is required.
+
+| Exit code | Meaning |
+|---|---|
+| `0` | success (including a best-effort `nudge` no-op when the peer's agent is not running) |
+| `2` | invalid invocation |
+| `4` | SQLite backend failure |
+
+Run `fanout msg --help` for the full surface.
+
 ### `fanout update`
 
 ```text
@@ -288,6 +322,10 @@ Read-only: fetches the latest release tag from `butaosuinu/fanout`, compares it 
 | `FANOUT_AGENT_TEAMS_HINT` | Environment layer for the Claude Agent Teams hint (`agentTeamsHint`). |
 | `FANOUT_PR_VISUALIZATION` | Environment layer for the structured PR-body and gated Mermaid guidance (`prVisualization`). |
 | `FANOUT_DASHBOARD_KEYBIND` | Environment layer for the dashboard `prefix + D` tmux keybinding (`dashboardKeybind`). |
+| `FANOUT_NOTIFICATIONS` | Environment layer for the TUI transition notification channels (`notifications`); see [Settings]({{< relref "/docs/settings" >}}). |
+| `FANOUT_NTFY_URL` | Environment layer for the ntfy POST URL (`ntfyURL`). |
+| `FANOUT_SLACK_WEBHOOK_URL` | Environment layer for the Slack webhook POST URL (`slackWebhookURL`). |
+| `FANOUT_DB_PATH` | Override the per-parent peer-messaging SQLite path used by `--team` and `fanout msg`. Default: `/tmp/fanout-<repo>-<parent>.db`. |
 | `FANOUT_SKIP_PR_REVIEW` | One-shot bypass of the PR review-gate hook: prefix `gh pr create` with `FANOUT_SKIP_PR_REVIEW=1`. See [Troubleshooting]({{< relref "/docs/troubleshooting" >}}). |
 
 The boolean settings variables accept `1/true/yes/on` and `0/false/no/off`, case-insensitive. Invalid values are warned and ignored. They sit between CLI flags and the config files in the settings resolution order.

--- a/site/content/docs/installation.ja.md
+++ b/site/content/docs/installation.ja.md
@@ -99,7 +99,7 @@ CLAUDE_DIR=/path/to/.claude make install # 既定以外の Claude データデ�
 CODEX_DIR=/path/to/.codex make install   # 既定以外の Codex データディレクトリを指定
 ```
 
-チェックアウトからのビルドには **Go ツールチェイン**(Go 1.26+)が必要です。`make install`・`make link`・`make build-go` はいずれも `go build ./cmd/fanout` を実行します。上記の curl インストールは prebuilt バイナリを配置するので Go は不要です。
+チェックアウトからのビルドには **Go ツールチェイン**(Go 1.26+)に加えて **Node.js 24+ と pnpm 10+** が必要です。`make install`・`make link`・`make build-go` はまずダッシュボード Web UI をビルドし(`make build-web`、`web/` の Vite バンドル)、それを embed して `go build ./cmd/fanout` を実行します。上記の curl インストールは prebuilt バイナリを配置するので Go も Node も不要です。
 
 ## 更新を保つ
 

--- a/site/content/docs/installation.md
+++ b/site/content/docs/installation.md
@@ -99,7 +99,7 @@ CLAUDE_DIR=/path/to/.claude make install # non-default Claude data dir
 CODEX_DIR=/path/to/.codex make install   # non-default Codex data dir
 ```
 
-Building from a checkout needs a **Go toolchain** (Go 1.26+): `make install`, `make link`, and `make build-go` all run `go build ./cmd/fanout`. The curl install above ships a prebuilt binary and needs no Go.
+Building from a checkout needs a **Go toolchain** (Go 1.26+) plus **Node.js 24+ and pnpm 10+**: `make install`, `make link`, and `make build-go` first build the dashboard web UI (`make build-web`, the Vite bundle under `web/`) and embed it into `go build ./cmd/fanout`. The curl install above ships a prebuilt binary and needs neither Go nor Node.
 
 ## Keeping it updated
 

--- a/site/content/docs/monitoring.ja.md
+++ b/site/content/docs/monitoring.ja.md
@@ -58,6 +58,7 @@ fanout   # start the persistent tmux console
     "total":      2,
     "merged":     1,
     "pending":    1,
+    "blocked":    0,
     "all_merged": false
   }
 }
@@ -103,15 +104,16 @@ fanout 123 --status --post-dashboard
 
 ## Web ダッシュボード（fanout dashboard --web）
 
-`fanout dashboard --web` は**読み取り専用**の Web ダッシュボードを起動し、fanout の **Session**（`.fanout/state.json` に記録された pane を親 issue 単位でまとめたもの）をブラウザで SSE によりライブ表示します。pane の生存（`tmux list-panes`）、issue 状態、PR マージ状態（`--status` と同じデータ源を、リポジトリ内の全親について一度に再利用）を更新し続けます。GitHub の状態は一切変更せず、tmux も*読み取る*だけです。意図的な便宜が 2 つだけあります: 起動中サーバを `.fanout/dashboard.json` に記録して 2 回目の起動で再利用すること、そして後述の `prefix + D` tmux キーバインドを登録すること(`--no-keybind` でオプトアウト可)です。
+`fanout dashboard --web` は**読み取り専用**の Web ダッシュボードを起動し、fanout の **Session**（`.fanout/state.json` に記録された pane を親 issue 単位でまとめたもの）をブラウザで SSE によりライブ表示します。pane の生存（`tmux list-panes`）、ライブの tmux ペインタイトル、`running` / `done` の agent 実行状態バッジ、wave / 未解決 blocker 列（親 issue グラフ由来）、issue 状態、PR マージ状態、CI 状態、diff/dirty（`--status` と同じデータ源を、リポジトリ内の全親について一度に再利用）を更新し続けます。まだ fanout していない子 issue は synthetic な未開始行として表示されます。GitHub の状態は一切変更せず、tmux も*読み取る*だけです。意図的な便宜が 2 つだけあります: 起動中サーバを `.fanout/dashboard.json` に記録して 2 回目の起動で再利用すること、そして後述の `prefix + D` tmux キーバインドを登録すること(`--no-keybind` でオプトアウト可)です。
 
 ```bash
 fanout dashboard --web [--port N] [--open] [--no-token] [--no-keybind]
 ```
 
-- **localhost 限定。** サーバは `127.0.0.1` にのみバインドし、GET 専用の endpoint（`/api/snapshot`、SSE の `/api/stream`、埋め込み UI）を公開します。`--port` は既定 `0`（OS 割り当ての ephemeral port）で、確定した URL が表示されます。
+- **localhost 限定。** サーバは `127.0.0.1` にのみバインドし、GET 専用の endpoint（`/api/snapshot`、SSE の `/api/stream`、`/api/peek`（記録ペイン 1 つの `tmux capture-pane` スナップショット）、`/api/plan`（`--codex-plan-mode` ペインの最後の完全な `<proposed_plan>` ブロック）、埋め込み UI）を公開します。`--port` は既定 `0`（OS 割り当ての ephemeral port）で、確定した URL が表示されます。
 - **トークン既定 ON。** 起動毎にランダムトークンを生成して表示 / オープンされる URL に埋め込み、`/api/*` をゲートします。同一ホストの他ユーザ / プロセスがループバックポート経由で issue/PR データを読むのを防ぎます。単一ユーザ端末では `--no-token` で外せます。
 - **`--open`** は既定ブラウザで URL を開きます。すでに起動中のサーバ（`.fanout/dashboard.json` に記録）があればそれを再利用し、二重起動しません。
+- **SPA。** 埋め込みの React+Vite SPA は、API 単体よりも多くの情報をライブ Session 一覧に重ねます: 構造化フィルタ欄（自由語と `state:` / `run:` / `agent:` / `wave:` / `ci:` / `dirty:` / `live:` / `issue:` / `task:` / `pr:` の各 term を AND、ドロップダウンと外せるチップ付き）、行クリックで開く詳細ドロワー（ペインのメタ情報・wave/blockers・worktree・CI 付き PR・元プロンプト、5 秒ごとに更新される直近出力のライブ *peek*）、`--codex-plan-mode` ペインの *plan* セクション、repo 全体の running / blocked 数を出す上部 HUD、PAPER BREEZE のライト/ダークテーマ。
 
 全フラグは `fanout dashboard --help` を参照してください。
 

--- a/site/content/docs/monitoring.md
+++ b/site/content/docs/monitoring.md
@@ -58,6 +58,7 @@ For recorded issue parents the console also reloads the parent's child set and s
     "total":      2,
     "merged":     1,
     "pending":    1,
+    "blocked":    0,
     "all_merged": false
   }
 }
@@ -103,15 +104,16 @@ It puts `<!-- fanout:dashboard parent=N -->` at the start of the comment body, f
 
 ## Web dashboard (fanout dashboard --web)
 
-`fanout dashboard --web` starts a **read-only** web dashboard that visualizes fanout **Sessions** — the panes recorded in `.fanout/state.json`, grouped by parent issue — and keeps them live in the browser over SSE: pane liveness (from `tmux list-panes`), issue state, and PR merge status (the same data source as `--status`, reused across every parent in the repo at once). It never mutates GitHub state and only ever *reads* tmux, with two deliberate conveniences: it records the running server in `.fanout/dashboard.json` so a second launch reuses it, and it registers the `prefix + D` tmux keybinding described below (opt out with `--no-keybind`).
+`fanout dashboard --web` starts a **read-only** web dashboard that visualizes fanout **Sessions** — the panes recorded in `.fanout/state.json`, grouped by parent issue — and keeps them live in the browser over SSE: pane liveness (from `tmux list-panes`), the live tmux pane title, a `running` / `done` agent-state badge, wave / open-blocker columns (from the parent issue graph), issue state, PR merge status, CI status, and diff/dirty (the same data source as `--status`, reused across every parent in the repo at once). Children that have not been fanned out yet appear as synthetic not-started rows. It never mutates GitHub state and only ever *reads* tmux, with two deliberate conveniences: it records the running server in `.fanout/dashboard.json` so a second launch reuses it, and it registers the `prefix + D` tmux keybinding described below (opt out with `--no-keybind`).
 
 ```bash
 fanout dashboard --web [--port N] [--open] [--no-token] [--no-keybind]
 ```
 
-- **localhost only.** The server binds `127.0.0.1` and exposes GET-only endpoints: `/api/snapshot`, an SSE `/api/stream`, and the embedded UI. `--port` defaults to `0` (an OS-assigned ephemeral port); the chosen URL is printed.
+- **localhost only.** The server binds `127.0.0.1` and exposes GET-only endpoints: `/api/snapshot`, an SSE `/api/stream`, `/api/peek` (a `tmux capture-pane` snapshot of one recorded pane), `/api/plan` (the last complete `<proposed_plan>` block of a `--codex-plan-mode` pane), and the embedded UI. `--port` defaults to `0` (an OS-assigned ephemeral port); the chosen URL is printed.
 - **Token by default.** A random token is generated each start and embedded in the printed/opened URL, gating `/api/*` so other local users or processes cannot read your issue/PR data off the loopback port. Pass `--no-token` on a single-user machine to drop it.
 - **`--open`** opens the URL in your default browser. The dashboard reuses a server that is already running (recorded in `.fanout/dashboard.json`) instead of starting a second one.
+- **Single-page UI.** The embedded React + Vite SPA layers more onto the live Session list than the API alone: a structured filter box (free words ANDed with `state:` / `run:` / `agent:` / `wave:` / `ci:` / `dirty:` / `live:` / `issue:` / `task:` / `pr:` terms, plus dropdowns and removable chips), a detail drawer (click a row) showing pane metadata, wave / blockers, the worktree, PRs with CI, the original prompt, and a live *peek* of recent output refreshed every 5 s, a *plan* section for `--codex-plan-mode` panes, a top HUD with repo-wide running / blocked counts, and a PAPER BREEZE light/dark theme.
 
 Run `fanout dashboard --help` for the full flag list.
 

--- a/site/content/docs/settings.ja.md
+++ b/site/content/docs/settings.ja.md
@@ -1,13 +1,13 @@
 ---
 title: 設定
 linkTitle: 設定
-description: "オン/オフできる 6 つの opinionated な挙動と、その背後にある flag > env > repo > user > default の解決順序。"
+description: "オン/オフできる opinionated な挙動トグルと TUI 通知 channel、そしてその背後にある flag > env > repo > user > default の解決順序。"
 weight: 60
 kanji: 整
 yomi: settings
 ---
 
-fanout は opinionated な 6 つの挙動(briefing の 5 トグル+ダッシュボードの tmux キーバインド)をオン/オフできます。後方互換のため、既定値はすべて `true` です。
+fanout は opinionated な 6 つの挙動(briefing の 5 トグル+ダッシュボードの tmux キーバインド)をオン/オフでき、TUI 通知 channel も選択できます。後方互換のため、bool の既定値はすべて `true`、通知の既定値は `bell` です。
 
 ## 解決順序
 
@@ -16,7 +16,7 @@ fanout は opinionated な 6 つの挙動(briefing の 5 トグル+ダッシュ�
 - リポジトリ設定: `<project_root>/.fanout/config.json`。この `project_root` は親リポジトリルートで、子 worktree ではありません。
 - ユーザー設定: `$XDG_CONFIG_HOME/fanout/config.json`、`XDG_CONFIG_HOME` が無い場合は `~/.config/fanout/config.json`。
 
-## 6 つのトグル
+## トグルと通知 channel
 
 | 挙動 | ファイルキー | env | CLI flag | 既定値 |
 |---|---|---|---|---|
@@ -26,12 +26,15 @@ fanout は opinionated な 6 つの挙動(briefing の 5 トグル+ダッシュ�
 | Claude Agent Teams ヒント | `agentTeamsHint` | `FANOUT_AGENT_TEAMS_HINT` | `--agent-teams-hint` / `--no-agent-teams-hint` | `true` |
 | 構造化 PR 本文とゲート付き Mermaid の briefing 指示 | `prVisualization` | `FANOUT_PR_VISUALIZATION` | `--pr-visualization` / `--no-pr-visualization` | `true` |
 | ダッシュボード `prefix + D` tmux キーバインド | `dashboardKeybind` | `FANOUT_DASHBOARD_KEYBIND` | `--dashboard-keybind` / `--no-dashboard-keybind` | `true` |
+| TUI 状態遷移通知 | `notifications` | `FANOUT_NOTIFICATIONS` | n/a | `bell` |
+| ntfy POST URL | `ntfyURL` | `FANOUT_NTFY_URL` | n/a | 未設定 |
+| Slack webhook POST URL | `slackWebhookURL` | `FANOUT_SLACK_WEBHOOK_URL` | n/a | 未設定 |
 
-flag の一覧は [CLI リファレンス]({{< relref "/docs/cli" >}})にも載っています。
+これらの flag ペアは [CLI リファレンス]({{< relref "/docs/cli" >}})にも載っています（CLI リファレンスには、設定ではなく起動フラグである `--codex-plan-mode` も含まれます）。通知設定に CLI flag はありません。
 
 ## config.json サンプル
 
-リポジトリ設定とユーザー設定はどちらも同じ形で、bool のみのフラットな JSON オブジェクトです:
+リポジトリ設定とユーザー設定はどちらも同じ形で、bool のトグルに加えて 3 つの string な通知キーを持つフラットな JSON オブジェクトです:
 
 ```json
 {
@@ -40,15 +43,22 @@ flag の一覧は [CLI リファレンス]({{< relref "/docs/cli" >}})にも載�
   "briefingCodeReview": true,
   "agentTeamsHint": false,
   "prVisualization": true,
-  "dashboardKeybind": true
+  "dashboardKeybind": true,
+  "notifications": "bell",
+  "ntfyURL": "https://ntfy.sh/my-topic",
+  "slackWebhookURL": "https://hooks.slack.com/services/..."
 }
 ```
 
-環境変数は `1/true/yes/on` と `0/false/no/off` を受け付けます(大小文字は無視)。
+bool の環境変数は `1/true/yes/on` と `0/false/no/off` を受け付けます(大小文字は無視)。
+
+## 通知 channel
+
+`notifications` は comma または空白区切りの selector です。指定できる値は `bell`、`tmux`、`ntfy`、`slack`、`none` です。`ntfy` は `ntfyURL`、`slack` は `slackWebhookURL` が必要です。どちらの HTTP channel も outbound POST のみで、inbound socket は開きません。repository-controlled な外部送信を避けるため、repo config で選択できるのは `bell`、`tmux`、`none` だけです。`ntfy`、`slack`、`ntfyURL`、`slackWebhookURL` は user config または環境変数からだけ有効になります。
 
 ## 前方互換
 
-不正な env 値、設定ファイル内の未知キー、bool 以外の値は warn して無視します。将来の設定追加で古い fanout バイナリが壊れないようにするためです。
+不正な bool env 値、設定ファイル内の未知キー、JSON type が合わない値は warn して無視します。将来の設定追加で古い fanout バイナリが壊れないようにするためです。
 
 ## prVisualization の詳細
 

--- a/site/content/docs/settings.md
+++ b/site/content/docs/settings.md
@@ -1,13 +1,13 @@
 ---
 title: Settings
 linkTitle: Settings
-description: "Six opinionated behaviors you can switch — and the flag > env > repo > user > default resolution order behind them."
+description: "Opinionated behavior toggles plus TUI notification channels — and the flag > env > repo > user > default resolution order behind them."
 weight: 60
 kanji: 整
 yomi: settings
 ---
 
-fanout can turn six opinionated behaviors on or off — five briefing toggles plus the dashboard tmux keybinding. Defaults are all `true` to preserve existing behavior.
+fanout can turn six opinionated behaviors on or off — five briefing toggles plus the dashboard tmux keybinding — and select TUI notification channels. Boolean defaults are all `true` to preserve existing behavior; notifications default to `bell`.
 
 ## Resolution order
 
@@ -16,7 +16,7 @@ Each setting resolves as: **CLI flag > environment variable > repo config file >
 - Repo config: `<project_root>/.fanout/config.json`, where `project_root` is the parent repository root, not the child worktree.
 - User config: `$XDG_CONFIG_HOME/fanout/config.json`, or `~/.config/fanout/config.json` when `XDG_CONFIG_HOME` is unset.
 
-## The six toggles
+## The toggles and notification channels
 
 | Behavior | File key | Env | CLI flags | Default |
 |---|---|---|---|---|
@@ -26,12 +26,15 @@ Each setting resolves as: **CLI flag > environment variable > repo config file >
 | Claude Agent Teams hint | `agentTeamsHint` | `FANOUT_AGENT_TEAMS_HINT` | `--agent-teams-hint` / `--no-agent-teams-hint` | `true` |
 | Structured PR body and gated Mermaid briefing guidance | `prVisualization` | `FANOUT_PR_VISUALIZATION` | `--pr-visualization` / `--no-pr-visualization` | `true` |
 | Dashboard `prefix + D` tmux keybinding | `dashboardKeybind` | `FANOUT_DASHBOARD_KEYBIND` | `--dashboard-keybind` / `--no-dashboard-keybind` | `true` |
+| TUI transition notifications | `notifications` | `FANOUT_NOTIFICATIONS` | n/a | `bell` |
+| ntfy POST URL | `ntfyURL` | `FANOUT_NTFY_URL` | n/a | unset |
+| Slack webhook POST URL | `slackWebhookURL` | `FANOUT_SLACK_WEBHOOK_URL` | n/a | unset |
 
-The flag pairs are also listed in the [CLI Reference]({{< relref "/docs/cli" >}}).
+These flag pairs are also listed in the [CLI Reference]({{< relref "/docs/cli" >}}) (which also covers `--codex-plan-mode`, a launch flag rather than a resolved setting); the notification settings have no CLI flag.
 
 ## Sample config.json
 
-Both config files share the same shape — a flat JSON object of booleans only:
+Both config files share the same shape — a flat JSON object of boolean toggles plus the three string notification keys:
 
 ```json
 {
@@ -40,15 +43,22 @@ Both config files share the same shape — a flat JSON object of booleans only:
   "briefingCodeReview": true,
   "agentTeamsHint": false,
   "prVisualization": true,
-  "dashboardKeybind": true
+  "dashboardKeybind": true,
+  "notifications": "bell",
+  "ntfyURL": "https://ntfy.sh/my-topic",
+  "slackWebhookURL": "https://hooks.slack.com/services/..."
 }
 ```
 
-Environment values accept `1/true/yes/on` and `0/false/no/off` (case-insensitive).
+Boolean environment values accept `1/true/yes/on` and `0/false/no/off` (case-insensitive).
+
+## Notification channels
+
+`notifications` is a comma- or space-separated selector. Supported values are `bell`, `tmux`, `ntfy`, `slack`, and `none`. `ntfy` requires `ntfyURL`; `slack` requires `slackWebhookURL`. Both HTTP channels only send outbound POST requests and never open inbound sockets. To avoid repository-controlled exfiltration, repo config may only select `bell`, `tmux`, or `none`; `ntfy`, `slack`, `ntfyURL`, and `slackWebhookURL` are honored only from user config or environment variables.
 
 ## Forward compatibility
 
-Invalid env values, unknown file keys, and non-boolean file values are warned and ignored, so future settings additions do not break older fanout binaries.
+Invalid boolean env values, unknown file keys, and file values with the wrong JSON type are warned and ignored, so future settings additions do not break older fanout binaries.
 
 ## prVisualization in detail
 

--- a/site/content/docs/workflow.ja.md
+++ b/site/content/docs/workflow.ja.md
@@ -113,6 +113,40 @@ GitHub issue-closing footer を避け、PR body 末尾を
 `$fanout-plan`、または `fanout plan` の依頼を使います。skill は live launch 前に
 dry-run を要約します（確認スキップが明示された場合を除く）。
 
+## 兄弟協調（peer messaging）
+
+親を複数ペインに fan out すると、各子は自分のペインで動く独立した agent
+セッションになり、既定ではペイン同士は互いを認識できません。run ごとに
+`--team` で opt-in すると、fanout が（best-effort で）各子の通常 briefing に
+「Coordinating with your sibling panes」節を注入し、per-parent の peer
+レジストリに seed するので、兄弟がお互いを把握できます。なお `--codex-plan-mode`
+の子はレジストリには seed されますが最小限の Plan-Mode briefing を受け取るため、
+協調節は付きません。
+
+fanout したペイン内では、`fanout msg` が自分が今どの子（または親）かを自動
+検出し、per-parent の SQLite バス `/tmp/fanout-<repo>-<parent>.db`
+（`FANOUT_DB_PATH` で上書き可）上でやり取りします。バスは全員へ配る共有
+`board`（ブロードキャスト）に加え、`--to <issue>` 宛の `1:1` メッセージを
+運びます。協調は pull ベース — 自分から要求しない限り、何かがペインを
+つつくことはありません。
+
+| verb | 効果 |
+|---|---|
+| `peers` | この親で把握している兄弟ペインを一覧する。 |
+| `inbox [--mark-read]` | 自分宛の未読 1:1 メッセージを表示する（任意で既読化）。 |
+| `board [--all]` | 最近のブロードキャストを表示する（`--all` で全件）。 |
+| `send --to <N> <body>` | 兄弟 `#N` へ 1:1 メッセージを送る。 |
+| `post [--kind K] <body>` | 共有 board へブロードキャストを投稿する。 |
+| `mark-read [--all]` | メッセージを既読にする。 |
+| `register` | 自分を peer レジストリへ（再）seed する。 |
+| `nudge <N>` | peer `#N` のペインへ `send-keys` でヒントを送る best-effort 通知。agent が running のときだけ送り、DB は一切触らない。 |
+
+`claude` / `codex` どちらのペインでも同じく動きます。これは 1 セッション内の
+チームメイトを協調させる Claude Code Agent Teams とは別物で、peer messaging は
+別々の fanout ペイン同士を協調させます。全サーフェスは
+[CLI リファレンス]({{< relref "/docs/cli" >}}) または `fanout msg --help` を
+参照してください。
+
 ## 命名とブランチ
 
 既定では、各子の worktree slug は `slugify(title)-<issueNum>`、branch は `fanout/<slug>` です。これを 3 つの flag で上書きできます:

--- a/site/content/docs/workflow.md
+++ b/site/content/docs/workflow.md
@@ -115,6 +115,40 @@ The bundled agent wrappers can create the spec for you. In Claude Code,
 `$fanout-plan` or ask for `fanout plan`. The skill summarizes the dry-run
 before live launch unless confirmation was explicitly skipped.
 
+## Sibling coordination (peer messaging)
+
+When a parent is fanned out, each child is an independent agent session in its
+own pane — by default the panes cannot see each other. Opt in per run with
+`--team`: fanout (best-effort) injects a "Coordinating with your sibling panes"
+section into each child's standard briefing and seeds a per-parent peer registry
+so the siblings know about one another. (`--codex-plan-mode` children are seeded
+into the registry but receive the minimal Plan-Mode briefing, so the roster
+section is not added to them.)
+
+Inside any fanned pane, `fanout msg` auto-detects which child (or parent) you
+are and talks over a per-parent SQLite bus at
+`/tmp/fanout-<repo>-<parent>.db` (override with `FANOUT_DB_PATH`). The bus
+carries a shared `board` (broadcast to everyone) plus `1:1` messages addressed
+with `--to <issue>`. Coordination is pull-based — nothing nudges a pane unless
+you ask it to.
+
+| Verb | Effect |
+|---|---|
+| `peers` | List the sibling panes known for this parent. |
+| `inbox [--mark-read]` | Show your unread 1:1 messages (optionally mark them read). |
+| `board [--all]` | Show recent broadcasts (all of them with `--all`). |
+| `send --to <N> <body>` | Send a 1:1 message to sibling `#N`. |
+| `post [--kind K] <body>` | Post a broadcast to the shared board. |
+| `mark-read [--all]` | Mark messages read. |
+| `register` | (Re-)seed yourself into the peer registry. |
+| `nudge <N>` | Best-effort `send-keys` hint into peer `#N`'s pane — only when its agent is running, and it never touches the DB. |
+
+This works the same for `claude` and `codex` panes. It is distinct from Claude
+Code Agent Teams, which coordinates teammates inside a single session; peer
+messaging coordinates separate fanout panes. See the
+[CLI Reference]({{< relref "/docs/cli" >}}) or `fanout msg --help` for the full
+surface.
+
 ## Naming and branches
 
 By default each child gets the worktree slug `slugify(title)-<issueNum>` and the branch `fanout/<slug>`. Three flags override this:


### PR DESCRIPTION
## What

Reconcile the public docs (Hugo site under `site/` + `README.md` / `README.ja.md`) with the implementation ahead of the next release (`v0.3.0` → HEAD, ~62 unreleased commits). Targeted patches only — no rewrites — built via a fan-out workflow that audited each docs topic against the code, then applied edits with en/ja parity throughout.

## Why

Several user-facing features merged since `v0.3.0` were under-documented on the site (the README was mostly ahead). This brings the site up to parity so the release docs are accurate.

## Changes by topic

- **monitoring**: document the `/api/peek` + `/api/plan` endpoints, the React + Vite SPA (filter box, detail drawer + live peek, plan section, HUD), agent-state badges, wave/blocker columns, synthetic not-started rows, and the `blocked` status-JSON summary field.
- **workflow**: new "Sibling coordination (peer messaging)" section — `--team` + the full `fanout msg` verb table (incl. `nudge`), with the Codex Plan Mode briefing exception noted.
- **cli**: add the `fanout msg` subcommand section, the `--team` flag, `FANOUT_DB_PATH`, and the three notification env vars; make the "complete surface" claim true.
- **settings**: document `notifications` / `ntfyURL` / `slackWebhookURL` and fix the stale "booleans only" config description.
- **agents / README**: list the Claude `pr-watch` command + `post-work-review` / `pr-watch` skills; describe the shell-tokenizer PR review-gate (not a regex) and the `python3` fail-closed note.
- **installation**: note Node.js 24+ / pnpm 10+ build deps and that `make build-go` embeds the web bundle.
- **landing**: surface `fanout plan` in the daily-moves list; README intro now mentions the plan and peer-messaging lanes.
- bump a stale `FANOUT_VERSION` pin to `v0.2.0` (README.ja).

## Verification

- `hugo --minify --gc -s site` builds clean (no broken `relref` / shortcode errors).
- Every added claim cross-checked against the implementation (`internal/cliflags`, `cmd/fanout/msg.go`, `internal/settings`, `internal/dashboard`, `internal/agent`, hooks).
- Passed `/post-work-review`: code-review plugin (3 internal-consistency findings fixed) + `codex review` loop (2 findings fixed — `--team` Plan Mode exception, `nudge` running-state semantics — then clean).

Docs-only; no code or CLI behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)