### PR TITLE
feat(site): Pagefind static search for the docs site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -26,6 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       HUGO_VERSION: 0.163.0
+      PAGEFIND_VERSION: 1.5.2
     steps:
       - uses: actions/checkout@v4
       - name: Install Hugo CLI
@@ -40,6 +41,10 @@ jobs:
         env:
           HUGO_ENVIRONMENT: production
         run: hugo --minify --gc -s site --baseURL "${{ steps.pages.outputs.base_url || 'https://butaosuinu.github.io/fanout' }}/"
+      - name: Index with Pagefind
+        run: |
+          curl -fsSL "https://github.com/Pagefind/pagefind/releases/download/v${PAGEFIND_VERSION}/pagefind_extended-v${PAGEFIND_VERSION}-x86_64-unknown-linux-musl.tar.gz" | tar -xz
+          ./pagefind_extended --site site/public
       - name: Upload artifact
         if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@v3

--- a/site/README.md
+++ b/site/README.md
@@ -1,0 +1,33 @@
+# fanout docs site
+
+Hugo (Extended) site published to <https://butaosuinu.github.io/fanout/>.
+Custom theme **PAPER BREEZE** (no external theme/module); bilingual via
+`*.md` (en) / `*.ja.md` (ja). Deployed by `.github/workflows/pages.yml`.
+
+## Local preview
+
+```bash
+hugo server -s site
+```
+
+## Search (Pagefind)
+
+Search is powered by [Pagefind](https://pagefind.app/) — a fully static,
+build-time index (no external service). The `pages.yml` workflow downloads the
+`pagefind_extended` binary (extended = CJK/Japanese segmentation) and runs it
+against `site/public` after the Hugo build, emitting `site/public/pagefind/`
+(git-ignored; never committed).
+
+A plain `hugo server` does **not** generate that index, so the search modal
+opens but returns nothing. To preview search locally, build to disk and let
+Pagefind serve it. Override the production `baseURL` (`/fanout/` in `hugo.toml`)
+with `/` so assets resolve at Pagefind's server root instead of 404-ing:
+
+```bash
+hugo --gc -s site --baseURL / && npx -y pagefind --site site/public --serve
+```
+
+The UI is Pagefind's default `PagefindUI`, themed via CSS variables in
+`assets/css/main.css`, mounted in a `⌘K` / `/` modal (`layouts/_partials/search.html`,
+triggered from `layouts/_partials/nav.html`). Indexing is scoped to docs bodies
+via `data-pagefind-body` on `<article class="docs-main">`.

--- a/site/assets/css/main.css
+++ b/site/assets/css/main.css
@@ -806,6 +806,85 @@ code.in{
 }
 
 /* ============================================================
+   検索(Pagefind モーダル)
+   ============================================================ */
+/* ナビのトリガー — GitHub ピル・言語スイッチャーと同じ佇まい */
+.nav-search{
+  display:inline-flex; align-items:center; gap:8px;
+  border:1px solid var(--suna); border-radius:999px;
+  padding:7px 14px; font-size:13px; font-weight:500;
+  font-family:inherit; color:var(--ai); background:var(--paper);
+  cursor:pointer;
+  transition:border-color .25s ease, color .25s ease, transform .25s ease;
+}
+.nav-search:hover{ border-color:var(--asagi); color:var(--asagi); transform:translateY(-1px); }
+.nav-search svg{ display:block; }
+.nav-search-hint{
+  font-family:var(--f-code); font-size:11px; line-height:1;
+  color:var(--ink-60);
+  border:1px solid var(--suna); border-radius:5px;
+  padding:2px 5px; background:var(--washi);
+}
+
+/* オーバーレイ + パネル */
+.search-modal{
+  position:fixed; inset:0; z-index:90;
+  display:flex; justify-content:center; align-items:flex-start;
+  padding:84px 20px 20px;
+  background:rgba(42,46,51,.34);
+  -webkit-backdrop-filter:blur(3px); backdrop-filter:blur(3px);
+  animation:searchFade .2s ease both;
+}
+.search-modal[hidden]{ display:none; }
+html.search-open{ overflow:hidden; }
+@keyframes searchFade{ from{ opacity:0; } }
+
+.search-panel{
+  position:relative;
+  width:min(620px, 100%);
+  max-height:calc(100vh - 120px);
+  overflow:auto;
+  background:var(--paper);
+  border:1px solid var(--suna); border-radius:14px;
+  box-shadow:0 24px 60px -24px rgba(42,46,51,.42);
+  padding:18px 18px 8px;
+  animation:riseIn .34s var(--ease-fan) both;
+}
+.search-close{
+  position:absolute; top:10px; right:12px; z-index:1;
+  width:30px; height:30px; line-height:1;
+  font-size:22px; color:var(--ink-60);
+  background:none; border:none; border-radius:8px; cursor:pointer;
+  transition:color .2s ease, background .2s ease;
+}
+.search-close:hover{ color:var(--ai); background:var(--washi); }
+
+/* Pagefind 既定 UI を PAPER BREEZE に寄せる(.search-panel スコープで既定値より優先) */
+.search-panel .pagefind-ui{
+  --pagefind-ui-primary:var(--ai);
+  --pagefind-ui-text:var(--sumi);
+  --pagefind-ui-background:var(--paper);
+  --pagefind-ui-border:var(--suna);
+  --pagefind-ui-tag:var(--washi);
+  --pagefind-ui-border-width:1px;
+  --pagefind-ui-border-radius:10px;
+  --pagefind-ui-font:var(--f-body);
+}
+.search-panel .pagefind-ui__result-title a{ color:var(--ai); }
+.search-panel .pagefind-ui__result-title a:hover{ color:var(--asagi); }
+
+/* EN keeps all five text links until 820px; collapse the search pill to an
+   icon well before then so the added control never overflows the nav (which
+   the body's overflow-x:hidden would otherwise clip) at tablet/small-laptop widths. */
+@media (max-width:1080px){
+  .nav-search{ padding:7px 10px; gap:6px; }
+  .nav-search-label, .nav-search-hint{ display:none; }
+}
+@media (max-width:480px){
+  .search-modal{ padding:64px 12px 12px; }
+}
+
+/* ============================================================
    モーション停止
    ============================================================ */
 @media (prefers-reduced-motion: reduce){

--- a/site/i18n/en.toml
+++ b/site/i18n/en.toml
@@ -18,3 +18,12 @@ other = "Fan a parent issue out into parallel panes — quietly."
 
 [on_this_section]
 other = "Guide"
+
+[search]
+other = "Search"
+
+[search_placeholder]
+other = "Search the docs…"
+
+[search_close]
+other = "Close search"

--- a/site/i18n/ja.toml
+++ b/site/i18n/ja.toml
@@ -18,3 +18,12 @@ other = "ひとつの親 issue を、扇のように。"
 
 [on_this_section]
 other = "ガイド"
+
+[search]
+other = "検索"
+
+[search_placeholder]
+other = "ドキュメントを検索…"
+
+[search_close]
+other = "検索を閉じる"

--- a/site/layouts/_partials/head.html
+++ b/site/layouts/_partials/head.html
@@ -24,3 +24,7 @@
 {{ with resources.Get "css/main.css" | minify | fingerprint }}
 <link rel="stylesheet" href="{{ .RelPermalink }}" integrity="{{ .Data.Integrity }}">
 {{ end }}
+{{/* Pagefind static search — assets are generated into /pagefind/ at build time
+     (see .github/workflows/pages.yml). relURL keeps the /fanout/ subpath correct. */}}
+<link rel="stylesheet" href="{{ "pagefind/pagefind-ui.css" | relURL }}">
+<script src="{{ "pagefind/pagefind-ui.js" | relURL }}" defer></script>

--- a/site/layouts/_partials/nav.html
+++ b/site/layouts/_partials/nav.html
@@ -16,6 +16,16 @@
       {{ with site.GetPage . }}<li><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></li>{{ end }}
       {{ end }}
       <li class="keep">
+        <button type="button" class="nav-search" data-search-open aria-label="{{ i18n "search" }}">
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+            <circle cx="7" cy="7" r="5" stroke="currentColor" stroke-width="1.5"/>
+            <path d="m11 11 3.5 3.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+          </svg>
+          <span class="nav-search-label">{{ i18n "search" }}</span>
+          <kbd class="nav-search-hint" aria-hidden="true">⌘K</kbd>
+        </button>
+      </li>
+      <li class="keep">
         <span class="lang-switch" aria-label="language">
           {{ $curLang := .Language.Lang -}}
           {{ range .AllTranslations -}}

--- a/site/layouts/_partials/search.html
+++ b/site/layouts/_partials/search.html
@@ -1,0 +1,99 @@
+{{/* Static search modal — Pagefind default UI (PagefindUI), themed in main.css.
+     Triggered from the nav button ([data-search-open]) and ⌘K / Ctrl+K / "/".
+     The Pagefind assets are produced at build time; in a plain `hugo server`
+     they are absent, so the modal opens but returns no results — use
+     `pagefind --serve` to preview search locally. */}}
+<div id="search-modal" class="search-modal" hidden role="dialog" aria-modal="true" aria-label="{{ i18n "search" }}">
+  <div class="search-panel" role="document">
+    <button type="button" class="search-close" data-search-close aria-label="{{ i18n "search_close" }}">&times;</button>
+    <div id="search"></div>
+  </div>
+</div>
+<script>
+  (function () {
+    var modal = document.getElementById('search-modal');
+    if (!modal) return;
+    var ui, lastFocus, polling;
+
+    function focusInput() {
+      var input = modal.querySelector('input');
+      if (input) input.focus();
+    }
+
+    function initUI() {
+      ui = new PagefindUI({
+        element: "#search",
+        {{/* Go html/template JS-context auto-escaping emits these as quoted,
+             escaped JS string literals — do NOT add jsonify (double-encodes). */}}
+        bundlePath: {{ "pagefind/" | relURL }},
+        showSubResults: true,
+        showImages: false,
+        {{/* Pagefind records site-root-relative URLs (/docs/…); this site is
+             served from the /fanout/ subpath, so prefix result links with it. */}}
+        processResult: function (result) {
+          var base = {{ (urls.Parse site.BaseURL).Path }};
+          if (base && base !== "/") {
+            var prefix = base.replace(/\/$/, "");
+            var fix = function (u) {
+              return (u && u.charAt(0) === '/' && u.indexOf(prefix + '/') !== 0) ? prefix + u : u;
+            };
+            result.url = fix(result.url);
+            if (result.sub_results) {
+              result.sub_results.forEach(function (s) { s.url = fix(s.url); });
+            }
+          }
+          return result;
+        },
+        translations: { placeholder: {{ i18n "search_placeholder" }} }
+      });
+      {{/* If the modal was opened before the deferred script loaded, focus now. */}}
+      if (!modal.hidden) focusInput();
+    }
+
+    {{/* pagefind-ui.js is loaded with `defer`, so window.PagefindUI may not exist
+         yet when the user opens search early. Init immediately if ready, otherwise
+         poll briefly until the deferred script defines it, then mount into the
+         (already open) modal so the first dialog is never left blank. */}}
+    function ensureUI() {
+      if (ui || polling) return;
+      if (window.PagefindUI) { initUI(); return; }
+      polling = true;
+      var tries = 0;
+      var timer = setInterval(function () {
+        if (window.PagefindUI) { clearInterval(timer); polling = false; initUI(); }
+        else if (++tries > 100) { clearInterval(timer); polling = false; }
+      }, 100);
+    }
+
+    function open() {
+      lastFocus = document.activeElement;
+      modal.hidden = false;
+      document.documentElement.classList.add('search-open');
+      ensureUI();
+      focusInput();
+    }
+
+    function close() {
+      modal.hidden = true;
+      document.documentElement.classList.remove('search-open');
+      if (lastFocus && lastFocus.focus) lastFocus.focus();
+    }
+
+    document.addEventListener('click', function (e) {
+      if (e.target.closest('[data-search-open]')) { e.preventDefault(); open(); }
+      else if (e.target.closest('[data-search-close]') || e.target === modal) { close(); }
+    });
+
+    document.addEventListener('keydown', function (e) {
+      var tag = (document.activeElement && document.activeElement.tagName) || '';
+      var typing = tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
+      if ((e.key === 'k' || e.key === 'K') && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault(); open();
+      } else if (e.key === '/' && !typing && modal.hidden) {
+        e.preventDefault(); open();
+      } else if (e.key === 'Escape' && !modal.hidden) {
+        e.preventDefault(); close();
+      }
+    });
+  })();
+</script>

--- a/site/layouts/baseof.html
+++ b/site/layouts/baseof.html
@@ -5,6 +5,7 @@
 </head>
 <body>
   {{ partial "nav.html" . }}
+  {{ partial "search.html" . }}
   <main id="top">
     {{ block "main" . }}{{ end }}
   </main>

--- a/site/layouts/page.html
+++ b/site/layouts/page.html
@@ -9,7 +9,7 @@
   </div>
   {{ end }}
 
-  <article class="docs-main">
+  <article class="docs-main" data-pagefind-body>
     <header class="doc-head">
       <p class="kicker">{{ i18n "docs_section" }}</p>
       <h1>{{ .Title }}</h1>
@@ -21,7 +21,7 @@
     </div>
 
     {{ if or .PrevInSection .NextInSection }}
-    <nav class="doc-nav" aria-label="pagination">
+    <nav class="doc-nav" aria-label="pagination" data-pagefind-ignore>
       {{ with .PrevInSection }}
       <a class="prev" href="{{ .RelPermalink }}">
         <span class="dir">&larr; {{ i18n "prev_page" }}</span>

--- a/site/layouts/section.html
+++ b/site/layouts/section.html
@@ -2,7 +2,7 @@
 <div class="docs docs-index">
   {{ partial "sidebar.html" . }}
 
-  <article class="docs-main">
+  <article class="docs-main" data-pagefind-body>
     <header class="doc-head">
       <p class="kicker">{{ i18n "docs_section" }}</p>
       <h1>{{ .Title }}</h1>


### PR DESCRIPTION
## What

ドキュメントサイト(Hugo / PAPER BREEZE、`butaosuinu.github.io/fanout`)に **Pagefind** ベースの静的検索を追加。実 dev-docs(Astro Starlight 等)に倣ったナビ起動のモーダル検索で、外部サービス不要・プライバシー方針(外部 fetch は Google Fonts のみ)を維持。

## Why

docs ページが増え、目的のドキュメントへ素早く到達する手段が必要だった。Algolia DocSearch は外部にクエリ送信・クロール依存のため、完全静的・CJK 対応の Pagefind を採用。バイナリを curl 取得することで CI を **Node-free のまま**維持。

## Changes

| File | What |
|---|---|
| `.github/workflows/pages.yml` | Hugo build 後に `pagefind_extended` v1.5.2 を取得しインデックス生成 |
| `site/layouts/_partials/search.html`(新規) | モーダル + `PagefindUI` 初期化 + ⌘K / `/` / Esc + defer レース対応 + サブパス `processResult` |
| `site/layouts/_partials/nav.html` | 検索トリガーピル(虫眼鏡 + ⌘K) |
| `site/layouts/_partials/head.html` | `relURL` で Pagefind UI アセット読み込み(サブパス対応) |
| `site/layouts/baseof.html` | search partial を全ページに include |
| `site/layouts/page.html` / `section.html` | `data-pagefind-body` / `data-pagefind-ignore`(docs 本文のみ索引・home 除外) |
| `site/assets/css/main.css` | ピル/モーダル + Pagefind CSS 変数を PAPER BREEZE 化、≤1080px でアイコンのみ化 |
| `site/i18n/en.toml` / `ja.toml` | `search` / `search_placeholder` / `search_close` |
| `site/README.md`(新規) | サイト/検索のビルド・ローカルプレビュー手順 |

## Verification

ローカルで本番同様の `/fanout/` サブパス構造を再現し、ブラウザで実機検証:

- ⌘K / `/` / Esc / overlay クリックでの開閉、スクロールロック
- EN ページ「worktree」→ 9 件・EN docs のみ・全リンク `/fanout/docs/...`
- JA ページ「ワークツリー」→ JA docs のみ・全リンク `/fanout/ja/docs/...`(extended の CJK 分かち書き、UI も日本語ローカライズ)
- Pagefind がちょうど 20 ページ(docs 10×2言語)を索引、home 除外
- `defer` ロード前に開いても、ロード後にポーリングで自動マウント(空モーダルにならない)
- ≤1080px で検索ピルがアイコンのみ化し、タブレット幅のナビ溢れなし

`post-work-review`(code-review + codex ×4 反復)を通過。codex の最終反復は clean。

> [!NOTE]
> Pagefind のインデックス出力(`site/public/pagefind/`)はビルド成果物で git 管理外。ローカル検索プレビューは `hugo --gc -s site --baseURL / && npx -y pagefind --site site/public --serve`(手順は `site/README.md`)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
