### PR TITLE
docs(site): publish fanout plan --team + add v0.6.0 changelog

### DIFF
--- a/site/content/docs/changelog.ja.md
+++ b/site/content/docs/changelog.ja.md
@@ -9,6 +9,12 @@ yomi: changelog
 
 リリースのハイライトを新しい順に並べています。各タグには完全なコミット一覧とビルド済みバイナリ（darwin / linux × amd64 / arm64）を含む [GitHub release](https://github.com/butaosuinu/fanout/releases) があります。バージョンは git タグから ldflags 経由で埋め込まれます — `fanout --check-update` で自分の版を確認できます。
 
+## v0.6.0 — 2026-06-15
+
+- **issue-less plan の peer messaging（`fanout plan --team`）。** plan レーンが `--team` に対応し、issue / Project レーンと同じ兄弟ペイン協調を `fanout plan` に組み込みました。issue-less な plan task には GitHub issue 番号が無いため、peer は **task id** で指定します —— `fanout msg send --to <task-id>`、`fanout msg peers` が現在の task id 一覧を表示します。plan のバスは `/tmp/fanout-<repo>-plan-<slug>.db` に置かれます。[Workflow]({{< relref "/docs/workflow" >}}) を参照。
+
+[リリースノート →](https://github.com/butaosuinu/fanout/releases/tag/v0.6.0)
+
 ## v0.5.0 — 2026-06-14
 
 - **Per-target agent overrides（ターゲット別 agent 上書き）。** 素の `--agent <name>` は引き続き全ての子の既定を設定しますが、繰り返し可能な `--agent <NUM>=<name>`（issue / Project の子）や `--agent <task-id>=<name>`（`fanout plan`）で 1 回の run の中に agent を混在させられるようになりました。各ターゲットはまず一致する上書き、次に global `--agent`、最後に `FANOUT_AGENT` の順に解決し、検証は実際に選択された agent のみに行います。[CLI Reference]({{< relref "/docs/cli" >}}) を参照。

--- a/site/content/docs/changelog.md
+++ b/site/content/docs/changelog.md
@@ -9,6 +9,12 @@ yomi: changelog
 
 Release highlights, newest first. Every tag also has a [GitHub release](https://github.com/butaosuinu/fanout/releases) with the full commit list and prebuilt binaries (darwin / linux × amd64 / arm64). Versions come from git tags via ldflags — check yours with `fanout --check-update`.
 
+## v0.6.0 — 2026-06-15
+
+- **Peer messaging for issue-less plans (`fanout plan --team`).** The plan lane now accepts `--team`, wiring the same sibling-pane coordination the issue / Project lanes use into `fanout plan`. Issue-less plan tasks have no GitHub issue number, so peers are addressed by **task id** — `fanout msg send --to <task-id>`, and `fanout msg peers` lists the live task ids. The plan bus lives at `/tmp/fanout-<repo>-plan-<slug>.db`. See [Workflow]({{< relref "/docs/workflow" >}}).
+
+[Release notes →](https://github.com/butaosuinu/fanout/releases/tag/v0.6.0)
+
 ## v0.5.0 — 2026-06-14
 
 - **Per-target agent overrides.** A bare `--agent <name>` still sets the default for every child, but you can now mix agents in one run with the repeatable `--agent <NUM>=<name>` form (issue / Project children) or `--agent <task-id>=<name>` (`fanout plan`). Each target resolves a matching override first, then the global `--agent`, then `FANOUT_AGENT`; only the agents actually selected are validated. See [CLI Reference]({{< relref "/docs/cli" >}}).

--- a/site/content/docs/cli.ja.md
+++ b/site/content/docs/cli.ja.md
@@ -26,8 +26,9 @@ fanout <parent-issue|project-url>
        [--team]
 fanout plan <spec.json|plan-slug> [--agent <name|task-id=name>] [--dry-run]
        [--limit <N>] [--only <task-id[,id...]>] [--skip <task-id[,id...]>]
-       [--unblocked-only] [--base-branch <branch>] [--branch-prefix <prefix>]
-       [--no-refresh] [--session <tmux-session>] [--sleep <seconds>]
+       [--unblocked-only] [--team] [--base-branch <branch>]
+       [--branch-prefix <prefix>] [--no-refresh] [--session <tmux-session>]
+       [--sleep <seconds>]
 fanout plan <spec.json|plan-slug> --status [--format json|table]
 fanout plan <spec.json|plan-slug> --merge <task-id>
 fanout plan <spec.json|plan-slug> --close <task-id>
@@ -153,6 +154,7 @@ spec フォーマット:
 | `--base-branch` | `<branch>` | `plan.base_branch` を上書きする。どちらも無い場合は repository default branch を解決する。 |
 | `--branch-prefix` | `<prefix>` | 生成 task branch 名の prefix。 |
 | `--no-refresh` | — | task worktree 作成前の base branch refresh をスキップする。 |
+| `--team` | — | その plan run を兄弟協調に opt-in する。issue モードと同じだが、peer は issue 番号ではなく **task ID** で指定する（issue-less な plan task には `#N` が無い）。plan の per-parent peer レジストリに seed し、各 task briefing に roster 節を付ける。plan のバスは `/tmp/fanout-<repo>-plan-<slug>.db`。plan の read / lifecycle モード（`--status` / `--close` / `--merge` / `--cleanup`）とは併用不可。既定: off。 |
 
 `--agent` は issue モードと同じ働きですが、per-target 上書きは issue 番号ではなく task ID をキーにします。`--agent <name>` が既定を設定し、繰り返し可能な `--agent <task-id>=<name>` 形式が task 1 件を上書きします。各 task はまず一致する上書き、次に global `--agent`、最後に `FANOUT_AGENT` の順に解決します。
 
@@ -289,6 +291,8 @@ parent ごとの SQLite メッセージバス上での兄弟協調です。fanou
 | `nudge` | `<N>` —— best-effort: peer `#N` の agent が running のときだけ、tmux 経由でそのペインに inbox の hint を送る。メッセージではなく通知専用 verb で、DB は触らない。対象の agent が running でない（ペイン消失 / 状態不明 / done）ときは何もせず success（no-op）。 |
 
 verb 共通のオプション: `--json`（機械可読出力）、`--self <N>` と `--parent <ref>`（ペイン検出を上書き）、`--dry-run`（write / notify verb のみ —— `# would ...` の書き込み内容を表示し何も触らない。`--json` とは併用不可）。
+
+[`fanout plan --team`](#plan-fan-out-issue-less) の run では、peer は issue 番号ではなく **task ID** で指定します: `send --to <task-id>`、`peers` は現在の task ID 一覧を表示します。plan モードのペインの `--json` 出力には `selfTask` / `fromTask` / `toTask` フィールドが付き、合成 peer 番号から task ID を解決できます。issue / Project の JSON は変わりません。
 
 データベースは `/tmp/fanout-<repo>-<parent>.db` に置かれ、`FANOUT_DB_PATH` で上書きできます。協調は **pull ベース**です: メッセージは DB に永続し、兄弟は自分のチェックポイントで読みます —— `fanout msg` は忙しいペインに割り込みません。pure-Go の SQLite ドライバが同梱されているため、外部 `sqlite3` は不要です。
 

--- a/site/content/docs/cli.md
+++ b/site/content/docs/cli.md
@@ -26,8 +26,9 @@ fanout <parent-issue|project-url>
        [--team]
 fanout plan <spec.json|plan-slug> [--agent <name|task-id=name>] [--dry-run]
        [--limit <N>] [--only <task-id[,id...]>] [--skip <task-id[,id...]>]
-       [--unblocked-only] [--base-branch <branch>] [--branch-prefix <prefix>]
-       [--no-refresh] [--session <tmux-session>] [--sleep <seconds>]
+       [--unblocked-only] [--team] [--base-branch <branch>]
+       [--branch-prefix <prefix>] [--no-refresh] [--session <tmux-session>]
+       [--sleep <seconds>]
 fanout plan <spec.json|plan-slug> --status [--format json|table]
 fanout plan <spec.json|plan-slug> --merge <task-id>
 fanout plan <spec.json|plan-slug> --close <task-id>
@@ -153,6 +154,7 @@ generated branches use `fanout/<slug>` unless the task supplies `branch`.
 | `--base-branch` | `<branch>` | Override `plan.base_branch`; if neither is set, fanout resolves the repository default branch. |
 | `--branch-prefix` | `<prefix>` | Prefix generated task branch names. |
 | `--no-refresh` | — | Skip base-branch refresh before creating task worktrees. |
+| `--team` | — | Opt the plan run into sibling coordination, exactly like issue mode — except peers are addressed by **task ID** (issue-less plan tasks have no `#N`). Seeds the plan's per-parent peer registry and appends the roster section to each task briefing. The plan bus lives at `/tmp/fanout-<repo>-plan-<slug>.db`. Not combinable with the plan read/lifecycle modes (`--status` / `--close` / `--merge` / `--cleanup`). Off by default. |
 
 `--agent` works the same way as in issue mode, but per-target overrides are keyed by task ID instead of issue number: `--agent <name>` sets the default and the repeatable `--agent <task-id>=<name>` form overrides a single task. Each task resolves a matching override first, then the global `--agent`, then `FANOUT_AGENT`.
 
@@ -290,6 +292,8 @@ Sibling coordination over a per-parent SQLite message bus. Run from inside a fan
 | `nudge` | `<N>` — best-effort: drop an inbox hint into peer `#N`'s pane via tmux only when its agent is running. A notify verb, not a message: it never touches the DB and is a no-op success when the peer's agent is not running (pane gone, state unknown, or done). |
 
 Common options across verbs: `--json` (machine-readable output), `--self <N>` and `--parent <ref>` (override pane detection), and `--dry-run` (write/notify verbs only — prints the `# would ...` writes and touches nothing; not combinable with `--json`).
+
+Under a [`fanout plan --team`](#plan-fan-out-issue-less) run, peers are addressed by **task ID** rather than issue number: `send --to <task-id>`, and `peers` lists the live task IDs. The `--json` output of plan-mode panes adds `selfTask` / `fromTask` / `toTask` fields so automation can resolve task IDs from the synthetic peer numbers; issue / Project JSON is unchanged.
 
 The database lives at `/tmp/fanout-<repo>-<parent>.db` and is overridable with `FANOUT_DB_PATH`. Coordination is **pull-based**: messages persist in the DB and a sibling reads them at its own checkpoints — `fanout msg` does not interrupt a busy pane. The pure-Go SQLite driver is embedded, so no external `sqlite3` is required.
 

--- a/site/content/docs/workflow.ja.md
+++ b/site/content/docs/workflow.ja.md
@@ -130,6 +130,14 @@ fanout したペイン内では、`fanout msg` が自分が今どの子（また
 運びます。協調は pull ベース — 自分から要求しない限り、何かがペインを
 つつくことはありません。
 
+plan レーンも `--team` に対応します（`fanout plan <spec> --team`）。動作は同じ
+ですが、issue-less な plan task には `#N` が無いため、peer は **task id** で
+指定します: `fanout msg send --to <task-id> "<body>"` で兄弟 task に送り、
+`fanout msg peers` が現在の task id 一覧を表示します。plan のバスは
+`/tmp/fanout-<repo>-plan-<slug>.db` に置かれ、`--team` は plan の
+read / lifecycle モード（`--status` / `--close` / `--merge` / `--cleanup`）とは
+併用できません。
+
 | verb | 効果 |
 |---|---|
 | `peers` | この親で把握している兄弟ペインを一覧する。 |

--- a/site/content/docs/workflow.md
+++ b/site/content/docs/workflow.md
@@ -132,6 +132,13 @@ carries a shared `board` (broadcast to everyone) plus `1:1` messages addressed
 with `--to <issue>`. Coordination is pull-based — nothing nudges a pane unless
 you ask it to.
 
+The plan lane supports `--team` too (`fanout plan <spec> --team`). It behaves
+identically, except issue-less plan tasks have no `#N`, so peers are addressed
+by **task id**: `fanout msg send --to <task-id> "<body>"` messages a sibling
+task and `fanout msg peers` lists the live task ids. The plan bus lives at
+`/tmp/fanout-<repo>-plan-<slug>.db`, and `--team` is not combinable with the
+plan read/lifecycle modes (`--status` / `--close` / `--merge` / `--cleanup`).
+
 | Verb | Effect |
 |---|---|
 | `peers` | List the sibling panes known for this parent. |


### PR DESCRIPTION
## What

Mirror the one user-facing feature that landed on `main` since **v0.5.0** onto the Hugo docs site (en/ja). #275 (`fanout plan --team`) updated `README.md` / `README.ja.md` and the bundled skills, but the docs site was not touched.

Since v0.5.0 (#273), `main` has exactly two commits: #274 (the v0.5.0 docs/changelog sync) and **#275** — so #275 is the only site-undocumented feature.

## Changes (docs-only, en + ja)

- **CLI Reference** (`cli.{md,ja.md}`)
  - Add `[--team]` to the `fanout plan` synopsis (matching the README #275 re-wrap).
  - Add a `--team` row to the plan run-control flags table: peers addressed by **task id**, plan bus at `/tmp/fanout-<repo>-plan-<slug>.db`, not combinable with the plan read/lifecycle modes (`--status` / `--close` / `--merge` / `--cleanup`).
  - Add a `fanout msg` note: under `fanout plan --team`, peers are addressed by task id (`--to <task-id>`, `peers` lists task ids); plan-mode `--json` adds `selfTask` / `fromTask` / `toTask`.
- **Workflow** (`workflow.{md,ja.md}`): a peer-messaging paragraph for `fanout plan --team`.
- **Changelog** (`changelog.{md,ja.md}`): new `v0.6.0 — 2026-06-15` entry.

## Verification

- `hugo --minify --gc -s site` builds clean (Hugo extended v0.163.0, same as `pages.yml`).
- Confirmed in generated HTML: the `#plan-fan-out-issue-less` and `#fanout-msg` anchors resolve (en + ja), and the v0.6.0 changelog entry renders in both languages.
- No code touched — README #275 already covers the same surface; this only brings the site to parity.

## Release note

This is the docs half of the **v0.6.0** release. After merge, the `vX.Y.Z` tag (`v0.6.0`) is cut per `RELEASE.md` (tag push is not gated). Merging also auto-deploys the docs via `pages.yml` (`site/**` on `main`).

> PR review gate: docs-only / no code change, so the documented `FANOUT_SKIP_PR_REVIEW=1` escape hatch was used. Content was verified against README #275 and a clean Hugo build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)