### PR TITLE
feat(plan): --team peer messaging for issue-less plan tasks

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -318,8 +318,9 @@ fanout <parent-issue|project-url>  # 一括 pane 作成; tmux 内から実行
        [--team]
 fanout plan <spec.json|plan-slug> [--agent <name|task-id=name>] [--dry-run]
        [--limit <N>] [--only <task-id[,id...]>] [--skip <task-id[,id...]>]
-       [--unblocked-only] [--base-branch <branch>] [--branch-prefix <prefix>]
-       [--no-refresh] [--session <tmux-session>] [--sleep <seconds>]
+       [--unblocked-only] [--team] [--base-branch <branch>]
+       [--branch-prefix <prefix>] [--no-refresh] [--session <tmux-session>]
+       [--sleep <seconds>]
 fanout plan <spec.json|plan-slug> --status [--format json|table]
 fanout plan <spec.json|plan-slug> --merge <task-id>
 fanout plan <spec.json|plan-slug> --close <task-id>
@@ -569,8 +570,9 @@ agent セッションになります。`--team` と `fanout msg` サブコマン
 
 **何なのか。** parent ごとの SQLite メッセージバスです。同じ親の兄弟は全員が
 同じデータベースに到達し、そこには 2 種類のトラフィックが流れます: 全兄弟への
-ブロードキャストである共有**ボード**と、1 つの issue 番号宛の **1:1** メッセージ
-です。各メッセージは自由記述の `kind` ラベルを持ちます（既定 `note`。固定語彙は
+ブロードキャストである共有**ボード**と、1 つの peer 宛（issue 番号、または
+`fanout plan --team` では plan の task id）の **1:1** メッセージです。各メッセージは
+自由記述の `kind` ラベルを持ちます（既定 `note`。固定語彙は
 無く、`blocker` / `heads-up` などチームで有用なものを使えます）。データベースは
 `/tmp/fanout-<repo>-<parent>.db` に置かれます（`FANOUT_DB_PATH` で上書き可）。
 
@@ -590,6 +592,14 @@ briefing に付け、バッチ起動後に作成済みペインを親の peer �
 > Plan Mode briefing を受け取るため、協調節は**付きません**。レジストリへの
 > seed は行われ `fanout msg` も通常どおり使えます —— 注入される briefing 節
 > だけがスキップされます。
+
+**issue-less plan（`fanout plan --team`）。** plan レーンも `--team` に対応します。
+動作は同じですが、issue-less な plan task には `#N` が無いため、peer は issue 番号
+ではなく **task id** で指定します。task ペインからは
+`fanout msg send --to <task-id> "<body>"` で兄弟 task に送り、`fanout msg peers` が
+現在の task id 一覧を表示します。plan の DB は `/tmp/fanout-<repo>-plan-<slug>.db`
+です。`--team` は plan の read/lifecycle モード（`--status` / `--close` / `--merge`
+/ `--cleanup`）とは併用できません。
 
 **使い方（`fanout msg`）。** fanout したペイン内なら、`fanout msg` は自分が
 どの子か（tmux pane と `.fanout/state.json` から）・どの親に属すかを自動検出

--- a/README.md
+++ b/README.md
@@ -330,8 +330,9 @@ fanout <parent-issue|project-url>  # batch pane creation; run from inside tmux
        [--team]
 fanout plan <spec.json|plan-slug> [--agent <name|task-id=name>] [--dry-run]
        [--limit <N>] [--only <task-id[,id...]>] [--skip <task-id[,id...]>]
-       [--unblocked-only] [--base-branch <branch>] [--branch-prefix <prefix>]
-       [--no-refresh] [--session <tmux-session>] [--sleep <seconds>]
+       [--unblocked-only] [--team] [--base-branch <branch>]
+       [--branch-prefix <prefix>] [--no-refresh] [--session <tmux-session>]
+       [--sleep <seconds>]
 fanout plan <spec.json|plan-slug> --status [--format json|table]
 fanout plan <spec.json|plan-slug> --merge <task-id>
 fanout plan <spec.json|plan-slug> --close <task-id>
@@ -649,7 +650,8 @@ same for `claude` and `codex` panes, and needs no shared model context.
 **What it is.** A per-parent SQLite message bus. Every sibling of the same
 parent reaches the same database, which carries two traffic types: a shared
 **board** (broadcast to all siblings) and **1:1** messages (addressed to one
-issue number). Each message has a free-form `kind` label (default `note`; no
+peer — an issue number, or a plan task id in `fanout plan --team` runs). Each
+message has a free-form `kind` label (default `note`; no
 fixed vocabulary — use whatever your team finds useful, e.g. `blocker`,
 `heads-up`). The database lives at `/tmp/fanout-<repo>-<parent>.db` (override
 with `FANOUT_DB_PATH`).
@@ -671,6 +673,14 @@ panes into the parent's peer registry.
 > minimal Plan-Mode briefing instead, so the coordination section is **not**
 > added to them. They are still seeded into the registry and can use
 > `fanout msg` normally — only the injected briefing section is skipped.
+
+**Issue-less plans (`fanout plan --team`).** The plan lane supports `--team`
+too. It works identically, except peers are addressed by **task id** rather
+than issue number — issue-less plan tasks have no `#N`. From a task pane,
+`fanout msg send --to <task-id> "<body>"` messages a sibling task, and
+`fanout msg peers` lists the live task ids. The plan DB is
+`/tmp/fanout-<repo>-plan-<slug>.db`. `--team` is not combinable with the plan
+read/lifecycle modes (`--status` / `--close` / `--merge` / `--cleanup`).
 
 **Using it (`fanout msg`).** Inside any fanned pane, `fanout msg` auto-detects
 which child you are (from the tmux pane and `.fanout/state.json`) and which

--- a/claude/skills/fanout-plan/SKILL.md
+++ b/claude/skills/fanout-plan/SKILL.md
@@ -110,6 +110,7 @@ Forward only the flags supported by the current `fanout plan` implementation:
 - `--only <task-id[,id...]>`
 - `--skip <task-id[,id...]>`
 - `--unblocked-only`
+- `--team`
 - `--base-branch <branch>`
 - `--branch-prefix <prefix>`
 - `--no-refresh`
@@ -139,9 +140,12 @@ blockers are complete. Omit it only when the user explicitly asks to launch all
 waves together.
 
 Do not forward issue/project-mode-only flags to `fanout plan`: `--include`,
-`--name`, `--project-status`, `--post-dashboard`, `--team`,
-`--popup-timeout`, or `--codex-plan-mode`. Names belong in the spec (`slug`,
-`display_name`, `branch`), and dependencies belong in `blocked_by`.
+`--name`, `--project-status`, `--post-dashboard`, `--popup-timeout`, or
+`--codex-plan-mode`. Names belong in the spec (`slug`, `display_name`,
+`branch`), and dependencies belong in `blocked_by`.
+
+`--team` is supported in plan mode (see "Sibling coordination" below); it is
+not one of the forbidden issue/project-only flags.
 
 Use read/lifecycle flags only when the user explicitly asks for plan task
 status or cleanup, not during initial plan generation:
@@ -151,6 +155,34 @@ status or cleanup, not during initial plan generation:
 - `--close <task-id>`
 - `--merge <task-id>`
 - `--cleanup`
+
+## Sibling coordination (--team / fanout msg)
+
+`fanout plan --team` opts the plan run into sibling-pane peer messaging, the
+same SQLite message bus the issue/project lanes use — it just addresses peers
+by **task id** instead of issue number, because plan tasks have no GitHub
+issue. It adds a "Coordinating with your sibling panes" section to each task's
+briefing and seeds the created task panes into a per-parent peer registry
+(best-effort; a registry failure never fails the fan-out). `--team` is
+incompatible with the read/lifecycle modes (`--status` / `--close` / `--merge`
+/ `--cleanup`).
+
+Suggest it when tasks touch shared files (configs, schemas, lockfiles) or have
+ordering nuances beyond what `blocked_by` already encodes; skip it for fully
+independent tasks. From inside a task pane, `fanout msg` auto-detects which
+task you are (from the tmux pane and `.fanout/state.json`) and which plan you
+belong to. Peers are addressed by task id:
+
+- `fanout msg peers` — live sibling roster (task ids).
+- `fanout msg inbox [--mark-read]` — unread 1:1 + board messages addressed to you.
+- `fanout msg board` — the shared broadcast board.
+- `fanout msg send --to <task-id> "<body>"` — 1:1 message to a sibling task.
+- `fanout msg post "<body>"` — post to the shared board.
+
+Coordination is pull-based: messages persist and a sibling reads them at its
+own checkpoints; nothing nudges a busy pane. The DB is a plaintext SQLite file
+under `/tmp` (`0600`, owner-only) — never put secrets in messages. This is
+distinct from Claude Code Agent Teams (a Claude-only, single-session feature).
 
 ## Run
 

--- a/claude/skills/fanout/SKILL.md
+++ b/claude/skills/fanout/SKILL.md
@@ -163,6 +163,7 @@ fanned panes are separate agent sessions (not Agent Teams teammates — that is 
   - `fanout msg register` — (re-)register this pane in the roster.
 - Common options: `--json` (machine-readable), `--self <N>` / `--parent <ref>` (override pane detection), `--dry-run` (write verbs only — prints `# would ...` and writes nothing; not combinable with `--json`). `kind` is a free-form label (default `note`; no fixed vocabulary). Exit codes: `0` ok, `2` bad invocation, `4` SQLite backend failure.
 - Coordination is **pull-based**: messages persist and a sibling reads them at its own checkpoints; `fanout msg` never interrupts a busy pane. The merged CLI has no "nudge". A good rhythm is to check `fanout msg inbox` once after reading the briefing, post a one-line heads-up before editing shared files, and check the inbox once more before opening the PR.
+- **Plan mode** — `fanout plan --team` uses the same `fanout msg` surface, but peers are addressed by **task id** (`fanout msg send --to <task-id>`) instead of issue number, because issue-less plan tasks have no `#N`. See the fanout-plan skill.
 - **Security**: the DB is a plaintext SQLite file under `/tmp` (`0600`, owner-only). Never put secrets, tokens, or credentials in messages.
 
 ## Project mode notes

--- a/cmd/fanout/msg.go
+++ b/cmd/fanout/msg.go
@@ -643,11 +643,40 @@ func runMsgVerb(f *msgFlags, store *msgstore.Store, self int, parent string, pan
 }
 
 type msgMessagesReport struct {
-	Self       int                  `json:"self"`
+	Self int `json:"self"`
+	// SelfTask, FromTask, and ToTask are populated only for plan parents, where
+	// the numeric members are negative synthetic peer numbers; they carry the
+	// task ids automation actually addresses by. omitempty keeps issue/Project
+	// JSON byte-identical.
+	SelfTask   string               `json:"selfTask,omitempty"`
 	Parent     string               `json:"parent"`
 	All        bool                 `json:"all"`
-	Messages   []msgstore.Message   `json:"messages"`
+	Messages   []msgMessageView     `json:"messages"`
 	MarkedRead *msgstore.MarkResult `json:"marked_read,omitempty"`
+}
+
+// msgMessageView is a message plus, for plan parents, the task ids of its
+// from/to members. The embedded Message promotes its fields to the top level,
+// so issue-mode JSON (empty FromTask/ToTask) matches the bare Message encoding.
+type msgMessageView struct {
+	msgstore.Message
+	FromTask string `json:"fromTask,omitempty"`
+	ToTask   string `json:"toTask,omitempty"`
+}
+
+// msgMessageViews attaches plan task ids to each message's from/to from labels.
+// With a nil labels map (issue/Project parents) the views carry no task ids.
+func msgMessageViews(msgs []msgstore.Message, labels map[int]string) []msgMessageView {
+	views := make([]msgMessageView, len(msgs))
+	for i, m := range msgs {
+		v := msgMessageView{Message: m}
+		v.FromTask = labels[m.From]
+		if m.To != nil {
+			v.ToTask = labels[*m.To]
+		}
+		views[i] = v
+	}
+	return views
 }
 
 type msgPeersReport struct {
@@ -681,12 +710,22 @@ func runMsgPeers(f *msgFlags, store *msgstore.Store, parent string, lg *log.Logg
 // marked is non-nil only for `inbox --mark-read`. For a plan parent it maps the
 // synthetic peer numbers in From/To back to task ids for a readable table.
 func writeMsgMessages(f *msgFlags, store *msgstore.Store, self int, parent string, msgs []msgstore.Message, marked *msgstore.MarkResult, lg *log.Logger) exitcode.Code {
-	if f.json {
-		return writeMsgJSON(msgMessagesReport{Self: self, Parent: parent, All: f.all, Messages: msgs, MarkedRead: marked}, lg)
-	}
+	// labels is nil for issue/Project parents (no peers query, no task ids) and
+	// maps synthetic numbers to task ids for plan parents — used by both the
+	// JSON enrichment and the human table.
 	labels, code := msgMemberLabels(store, parent, lg)
 	if code != exitcode.OK {
 		return code
+	}
+	if f.json {
+		return writeMsgJSON(msgMessagesReport{
+			Self:       self,
+			SelfTask:   labels[self],
+			Parent:     parent,
+			All:        f.all,
+			Messages:   msgMessageViews(msgs, labels),
+			MarkedRead: marked,
+		}, lg)
 	}
 	writeMsgMessagesTable(msgs, f.all, labels, lg)
 	if marked != nil {

--- a/cmd/fanout/msg.go
+++ b/cmd/fanout/msg.go
@@ -628,7 +628,7 @@ func runMsgVerb(f *msgFlags, store *msgstore.Store, self int, parent string, pan
 		}
 		return writeMsgResult(f, msgSendView(msg, parent, pane.TaskID, ""), fmt.Sprintf("posted #%d to the board", msg.ID), lg)
 	case "mark-read":
-		return runMsgMarkRead(f, store, self, now, lg)
+		return runMsgMarkRead(f, store, self, pane.TaskID, now, lg)
 	case "register":
 		peer, err := store.Register(pane, now)
 		if err != nil {
@@ -703,6 +703,7 @@ type msgPeersReport struct {
 
 type msgMarkReadReport struct {
 	Self        int     `json:"self"`
+	SelfTask    string  `json:"selfTask,omitempty"`
 	MarkedIDs   []int64 `json:"marked_ids"`
 	BoardCursor *int64  `json:"board_cursor,omitempty"`
 }
@@ -789,8 +790,10 @@ func peerDisplayLabel(p msgstore.Peer) string {
 	return "#" + strconv.Itoa(p.Issue)
 }
 
-func runMsgMarkRead(f *msgFlags, store *msgstore.Store, self int, now string, lg *log.Logger) exitcode.Code {
-	report := msgMarkReadReport{Self: self}
+func runMsgMarkRead(f *msgFlags, store *msgstore.Store, self int, selfTask, now string, lg *log.Logger) exitcode.Code {
+	// selfTask is the reader's plan task id ("" for issue/Project parents), so
+	// plan-mode --json surfaces it alongside the synthetic Self number.
+	report := msgMarkReadReport{Self: self, SelfTask: selfTask}
 	if f.all {
 		marked, cursor, err := store.MarkReadAll(self, now)
 		if err != nil {
@@ -1000,6 +1003,7 @@ func msgBackendErr(verb string, err error, lg *log.Logger) exitcode.Code {
 // automation can tell a delivered push from a best-effort no-op.
 type msgNudgeReport struct {
 	Target     int    `json:"target"`
+	TargetTask string `json:"targetTask,omitempty"`
 	PaneID     string `json:"pane_id"`
 	AgentState string `json:"agent_state"`
 	Nudged     bool   `json:"nudged"`
@@ -1052,6 +1056,9 @@ func runMsgNudge(f *msgFlags, parent string, lg *log.Logger) exitcode.Code {
 	}
 
 	report := msgNudgeReport{Target: f.to, PaneID: pane.PaneID}
+	if team.IsPlanParent(parent) {
+		report.TargetTask = f.toRaw
+	}
 	switch {
 	case !found:
 		report.Reason = "recipient is not recorded in fanout state"

--- a/cmd/fanout/msg.go
+++ b/cmd/fanout/msg.go
@@ -105,12 +105,18 @@ var (
 )
 
 type msgFlags struct {
-	verb     string
-	json     bool
-	dryRun   bool
-	self     int // 0 = not given; --self only accepts positive integers
-	parent   string
-	to       int // 0 = not given; --to only accepts positive integers
+	verb   string
+	json   bool
+	dryRun bool
+	self   int // 0 = not given; resolved synthetic number for selfRaw
+	// selfRaw holds an explicit --self task id (plan parents) until the parent
+	// is known and it can be mapped to a synthetic number; "" otherwise.
+	selfRaw string
+	parent  string
+	to      int // 0 = not given; resolved synthetic number for toRaw
+	// toRaw holds a --to/nudge task id (plan parents) until the parent is known
+	// and it can be mapped to a synthetic number; "" otherwise.
+	toRaw    string
 	kind     string
 	ids      []int64
 	all      bool
@@ -305,52 +311,128 @@ func parseMsgFlag(f *msgFlags, allowed map[string]bool, args []string, i int, lg
 	return 0, exitcode.OK
 }
 
-// setNudgeTarget parses nudge's single positional <N> into f.to. Like --to it
-// accepts negative synthetic numbers (manual @manual panes) but rejects zero
-// and non-integers; a second positional is an error — nudge targets exactly
-// one peer. Reusing f.to keeps the recipient field shared with send.
+// setNudgeTarget parses nudge's single positional target into f.to/f.toRaw.
+// Like --to it accepts a non-zero issue number (manual @manual panes use
+// negative synthetic numbers) or a plan task id, but rejects zero and other
+// tokens; a second positional is an error — nudge targets exactly one peer.
+// Reusing f.to/f.toRaw keeps the recipient field shared with send.
 func setNudgeTarget(f *msgFlags, arg string, lg *log.Logger) exitcode.Code {
-	if f.to != 0 {
-		lg.Err("msg nudge: takes exactly one target issue, got extra argument: %s", arg)
+	if f.to != 0 || f.toRaw != "" {
+		lg.Err("msg nudge: takes exactly one target (issue number or plan task id), got extra argument: %s", arg)
 		return exitcode.Invocation
 	}
-	n, err := strconv.Atoi(arg)
-	if err != nil || n == 0 {
-		lg.Err("msg nudge: target must be a non-zero issue number (manual panes use negative synthetic numbers), got: %s", arg)
-		return exitcode.Invocation
+	n, raw, code := parseMemberToken(f.verb, "target", arg, lg)
+	if code != exitcode.OK {
+		return code
 	}
-	f.to = n
+	f.to, f.toRaw = n, raw
 	return exitcode.OK
+}
+
+// parseMemberToken parses a peer member token that is either a non-zero issue
+// number (manual panes use negative synthetic numbers) or a lowercase
+// kebab-case plan task id. It is parent-agnostic on purpose: an all-digit token
+// like "123" is BOTH a valid issue number and a valid task id, and only the
+// (not-yet-known) parent decides which. So it returns the raw token verbatim
+// plus its integer value (0 when non-numeric); resolveMemberNum picks the
+// interpretation once the parent is resolved. Returns "" raw only on a hard
+// parse error (a token that is neither a non-zero int nor a task-id shape).
+func parseMemberToken(verb, flag, value string, lg *log.Logger) (int, string, exitcode.Code) {
+	if n, err := strconv.Atoi(value); err == nil {
+		// A bare numeric 0 is neither a valid issue number nor — unless it is
+		// also a task-id shape ("0") — a valid token.
+		if n == 0 && !rePlanTaskID.MatchString(value) {
+			lg.Err("msg %s: %s must be a non-zero issue number or a plan task id, got: %s", verb, flag, value)
+			return 0, "", exitcode.Invocation
+		}
+		return n, value, exitcode.OK
+	}
+	if rePlanTaskID.MatchString(value) {
+		return 0, value, exitcode.OK
+	}
+	lg.Err("msg %s: %s must be a non-zero issue number or a plan task id, got: %s", verb, flag, value)
+	return 0, "", exitcode.Invocation
+}
+
+// normalizeMsgParentRef canonicalizes a --parent value. A plan parent
+// (plan:<slug>) is accepted verbatim so plan panes can scope their own DB;
+// everything else defers to cliflags.NormalizeParentRef (issue number /
+// Projects v2 URL).
+func normalizeMsgParentRef(raw string) (string, bool) {
+	raw = strings.TrimSpace(raw)
+	if slug, ok := strings.CutPrefix(raw, "plan:"); ok {
+		if rePlanTaskID.MatchString(slug) {
+			return "plan:" + slug, true
+		}
+		return "", false
+	}
+	return cliflags.NormalizeParentRef(raw)
+}
+
+// resolveMemberNum resolves a member token (raw + its parsed int) to the peer
+// number for the now-known parent. Under a plan parent the token is a task id
+// (even an all-digit one), mapped through TaskPeerNum; under an issue/Project
+// parent it must be a non-zero integer. This is the single seam where the
+// int-vs-task-id ambiguity of an all-digit token is decided.
+func resolveMemberNum(verb, flag, raw string, intVal int, parent string, lg *log.Logger) (int, exitcode.Code) {
+	if team.IsPlanParent(parent) {
+		if !rePlanTaskID.MatchString(raw) {
+			lg.Err("msg %s: under a plan parent, %s must be a task id (lowercase kebab-case), got: %s", verb, flag, raw)
+			return 0, exitcode.Invocation
+		}
+		return team.TaskPeerNum(parent, raw), exitcode.OK
+	}
+	if intVal == 0 {
+		// parseMemberToken only yields intVal 0 for a task-id-shaped token, so a
+		// 0 here means a task id was passed under a numeric parent.
+		lg.Err("msg %s: %s %q is a task id, only valid under a plan parent; issue/project peers are addressed by number", verb, flag, raw)
+		return 0, exitcode.Invocation
+	}
+	return intVal, exitcode.OK
+}
+
+// recipientLabel renders the recipient as the user addressed it: the task id
+// under a plan parent, "#<issue>" otherwise. f.to must already be resolved.
+func recipientLabel(f *msgFlags, parent string) string {
+	if team.IsPlanParent(parent) {
+		return f.toRaw
+	}
+	return "#" + strconv.Itoa(f.to)
+}
+
+// recipientFlagLabel names the recipient flag for error messages: nudge's
+// positional "target", send's "--to".
+func recipientFlagLabel(verb string) string {
+	if verb == "nudge" {
+		return "target"
+	}
+	return "--to"
 }
 
 func setMsgFlagValue(f *msgFlags, flag, value string, lg *log.Logger) exitcode.Code {
 	switch flag {
 	case "--self":
-		// Zero is the "not given" sentinel; negative numbers are valid — TUI
-		// manual panes record synthetic issue numbers -1, -2, ... (pane.go
-		// nextSyntheticPaneNumber) and team.Detect returns them verbatim.
-		n, err := strconv.Atoi(value)
-		if err != nil || n == 0 {
-			lg.Err("msg %s: --self must be a non-zero issue number (manual panes use negative synthetic numbers), got: %s", f.verb, value)
-			return exitcode.Invocation
+		n, raw, code := parseMemberToken(f.verb, "--self", value, lg)
+		if code != exitcode.OK {
+			return code
 		}
-		f.self = n
+		f.self, f.selfRaw = n, raw
 	case "--parent":
 		// Canonicalize so an explicit ref matches the parent recorded at
-		// pane-launch time: "0068" and "68" must scope the same messages.
-		ref, ok := cliflags.NormalizeParentRef(value)
+		// pane-launch time: "0068" and "68" must scope the same messages, and
+		// plan:<slug> is accepted verbatim for issue-less plan runs.
+		ref, ok := normalizeMsgParentRef(value)
 		if !ok {
-			lg.Err("msg %s: --parent must be an issue number or a GitHub Projects v2 URL, got: %s", f.verb, value)
+			lg.Err("msg %s: --parent must be an issue number, a GitHub Projects v2 URL, or plan:<slug>, got: %s", f.verb, value)
 			return exitcode.Invocation
 		}
 		f.parent = ref
 	case "--to":
-		n, err := strconv.Atoi(value)
-		if err != nil || n == 0 {
-			lg.Err("msg %s: --to must be a non-zero issue number (manual panes use negative synthetic numbers), got: %s", f.verb, value)
-			return exitcode.Invocation
+		n, raw, code := parseMemberToken(f.verb, "--to", value, lg)
+		if code != exitcode.OK {
+			return code
 		}
-		f.to = n
+		f.to, f.toRaw = n, raw
 	case "--kind":
 		if strings.TrimSpace(value) == "" {
 			lg.Err("msg %s: --kind must not be empty", f.verb)
@@ -377,8 +459,8 @@ func validateMsgFlags(f *msgFlags, lg *log.Logger) exitcode.Code {
 	}
 	switch f.verb {
 	case "send":
-		if f.to == 0 {
-			lg.Err("msg send: --to <issue> is required")
+		if f.to == 0 && f.toRaw == "" {
+			lg.Err("msg send: --to <issue|task-id> is required")
 			return exitcode.Invocation
 		}
 		fallthrough
@@ -393,10 +475,10 @@ func validateMsgFlags(f *msgFlags, lg *log.Logger) exitcode.Code {
 			return exitcode.Invocation
 		}
 	case "nudge":
-		// setNudgeTarget already rejected zero/non-integer; a still-zero f.to
-		// means no positional target was supplied at all.
-		if f.to == 0 {
-			lg.Err("msg nudge: target issue <N> is required")
+		// setNudgeTarget already rejected zero/unparseable tokens; a still-empty
+		// recipient means no positional target was supplied at all.
+		if f.to == 0 && f.toRaw == "" {
+			lg.Err("msg nudge: target <issue|task-id> is required")
 			return exitcode.Invocation
 		}
 	}
@@ -413,16 +495,20 @@ func resolveMsgIdentity(f *msgFlags, lg *log.Logger) (int, string, msgstore.Peer
 	// targets a peer, never speaks as self — so it does not require self to be
 	// detectable.
 	needSelf := f.verb != "peers" && f.verb != "nudge"
-	if (needSelf && self == 0) || parent == "" {
+	// An explicit --self task id (selfRaw) is "self given" too; it is resolved
+	// to a synthetic number below once the parent is known.
+	haveSelf := f.self != 0 || f.selfRaw != ""
+	if (needSelf && !haveSelf) || parent == "" {
 		id, err := detectIdentity()
 		if err != nil {
-			lg.Err("msg %s: could not detect this pane (%v); pass %s", f.verb, err, msgMissingIdentityFlags(needSelf && self == 0, parent == ""))
+			lg.Err("msg %s: could not detect this pane (%v); pass %s", f.verb, err, msgMissingIdentityFlags(needSelf && !haveSelf, parent == ""))
 			return 0, "", msgstore.Peer{}, exitcode.Invocation
 		}
-		if self == 0 {
+		if !haveSelf {
 			self = id.Issue
 			pane = msgstore.Peer{
 				Issue:        id.Issue,
+				TaskID:       id.TaskID,
 				PaneID:       id.Pane.PaneID,
 				Slug:         id.Pane.Slug,
 				WorktreePath: id.Pane.WorktreePath,
@@ -438,11 +524,36 @@ func resolveMsgIdentity(f *msgFlags, lg *log.Logger) (int, string, msgstore.Peer
 		lg.Err("msg %s: parent is unknown; pass --parent <ref>", f.verb)
 		return 0, "", msgstore.Peer{}, exitcode.Invocation
 	}
+	// An explicit --self resolves against the now-known parent: a task id under
+	// a plan parent, a non-zero issue number otherwise.
+	if f.selfRaw != "" {
+		n, code := resolveMemberNum(f.verb, "--self", f.selfRaw, f.self, parent, lg)
+		if code != exitcode.OK {
+			return 0, "", msgstore.Peer{}, code
+		}
+		self, pane.Issue = n, n
+		if team.IsPlanParent(parent) {
+			pane.TaskID = f.selfRaw
+		} else {
+			pane.TaskID = ""
+		}
+	}
 	// Negative self is legitimate: manual panes carry synthetic numbers
-	// (-1, -2, ...) under the @manual parent. Only zero means unknown.
+	// (-1, -2, ...) under the @manual parent, and plan tasks carry synthetic
+	// negatives under plan:<slug>. Only zero means unknown.
 	if needSelf && self == 0 {
-		lg.Err("msg %s: self issue is unknown; pass --self <issue>", f.verb)
+		lg.Err("msg %s: self issue is unknown; pass --self <issue|task-id>", f.verb)
 		return 0, "", msgstore.Peer{}, exitcode.Invocation
+	}
+	// Resolve the --to/nudge recipient now that the parent is known: an
+	// all-digit token routes to a task id under a plan parent, an issue number
+	// otherwise.
+	if f.toRaw != "" {
+		n, code := resolveMemberNum(f.verb, recipientFlagLabel(f.verb), f.toRaw, f.to, parent, lg)
+		if code != exitcode.OK {
+			return 0, "", msgstore.Peer{}, code
+		}
+		f.to = n
 	}
 	return self, parent, pane, exitcode.OK
 }
@@ -452,9 +563,9 @@ func resolveMsgIdentity(f *msgFlags, lg *log.Logger) (int, string, msgstore.Peer
 func msgMissingIdentityFlags(needSelf, needParent bool) string {
 	switch {
 	case needSelf && needParent:
-		return "--self <issue> and --parent <ref>"
+		return "--self <issue|task-id> and --parent <ref>"
 	case needSelf:
-		return "--self <issue>"
+		return "--self <issue|task-id>"
 	default:
 		return "--parent <ref>"
 	}
@@ -497,19 +608,19 @@ func runMsgVerb(f *msgFlags, store *msgstore.Store, self int, parent string, pan
 		if err != nil {
 			return msgBackendErr(f.verb, err, lg)
 		}
-		return writeMsgMessages(f, self, parent, msgs, marked, lg)
+		return writeMsgMessages(f, store, self, parent, msgs, marked, lg)
 	case "board":
 		msgs, err := store.Board(self, f.all)
 		if err != nil {
 			return msgBackendErr(f.verb, err, lg)
 		}
-		return writeMsgMessages(f, self, parent, msgs, nil, lg)
+		return writeMsgMessages(f, store, self, parent, msgs, nil, lg)
 	case "send":
 		msg, err := store.Send(self, f.to, f.kind, f.body, now)
 		if err != nil {
 			return msgBackendErr(f.verb, err, lg)
 		}
-		return writeMsgResult(f, msg, fmt.Sprintf("sent #%d to #%d", msg.ID, f.to), lg)
+		return writeMsgResult(f, msg, fmt.Sprintf("sent #%d to %s", msg.ID, recipientLabel(f, parent)), lg)
 	case "post":
 		msg, err := store.Post(self, f.kind, f.body, now)
 		if err != nil {
@@ -523,7 +634,7 @@ func runMsgVerb(f *msgFlags, store *msgstore.Store, self int, parent string, pan
 		if err != nil {
 			return msgBackendErr(f.verb, err, lg)
 		}
-		return writeMsgResult(f, msgRegisterReport{Peer: peer}, fmt.Sprintf("registered peer #%d", peer.Issue), lg)
+		return writeMsgResult(f, msgRegisterReport{Peer: peer}, fmt.Sprintf("registered peer %s", peerDisplayLabel(peer)), lg)
 	}
 	// Unreachable while msgVerbFlags and this switch stay in sync; fail loud
 	// instead of silently exiting so a half-added verb is caught immediately.
@@ -567,16 +678,59 @@ func runMsgPeers(f *msgFlags, store *msgstore.Store, parent string, lg *log.Logg
 }
 
 // writeMsgMessages is the shared renderer for the inbox and board views.
-// marked is non-nil only for `inbox --mark-read`.
-func writeMsgMessages(f *msgFlags, self int, parent string, msgs []msgstore.Message, marked *msgstore.MarkResult, lg *log.Logger) exitcode.Code {
+// marked is non-nil only for `inbox --mark-read`. For a plan parent it maps the
+// synthetic peer numbers in From/To back to task ids for a readable table.
+func writeMsgMessages(f *msgFlags, store *msgstore.Store, self int, parent string, msgs []msgstore.Message, marked *msgstore.MarkResult, lg *log.Logger) exitcode.Code {
 	if f.json {
 		return writeMsgJSON(msgMessagesReport{Self: self, Parent: parent, All: f.all, Messages: msgs, MarkedRead: marked}, lg)
 	}
-	writeMsgMessagesTable(msgs, f.all, lg)
+	labels, code := msgMemberLabels(store, parent, lg)
+	if code != exitcode.OK {
+		return code
+	}
+	writeMsgMessagesTable(msgs, f.all, labels, lg)
 	if marked != nil {
 		lg.Ok("marked %d message(s) read, board cursor at %d", len(marked.MessageIDs), marked.BoardCursor)
 	}
 	return exitcode.OK
+}
+
+// msgMemberLabels maps synthetic peer numbers to plan task ids so inbox/board
+// rows render readable FROM/TO. It returns nil for non-plan parents, so numeric
+// issue/Project views keep rendering "#<n>" with no extra DB read.
+func msgMemberLabels(store *msgstore.Store, parent string, lg *log.Logger) (map[int]string, exitcode.Code) {
+	if !team.IsPlanParent(parent) {
+		return nil, exitcode.OK
+	}
+	peers, err := store.Peers()
+	if err != nil {
+		return nil, msgBackendErr("inbox", err, lg)
+	}
+	labels := make(map[int]string, len(peers))
+	for _, p := range peers {
+		if p.TaskID != "" {
+			labels[p.Issue] = p.TaskID
+		}
+	}
+	return labels, exitcode.OK
+}
+
+// memberDisplay renders a peer number as its plan task id when known, else as
+// "#<n>". A nil labels map (issue/Project parents) always yields "#<n>".
+func memberDisplay(num int, labels map[int]string) string {
+	if id, ok := labels[num]; ok {
+		return id
+	}
+	return "#" + strconv.Itoa(num)
+}
+
+// peerDisplayLabel is the human label for a registered peer: the task id for a
+// plan-task peer, "#<issue>" for a numeric issue peer.
+func peerDisplayLabel(p msgstore.Peer) string {
+	if p.TaskID != "" {
+		return p.TaskID
+	}
+	return "#" + strconv.Itoa(p.Issue)
 }
 
 func runMsgMarkRead(f *msgFlags, store *msgstore.Store, self int, now string, lg *log.Logger) exitcode.Code {
@@ -620,7 +774,7 @@ func writeMsgJSON(report any, lg *log.Logger) exitcode.Code {
 	return exitcode.OK
 }
 
-func writeMsgMessagesTable(msgs []msgstore.Message, all bool, lg *log.Logger) {
+func writeMsgMessagesTable(msgs []msgstore.Message, all bool, labels map[int]string, lg *log.Logger) {
 	out := lg.Stdout()
 	if len(msgs) == 0 {
 		if all {
@@ -635,11 +789,11 @@ func writeMsgMessagesTable(msgs []msgstore.Message, all bool, lg *log.Logger) {
 	for _, m := range msgs {
 		to := "board"
 		if m.To != nil {
-			to = "#" + strconv.Itoa(*m.To)
+			to = memberDisplay(*m.To, labels)
 		}
 		rows = append(rows, []string{
 			strconv.FormatInt(m.ID, 10),
-			"#" + strconv.Itoa(m.From),
+			memberDisplay(m.From, labels),
 			to,
 			m.Kind,
 			m.CreatedAt,
@@ -660,11 +814,11 @@ func writeMsgPeersTable(peers []msgstore.Peer, lg *log.Logger) {
 		fmt.Fprintln(out, "no peers registered")
 		return
 	}
-	headers := []string{"ISSUE", "SLUG", "AGENT", "DISPLAY_NAME", "PANE", "LAST_SEEN"}
+	headers := []string{"PEER", "SLUG", "AGENT", "DISPLAY_NAME", "PANE", "LAST_SEEN"}
 	rows := make([][]string, 0, len(peers))
 	for _, p := range peers {
 		rows = append(rows, []string{
-			"#" + strconv.Itoa(p.Issue),
+			peerDisplayLabel(p),
 			dashIfEmpty(p.Slug),
 			dashIfEmpty(p.Agent),
 			dashIfEmpty(p.DisplayName),
@@ -754,10 +908,16 @@ func msgDryRunLines(f *msgFlags, self int, parent string, pane msgstore.Peer, no
 			"# would UPDATE messages SET read_at = %s WHERE parent = %s AND to_issue = %d AND id IN (%s) AND read_at IS NULL",
 			sqlLiteral(now), sqlLiteral(parent), self, strings.Join(ids, ", "))}
 	case "register":
+		// task_id mirrors the real INSERT: NULL for numeric issue peers, the
+		// quoted task id for plan-task peers.
+		taskIDLiteral := "NULL"
+		if pane.TaskID != "" {
+			taskIDLiteral = sqlLiteral(pane.TaskID)
+		}
 		return []string{fmt.Sprintf(
-			"# would UPSERT INTO peers(issue, pane_id, slug, worktree_path, agent, display_name, joined_at, last_seen) VALUES (%d, %s, %s, %s, %s, %s, %s, %s)",
+			"# would UPSERT INTO peers(issue, pane_id, slug, worktree_path, agent, display_name, joined_at, last_seen, task_id) VALUES (%d, %s, %s, %s, %s, %s, %s, %s, %s)",
 			self, sqlLiteral(pane.PaneID), sqlLiteral(pane.Slug), sqlLiteral(pane.WorktreePath),
-			sqlLiteral(pane.Agent), sqlLiteral(pane.DisplayName), sqlLiteral(now), sqlLiteral(now))}
+			sqlLiteral(pane.Agent), sqlLiteral(pane.DisplayName), sqlLiteral(now), sqlLiteral(now), taskIDLiteral)}
 	}
 	return nil
 }
@@ -819,10 +979,19 @@ func runMsgNudge(f *msgFlags, parent string, lg *log.Logger) exitcode.Code {
 		lg.Err("msg nudge: %v", err)
 		return exitcode.Invocation
 	}
-	pane, found := st.Find(parent, f.to)
+	// Plan recipients are addressed by task id (state rows carry IssueNum 0),
+	// so look them up by task id under a plan parent; issue/Project recipients
+	// keep the numeric lookup.
+	var pane state.Pane
+	var found bool
+	if team.IsPlanParent(parent) {
+		pane, found = st.FindTask(parent, f.toRaw)
+	} else {
+		pane, found = st.Find(parent, f.to)
+	}
 
 	if f.dryRun {
-		lg.Dim("%s", nudgeDryRunLine(f.to, pane.PaneID, found))
+		lg.Dim("%s", nudgeDryRunLine(recipientLabel(f, parent), pane.PaneID, found))
 		return exitcode.OK
 	}
 
@@ -835,7 +1004,7 @@ func runMsgNudge(f *msgFlags, parent string, lg *log.Logger) exitcode.Code {
 	default:
 		report.AgentState, report.Reason, report.Nudged = deliverNudge(pane)
 	}
-	return writeMsgNudgeResult(f, report, lg)
+	return writeMsgNudgeResult(f, parent, report, lg)
 }
 
 // deliverNudge re-reads the live tmux panes immediately before sending (TOCTOU),
@@ -899,22 +1068,28 @@ func matchLivePane(panes []tmuxrun.LivePane, paneID, worktree string) (tmuxrun.L
 // line, resolved from state.json only (never live tmux) so it is golden
 // stable. An unresolved recipient prints a <unknown> pane id rather than
 // erroring, keeping the dry-run a single informative line.
-func nudgeDryRunLine(target int, paneID string, found bool) string {
+// nudgeDryRunLine renders the would-send-keys preview. target is the human
+// recipient label ("#<issue>" for numeric peers, the task id for plan peers).
+func nudgeDryRunLine(target, paneID string, found bool) string {
 	if !found || paneID == "" {
 		paneID = "<unknown>"
 	}
-	return fmt.Sprintf("# would send-keys -t %s -l %s then Enter (target #%d, only if agent is running)",
+	return fmt.Sprintf("# would send-keys -t %s -l %s then Enter (target %s, only if agent is running)",
 		paneID, sqlLiteral(nudgeText), target)
 }
 
-func writeMsgNudgeResult(f *msgFlags, report msgNudgeReport, lg *log.Logger) exitcode.Code {
+func writeMsgNudgeResult(f *msgFlags, parent string, report msgNudgeReport, lg *log.Logger) exitcode.Code {
 	if f.json {
 		return writeMsgJSON(report, lg)
 	}
+	// Show the recipient as the user addressed it: "#<issue>" for numeric
+	// peers, the task id for plan peers (report.Target holds the synthetic
+	// number, which is not user-facing).
+	label := recipientLabel(f, parent)
 	if report.Nudged {
-		lg.Ok("nudged #%d", report.Target)
+		lg.Ok("nudged %s", label)
 	} else {
-		lg.Warn("did not nudge #%d: %s", report.Target, report.Reason)
+		lg.Warn("did not nudge %s: %s", label, report.Reason)
 	}
 	return exitcode.OK
 }

--- a/cmd/fanout/msg.go
+++ b/cmd/fanout/msg.go
@@ -620,13 +620,13 @@ func runMsgVerb(f *msgFlags, store *msgstore.Store, self int, parent string, pan
 		if err != nil {
 			return msgBackendErr(f.verb, err, lg)
 		}
-		return writeMsgResult(f, msg, fmt.Sprintf("sent #%d to %s", msg.ID, recipientLabel(f, parent)), lg)
+		return writeMsgResult(f, msgSendView(msg, parent, pane.TaskID, f.toRaw), fmt.Sprintf("sent #%d to %s", msg.ID, recipientLabel(f, parent)), lg)
 	case "post":
 		msg, err := store.Post(self, f.kind, f.body, now)
 		if err != nil {
 			return msgBackendErr(f.verb, err, lg)
 		}
-		return writeMsgResult(f, msg, fmt.Sprintf("posted #%d to the board", msg.ID), lg)
+		return writeMsgResult(f, msgSendView(msg, parent, pane.TaskID, ""), fmt.Sprintf("posted #%d to the board", msg.ID), lg)
 	case "mark-read":
 		return runMsgMarkRead(f, store, self, now, lg)
 	case "register":
@@ -662,6 +662,23 @@ type msgMessageView struct {
 	msgstore.Message
 	FromTask string `json:"fromTask,omitempty"`
 	ToTask   string `json:"toTask,omitempty"`
+}
+
+// msgSendView is the JSON encoding of a send/post echo: the raw message for
+// issue/Project parents (byte-identical), or a task-id-enriched view for plan
+// parents so a sending automation can reuse fromTask/toTask from the response
+// without reverse-engineering the synthetic numbers. fromTask is the sender's
+// task id (the resolved pane's TaskID); toTask is the recipient's (the raw --to
+// token), unset for board posts (msg.To == nil).
+func msgSendView(msg msgstore.Message, parent, fromTask, toTask string) any {
+	if !team.IsPlanParent(parent) {
+		return msg
+	}
+	v := msgMessageView{Message: msg, FromTask: fromTask}
+	if msg.To != nil {
+		v.ToTask = toTask
+	}
+	return v
 }
 
 // msgMessageViews attaches plan task ids to each message's from/to from labels.

--- a/cmd/fanout/msg_test.go
+++ b/cmd/fanout/msg_test.go
@@ -36,7 +36,13 @@ func TestParseMsgFlags(t *testing.T) {
 			}
 		}},
 		{name: "send missing --to", args: []string{"send", "--self", "70", "--parent", "68", "hi"}, code: exitcode.Invocation},
-		{name: "send non-integer --to", args: []string{"send", "--to", "abc", "--self", "70", "--parent", "68", "hi"}, code: exitcode.Invocation},
+		{name: "send invalid --to token", args: []string{"send", "--to", "ABC", "--self", "70", "--parent", "68", "hi"}, code: exitcode.Invocation},
+		{name: "send task-id --to parses (semantic check is deferred)", args: []string{"send", "--to", "api-client", "--self", "70", "--parent", "68", "hi"}, code: exitcode.OK, want: func(t *testing.T, f *msgFlags) {
+			t.Helper()
+			if f.toRaw != "api-client" || f.to != 0 {
+				t.Errorf("parsed = %+v, want toRaw=api-client to=0", f)
+			}
+		}},
 		{name: "send empty body", args: []string{"send", "--to", "71", "--self", "70", "--parent", "68"}, code: exitcode.Invocation},
 		{name: "send whitespace body", args: []string{"send", "--to", "71", "--self", "70", "--parent", "68", " "}, code: exitcode.Invocation},
 		{name: "post custom kind", args: []string{"post", "--kind", "blocker", "watch", "out"}, code: exitcode.OK, want: func(t *testing.T, f *msgFlags) {
@@ -75,7 +81,12 @@ func TestParseMsgFlags(t *testing.T) {
 			}
 		}},
 		{name: "inline value on boolean flag", args: []string{"inbox", "--all=1"}, code: exitcode.Invocation},
-		{name: "zero self is rejected", args: []string{"inbox", "--self", "0"}, code: exitcode.Invocation},
+		{name: "numeric-zero self parses as a task-id shape (rejected later under a numeric parent)", args: []string{"inbox", "--self", "0"}, code: exitcode.OK, want: func(t *testing.T, f *msgFlags) {
+			t.Helper()
+			if f.selfRaw != "0" || f.self != 0 {
+				t.Errorf("parsed = %+v, want selfRaw=0 self=0", f)
+			}
+		}},
 		{name: "negative self is a manual-pane synthetic number", args: []string{"inbox", "--self", "-3", "--parent", "68"}, code: exitcode.OK, want: func(t *testing.T, f *msgFlags) {
 			t.Helper()
 			if f.self != -3 {
@@ -138,8 +149,19 @@ func TestParseMsgFlags(t *testing.T) {
 			}
 		}},
 		{name: "nudge without a target exits invalid", args: []string{"nudge"}, code: exitcode.Invocation},
-		{name: "nudge zero target rejected", args: []string{"nudge", "0"}, code: exitcode.Invocation},
-		{name: "nudge non-integer target rejected", args: []string{"nudge", "abc"}, code: exitcode.Invocation},
+		{name: "numeric-zero nudge target parses as a task-id shape (rejected later under a numeric parent)", args: []string{"nudge", "0"}, code: exitcode.OK, want: func(t *testing.T, f *msgFlags) {
+			t.Helper()
+			if f.toRaw != "0" || f.to != 0 {
+				t.Errorf("parsed = %+v, want toRaw=0 to=0", f)
+			}
+		}},
+		{name: "nudge invalid target token rejected", args: []string{"nudge", "ABC"}, code: exitcode.Invocation},
+		{name: "nudge task-id target parses (semantic check is deferred)", args: []string{"nudge", "api-client"}, code: exitcode.OK, want: func(t *testing.T, f *msgFlags) {
+			t.Helper()
+			if f.toRaw != "api-client" || f.to != 0 {
+				t.Errorf("parsed = %+v, want toRaw=api-client to=0", f)
+			}
+		}},
 		{name: "nudge rejects a second target", args: []string{"nudge", "71", "72"}, code: exitcode.Invocation},
 		{name: "nudge does not accept --to", args: []string{"nudge", "--to", "71"}, code: exitcode.Invocation},
 		{name: "nudge dry-run rejects json", args: []string{"nudge", "--dry-run", "--json", "71"}, code: exitcode.Invocation},
@@ -302,14 +324,22 @@ func TestMsgDryRunLines(t *testing.T) {
 			flags: msgFlags{verb: "register"},
 			pane:  msgstore.Peer{Issue: 70, PaneID: "%1", Slug: "s-70", WorktreePath: "/tmp/wt", Agent: "claude", DisplayName: "name"},
 			want: []string{
-				"# would UPSERT INTO peers(issue, pane_id, slug, worktree_path, agent, display_name, joined_at, last_seen) VALUES (70, '%1', 's-70', '/tmp/wt', 'claude', 'name', '2026-06-13T00:00:00Z', '2026-06-13T00:00:00Z')",
+				"# would UPSERT INTO peers(issue, pane_id, slug, worktree_path, agent, display_name, joined_at, last_seen, task_id) VALUES (70, '%1', 's-70', '/tmp/wt', 'claude', 'name', '2026-06-13T00:00:00Z', '2026-06-13T00:00:00Z', NULL)",
 			},
 		},
 		{
 			name:  "register without pane",
 			flags: msgFlags{verb: "register"},
 			want: []string{
-				"# would UPSERT INTO peers(issue, pane_id, slug, worktree_path, agent, display_name, joined_at, last_seen) VALUES (70, '', '', '', '', '', '2026-06-13T00:00:00Z', '2026-06-13T00:00:00Z')",
+				"# would UPSERT INTO peers(issue, pane_id, slug, worktree_path, agent, display_name, joined_at, last_seen, task_id) VALUES (70, '', '', '', '', '', '2026-06-13T00:00:00Z', '2026-06-13T00:00:00Z', NULL)",
+			},
+		},
+		{
+			name:  "register a plan task pane records the task id",
+			flags: msgFlags{verb: "register"},
+			pane:  msgstore.Peer{Issue: -42, TaskID: "api-client", Slug: "launch-plan-api-client"},
+			want: []string{
+				"# would UPSERT INTO peers(issue, pane_id, slug, worktree_path, agent, display_name, joined_at, last_seen, task_id) VALUES (70, '', 'launch-plan-api-client', '', '', '', '2026-06-13T00:00:00Z', '2026-06-13T00:00:00Z', 'api-client')",
 			},
 		},
 	} {
@@ -336,7 +366,7 @@ func TestWriteMsgMessagesTable(t *testing.T) {
 	}
 	var out strings.Builder
 	lg := log.NewWith(&out, &strings.Builder{}, false)
-	writeMsgMessagesTable(msgs, true, lg)
+	writeMsgMessagesTable(msgs, true, nil, lg)
 	got := out.String()
 	for _, want := range []string{
 		"ID  FROM  TO     KIND  CREATED               BODY",
@@ -349,14 +379,35 @@ func TestWriteMsgMessagesTable(t *testing.T) {
 	}
 
 	out.Reset()
-	writeMsgMessagesTable(nil, false, lg)
+	writeMsgMessagesTable(nil, false, nil, lg)
 	if got := out.String(); got != "no unread messages\n" {
 		t.Errorf("empty unread table = %q", got)
 	}
 	out.Reset()
-	writeMsgMessagesTable(nil, true, lg)
+	writeMsgMessagesTable(nil, true, nil, lg)
 	if got := out.String(); got != "no messages\n" {
 		t.Errorf("empty all table = %q", got)
+	}
+}
+
+// TestWriteMsgMessagesTablePlanLabels checks that a plan label map renders
+// synthetic peer numbers as task ids in the FROM/TO columns.
+func TestWriteMsgMessagesTablePlanLabels(t *testing.T) {
+	apiNum := -111
+	dbNum := -222
+	msgs := []msgstore.Message{
+		{ID: 1, From: dbNum, To: &apiNum, Kind: "note", Body: "ping", CreatedAt: "2026-06-13T00:00:00Z"},
+	}
+	labels := map[int]string{apiNum: "api-client", dbNum: "db-layer"}
+	var out strings.Builder
+	lg := log.NewWith(&out, &strings.Builder{}, false)
+	writeMsgMessagesTable(msgs, true, labels, lg)
+	got := out.String()
+	if !strings.Contains(got, "db-layer") || !strings.Contains(got, "api-client") {
+		t.Errorf("plan label table missing task ids in:\n%s", got)
+	}
+	if strings.Contains(got, "#-111") || strings.Contains(got, "#-222") {
+		t.Errorf("plan label table leaked synthetic numbers in:\n%s", got)
 	}
 }
 
@@ -394,22 +445,26 @@ func TestShouldNudge(t *testing.T) {
 func TestNudgeDryRunLine(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
-		target int
+		target string
 		paneID string
 		found  bool
 		want   string
 	}{
 		{
-			name: "resolved pane", target: 70, paneID: "%1", found: true,
+			name: "resolved pane", target: "#70", paneID: "%1", found: true,
 			want: "# would send-keys -t %1 -l '[fanout] peer message in your inbox — run: fanout msg inbox' then Enter (target #70, only if agent is running)",
 		},
 		{
-			name: "unresolved recipient", target: 99, paneID: "", found: false,
+			name: "unresolved recipient", target: "#99", paneID: "", found: false,
 			want: "# would send-keys -t <unknown> -l '[fanout] peer message in your inbox — run: fanout msg inbox' then Enter (target #99, only if agent is running)",
 		},
 		{
-			name: "found row but empty pane id", target: 72, paneID: "", found: true,
+			name: "found row but empty pane id", target: "#72", paneID: "", found: true,
 			want: "# would send-keys -t <unknown> -l '[fanout] peer message in your inbox — run: fanout msg inbox' then Enter (target #72, only if agent is running)",
+		},
+		{
+			name: "plan task recipient renders the task id", target: "api-client", paneID: "%3", found: true,
+			want: "# would send-keys -t %3 -l '[fanout] peer message in your inbox — run: fanout msg inbox' then Enter (target api-client, only if agent is running)",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -653,5 +708,38 @@ func TestMatchLivePane(t *testing.T) {
 				t.Errorf("matched pane id = %q, want %q", got.ID, tc.wantID)
 			}
 		})
+	}
+}
+
+// TestResolveMemberNum covers the seam that decides whether a token is an issue
+// number or a plan task id once the parent is known — in particular that an
+// all-digit token routes to a task under a plan parent (not the issue number).
+func TestResolveMemberNum(t *testing.T) {
+	var buf strings.Builder
+	lg := log.NewWith(&buf, &buf, false)
+	const planParent = "plan:demo"
+
+	n, code := resolveMemberNum("send", "--to", "123", 123, planParent, lg)
+	if code != exitcode.OK {
+		t.Fatalf("plan all-digit code = %d, want OK", code)
+	}
+	if n == 123 || n >= 0 {
+		t.Errorf("plan all-digit resolved to %d, want a negative task number (not the issue number 123)", n)
+	}
+	if again, _ := resolveMemberNum("send", "--to", "123", 123, planParent, lg); again != n {
+		t.Errorf("resolveMemberNum not deterministic: %d != %d", again, n)
+	}
+
+	if _, code := resolveMemberNum("send", "--to", "api-client", 0, "68", lg); code != exitcode.Invocation {
+		t.Error("a task id under an issue parent must be rejected")
+	}
+	if got, code := resolveMemberNum("send", "--to", "71", 71, "68", lg); code != exitcode.OK || got != 71 {
+		t.Errorf("numeric under issue = (%d, %d), want (71, OK)", got, code)
+	}
+	if got, code := resolveMemberNum("send", "--to", "-1", -1, "68", lg); code != exitcode.OK || got != -1 {
+		t.Errorf("manual negative under issue = (%d, %d), want (-1, OK)", got, code)
+	}
+	if _, code := resolveMemberNum("send", "--to", "-1", -1, planParent, lg); code != exitcode.Invocation {
+		t.Error("a non-task token under a plan parent must be rejected")
 	}
 }

--- a/cmd/fanout/pane.go
+++ b/cmd/fanout/pane.go
@@ -271,7 +271,7 @@ func newPaneRequest(cfg *cliflags.Config, projectRoot string, issue ghissue.Issu
 	return req
 }
 
-func newTaskPaneRequest(cfg *cliflags.Config, projectRoot string, spec planspec.Spec, task planspec.Task, resolvedSettings settings.Settings) paneRequest {
+func newTaskPaneRequest(cfg *cliflags.Config, projectRoot string, spec planspec.Spec, task planspec.Task, resolvedSettings settings.Settings, teamCtx *briefing.TeamContext) paneRequest {
 	slug := planTaskSlug(spec.Plan.Slug, task)
 	branchName := task.Branch
 	if branchName == "" {
@@ -299,7 +299,7 @@ func newTaskPaneRequest(cfg *cliflags.Config, projectRoot string, spec planspec.
 			NoRefresh:   cfg.NoRefresh,
 		}),
 	}
-	req.BriefingBody = briefing.RenderTask(spec.Plan.Slug, spec.Plan.Title, task.ID, task.Title, task.Briefing, agentName, req.Worktree.BaseBranch, resolvedSettings)
+	req.BriefingBody = briefing.RenderTask(spec.Plan.Slug, spec.Plan.Title, task.ID, task.Title, task.Briefing, agentName, req.Worktree.BaseBranch, resolvedSettings, teamCtx)
 	req.Prompt = taskOneLinePrompt(spec.Plan.Slug, req)
 	return req
 }

--- a/cmd/fanout/pane_test.go
+++ b/cmd/fanout/pane_test.go
@@ -262,7 +262,7 @@ func TestNewTaskPaneRequestUsesTaskBriefingPathAndPrompt(t *testing.T) {
 		Wave:        "2",
 	}
 
-	got := newTaskPaneRequest(cfg, "/repo", spec, task, settings.Defaults())
+	got := newTaskPaneRequest(cfg, "/repo", spec, task, settings.Defaults(), nil)
 
 	if got.ParentRef != "plan:launch-plan" || got.TaskID != "api-client" || got.Number != 0 {
 		t.Fatalf("task identity = parent %q task %q issue %d", got.ParentRef, got.TaskID, got.Number)
@@ -295,7 +295,7 @@ func TestNewTaskPaneRequestUsesTaskAgentOverride(t *testing.T) {
 	spec := planspec.Spec{Plan: planspec.Plan{Slug: "launch-plan", Title: "Launch plan"}}
 	task := planspec.Task{ID: "api-client", Title: "Extract API client", Briefing: "## Goal\nExtract it"}
 
-	got := newTaskPaneRequest(cfg, "/repo", spec, task, settings.Defaults())
+	got := newTaskPaneRequest(cfg, "/repo", spec, task, settings.Defaults(), nil)
 
 	if got.Agent != "codex" {
 		t.Fatalf("Agent = %q, want codex", got.Agent)
@@ -314,7 +314,7 @@ func TestNewTaskPaneRequestCollapsesMultilineTitleInPrompt(t *testing.T) {
 		Briefing: "## Goal\nExtract it",
 	}
 
-	got := newTaskPaneRequest(cfg, "/repo", spec, task, settings.Defaults())
+	got := newTaskPaneRequest(cfg, "/repo", spec, task, settings.Defaults(), nil)
 
 	if strings.ContainsAny(got.Prompt, "\n\t") {
 		t.Fatalf("prompt contains embedded newline/tab: %q", got.Prompt)
@@ -328,16 +328,16 @@ func TestNewTaskPaneRequestQualifiesDefaultSlugByPlan(t *testing.T) {
 	cfg := &cliflags.Config{Agent: "claude", BaseBranch: "main"}
 	task := planspec.Task{ID: "api-client", Title: "Extract API client", Briefing: "## Goal\nExtract it"}
 
-	first := newTaskPaneRequest(cfg, "/repo", planspec.Spec{Plan: planspec.Plan{Slug: "launch-plan", Title: "Launch plan"}}, task, settings.Defaults())
-	second := newTaskPaneRequest(cfg, "/repo", planspec.Spec{Plan: planspec.Plan{Slug: "cleanup-plan", Title: "Cleanup plan"}}, task, settings.Defaults())
+	first := newTaskPaneRequest(cfg, "/repo", planspec.Spec{Plan: planspec.Plan{Slug: "launch-plan", Title: "Launch plan"}}, task, settings.Defaults(), nil)
+	second := newTaskPaneRequest(cfg, "/repo", planspec.Spec{Plan: planspec.Plan{Slug: "cleanup-plan", Title: "Cleanup plan"}}, task, settings.Defaults(), nil)
 
 	if first.Slug == second.Slug || first.BranchName == second.BranchName {
 		t.Fatalf("default task slugs must be plan-qualified, got %q/%q and %q/%q", first.Slug, first.BranchName, second.Slug, second.BranchName)
 	}
 
 	task.Slug = "shared-api-client"
-	first = newTaskPaneRequest(cfg, "/repo", planspec.Spec{Plan: planspec.Plan{Slug: "launch-plan", Title: "Launch plan"}}, task, settings.Defaults())
-	second = newTaskPaneRequest(cfg, "/repo", planspec.Spec{Plan: planspec.Plan{Slug: "cleanup-plan", Title: "Cleanup plan"}}, task, settings.Defaults())
+	first = newTaskPaneRequest(cfg, "/repo", planspec.Spec{Plan: planspec.Plan{Slug: "launch-plan", Title: "Launch plan"}}, task, settings.Defaults(), nil)
+	second = newTaskPaneRequest(cfg, "/repo", planspec.Spec{Plan: planspec.Plan{Slug: "cleanup-plan", Title: "Cleanup plan"}}, task, settings.Defaults(), nil)
 	if first.Slug != "shared-api-client" || second.Slug != "shared-api-client" {
 		t.Fatalf("explicit slug should be shared exactly, got %q and %q", first.Slug, second.Slug)
 	}

--- a/cmd/fanout/plancmd.go
+++ b/cmd/fanout/plancmd.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/butaosuinu/fanout/internal/atomicfs"
+	"github.com/butaosuinu/fanout/internal/briefing"
 	"github.com/butaosuinu/fanout/internal/cliflags"
 	"github.com/butaosuinu/fanout/internal/exitcode"
 	"github.com/butaosuinu/fanout/internal/ghissue"
@@ -54,6 +55,7 @@ type planCommandConfig struct {
 	DryRun             bool
 	Debug              bool
 	UnblockedOnly      bool
+	Team               bool
 	StatusMode         bool
 	Format             string
 	CloseTaskID        string
@@ -232,12 +234,29 @@ func cmdPlan(args []string, lg *log.Logger, commandName string) exitcode.Code {
 		printTaskDryRunPlan(plan, lg, c)
 	}
 
-	result := executeTaskPlan(cliCfg, lg, rt.info, spec, plan.Targets, resolvedSettings, recorder, c, commandName)
+	var teamCtx *briefing.TeamContext
+	if cfg.Team {
+		teamCtx = buildTaskTeamContext(rt.info.ProjectRoot, parentRef, plan.Targets)
+	}
+
+	result := executeTaskPlan(cliCfg, lg, rt.info, spec, plan.Targets, resolvedSettings, recorder, c, commandName, teamCtx)
 	printTaskSummary(plan, result, cfg, lg, c, commandName)
 
 	if !cfg.DryRun && result.Created > 0 {
 		bindDashboardKey(lg, resolvedSettings.DashboardKeybind)
 	}
+
+	// Seed the peers registry for --team runs, fail-fast partial successes
+	// included. Best-effort: this runs outside the executeTaskPlan loop and a
+	// failure only warns, never changes the exit code.
+	if cfg.Team && len(result.CreatedIDs) > 0 {
+		if cfg.DryRun {
+			fmt.Fprintf(lg.Stdout(), "%s# would seed team registry: %d peer(s) -> %s%s\n", c.Dim, len(result.CreatedIDs), teamCtx.DBPath, c.Reset)
+		} else {
+			seedTaskTeamRegistry(lg, teamCtx.DBPath, recorder.Store, parentRef, result.CreatedIDs)
+		}
+	}
+
 	if result.Failed > 0 {
 		return exitcode.Env
 	}
@@ -270,6 +289,7 @@ func parsePlanCommand(args []string, lg *log.Logger) (planCommandConfig, exitcod
 		"--debug":                   func() { cfg.Debug = true },
 		"--no-refresh":              func() { cfg.NoRefresh = true },
 		"--unblocked-only":          func() { cfg.UnblockedOnly = true },
+		"--team":                    func() { cfg.Team = true },
 		"--status":                  func() { cfg.StatusMode = true },
 		"--cleanup":                 func() { cfg.CleanupMode = true },
 		"--auto-pr":                 func() { cfg.AutoPullRequest = new(true) },
@@ -431,6 +451,8 @@ func validatePlanActionFlags(cfg planCommandConfig, limitRaw, sleepRaw string, h
 			return planStatusConflict(lg, "--dry-run")
 		case cfg.UnblockedOnly:
 			return planStatusConflict(lg, "--unblocked-only")
+		case cfg.Team:
+			return planStatusConflict(lg, "--team")
 		case cfg.NoRefresh:
 			return planStatusConflict(lg, "--no-refresh")
 		case cfg.AutoPullRequest != nil:
@@ -474,6 +496,8 @@ func validatePlanActionFlags(cfg planCommandConfig, limitRaw, sleepRaw string, h
 			return planLifecycleConflict(lg, "--dry-run")
 		case cfg.UnblockedOnly:
 			return planLifecycleConflict(lg, "--unblocked-only")
+		case cfg.Team:
+			return planLifecycleConflict(lg, "--team")
 		case cfg.NoRefresh:
 			return planLifecycleConflict(lg, "--no-refresh")
 		case cfg.AutoPullRequest != nil:
@@ -545,6 +569,7 @@ func (cfg planCommandConfig) cliConfig() *cliflags.Config {
 		DryRun:             cfg.DryRun,
 		Debug:              cfg.Debug,
 		UnblockedOnly:      cfg.UnblockedOnly,
+		Team:               cfg.Team,
 		AutoPullRequest:    cfg.AutoPullRequest,
 		PRReviewGate:       cfg.PRReviewGate,
 		BriefingCodeReview: cfg.BriefingCodeReview,
@@ -1277,10 +1302,10 @@ func applyTaskLimit(tasks []planspec.Task, limit int) (targets, deferred []plans
 	return tasks, nil
 }
 
-func executeTaskPlan(cfg *cliflags.Config, lg *log.Logger, info *fanoutruntime.Info, spec planspec.Spec, targets []planspec.Task, resolvedSettings settings.Settings, recorder paneStateRecorder, c log.Palette, commandName string) taskExecutionResult {
+func executeTaskPlan(cfg *cliflags.Config, lg *log.Logger, info *fanoutruntime.Info, spec planspec.Spec, targets []planspec.Task, resolvedSettings settings.Settings, recorder paneStateRecorder, c log.Palette, commandName string, teamCtx *briefing.TeamContext) taskExecutionResult {
 	var result taskExecutionResult
 	for i, task := range targets {
-		req := newTaskPaneRequest(cfg, info.ProjectRoot, spec, task, resolvedSettings)
+		req := newTaskPaneRequest(cfg, info.ProjectRoot, spec, task, resolvedSettings, teamCtx)
 		if !createPane(cfg, lg, info, req, recorder, c, commandName) {
 			result.Failed++
 			break
@@ -1381,11 +1406,12 @@ func printTaskSummary(plan taskPlan, result taskExecutionResult, cfg planCommand
 	ids := taskIDCSV(plan.LimitDeferred)
 	fmt.Fprintf(lg.Stdout(), "  %s\n", strings.Join(taskIDs(plan.LimitDeferred), " "))
 	cliCfg := cfg.cliConfig()
-	fmt.Fprintf(lg.Stdout(), "  %s plan %s --only %s%s%s%s%s%s%s\n",
+	fmt.Fprintf(lg.Stdout(), "  %s plan %s --only %s%s%s%s%s%s%s%s\n",
 		shellQuote(commandName),
 		shellQuote(cfg.SpecArg),
 		shellQuote(ids),
 		boolFlag(" --unblocked-only", cfg.UnblockedOnly),
+		boolFlag(" --team", cfg.Team),
 		settingsFlags(cliCfg),
 		worktreeFlags(cliCfg),
 		agentFlagsForTasks(cfg.Agent, cfg.AgentOverrides, plan.LimitDeferred),
@@ -1427,6 +1453,7 @@ Options:
   --only <task-id[,id...]>    Restrict to task IDs
   --skip <task-id[,id...]>    Exclude task IDs
   --unblocked-only            Defer tasks whose blocked_by dependencies are incomplete
+  --team                      Seed sibling-task peer messaging (fanout msg, addressed by task id)
   --base-branch <branch>      Override spec plan.base_branch
   --branch-prefix <prefix>    Prefix generated branch names
   --no-refresh                Do not fetch/fast-forward the base branch

--- a/cmd/fanout/plancmd_test.go
+++ b/cmd/fanout/plancmd_test.go
@@ -164,6 +164,42 @@ func TestParsePlanLifecycleRejectsAgentOverride(t *testing.T) {
 	}
 }
 
+func TestParsePlanTeamFlagSetsConfig(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	cfg, code := parsePlanCommand([]string{"launch-plan", "--team"}, log.NewWith(&stdout, &stderr, false))
+	if code != exitcode.OK {
+		t.Fatalf("parsePlanCommand(--team) code = %d, want OK; stderr=%q", code, stderr.String())
+	}
+	if !cfg.Team {
+		t.Fatal("cfg.Team = false, want true")
+	}
+	if !cfg.cliConfig().Team {
+		t.Fatal("cliConfig().Team = false, want true (forwarded to executeTaskPlan)")
+	}
+}
+
+func TestParsePlanTeamRejectedInStatusAndLifecycle(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"status", []string{"launch-plan", "--status", "--team"}, "--status cannot be combined with --team"},
+		{"lifecycle", []string{"launch-plan", "--cleanup", "--team"}, "--close/--merge/--cleanup cannot be combined with --team"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			_, code := parsePlanCommand(tc.args, log.NewWith(&stdout, &stderr, false))
+			if code != exitcode.Invocation {
+				t.Fatalf("parsePlanCommand(%v) code = %d, want %d", tc.args, code, exitcode.Invocation)
+			}
+			if got := stderr.String(); !strings.Contains(got, tc.want) {
+				t.Fatalf("stderr = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestPlanStatusAllowsBranchPrefixForFallbackBranches(t *testing.T) {
 	cfg := planCommandConfig{StatusMode: true, Format: "json", BranchPrefix: "custom/"}
 

--- a/cmd/fanout/team.go
+++ b/cmd/fanout/team.go
@@ -8,6 +8,7 @@ import (
 	"github.com/butaosuinu/fanout/internal/briefing"
 	"github.com/butaosuinu/fanout/internal/ghissue"
 	"github.com/butaosuinu/fanout/internal/log"
+	"github.com/butaosuinu/fanout/internal/planspec"
 	"github.com/butaosuinu/fanout/internal/state"
 	"github.com/butaosuinu/fanout/internal/team"
 )
@@ -20,6 +21,22 @@ func buildTeamContext(projectRoot, parentRef string, targets []ghissue.Issue) *b
 	siblings := make([]briefing.TeamSibling, 0, len(targets))
 	for _, issue := range targets {
 		siblings = append(siblings, briefing.TeamSibling{Num: issue.Number, Title: issue.Title})
+	}
+	return &briefing.TeamContext{
+		ParentLabel: teamParentLabel(parentRef),
+		DBPath:      team.DBPath(projectRoot, parentRef),
+		Siblings:    siblings,
+	}
+}
+
+// buildTaskTeamContext assembles the per-run --team data for an issue-less
+// plan: the DB path (so the briefing and the registry seed can never disagree)
+// and the sibling roster keyed by task id. Pure; it never touches the DB,
+// which keeps `fanout plan --team --dry-run` free of side effects.
+func buildTaskTeamContext(projectRoot, parentRef string, targets []planspec.Task) *briefing.TeamContext {
+	siblings := make([]briefing.TeamSibling, 0, len(targets))
+	for _, task := range targets {
+		siblings = append(siblings, briefing.TeamSibling{TaskID: task.ID, Title: task.Title})
 	}
 	return &briefing.TeamContext{
 		ParentLabel: teamParentLabel(parentRef),
@@ -65,6 +82,46 @@ func seedTeamRegistry(lg *log.Logger, dbPath string, st state.Store, parentRef s
 		pane, ok := st.Find(parentRef, num)
 		if !ok {
 			lg.Warn("team: #%d: no state row to seed into the peers registry", num)
+			continue
+		}
+		if err := team.UpsertPeer(db, pane, now); err != nil {
+			lg.Warn("team: %v", err)
+			continue
+		}
+		seeded++
+	}
+	if seeded > 0 {
+		lg.Ok("team: seeded %d peer(s) -> %s", seeded, dbPath)
+	}
+}
+
+// seedTaskTeamRegistry is the issue-less plan variant of seedTeamRegistry: it
+// upserts the plan-task panes created this run into the per-parent peers table,
+// looked up by task id. Best-effort by design: every failure is a warning and
+// the fan-out result is never affected.
+func seedTaskTeamRegistry(lg *log.Logger, dbPath string, st state.Store, parentRef string, createdIDs []string) {
+	db, err := team.Open(dbPath)
+	if err != nil {
+		lg.Warn("team: %v", err)
+		return
+	}
+	defer func() {
+		if err := db.Close(); err != nil {
+			lg.Warn("team: close registry db: %v", err)
+		}
+	}()
+	if err := team.EnsureSchema(db); err != nil {
+		lg.Warn("team: %v", err)
+		return
+	}
+
+	// One timestamp for the run so a cohort launched together joins together.
+	now := team.Now()
+	seeded := 0
+	for _, id := range createdIDs {
+		pane, ok := st.FindTask(parentRef, id)
+		if !ok {
+			lg.Warn("team: %s: no state row to seed into the peers registry", id)
 			continue
 		}
 		if err := team.UpsertPeer(db, pane, now); err != nil {

--- a/codex/skills/fanout-plan/SKILL.md
+++ b/codex/skills/fanout-plan/SKILL.md
@@ -112,6 +112,7 @@ Forward only the flags supported by the current `fanout plan` implementation:
 - `--only <task-id[,id...]>`
 - `--skip <task-id[,id...]>`
 - `--unblocked-only`
+- `--team`
 - `--base-branch <branch>`
 - `--branch-prefix <prefix>`
 - `--no-refresh`
@@ -141,9 +142,12 @@ blockers are complete. Omit it only when the user explicitly asks to launch all
 waves together.
 
 Do not forward issue/project-mode-only flags to `fanout plan`: `--include`,
-`--name`, `--project-status`, `--post-dashboard`, `--team`, `--popup-timeout`,
-or `--codex-plan-mode`. Names belong in the spec (`slug`, `display_name`,
+`--name`, `--project-status`, `--post-dashboard`, `--popup-timeout`, or
+`--codex-plan-mode`. Names belong in the spec (`slug`, `display_name`,
 `branch`), and dependencies belong in `blocked_by`.
+
+`--team` is supported in plan mode (see "Sibling coordination" below); it is
+not one of the forbidden issue/project-only flags.
 
 Use read/lifecycle flags only when the user explicitly asks for plan task
 status or cleanup, not during initial plan generation:
@@ -153,6 +157,34 @@ status or cleanup, not during initial plan generation:
 - `--close <task-id>`
 - `--merge <task-id>`
 - `--cleanup`
+
+## Sibling coordination (--team / fanout msg)
+
+`fanout plan --team` opts the plan run into sibling-pane peer messaging, the
+same SQLite message bus the issue/project lanes use — it just addresses peers
+by **task id** instead of issue number, because plan tasks have no GitHub
+issue. It adds a "Coordinating with your sibling panes" section to each task's
+briefing and seeds the created task panes into a per-parent peer registry
+(best-effort; a registry failure never fails the fan-out). `--team` is
+incompatible with the read/lifecycle modes (`--status` / `--close` / `--merge`
+/ `--cleanup`).
+
+Suggest it when tasks touch shared files (configs, schemas, lockfiles) or have
+ordering nuances beyond what `blocked_by` already encodes; skip it for fully
+independent tasks. From inside a task pane, `fanout msg` auto-detects which
+task you are (from the tmux pane and `.fanout/state.json`) and which plan you
+belong to. Peers are addressed by task id:
+
+- `fanout msg peers` — live sibling roster (task ids).
+- `fanout msg inbox [--mark-read]` — unread 1:1 + board messages addressed to you.
+- `fanout msg board` — the shared broadcast board.
+- `fanout msg send --to <task-id> "<body>"` — 1:1 message to a sibling task.
+- `fanout msg post "<body>"` — post to the shared board.
+
+Coordination is pull-based: messages persist and a sibling reads them at its
+own checkpoints; nothing nudges a busy pane. The DB is a plaintext SQLite file
+under `/tmp` (`0600`, owner-only) — never put secrets in messages. This is
+distinct from Claude Code Agent Teams (a Claude-only, single-session feature).
 
 ## Run
 

--- a/codex/skills/fanout/SKILL.md
+++ b/codex/skills/fanout/SKILL.md
@@ -480,3 +480,6 @@ single-session) and works the same for `codex` and `claude` panes.
 - Coordination is pull-based — messages persist and siblings read them at their
   own checkpoints; there is no nudge. The DB is a plaintext SQLite file under
   `/tmp` (`0600`, owner-only): never put secrets in messages.
+- Plan mode — `fanout plan --team` uses the same `fanout msg` surface, but peers
+  are addressed by task id (`fanout msg send --to <task-id>`) instead of issue
+  number, because issue-less plan tasks have no `#N`. See the fanout-plan skill.

--- a/internal/briefing/briefing.go
+++ b/internal/briefing/briefing.go
@@ -39,10 +39,12 @@ func taskPathComponent(value string) string {
 }
 
 // TeamSibling is one roster entry of a --team run: a child pane created
-// alongside this briefing's issue.
+// alongside this briefing's issue or plan task. Num identifies issue siblings;
+// TaskID identifies issue-less plan-task siblings (Num is 0 for those).
 type TeamSibling struct {
-	Num   int
-	Title string
+	Num    int
+	TaskID string
+	Title  string
 }
 
 // TeamContext carries the --team coordination data into the briefing: the
@@ -80,7 +82,8 @@ func Render(num int, title, body, agentName, baseBranch string, s settings.Setti
 
 // RenderTask produces an issue-less task brief. The task variant deliberately
 // avoids GitHub issue closing references because there is no issue to close.
-func RenderTask(planSlug, planTitle, taskID, title, body, agentName, baseBranch string, s settings.Settings) string {
+// team is nil unless the run opted in with --team.
+func RenderTask(planSlug, planTitle, taskID, title, body, agentName, baseBranch string, s settings.Settings, team *TeamContext) string {
 	footer := taskPRFooter(planSlug, taskID)
 	return renderWorkBriefing(workBriefing{
 		header:                     fmt.Sprintf("You are assigned task \"%s\" of plan \"%s\" (plan:%s) in this repository.", taskID, planTitle, planSlug),
@@ -93,6 +96,8 @@ func RenderTask(planSlug, planTitle, taskID, title, body, agentName, baseBranch 
 		agentName:                  agentName,
 		baseBranch:                 baseBranch,
 		settings:                   s,
+		team:                       team,
+		teamTaskID:                 taskID,
 	})
 }
 
@@ -109,6 +114,7 @@ type workBriefing struct {
 	settings                   settings.Settings
 	team                       *TeamContext
 	teamIssueNum               int
+	teamTaskID                 string
 }
 
 func renderWorkBriefing(b workBriefing) string {
@@ -123,7 +129,11 @@ func renderWorkBriefing(b workBriefing) string {
 		base += prVisualizationSection(b.prFooter, b.baseBranch)
 	}
 	if b.team != nil {
-		base += teamSection(b.teamIssueNum, b.team)
+		if b.teamTaskID != "" {
+			base += taskTeamSection(b.teamTaskID, b.team)
+		} else {
+			base += teamSection(b.teamIssueNum, b.team)
+		}
 	}
 	if b.agentName == "codex" {
 		return base + codexReviewSection(b.settings.AutoPullRequest)
@@ -325,6 +335,54 @@ Checkpoints (lightweight; never block waiting for a reply):
 3. Check your inbox once more before opening the PR.
 
 Etiquette: keep messages short and factual — file paths, branch names, issue numbers.
+Note: this is messaging between separate panes; it is unrelated to Claude Code
+Agent Teams, which coordinates teammates inside your own single session.
+`
+
+// taskTeamSection renders the --team coordination block for an issue-less plan
+// task. It mirrors teamSection but addresses peers by their plan task id (the
+// member key plan panes use everywhere) instead of an issue number, since plan
+// tasks have no GitHub issue.
+func taskTeamSection(self string, t *TeamContext) string {
+	var roster strings.Builder
+	for _, sibling := range t.Siblings {
+		fmt.Fprintf(&roster, "- %s: %s", sibling.TaskID, sibling.Title)
+		if sibling.TaskID == self {
+			roster.WriteString(" (you)")
+		}
+		roster.WriteString("\n")
+	}
+	return fmt.Sprintf(taskTeamSectionTemplate, self, t.ParentLabel, roster.String(), t.DBPath)
+}
+
+const taskTeamSectionTemplate = `
+## Coordinating with your sibling panes
+
+You are the pane for task %s (parent %s), launched alongside these sibling panes:
+%s
+A shared SQLite message board for this plan lives at:
+%s
+The roster above is a launch-time snapshot; ` + "`fanout msg peers`" + ` is the live list.
+
+Cheatsheet (best-effort; skip messaging if the ` + "`fanout msg`" + ` subcommand is unavailable):
+- ` + "`fanout msg peers`" + `                          — live sibling roster
+- ` + "`fanout msg inbox [--mark-read]`" + `           — read messages addressed to you
+- ` + "`fanout msg board`" + `                          — read the shared board
+- ` + "`fanout msg send --to <task-id> \"<body>\"`" + ` — message a sibling task directly
+- ` + "`fanout msg post \"<body>\"`" + `                — post to the shared board
+
+Peers are addressed by task id (this plan has no GitHub issue numbers); ` + "`fanout msg peers`" + `
+lists the live task ids.
+
+Checkpoints (lightweight; never block waiting for a reply):
+1. After reading this briefing, check ` + "`fanout msg inbox`" + ` and ` + "`fanout msg board`" + ` once.
+   Siblings are registered after the whole batch has launched, so a missing DB or
+   an empty roster early in the run only means they have not joined yet — do not
+   give up on messaging; just check again at the next checkpoint.
+2. Before touching files siblings may share (configs, schemas, lockfiles), post a one-line heads-up.
+3. Check your inbox once more before opening the PR.
+
+Etiquette: keep messages short and factual — file paths, branch names, task ids.
 Note: this is messaging between separate panes; it is unrelated to Claude Code
 Agent Teams, which coordinates teammates inside your own single session.
 `

--- a/internal/briefing/briefing_test.go
+++ b/internal/briefing/briefing_test.go
@@ -87,7 +87,7 @@ func TestRenderTaskDefaultsUsePlanTaskFooterAndSharedAgentSections(t *testing.T)
 			},
 		},
 	} {
-		got := RenderTask("plan-alpha", "Launch Plan", "task-001", "Task title", "Task body", tc.agent, "release/v1", defaults)
+		got := RenderTask("plan-alpha", "Launch Plan", "task-001", "Task title", "Task body", tc.agent, "release/v1", defaults, nil)
 		commonWants := []string{
 			`You are assigned task "task-001" of plan "Launch Plan" (plan:plan-alpha) in this repository.`,
 			"Title: Task title",
@@ -115,7 +115,7 @@ func TestRenderTaskSettingsToggleCombinations(t *testing.T) {
 
 	noAutoPR := defaults
 	noAutoPR.AutoPullRequest = false
-	got := RenderTask("plan-alpha", "Launch Plan", "task-001", "Task title", "Task body", "codex", "release/v1", noAutoPR)
+	got := RenderTask("plan-alpha", "Launch Plan", "task-001", "Task title", "Task body", "codex", "release/v1", noAutoPR, nil)
 	for _, unwanted := range []string{
 		"Open a pull request",
 		"structure the PR body",
@@ -133,7 +133,7 @@ func TestRenderTaskSettingsToggleCombinations(t *testing.T) {
 
 	noVisualization := defaults
 	noVisualization.PRVisualization = false
-	got = RenderTask("plan-alpha", "Launch Plan", "task-001", "Task title", "Task body", "claude", "release/v1", noVisualization)
+	got = RenderTask("plan-alpha", "Launch Plan", "task-001", "Task title", "Task body", "claude", "release/v1", noVisualization, nil)
 	if !strings.Contains(got, `Open a pull request and end the PR body with "Plan: plan-alpha / Task: task-001"`) {
 		t.Fatalf("RenderTask(..., PRVisualization=false) missing auto-PR task requirement:\n%s", got)
 	}
@@ -148,7 +148,7 @@ func TestRenderTaskSettingsToggleCombinations(t *testing.T) {
 	claudeToggles.PRReviewGate = false
 	claudeToggles.BriefingCodeReview = false
 	claudeToggles.AgentTeamsHint = false
-	got = RenderTask("plan-alpha", "Launch Plan", "task-001", "Task title", "Task body", "claude", "release/v1", claudeToggles)
+	got = RenderTask("plan-alpha", "Launch Plan", "task-001", "Task title", "Task body", "claude", "release/v1", claudeToggles, nil)
 	if !strings.Contains(got, "The PR review gate is disabled for this fanout run") {
 		t.Fatalf("RenderTask(..., PRReviewGate=false) missing bypass notice:\n%s", got)
 	}
@@ -164,7 +164,7 @@ func TestRenderTaskSettingsToggleCombinations(t *testing.T) {
 }
 
 func TestRenderTaskPRVisualizationQuotesBaseBranch(t *testing.T) {
-	got := RenderTask("plan-alpha", "Launch Plan", "task-001", "Task title", "Task body", "codex", "foo;bar", settings.Defaults())
+	got := RenderTask("plan-alpha", "Launch Plan", "task-001", "Task title", "Task body", "codex", "foo;bar", settings.Defaults(), nil)
 	want := "git diff --name-only 'foo;bar'...HEAD"
 	if !strings.Contains(got, want) {
 		t.Fatalf("RenderTask(...) missing shell-quoted base branch command %q:\n%s", want, got)
@@ -234,6 +234,52 @@ func TestTeamSectionAbsentInCodexPlanBriefing(t *testing.T) {
 	got := Render(101, "First child", "Issue body", "codex", "main", settings.Defaults(), true, testTeamContext())
 	if strings.Contains(got, "Coordinating with your sibling panes") {
 		t.Fatalf("codex plan briefing contains the team section:\n%s", got)
+	}
+}
+
+func testTaskTeamContext() *TeamContext {
+	return &TeamContext{
+		ParentLabel: "plan:launch-plan",
+		DBPath:      "/tmp/fanout-project_root-plan-launch-plan.db",
+		Siblings: []TeamSibling{
+			{TaskID: "base-types", Title: "Define base types"},
+			{TaskID: "api-client", Title: "Extract API client"},
+		},
+	}
+}
+
+func TestTaskTeamSectionAddressesSiblingsByTaskID(t *testing.T) {
+	team := testTaskTeamContext()
+	got := RenderTask("launch-plan", "Launch plan", "base-types", "Define base types", "Task body", "claude", "main", settings.Defaults(), team)
+	for _, want := range []string{
+		"## Coordinating with your sibling panes",
+		"You are the pane for task base-types (parent plan:launch-plan)",
+		"- base-types: Define base types (you)",
+		"- api-client: Extract API client",
+		"/tmp/fanout-project_root-plan-launch-plan.db",
+		"fanout msg send --to <task-id>",
+		"Peers are addressed by task id",
+		"Agent Teams, which coordinates teammates inside your own single session",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("RenderTask(..., team) missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "- api-client: Extract API client (you)") {
+		t.Fatal("RenderTask(..., team) marks a non-self sibling as (you)")
+	}
+	// The plan variant must not leak the issue-numbered cheatsheet.
+	if strings.Contains(got, "fanout msg send --to <N>") {
+		t.Fatalf("RenderTask(..., team) used the issue cheatsheet:\n%s", got)
+	}
+	// Issue-closing references stay absent in the task briefing.
+	assertIssueLessTaskBriefing(t, got)
+}
+
+func TestTaskTeamSectionAbsentWithoutTeamContext(t *testing.T) {
+	got := RenderTask("launch-plan", "Launch plan", "base-types", "Define base types", "Task body", "claude", "main", settings.Defaults(), nil)
+	if strings.Contains(got, "Coordinating with your sibling panes") {
+		t.Fatalf("RenderTask(..., team=nil) contains the team section:\n%s", got)
 	}
 }
 

--- a/internal/msgstore/store.go
+++ b/internal/msgstore/store.go
@@ -30,9 +30,13 @@ type Message struct {
 
 // Peer is one peers row, also the canonical JSON encoding. Nullable text
 // columns scan to "" — register writes "" rather than NULL for unknown
-// fields, so the distinction carries no information.
+// fields, so the distinction carries no information. TaskID is set only for
+// issue-less plan-task peers (whose Issue is a synthetic number); it stays ""
+// for numeric issue peers, so JSON omits it and the `fanout msg peers` table
+// falls back to the numeric "#<issue>" label.
 type Peer struct {
 	Issue        int    `json:"issue"`
+	TaskID       string `json:"taskId,omitempty"`
 	PaneID       string `json:"pane_id"`
 	Slug         string `json:"slug"`
 	WorktreePath string `json:"worktree_path"`
@@ -133,6 +137,10 @@ func claimDBOwner(db *sql.DB, parent string) (string, error) {
 }
 
 const messageColumns = "id, from_issue, to_issue, kind, body, created_at, read_at, reply_to"
+
+// peerColumns is the SELECT column order scanPeer expects; Register and Peers
+// share it so the two read paths can never drift from the scan.
+const peerColumns = "issue, pane_id, slug, worktree_path, agent, display_name, joined_at, last_seen, task_id"
 
 // boardUnreadCond selects unread board posts: beyond self's cursor, excluding
 // self's own posts so `post` followed by `inbox`/`board` doesn't surface the
@@ -372,18 +380,19 @@ func (s *Store) MarkReadAll(self int, now string) ([]int64, int64, error) {
 // last_seen is refreshed on every call.
 func (s *Store) Register(p Peer, now string) (Peer, error) {
 	_, err := s.db.Exec(
-		`INSERT INTO peers(issue, pane_id, slug, worktree_path, agent, display_name, joined_at, last_seen)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+		`INSERT INTO peers(issue, pane_id, slug, worktree_path, agent, display_name, joined_at, last_seen, task_id)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(issue) DO UPDATE SET
   pane_id=excluded.pane_id, slug=excluded.slug, worktree_path=excluded.worktree_path,
-  agent=excluded.agent, display_name=excluded.display_name, last_seen=excluded.last_seen`,
-		p.Issue, p.PaneID, p.Slug, p.WorktreePath, p.Agent, p.DisplayName, now, now,
+  agent=excluded.agent, display_name=excluded.display_name, last_seen=excluded.last_seen,
+  task_id=excluded.task_id`,
+		p.Issue, p.PaneID, p.Slug, p.WorktreePath, p.Agent, p.DisplayName, now, now, nullableText(p.TaskID),
 	)
 	if err != nil {
 		return Peer{}, fmt.Errorf("register peer: %w", err)
 	}
 	row := s.db.QueryRow(
-		"SELECT issue, pane_id, slug, worktree_path, agent, display_name, joined_at, last_seen FROM peers WHERE issue = ?",
+		"SELECT "+peerColumns+" FROM peers WHERE issue = ?",
 		p.Issue,
 	)
 	stored, err := scanPeer(row)
@@ -396,7 +405,7 @@ ON CONFLICT(issue) DO UPDATE SET
 // Peers returns every registered peer ordered by issue.
 func (s *Store) Peers() ([]Peer, error) {
 	rows, err := s.db.Query(
-		"SELECT issue, pane_id, slug, worktree_path, agent, display_name, joined_at, last_seen FROM peers ORDER BY issue",
+		"SELECT " + peerColumns + " FROM peers ORDER BY issue",
 	)
 	if err != nil {
 		return nil, fmt.Errorf("list peers: %w", err)
@@ -451,8 +460,8 @@ type rowScanner interface {
 
 func scanPeer(row rowScanner) (Peer, error) {
 	var p Peer
-	var paneID, slug, worktree, agent, display, lastSeen sql.NullString
-	if err := row.Scan(&p.Issue, &paneID, &slug, &worktree, &agent, &display, &p.JoinedAt, &lastSeen); err != nil {
+	var paneID, slug, worktree, agent, display, lastSeen, taskID sql.NullString
+	if err := row.Scan(&p.Issue, &paneID, &slug, &worktree, &agent, &display, &p.JoinedAt, &lastSeen, &taskID); err != nil {
 		return Peer{}, err
 	}
 	p.PaneID = paneID.String
@@ -461,7 +470,17 @@ func scanPeer(row rowScanner) (Peer, error) {
 	p.Agent = agent.String
 	p.DisplayName = display.String
 	p.LastSeen = lastSeen.String
+	p.TaskID = taskID.String
 	return p, nil
+}
+
+// nullableText binds s as NULL when empty (numeric issue peers carry no task
+// id) and as the string otherwise, matching team.UpsertPeer's encoding.
+func nullableText(s string) any {
+	if s == "" {
+		return nil
+	}
+	return s
 }
 
 func scanIDs(rows *sql.Rows) ([]int64, error) {

--- a/internal/msgstore/store_test.go
+++ b/internal/msgstore/store_test.go
@@ -388,3 +388,60 @@ func TestPeersOrderedByIssue(t *testing.T) {
 		t.Errorf("peer order = %v, want %v", got, want)
 	}
 }
+
+// TestPlanTaskPeerAndMessagingRoundTrip exercises the issue-less plan path:
+// peers carry a synthetic negative number plus a task id, and 1:1 messaging
+// round-trips between two such peers through the unchanged int-keyed schema.
+func TestPlanTaskPeerAndMessagingRoundTrip(t *testing.T) {
+	const parent = "plan:launch-plan"
+	path := filepath.Join(t.TempDir(), "team.db")
+	db, err := team.Open(path)
+	if err != nil {
+		t.Fatalf("team.Open(%q): %v", path, err)
+	}
+	t.Cleanup(func() {
+		if closeErr := db.Close(); closeErr != nil {
+			t.Errorf("close db: %v", closeErr)
+		}
+	})
+	if schemaErr := team.EnsureSchema(db); schemaErr != nil {
+		t.Fatalf("team.EnsureSchema: %v", schemaErr)
+	}
+	s, err := New(db, parent)
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	apiNum := team.TaskPeerNum(parent, "api-client")
+	dbNum := team.TaskPeerNum(parent, "db-layer")
+	if apiNum >= 0 || dbNum >= 0 {
+		t.Fatalf("synthetic numbers must be negative, got api=%d db=%d", apiNum, dbNum)
+	}
+
+	stored, err := s.Register(Peer{Issue: apiNum, TaskID: "api-client", Slug: "launch-plan-api-client"}, testNow)
+	if err != nil {
+		t.Fatalf("Register: %v", err)
+	}
+	if stored.Issue != apiNum || stored.TaskID != "api-client" {
+		t.Fatalf("Register stored = %+v, want issue %d task api-client", stored, apiNum)
+	}
+
+	if _, sendErr := s.Send(dbNum, apiNum, "note", "schema ready", testNow); sendErr != nil {
+		t.Fatalf("Send: %v", sendErr)
+	}
+	msgs, _, err := s.Inbox(apiNum, false, false, testNow)
+	if err != nil {
+		t.Fatalf("Inbox: %v", err)
+	}
+	if len(msgs) != 1 || msgs[0].From != dbNum || msgs[0].To == nil || *msgs[0].To != apiNum {
+		t.Fatalf("Inbox(api) = %+v, want one db-layer->api-client message", msgs)
+	}
+
+	peers, err := s.Peers()
+	if err != nil {
+		t.Fatalf("Peers: %v", err)
+	}
+	if len(peers) != 1 || peers[0].TaskID != "api-client" {
+		t.Fatalf("Peers = %+v, want one peer with task id api-client", peers)
+	}
+}

--- a/internal/team/db.go
+++ b/internal/team/db.go
@@ -29,9 +29,10 @@ const (
 	dsnPragmas = "_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)&_pragma=foreign_keys(ON)"
 
 	// schemaUserVersion is the PRAGMA user_version stamped by EnsureSchema.
-	// Future migrations bump it and add nullable columns for forward
-	// compatibility.
-	schemaUserVersion = 1
+	// Migrations bump it and add nullable columns for forward compatibility.
+	// v2 adds the nullable peers.task_id column so issue-less plan tasks
+	// (string task id, synthetic peer number) carry their task id for display.
+	schemaUserVersion = 2
 )
 
 // dsnPathEscaper percent-encodes the bytes that would derail file-URI
@@ -41,15 +42,18 @@ const (
 // via filepath.Base, so the path cannot be assumed clean.
 var dsnPathEscaper = strings.NewReplacer("%", "%25", "?", "%3F", "#", "%23")
 
-// schemaStatements is the agreed v1 DDL from the #68 design. messages unifies
-// 1:1 and board traffic: to_issue IS NULL means a board/broadcast post, and
-// board reads track their position per reader in board_cursors instead of
-// mutating read_at. Statements run one by one so a failure names the
-// offending statement.
+// schemaStatements is the DDL from the #68 design. messages unifies 1:1 and
+// board traffic: to_issue IS NULL means a board/broadcast post, and board
+// reads track their position per reader in board_cursors instead of mutating
+// read_at. Statements run one by one so a failure names the offending
+// statement. The nullable peers.task_id column (v2) records the plan task id
+// of a synthetic plan-task peer; it stays NULL for numeric issue panes. A
+// pre-v2 DB gains the column via the additive ALTER in EnsureSchema.
 var schemaStatements = []string{
 	`CREATE TABLE IF NOT EXISTS peers (
   issue INTEGER PRIMARY KEY, pane_id TEXT, slug TEXT, worktree_path TEXT,
-  agent TEXT, display_name TEXT, joined_at TEXT NOT NULL, last_seen TEXT)`,
+  agent TEXT, display_name TEXT, joined_at TEXT NOT NULL, last_seen TEXT,
+  task_id TEXT)`,
 	`CREATE TABLE IF NOT EXISTS messages (
   id INTEGER PRIMARY KEY AUTOINCREMENT, parent TEXT NOT NULL,
   from_issue INTEGER NOT NULL, to_issue INTEGER,
@@ -138,10 +142,11 @@ func checkPrivate(path string, info os.FileInfo) error {
 	return nil
 }
 
-// EnsureSchema creates the v1 tables and index idempotently and stamps
-// PRAGMA user_version=1. A DB already at version 1 is left untouched apart
-// from the harmless CREATE IF NOT EXISTS re-runs; a DB at a newer version
-// returns an error instead of being downgraded.
+// EnsureSchema creates the tables and index idempotently, brings a pre-v2 DB
+// forward with the additive peers.task_id column, and stamps PRAGMA
+// user_version. A DB already at the current version is left untouched apart
+// from the harmless CREATE IF NOT EXISTS re-runs and the no-op column check; a
+// DB at a newer version returns an error instead of being downgraded.
 func EnsureSchema(db *sql.DB) error {
 	var version int
 	if err := db.QueryRow("PRAGMA user_version").Scan(&version); err != nil {
@@ -155,11 +160,63 @@ func EnsureSchema(db *sql.DB) error {
 			return fmt.Errorf("ensure team db schema: %w", err)
 		}
 	}
-	if version == 0 {
+	if err := ensurePeersTaskIDColumn(db); err != nil {
+		return err
+	}
+	if version < schemaUserVersion {
 		// PRAGMA cannot take placeholders; the value is a package const.
 		if _, err := db.Exec(fmt.Sprintf("PRAGMA user_version = %d", schemaUserVersion)); err != nil {
 			return fmt.Errorf("stamp team db schema version: %w", err)
 		}
 	}
 	return nil
+}
+
+// ensurePeersTaskIDColumn adds the nullable peers.task_id column to a pre-v2
+// DB. A fresh DB already has it from schemaStatements, so the column check is
+// a no-op there; a v1 issue DB gains the nullable column without a destructive
+// rebuild and keeps every existing peer row intact.
+func ensurePeersTaskIDColumn(db *sql.DB) error {
+	has, err := columnExists(db, "peers", "task_id")
+	if err != nil {
+		return err
+	}
+	if has {
+		return nil
+	}
+	if _, err := db.Exec("ALTER TABLE peers ADD COLUMN task_id TEXT"); err != nil {
+		return fmt.Errorf("add peers.task_id column: %w", err)
+	}
+	return nil
+}
+
+// columnExists reports whether table has a column named column, via
+// PRAGMA table_info. table is a package-internal literal, never caller input,
+// so interpolating it into the PRAGMA (which cannot take placeholders) is safe.
+func columnExists(db *sql.DB, table, column string) (bool, error) {
+	rows, err := db.Query("PRAGMA table_info(" + table + ")")
+	if err != nil {
+		return false, fmt.Errorf("inspect %s columns: %w", table, err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var (
+			cid       int
+			name      string
+			ctype     string
+			notNull   int
+			dfltValue sql.NullString
+			pk        int
+		)
+		if err := rows.Scan(&cid, &name, &ctype, &notNull, &dfltValue, &pk); err != nil {
+			return false, fmt.Errorf("inspect %s columns: %w", table, err)
+		}
+		if name == column {
+			return true, nil
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return false, fmt.Errorf("inspect %s columns: %w", table, err)
+	}
+	return false, nil
 }

--- a/internal/team/db.go
+++ b/internal/team/db.go
@@ -175,7 +175,10 @@ func EnsureSchema(db *sql.DB) error {
 // ensurePeersTaskIDColumn adds the nullable peers.task_id column to a pre-v2
 // DB. A fresh DB already has it from schemaStatements, so the column check is
 // a no-op there; a v1 issue DB gains the nullable column without a destructive
-// rebuild and keeps every existing peer row intact.
+// rebuild and keeps every existing peer row intact. SQLite has no
+// ADD COLUMN IF NOT EXISTS, and two panes upgrading the same shared /tmp DB can
+// both observe the column absent and race to ALTER it, so a duplicate-column
+// error from a concurrent winner is treated as success (the column now exists).
 func ensurePeersTaskIDColumn(db *sql.DB) error {
 	has, err := columnExists(db, "peers", "task_id")
 	if err != nil {
@@ -185,9 +188,19 @@ func ensurePeersTaskIDColumn(db *sql.DB) error {
 		return nil
 	}
 	if _, err := db.Exec("ALTER TABLE peers ADD COLUMN task_id TEXT"); err != nil {
+		if isDuplicateColumnErr(err) {
+			return nil
+		}
 		return fmt.Errorf("add peers.task_id column: %w", err)
 	}
 	return nil
+}
+
+// isDuplicateColumnErr reports whether err is SQLite's "duplicate column name"
+// from an ADD COLUMN that lost a concurrent race — i.e. the column already
+// exists, so the migration is effectively done.
+func isDuplicateColumnErr(err error) bool {
+	return err != nil && strings.Contains(strings.ToLower(err.Error()), "duplicate column name")
 }
 
 // columnExists reports whether table has a column named column, via

--- a/internal/team/db_test.go
+++ b/internal/team/db_test.go
@@ -209,8 +209,13 @@ func TestEnsureSchema(t *testing.T) {
 	if err := db.QueryRow("PRAGMA user_version").Scan(&version); err != nil {
 		t.Fatalf("user_version: %v", err)
 	}
-	if version != 1 {
-		t.Errorf("user_version = %d, want 1", version)
+	if version != schemaUserVersion {
+		t.Errorf("user_version = %d, want %d", version, schemaUserVersion)
+	}
+
+	// The nullable v2 peers.task_id column must be present on a fresh DB.
+	if has, err := columnExists(db, "peers", "task_id"); err != nil || !has {
+		t.Errorf("peers.task_id column: has=%v err=%v, want present", has, err)
 	}
 
 	// Idempotent: a second run must not error or move the version.
@@ -220,8 +225,51 @@ func TestEnsureSchema(t *testing.T) {
 	if err := db.QueryRow("PRAGMA user_version").Scan(&version); err != nil {
 		t.Fatalf("user_version after rerun: %v", err)
 	}
-	if version != 1 {
-		t.Errorf("user_version after rerun = %d, want 1", version)
+	if version != schemaUserVersion {
+		t.Errorf("user_version after rerun = %d, want %d", version, schemaUserVersion)
+	}
+}
+
+// TestEnsureSchemaMigratesV1 verifies a pre-v2 DB (peers without task_id,
+// user_version 1) gains the nullable column and is stamped to v2 without
+// losing existing rows.
+func TestEnsureSchemaMigratesV1(t *testing.T) {
+	db, _ := openTestDB(t)
+	// Recreate the v1 peers table (no task_id) and stamp version 1, mimicking
+	// a DB created before the v2 migration.
+	for _, stmt := range []string{
+		`CREATE TABLE peers (
+  issue INTEGER PRIMARY KEY, pane_id TEXT, slug TEXT, worktree_path TEXT,
+  agent TEXT, display_name TEXT, joined_at TEXT NOT NULL, last_seen TEXT)`,
+		`INSERT INTO peers (issue, joined_at) VALUES (70, '2026-06-13T00:00:00Z')`,
+		"PRAGMA user_version = 1",
+	} {
+		if _, err := db.Exec(stmt); err != nil {
+			t.Fatalf("seed v1 DB (%s): %v", stmt, err)
+		}
+	}
+
+	if err := EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema migrate: %v", err)
+	}
+
+	if has, err := columnExists(db, "peers", "task_id"); err != nil || !has {
+		t.Errorf("peers.task_id after migrate: has=%v err=%v, want present", has, err)
+	}
+	var version int
+	if err := db.QueryRow("PRAGMA user_version").Scan(&version); err != nil {
+		t.Fatalf("user_version: %v", err)
+	}
+	if version != schemaUserVersion {
+		t.Errorf("user_version after migrate = %d, want %d", version, schemaUserVersion)
+	}
+	var issue int
+	var taskID sql.NullString
+	if err := db.QueryRow("SELECT issue, task_id FROM peers WHERE issue = 70").Scan(&issue, &taskID); err != nil {
+		t.Fatalf("existing row lost after migrate: %v", err)
+	}
+	if issue != 70 || taskID.Valid {
+		t.Errorf("migrated row = (issue %d, task_id %v), want (70, NULL)", issue, taskID)
 	}
 }
 

--- a/internal/team/db_test.go
+++ b/internal/team/db_test.go
@@ -273,6 +273,30 @@ func TestEnsureSchemaMigratesV1(t *testing.T) {
 	}
 }
 
+// TestIsDuplicateColumnErrMatchesSQLite pins the duplicate-column detection to
+// the actual driver error message, so a concurrent ADD COLUMN race in
+// ensurePeersTaskIDColumn is recognized (and swallowed) rather than surfacing
+// as a backend failure.
+func TestIsDuplicateColumnErrMatchesSQLite(t *testing.T) {
+	db, _ := openTestDB(t)
+	if _, err := db.Exec("CREATE TABLE t (a INTEGER)"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, err := db.Exec("ALTER TABLE t ADD COLUMN b TEXT"); err != nil {
+		t.Fatalf("first add: %v", err)
+	}
+	_, err := db.Exec("ALTER TABLE t ADD COLUMN b TEXT")
+	if err == nil {
+		t.Fatal("expected a duplicate-column error on the second ADD COLUMN")
+	}
+	if !isDuplicateColumnErr(err) {
+		t.Fatalf("isDuplicateColumnErr(%q) = false, want true (driver message drifted)", err)
+	}
+	if isDuplicateColumnErr(nil) {
+		t.Error("isDuplicateColumnErr(nil) = true, want false")
+	}
+}
+
 func TestEnsureSchemaRejectsNewerVersion(t *testing.T) {
 	db, _ := openTestDB(t)
 	if _, err := db.Exec("PRAGMA user_version = 99"); err != nil {

--- a/internal/team/detect.go
+++ b/internal/team/detect.go
@@ -37,8 +37,9 @@ func ParseFanoutTag(prompt string) (issue int, parent string, ok bool) {
 
 // Identity is the resolved "who am I" of a fanout pane.
 type Identity struct {
-	Issue  int        // child issue number (state.Pane.IssueNum)
-	Parent string     // parent ref: issue number string or Projects URL
+	Issue  int        // peer number: child IssueNum, or synthetic for plan tasks
+	TaskID string     // plan task id (state.Pane.TaskID); "" for issue panes
+	Parent string     // parent ref: issue number string, Projects URL, or plan:<slug>
 	Pane   state.Pane // full state row, for slug/agent/worktree consumers
 }
 
@@ -86,7 +87,7 @@ func IdentifyPane(paneID, worktree string, st state.Store) (Identity, error) {
 }
 
 func paneIdentity(pane state.Pane) Identity {
-	id := Identity{Issue: pane.IssueNum, Parent: pane.Parent, Pane: pane}
+	id := Identity{Issue: pane.IssueNum, TaskID: pane.TaskID, Parent: pane.Parent, Pane: pane}
 	if id.Issue <= 0 || id.Parent == "" {
 		if n, parent, ok := ParseFanoutTag(pane.Prompt); ok {
 			if id.Issue <= 0 {
@@ -96,6 +97,13 @@ func paneIdentity(pane state.Pane) Identity {
 				id.Parent = parent
 			}
 		}
+	}
+	// Plan-task panes carry a string TaskID and IssueNum 0; synthesize the
+	// same stable peer number the registry seed and the
+	// `fanout msg --to <task-id>` translation use, so a plan pane self-detects
+	// a non-zero, message-addressable self without changing the int schema.
+	if id.Issue == 0 && id.TaskID != "" && id.Parent != "" {
+		id.Issue = TaskPeerNum(id.Parent, id.TaskID)
 	}
 	return id
 }

--- a/internal/team/detect_test.go
+++ b/internal/team/detect_test.go
@@ -204,6 +204,36 @@ func TestIdentifyPane(t *testing.T) {
 	}
 }
 
+func TestIdentifyPaneSynthesizesPlanTaskIdentity(t *testing.T) {
+	plan := state.Pane{
+		Parent:       "plan:launch-plan",
+		IssueNum:     0,
+		TaskID:       "base-types",
+		PaneID:       "%5",
+		WorktreePath: "/repo/.fanout/worktrees/launch-plan-base-types",
+		Prompt:       "[fanout base-types of plan:launch-plan] launch-plan-base-types: t. read /tmp/x.md and begin.",
+	}
+	st := state.Store{Panes: []state.Pane{plan}}
+
+	id, err := IdentifyPane("%5", "", st)
+	if err != nil {
+		t.Fatalf("IdentifyPane: %v", err)
+	}
+	if id.TaskID != "base-types" {
+		t.Errorf("Identity.TaskID = %q, want base-types", id.TaskID)
+	}
+	if id.Parent != "plan:launch-plan" {
+		t.Errorf("Identity.Parent = %q, want plan:launch-plan", id.Parent)
+	}
+	want := TaskPeerNum("plan:launch-plan", "base-types")
+	if id.Issue != want {
+		t.Errorf("Identity.Issue = %d, want synthetic %d", id.Issue, want)
+	}
+	if id.Issue == 0 {
+		t.Error("Identity.Issue is 0; a plan pane must self-detect a non-zero peer number")
+	}
+}
+
 func TestDetectWithStatePathOverride(t *testing.T) {
 	// A bare temp dir is not a git work tree, so detection rests on
 	// TMUX_PANE + FANOUT_STATE_PATH alone regardless of where tests run.

--- a/internal/team/registry.go
+++ b/internal/team/registry.go
@@ -8,21 +8,51 @@ import (
 )
 
 // UpsertPeer records pane p in the peers registry, replacing any existing row
-// for the same issue. A conflict means the issue was fanned out again after a
-// --close (the /tmp DB outlives .fanout/state.json), so the row is rewritten
-// as the new pane's identity: joined_at moves to now and last_seen resets to
-// NULL so a dead pane's activity never shows as recent. now is the caller's
-// timestamp (team.Now()) so tests stay deterministic.
+// for the same peer number. A conflict means the pane was fanned out again
+// after a --close (the /tmp DB outlives .fanout/state.json), so the row is
+// rewritten as the new pane's identity: joined_at moves to now and last_seen
+// resets to NULL so a dead pane's activity never shows as recent. now is the
+// caller's timestamp (team.Now()) so tests stay deterministic. Issue panes key
+// on their issue number; issue-less plan-task panes key on the synthetic
+// TaskPeerNum and carry their task id in the task_id column.
 func UpsertPeer(db *sql.DB, p state.Pane, now string) error {
-	_, err := db.Exec(`INSERT INTO peers (issue, pane_id, slug, worktree_path, agent, display_name, joined_at)
-VALUES (?, ?, ?, ?, ?, ?, ?)
+	_, err := db.Exec(`INSERT INTO peers (issue, pane_id, slug, worktree_path, agent, display_name, joined_at, task_id)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 ON CONFLICT(issue) DO UPDATE SET
   pane_id=excluded.pane_id, slug=excluded.slug, worktree_path=excluded.worktree_path,
   agent=excluded.agent, display_name=excluded.display_name,
-  joined_at=excluded.joined_at, last_seen=NULL`,
-		p.IssueNum, p.PaneID, p.Slug, p.WorktreePath, p.Agent, p.DisplayName, now)
+  joined_at=excluded.joined_at, last_seen=NULL, task_id=excluded.task_id`,
+		PeerNum(p), p.PaneID, p.Slug, p.WorktreePath, p.Agent, p.DisplayName, now, peerTaskIDArg(p.TaskID))
 	if err != nil {
-		return fmt.Errorf("upsert peer #%d: %w", p.IssueNum, err)
+		return fmt.Errorf("upsert peer %s: %w", peerLabel(p), err)
 	}
 	return nil
+}
+
+// PeerNum is the int key under which pane p is stored in the peers/messages
+// tables. Plan-task panes (string TaskID, IssueNum 0) map to the stable
+// synthetic TaskPeerNum; numeric issue panes use their IssueNum verbatim.
+func PeerNum(p state.Pane) int {
+	if p.TaskID != "" {
+		return TaskPeerNum(p.Parent, p.TaskID)
+	}
+	return p.IssueNum
+}
+
+// peerTaskIDArg binds the task id as NULL for numeric issue panes (no task id)
+// and as the task id string for plan-task panes.
+func peerTaskIDArg(taskID string) any {
+	if taskID == "" {
+		return nil
+	}
+	return taskID
+}
+
+// peerLabel is the human label for a pane in registry error messages: the task
+// id for plan-task panes, "#<issue>" for numeric issue panes.
+func peerLabel(p state.Pane) string {
+	if p.TaskID != "" {
+		return p.TaskID
+	}
+	return fmt.Sprintf("#%d", p.IssueNum)
 }

--- a/internal/team/registry_test.go
+++ b/internal/team/registry_test.go
@@ -70,3 +70,42 @@ func TestUpsertPeerInsertsAndRewritesOnConflict(t *testing.T) {
 		t.Errorf("last_seen = %q, want NULL after the conflict rewrite", lastSeen.String)
 	}
 }
+
+func TestUpsertPeerKeysPlanTaskBySyntheticNumber(t *testing.T) {
+	db, _ := openTestDB(t)
+	if err := EnsureSchema(db); err != nil {
+		t.Fatalf("EnsureSchema: %v", err)
+	}
+
+	pane := state.Pane{
+		Parent:       "plan:launch-plan",
+		IssueNum:     0,
+		TaskID:       "base-types",
+		PaneID:       "%5",
+		Slug:         "launch-plan-base-types",
+		WorktreePath: "/repo/.fanout/worktrees/launch-plan-base-types",
+		Agent:        "claude",
+		DisplayName:  "Base types",
+	}
+	if err := UpsertPeer(db, pane, "2026-06-13T01:00:00Z"); err != nil {
+		t.Fatalf("UpsertPeer plan task: %v", err)
+	}
+
+	wantNum := TaskPeerNum(pane.Parent, pane.TaskID)
+	if wantNum >= 0 {
+		t.Fatalf("synthetic peer number = %d, want negative", wantNum)
+	}
+	var (
+		issue  int
+		taskID sql.NullString
+	)
+	if err := db.QueryRow("SELECT issue, task_id FROM peers WHERE issue = ?", wantNum).Scan(&issue, &taskID); err != nil {
+		t.Fatalf("select plan peer: %v", err)
+	}
+	if issue != wantNum {
+		t.Errorf("peer issue = %d, want synthetic %d", issue, wantNum)
+	}
+	if !taskID.Valid || taskID.String != "base-types" {
+		t.Errorf("peer task_id = %v, want base-types", taskID)
+	}
+}

--- a/internal/team/taskid.go
+++ b/internal/team/taskid.go
@@ -1,0 +1,37 @@
+package team
+
+import (
+	"hash/fnv"
+	"strings"
+)
+
+// planParentPrefix marks a parent ref scoped to an issue-less `fanout plan`
+// run (cmd/fanout planParentRef builds "plan:<slug>"). Plan tasks are
+// identified by a string task id, not a numeric issue, so the messaging layer
+// — which is keyed by int — addresses them through a stable synthetic number
+// derived from the parent-scoped task id.
+const planParentPrefix = "plan:"
+
+// IsPlanParent reports whether parentRef names a `fanout plan` run.
+func IsPlanParent(parentRef string) bool {
+	return strings.HasPrefix(parentRef, planParentPrefix)
+}
+
+// TaskPeerNum maps a plan task to a stable, negative synthetic peer number so
+// it participates in the int-keyed peers/messages tables alongside numeric
+// issue panes. It is deterministic in (parentRef, taskID): the registry seed
+// (registry.go), pane self-detection (detect.go), and the
+// `fanout msg --to <task-id>` translation (cmd/fanout/msg.go) all derive the
+// same number for a given task. The value is always < 0 so it never collides
+// with the 0 "unknown" sentinel the msg layer rejects. The 63-bit fnv64a fold
+// over parent + NUL + task id makes collisions between two task ids in one
+// plan astronomically unlikely (a 31-bit fold could collide within a single
+// plan's task set, which would alias their peers/inbox rows). int is 64-bit on
+// every platform fanout targets, so a 63-bit magnitude fits without overflow.
+func TaskPeerNum(parentRef, taskID string) int {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(parentRef))
+	_, _ = h.Write([]byte{0})
+	_, _ = h.Write([]byte(taskID))
+	return -int(h.Sum64()&0x7fffffffffffffff) - 1
+}

--- a/internal/team/taskid_test.go
+++ b/internal/team/taskid_test.go
@@ -1,0 +1,42 @@
+package team
+
+import "testing"
+
+func TestTaskPeerNumIsStableNegativeAndDistinct(t *testing.T) {
+	const parent = "plan:launch-plan"
+	a := TaskPeerNum(parent, "base-types")
+	again := TaskPeerNum(parent, "base-types")
+	if a != again {
+		t.Fatalf("TaskPeerNum not deterministic: %d != %d", a, again)
+	}
+	if a >= 0 {
+		t.Fatalf("TaskPeerNum(%q, base-types) = %d, want negative", parent, a)
+	}
+	b := TaskPeerNum(parent, "api-client")
+	if a == b {
+		t.Fatalf("distinct task ids collided: both %d", a)
+	}
+	// The parent ref is part of the key, so the same task id under a different
+	// plan maps elsewhere.
+	if TaskPeerNum("plan:other", "base-types") == a {
+		t.Fatal("task id collided across plans")
+	}
+}
+
+func TestIsPlanParent(t *testing.T) {
+	for _, tc := range []struct {
+		ref  string
+		want bool
+	}{
+		{"plan:launch-plan", true},
+		{"plan:x", true},
+		{"68", false},
+		{"@manual", false},
+		{"https://github.com/users/u/projects/3", false},
+		{"", false},
+	} {
+		if got := IsPlanParent(tc.ref); got != tc.want {
+			t.Errorf("IsPlanParent(%q) = %v, want %v", tc.ref, got, tc.want)
+		}
+	}
+}

--- a/tests/bats/tier1_msg.bats
+++ b/tests/bats/tier1_msg.bats
@@ -253,6 +253,24 @@ msg_env() {
   [[ "$output" == *'"parent": "plan:launch-plan"'* ]]
 }
 
+@test "msg plan-mode inbox --json carries task ids, not synthetic numbers" {
+  msg_env
+  # Once peers are seeded (a real --team run does this at launch), inbox/board
+  # --json must surface task ids so automation can address from/to/self without
+  # reverse-engineering the synthetic hash.
+  run_fanout msg register --self db-layer --parent plan:demo
+  assert_success
+  run_fanout msg register --self api-client --parent plan:demo
+  assert_success
+  run_fanout msg send --to api-client --self db-layer --parent plan:demo "ping"
+  assert_success
+  run_fanout msg inbox --self api-client --parent plan:demo --json
+  assert_success
+  [[ "$output" == *'"selfTask": "api-client"'* ]]
+  [[ "$output" == *'"fromTask": "db-layer"'* ]]
+  [[ "$output" == *'"toTask": "api-client"'* ]]
+}
+
 @test "msg --to <all-digit task id> targets the task, not numeric peer N" {
   msg_env
   # Task id "123" is a valid plan task id. Under a plan parent it must address

--- a/tests/bats/tier1_msg.bats
+++ b/tests/bats/tier1_msg.bats
@@ -262,8 +262,12 @@ msg_env() {
   assert_success
   run_fanout msg register --self api-client --parent plan:demo
   assert_success
-  run_fanout msg send --to api-client --self db-layer --parent plan:demo "ping"
+  # The send echo itself must carry task ids (the sender does not need the
+  # registry to label its own from/to).
+  run_fanout msg send --to api-client --self db-layer --parent plan:demo --json "ping"
   assert_success
+  [[ "$output" == *'"fromTask": "db-layer"'* ]]
+  [[ "$output" == *'"toTask": "api-client"'* ]]
   run_fanout msg inbox --self api-client --parent plan:demo --json
   assert_success
   [[ "$output" == *'"selfTask": "api-client"'* ]]

--- a/tests/bats/tier1_msg.bats
+++ b/tests/bats/tier1_msg.bats
@@ -48,21 +48,32 @@ msg_env() {
   msg_env
   run_fanout msg send --to 71 hello
   [ "$status" -eq 2 ]
-  [[ "$output" == *"pass --self <issue> and --parent <ref>"* ]]
+  [[ "$output" == *"pass --self <issue|task-id> and --parent <ref>"* ]]
 }
 
 @test "msg send without --to exits 2" {
   msg_env
   run_fanout msg send --self 70 --parent 68 hello
   [ "$status" -eq 2 ]
-  [[ "$output" == *"--to <issue> is required"* ]]
+  [[ "$output" == *"--to <issue|task-id> is required"* ]]
 }
 
-@test "msg send with a non-integer --to exits 2" {
+@test "msg send with an invalid --to token exits 2" {
   msg_env
-  run_fanout msg send --to abc --self 70 --parent 68 hello
+  # Uppercase is neither an issue number nor a lowercase-kebab task id, so it is
+  # rejected at parse time.
+  run_fanout msg send --to ABC --self 70 --parent 68 hello
   [ "$status" -eq 2 ]
-  [[ "$output" == *"--to must be a non-zero issue number"* ]]
+  [[ "$output" == *"--to must be a non-zero issue number or a plan task id"* ]]
+}
+
+@test "msg send with a task-id --to under an issue parent exits 2" {
+  msg_env
+  # A valid task id is only addressable under a plan parent; issue/project peers
+  # are addressed by number.
+  run_fanout msg send --to api-client --self 70 --parent 68 hello
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"is a task id, only valid under a plan parent"* ]]
 }
 
 @test "msg send without a body exits 2" {
@@ -169,21 +180,21 @@ msg_env() {
   msg_env
   run_fanout msg nudge --parent 68
   [ "$status" -eq 2 ]
-  [[ "$output" == *"target issue <N> is required"* ]]
+  [[ "$output" == *"target <issue|task-id> is required"* ]]
 }
 
-@test "msg nudge with a non-integer target exits 2" {
+@test "msg nudge with an invalid target exits 2" {
   msg_env
-  run_fanout msg nudge abc --parent 68
+  run_fanout msg nudge ABC --parent 68
   [ "$status" -eq 2 ]
-  [[ "$output" == *"target must be a non-zero issue number"* ]]
+  [[ "$output" == *"target must be a non-zero issue number or a plan task id"* ]]
 }
 
 @test "msg nudge with a second target exits 2" {
   msg_env
   run_fanout msg nudge 71 72 --parent 68
   [ "$status" -eq 2 ]
-  [[ "$output" == *"takes exactly one target issue"* ]]
+  [[ "$output" == *"takes exactly one target"* ]]
 }
 
 @test "msg nudge rejects --to (target is positional): exit 2" {
@@ -227,6 +238,48 @@ msg_env() {
   assert_success
   [[ "$output" == *'"self": -1'* ]]
   [[ "$output" == *'"parent": "@manual"'* ]]
+}
+
+@test "msg send/inbox round-trip between plan tasks addressed by task id" {
+  msg_env
+  # Issue-less plan peers are addressed by task id under a plan:<slug> parent.
+  # Identity is explicit so the round-trip does not depend on pane detection.
+  run_fanout msg send --to api-client --self db-layer --parent plan:launch-plan "schema ready"
+  assert_success
+  [[ "$output" == *"to api-client"* ]]
+  run_fanout msg inbox --self api-client --parent plan:launch-plan --json
+  assert_success
+  [[ "$output" == *"schema ready"* ]]
+  [[ "$output" == *'"parent": "plan:launch-plan"'* ]]
+}
+
+@test "msg --to <all-digit task id> targets the task, not numeric peer N" {
+  msg_env
+  # Task id "123" is a valid plan task id. Under a plan parent it must address
+  # the task pane (registered/self-detected as a synthetic number), NOT numeric
+  # peer 123. The "123" pane auto-detects its own self from state.json; a sender
+  # using --to 123 must reach it.
+  printf '%s\n' '{"schemaVersion":1,"panes":[{"parent":"plan:demo","issueNum":0,"taskId":"123","slug":"demo-123","branchName":"b","paneId":"%1","agent":"claude","displayName":"d","worktreePath":"","prompt":"[fanout 123 of plan:demo] demo-123: t"}]}' \
+    > "$BATS_TEST_TMPDIR/state.json"
+  export FANOUT_STATE_PATH="$BATS_TEST_TMPDIR/state.json"
+  run_fanout msg send --to 123 --self db-layer --parent plan:demo "for task 123"
+  assert_success
+  [[ "$output" == *"to 123"* ]]
+  run_fanout msg inbox --json
+  assert_success
+  [[ "$output" == *"for task 123"* ]]
+}
+
+@test "msg auto-detects a plan task pane (parent plan:<slug>)" {
+  msg_env
+  # A recorded plan row (issueNum 0 + taskId) must self-detect from the pane id
+  # and scope messages to the plan parent.
+  printf '%s\n' '{"schemaVersion":1,"panes":[{"parent":"plan:launch-plan","issueNum":0,"taskId":"api-client","slug":"launch-plan-api-client","branchName":"b","paneId":"%1","agent":"claude","displayName":"API","worktreePath":"","prompt":"[fanout api-client of plan:launch-plan] launch-plan-api-client: t"}]}' \
+    > "$BATS_TEST_TMPDIR/state.json"
+  export FANOUT_STATE_PATH="$BATS_TEST_TMPDIR/state.json"
+  run_fanout msg inbox --json
+  assert_success
+  [[ "$output" == *'"parent": "plan:launch-plan"'* ]]
 }
 
 @test "msg rejects a DB already holding another parent's messages: exit 4" {

--- a/tests/bats/tier2_dry_run.bats
+++ b/tests/bats/tier2_dry_run.bats
@@ -198,6 +198,18 @@ load helpers
   assert_golden scenario-plan-basic-agent-override
 }
 
+@test "--team variant of scenario-plan-basic: task briefings grow and registry seed is printed" {
+  # --team adds the sibling-coordination section (addressed by task id) to every
+  # task briefing (size lines diverge from scenario-plan-basic.dry-run.txt) and
+  # prints the would-seed line after the summary; without --team the plan
+  # goldens stay byte-identical.
+  skip_unless_fanout_go
+  use_fixture scenario-plan-basic
+  run_fanout_plan_dry "$FIXTURE_DIR/plan.json" --team
+  assert_success
+  assert_golden scenario-plan-basic-team
+}
+
 @test "scenario-plan-idempotency: seeded taskId rows are skipped" {
   use_fixture scenario-plan-idempotency
   run_fanout_plan_dry "$FIXTURE_DIR/plan.json"

--- a/tests/golden/msg-register-bare.dry-run.txt
+++ b/tests/golden/msg-register-bare.dry-run.txt
@@ -1,1 +1,1 @@
-# would UPSERT INTO peers(issue, pane_id, slug, worktree_path, agent, display_name, joined_at, last_seen) VALUES (70, '', '', '', '', '', '2026-06-13T00:00:00Z', '2026-06-13T00:00:00Z')
+# would UPSERT INTO peers(issue, pane_id, slug, worktree_path, agent, display_name, joined_at, last_seen, task_id) VALUES (70, '', '', '', '', '', '2026-06-13T00:00:00Z', '2026-06-13T00:00:00Z', NULL)

--- a/tests/golden/scenario-plan-basic-team.dry-run.txt
+++ b/tests/golden/scenario-plan-basic-team.dry-run.txt
@@ -1,0 +1,44 @@
+[info] tmux session: fanout-fixture
+[info] tmux target:  %1
+[info] project root: <REPO>/tests/fixtures/scenario-plan-basic/project_root
+[info] plan launch-plan: 2 task(s)
+[info] will create 2 pane(s); deferred (blocked): 0; deferred (--limit): 0
+[info] base-types: Define base types
+  briefing -> /tmp/fanout-project_root-launch%2Dplan-base%2Dtypes.md
+  slug -> launch-plan-define-base-types-base-types
+  worktree -> <REPO>/tests/fixtures/scenario-plan-basic/project_root/.fanout/worktrees/launch-plan-define-base-types-base-types
+  branch -> fanout/launch-plan-define-base-types-base-types
+  base -> main
+  briefing size: 6147 bytes
+    $ git -C <REPO>/tests/fixtures/scenario-plan-basic/project_root fetch --quiet --no-tags origin main
+    # may fast-forward the local base before worktree creation
+    $ git -C <REPO>/tests/fixtures/scenario-plan-basic/project_root branch -f main refs/remotes/origin/main
+    # if the base is checked out elsewhere, fanout uses merge --ff-only in that worktree
+    $ git -C <REPO>/tests/fixtures/scenario-plan-basic/project_root worktree add -b fanout/launch-plan-define-base-types-base-types <REPO>/tests/fixtures/scenario-plan-basic/project_root/.fanout/worktrees/launch-plan-define-base-types-base-types main
+    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-plan-basic/project_root/.fanout/worktrees/launch-plan-define-base-types-base-types 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout base-types of plan:launch-plan] launch-plan-define-base-types-base-types: Define base types. read /tmp/fanout-project_root-launch%2Dplan-base%2Dtypes.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
+    $ tmux select-pane -t <pane_id> -T launch-plan-define-base-types-base-types
+    $ tmux select-layout -t '%1' tiled
+    # would write .fanout/state.json with paneId <pane_id>
+    # would write .fanout/worktree-metadata.json in the child worktree
+[ ok ] base-types: dry-run complete
+[info] api-client: Extract API client
+  briefing -> /tmp/fanout-project_root-launch%2Dplan-api%2Dclient.md
+  slug -> launch-plan-extract-api-client-api-client
+  worktree -> <REPO>/tests/fixtures/scenario-plan-basic/project_root/.fanout/worktrees/launch-plan-extract-api-client-api-client
+  branch -> fanout/launch-plan-extract-api-client-api-client
+  base -> main
+  briefing size: 6149 bytes
+    $ git -C <REPO>/tests/fixtures/scenario-plan-basic/project_root fetch --quiet --no-tags origin main
+    # may fast-forward the local base before worktree creation
+    $ git -C <REPO>/tests/fixtures/scenario-plan-basic/project_root branch -f main refs/remotes/origin/main
+    # if the base is checked out elsewhere, fanout uses merge --ff-only in that worktree
+    $ git -C <REPO>/tests/fixtures/scenario-plan-basic/project_root worktree add -b fanout/launch-plan-extract-api-client-api-client <REPO>/tests/fixtures/scenario-plan-basic/project_root/.fanout/worktrees/launch-plan-extract-api-client-api-client main
+    $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-plan-basic/project_root/.fanout/worktrees/launch-plan-extract-api-client-api-client 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout api-client of plan:launch-plan] launch-plan-extract-api-client-api-client: Extract API client. read /tmp/fanout-project_root-launch%2Dplan-api%2Dclient.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
+    $ tmux select-pane -t <pane_id> -T launch-plan-extract-api-client-api-client
+    $ tmux select-layout -t '%1' tiled
+    # would write .fanout/state.json with paneId <pane_id>
+    # would write .fanout/worktree-metadata.json in the child worktree
+[ ok ] api-client: dry-run complete
+
+[ ok ] created: 2
+# would seed team registry: 2 peer(s) -> /tmp/fanout-project_root-plan-launch-plan.db


### PR DESCRIPTION
## TL;DR
`fanout plan --team` now wires the same sibling-pane peer messaging the issue/project lanes use into the issue-less plan lane, addressing peers by **task id** (`fanout msg send --to <task-id>`). Also fixes the skill confusion that motivated this: `fanout-plan` previously listed `--team` as a forbidden flag without saying whether `fanout msg` worked in plan mode at all.

Review effort: 4

## Why
A user tried `fanout plan` + `fanout msg` for parallel implementation; the agent saw `--team` listed as "do not forward" in the fanout-plan skill and couldn't tell whether `fanout msg` worked in plan mode, so it went spelunking in the source. Investigation confirmed the gap was real: plan mode never seeded the peer registry, the task briefing had no coordination section, and `fanout msg` write verbs were rejected (`issueNum:0`). The decision was to make it genuinely usable, not just document the limitation.

## Design
Peer messaging is keyed by numeric issue number throughout (`peers.issue INTEGER PRIMARY KEY`, `messages.from/to_issue INTEGER`, `--self/--to` numeric). Plan tasks are `taskId` (string) + `issueNum:0`. Rather than refactor the whole identity model to strings (which would churn every `--json` golden and risk the shipped issue-mode feature), a plan task maps to a **stable negative synthetic peer number** (`team.TaskPeerNum`, a 63-bit fnv64a fold of `parent + taskId`) so it rides the existing int-keyed schema unchanged. The synthetic number is never user-facing — agents always see/use the task id. The plan DB is a separate `/tmp/fanout-<repo>-plan-<slug>.db` file, so issue DBs are untouched.

## Changes by file
<details><summary>Changed files</summary>

| File | What changed | Why |
| --- | --- | --- |
| `internal/team/taskid.go` (new) | `TaskPeerNum` (63-bit synthetic key) + `IsPlanParent` | single source of truth for task-id↔number mapping |
| `internal/team/db.go` | nullable `peers.task_id` column, schema v2, idempotent additive migration | display task ids; v1 DBs migrate forward, issue DBs unaffected |
| `internal/team/registry.go` | `UpsertPeer` keys plan panes by synthetic number, writes `task_id` | seed plan task panes |
| `internal/team/detect.go` | `Identity.TaskID`; `paneIdentity` synthesizes the peer number for plan rows | a plan pane self-detects a non-zero, addressable self |
| `internal/msgstore/store.go` | additive `Peer.TaskID` (json `omitempty`) through `Register`/`Peers`/`scanPeer` | display; int schema/API unchanged |
| `cmd/fanout/msg.go` | accept task id at `--self`/`--to`/nudge; resolve int-vs-task-id against the parent (`resolveMemberNum`); task-id-aware display/nudge | the feature surface; all-digit task ids route correctly |
| `cmd/fanout/plancmd.go` | `--team` flag, status/lifecycle exclusivity, teamCtx wiring + post-launch seed | plan `--team` entrypoint |
| `cmd/fanout/team.go` | `buildTaskTeamContext` + `seedTaskTeamRegistry` (plan variants) | briefing roster + registry seed |
| `cmd/fanout/pane.go` | thread teamCtx into `briefing.RenderTask` | inject the coordination section |
| `internal/briefing/briefing.go` | `RenderTask` team param + task-id `taskTeamSection` (issue `teamSection` byte-identical) | task-id-keyed roster/cheatsheet |
| `claude\|codex/skills/fanout-plan/SKILL.md`, `.../fanout/SKILL.md` | remove `--team` from the forbidden list, add a Sibling-coordination (plan mode) section | resolve the agent confusion at the source |
| `README.md`, `README.ja.md` | plan `--team` + task-id addressing | docs/README parity |
| `tests/**`, `tests/golden/**` | unit + bats + Tier2 golden (`scenario-plan-basic-team`); `msg-register-bare` golden mirrors the new `task_id` column | coverage; additive proof |

</details>

## Risk
> [!WARNING]
> An all-digit token (e.g. `--to 123`) is ambiguous (valid issue number *and* valid task id). It is resolved by the parent in `resolveMemberNum`: a task id under a plan parent, an issue number otherwise — covered by a unit test and an end-to-end bats round-trip.

## Test plan
- `make test` — Go unit + web (101/101) + bats (Tier1/Tier2, incl. new plan `--team` golden and plan `fanout msg` round-trips) — green.
- `make lint` — golangci-lint v2 + shellcheck — 0 issues.
- Post-work-review: `code-review` (3 display-consistency fixes) + `codex review` ×2 → clean. codex's two findings (all-digit task-id misrouting; 31-bit hash collision) fixed and verified.

```mermaid
flowchart TD
    A["fanout msg --to TOKEN"] --> B{"parseMemberToken<br/>int OR task-id shape"}
    B --> C["resolveMsgIdentity<br/>(parent known)"]
    C --> D{"resolveMemberNum:<br/>IsPlanParent(parent)?"}
    D -- "plan:&lt;slug&gt;" --> E["TaskPeerNum(parent, raw)<br/>negative synthetic key"]
    D -- "issue/Project" --> F["issue number (int)"]
    E --> G["peers / messages<br/>(int-keyed schema)"]
    F --> G
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
