### PR TITLE
Remove fanout msg dry-run

### DIFF
--- a/claude/skills/fanout/SKILL.md
+++ b/claude/skills/fanout/SKILL.md
@@ -161,7 +161,7 @@ fanned panes are separate agent sessions (not Agent Teams teammates — that is 
   - `fanout msg post [--kind K] "<body>"` — post to the shared board.
   - `fanout msg mark-read [--id N ...|--all]` — mark 1:1 messages read (`--all` also advances the board cursor).
   - `fanout msg register` — (re-)register this pane in the roster.
-- Common options: `--json` (machine-readable), `--self <N>` / `--parent <ref>` (override pane detection), `--dry-run` (write verbs only — prints `# would ...` and writes nothing; not combinable with `--json`). `kind` is a free-form label (default `note`; no fixed vocabulary). Exit codes: `0` ok, `2` bad invocation, `4` SQLite backend failure.
+- Common options: `--json` (machine-readable), `--self <N>` / `--parent <ref>` (override pane detection). `kind` is a free-form label (default `note`; no fixed vocabulary). Exit codes: `0` ok, `2` bad invocation, `4` SQLite backend failure.
 - Coordination is **pull-based**: messages persist and a sibling reads them at its own checkpoints; `fanout msg` never interrupts a busy pane. The merged CLI has no "nudge". A good rhythm is to check `fanout msg inbox` once after reading the briefing, post a one-line heads-up before editing shared files, and check the inbox once more before opening the PR.
 - **Plan mode** — `fanout plan --team` uses the same `fanout msg` surface, but peers are addressed by **task id** (`fanout msg send --to <task-id>`) instead of issue number, because issue-less plan tasks have no `#N`. See the fanout-plan skill.
 - **Security**: the DB is a plaintext SQLite file under `/tmp` (`0600`, owner-only). Never put secrets, tokens, or credentials in messages.

--- a/cmd/fanout/msg.go
+++ b/cmd/fanout/msg.go
@@ -47,8 +47,6 @@ Options:
   --json           Emit JSON instead of the human-readable view.
   --self <N>       Act as child issue N (overrides pane detection).
   --parent <ref>   Parent issue number or Projects URL (overrides pane detection).
-  --dry-run        Write/notify verbs only: print '# would ...' lines describing
-                   the writes, touch nothing. Not combinable with --json.
   --to <N>         send: recipient child issue number.
   --kind <K>       send/post: message kind (default: note).
   --id <N>         mark-read: message id (repeatable).
@@ -73,8 +71,7 @@ const nudgeText = "[fanout] peer message in your inbox — run: fanout msg inbox
 
 // listLivePanes and sendLiteralLine are the tmux seams nudge drives, declared
 // as vars so unit tests can swap them without a live tmux server (same pattern
-// as detectIdentity). The dry-run path uses neither — it must stay tmux-free
-// so its golden is deterministic.
+// as detectIdentity).
 var (
 	listLivePanes   = tmuxrun.ListLivePanes
 	sendLiteralLine = tmuxrun.SendLiteralLine
@@ -105,10 +102,9 @@ var (
 )
 
 type msgFlags struct {
-	verb   string
-	json   bool
-	dryRun bool
-	self   int // 0 = not given; resolved synthetic number for selfRaw
+	verb string
+	json bool
+	self int // 0 = not given; resolved synthetic number for selfRaw
 	// selfRaw holds an explicit --self task id (plan parents) until the parent
 	// is known and it can be mapped to a synthetic number; "" otherwise.
 	selfRaw string
@@ -125,20 +121,20 @@ type msgFlags struct {
 }
 
 // msgVerbFlags is the per-verb flag allowlist. msgUniversalFlags are accepted
-// by every verb; --dry-run is write-verb only per the #70 contract. The known
-// flag set is derived from these two tables (msgFlagKnown), so adding a flag
-// here is the single registration point for parsing.
+// by every verb. The known flag set is derived from these two tables
+// (msgFlagKnown), so adding a flag here is the single registration point for
+// parsing.
 var msgVerbFlags = map[string]map[string]bool{
 	"peers":     {},
 	"inbox":     {"--all": true, "--mark-read": true},
 	"board":     {"--all": true},
-	"send":      {"--dry-run": true, "--to": true, "--kind": true},
-	"post":      {"--dry-run": true, "--kind": true},
-	"mark-read": {"--dry-run": true, "--id": true, "--all": true},
-	"register":  {"--dry-run": true},
-	// nudge's target is a positional <N>, not --to; --dry-run is its only
-	// verb-specific flag (universal --json/--self/--parent still apply).
-	"nudge": {"--dry-run": true},
+	"send":      {"--to": true, "--kind": true},
+	"post":      {"--kind": true},
+	"mark-read": {"--id": true, "--all": true},
+	"register":  {},
+	// nudge's target is a positional <N>, not --to; universal
+	// --json/--self/--parent still apply.
+	"nudge": {},
 }
 
 var msgUniversalFlags = map[string]bool{"--json": true, "--self": true, "--parent": true}
@@ -174,15 +170,11 @@ func cmdMsg(args []string, lg *log.Logger) exitcode.Code {
 		return code
 	}
 
-	// nudge reads neither the messages DB nor the generic dry-run printer: it
-	// resolves the recipient from state.json and pushes via tmux, so short it
-	// out before openMsgDB (and before the DB-oriented dry-run path).
+	// nudge reads neither the messages DB nor store identity: it resolves the
+	// recipient from state.json and pushes via tmux, so short it out before
+	// openMsgDB.
 	if flags.verb == "nudge" {
 		return runMsgNudge(flags, parent, lg)
-	}
-
-	if flags.dryRun {
-		return printMsgDryRun(flags, self, parent, pane, lg)
 	}
 
 	db, code := openMsgDB(flags.verb, parent, lg)
@@ -282,8 +274,6 @@ func parseMsgFlag(f *msgFlags, allowed map[string]bool, args []string, i int, lg
 	switch a {
 	case "--json":
 		f.json = true
-	case "--dry-run":
-		f.dryRun = true
 	case "--all":
 		f.all = true
 	case "--mark-read":
@@ -451,12 +441,6 @@ func setMsgFlagValue(f *msgFlags, flag, value string, lg *log.Logger) exitcode.C
 }
 
 func validateMsgFlags(f *msgFlags, lg *log.Logger) exitcode.Code {
-	// Dry-run output is the "# would ..." line contract, not JSON; reject the
-	// combination instead of silently handing automation non-JSON output.
-	if f.dryRun && f.json {
-		lg.Err("msg %s: --dry-run cannot be combined with --json (dry-run prints '# would ...' lines)", f.verb)
-		return exitcode.Invocation
-	}
 	switch f.verb {
 	case "send":
 		if f.to == 0 && f.toRaw == "" {
@@ -922,75 +906,6 @@ func msgTableBody(s string) string {
 	return s
 }
 
-// --- dry-run -----------------------------------------------------------
-
-// printMsgDryRun prints the would-be writes without opening the DB, in the
-// pane.go printPaneDryRun "# would ..." idiom. Ids and cursor positions are
-// unknown by design (no DB access), so --all renders a symbolic MAX().
-func printMsgDryRun(f *msgFlags, self int, parent string, pane msgstore.Peer, lg *log.Logger) exitcode.Code {
-	lines := msgDryRunLines(f, self, parent, pane, team.Now())
-	if len(lines) == 0 {
-		// Unreachable while msgVerbFlags' --dry-run set and msgDryRunLines
-		// stay in sync; fail loud so a half-added verb can't fake success.
-		lg.Err("msg: internal error: no dry-run rendering for verb %s", f.verb)
-		return exitcode.Invocation
-	}
-	for _, line := range lines {
-		lg.Dim("%s", line)
-	}
-	return exitcode.OK
-}
-
-func msgDryRunLines(f *msgFlags, self int, parent string, pane msgstore.Peer, now string) []string {
-	switch f.verb {
-	case "send":
-		return []string{fmt.Sprintf(
-			"# would INSERT INTO messages(parent, from_issue, to_issue, kind, body, created_at) VALUES (%s, %d, %d, %s, %s, %s)",
-			sqlLiteral(parent), self, f.to, sqlLiteral(f.kind), sqlLiteral(f.body), sqlLiteral(now))}
-	case "post":
-		return []string{fmt.Sprintf(
-			"# would INSERT INTO messages(parent, from_issue, to_issue, kind, body, created_at) VALUES (%s, %d, NULL, %s, %s, %s)",
-			sqlLiteral(parent), self, sqlLiteral(f.kind), sqlLiteral(f.body), sqlLiteral(now))}
-	case "mark-read":
-		if f.all {
-			return []string{
-				fmt.Sprintf("# would UPDATE messages SET read_at = %s WHERE parent = %s AND to_issue = %d AND read_at IS NULL",
-					sqlLiteral(now), sqlLiteral(parent), self),
-				fmt.Sprintf("# would UPSERT board_cursors(issue=%d, last_read_id=MAX(id) of board posts)", self),
-			}
-		}
-		ids := make([]string, len(f.ids))
-		for i, id := range f.ids {
-			ids[i] = strconv.FormatInt(id, 10)
-		}
-		return []string{fmt.Sprintf(
-			"# would UPDATE messages SET read_at = %s WHERE parent = %s AND to_issue = %d AND id IN (%s) AND read_at IS NULL",
-			sqlLiteral(now), sqlLiteral(parent), self, strings.Join(ids, ", "))}
-	case "register":
-		// task_id mirrors the real INSERT: NULL for numeric issue peers, the
-		// quoted task id for plan-task peers.
-		taskIDLiteral := "NULL"
-		if pane.TaskID != "" {
-			taskIDLiteral = sqlLiteral(pane.TaskID)
-		}
-		return []string{fmt.Sprintf(
-			"# would UPSERT INTO peers(issue, pane_id, slug, worktree_path, agent, display_name, joined_at, last_seen, task_id) VALUES (%d, %s, %s, %s, %s, %s, %s, %s, %s)",
-			self, sqlLiteral(pane.PaneID), sqlLiteral(pane.Slug), sqlLiteral(pane.WorktreePath),
-			sqlLiteral(pane.Agent), sqlLiteral(pane.DisplayName), sqlLiteral(now), sqlLiteral(now), taskIDLiteral)}
-	}
-	return nil
-}
-
-// sqlLiteral renders s as a single-quoted SQL string literal for dry-run
-// display only — real statements always bind placeholders. Newlines become
-// \n so a dry-run line stays a single golden-friendly line.
-func sqlLiteral(s string) string {
-	s = strings.ReplaceAll(s, "'", "''")
-	s = strings.ReplaceAll(s, "\r", `\r`)
-	s = strings.ReplaceAll(s, "\n", `\n`)
-	return "'" + s + "'"
-}
-
 func msgBackendErr(verb string, err error, lg *log.Logger) exitcode.Code {
 	lg.Err("msg %s: %v", verb, err)
 	return exitcode.Backend
@@ -1027,12 +942,12 @@ func shouldNudge(agentState string) bool {
 	return agentState == "running"
 }
 
-// runMsgNudge resolves peer f.to's recorded pane from state.json and, unless
-// --dry-run, pushes the inbox hint when its agent is running. Every
-// operational miss (recipient absent, no pane id, pane gone, agent not
-// running, send-keys failure) is a no-op SUCCESS with a warning/reason: the
-// message is already persisted by send, so a failed nudge must never break
-// messaging. Only invocation errors (handled earlier) exit non-zero.
+// runMsgNudge resolves peer f.to's recorded pane from state.json and pushes the
+// inbox hint when its agent is running. Every operational miss (recipient
+// absent, no pane id, pane gone, agent not running, send-keys failure) is a
+// no-op SUCCESS with a warning/reason: the message is already persisted by
+// send, so a failed nudge must never break messaging. Only invocation errors
+// (handled earlier) exit non-zero.
 func runMsgNudge(f *msgFlags, parent string, lg *log.Logger) exitcode.Code {
 	st, err := loadStateStore()
 	if err != nil {
@@ -1048,11 +963,6 @@ func runMsgNudge(f *msgFlags, parent string, lg *log.Logger) exitcode.Code {
 		pane, found = st.FindTask(parent, f.toRaw)
 	} else {
 		pane, found = st.Find(parent, f.to)
-	}
-
-	if f.dryRun {
-		lg.Dim("%s", nudgeDryRunLine(recipientLabel(f, parent), pane.PaneID, found))
-		return exitcode.OK
 	}
 
 	report := msgNudgeReport{Target: f.to, PaneID: pane.PaneID}
@@ -1125,20 +1035,6 @@ func matchLivePane(panes []tmuxrun.LivePane, paneID, worktree string) (tmuxrun.L
 		return tmuxrun.LivePane{}, false
 	}
 	return tmuxrun.LivePane{}, false
-}
-
-// nudgeDryRunLine renders the would-be tmux push as a single deterministic
-// line, resolved from state.json only (never live tmux) so it is golden
-// stable. An unresolved recipient prints a <unknown> pane id rather than
-// erroring, keeping the dry-run a single informative line.
-// nudgeDryRunLine renders the would-send-keys preview. target is the human
-// recipient label ("#<issue>" for numeric peers, the task id for plan peers).
-func nudgeDryRunLine(target, paneID string, found bool) string {
-	if !found || paneID == "" {
-		paneID = "<unknown>"
-	}
-	return fmt.Sprintf("# would send-keys -t %s -l %s then Enter (target %s, only if agent is running)",
-		paneID, sqlLiteral(nudgeText), target)
 }
 
 func writeMsgNudgeResult(f *msgFlags, parent string, report msgNudgeReport, lg *log.Logger) exitcode.Code {

--- a/cmd/fanout/msg_test.go
+++ b/cmd/fanout/msg_test.go
@@ -68,8 +68,6 @@ func TestParseMsgFlags(t *testing.T) {
 			}
 		}},
 		{name: "inbox rejects positional", args: []string{"inbox", "hello"}, code: exitcode.Invocation},
-		{name: "inbox rejects dry-run", args: []string{"inbox", "--dry-run"}, code: exitcode.Invocation},
-		{name: "dry-run rejects json", args: []string{"send", "--dry-run", "--json", "--to", "71", "--self", "70", "--parent", "68", "hi"}, code: exitcode.Invocation},
 		{name: "board rejects mark-read", args: []string{"board", "--mark-read"}, code: exitcode.Invocation},
 		{name: "peers rejects --to", args: []string{"peers", "--to", "5"}, code: exitcode.Invocation},
 		{name: "unknown option", args: []string{"peers", "--bogus"}, code: exitcode.Invocation},
@@ -107,12 +105,6 @@ func TestParseMsgFlags(t *testing.T) {
 				t.Errorf("parent = %q, want %q (leading zeros must collapse)", f.parent, "68")
 			}
 		}},
-		{name: "register dry-run", args: []string{"register", "--dry-run", "--self", "70", "--parent", "68"}, code: exitcode.OK, want: func(t *testing.T, f *msgFlags) {
-			t.Helper()
-			if !f.dryRun {
-				t.Errorf("parsed = %+v", f)
-			}
-		}},
 		{name: "help as verb", args: []string{"-h"}, code: exitcode.OK},
 		{name: "long help flag mid-args", args: []string{"inbox", "--help"}, code: exitcode.OK},
 		{name: "short help before body", args: []string{"send", "-h"}, code: exitcode.OK},
@@ -142,12 +134,6 @@ func TestParseMsgFlags(t *testing.T) {
 				t.Errorf("to = %d, want -2", f.to)
 			}
 		}},
-		{name: "nudge dry-run with target", args: []string{"nudge", "--dry-run", "71"}, code: exitcode.OK, want: func(t *testing.T, f *msgFlags) {
-			t.Helper()
-			if !f.dryRun || f.to != 71 {
-				t.Errorf("parsed = %+v", f)
-			}
-		}},
 		{name: "nudge without a target exits invalid", args: []string{"nudge"}, code: exitcode.Invocation},
 		{name: "numeric-zero nudge target parses as a task-id shape (rejected later under a numeric parent)", args: []string{"nudge", "0"}, code: exitcode.OK, want: func(t *testing.T, f *msgFlags) {
 			t.Helper()
@@ -164,7 +150,6 @@ func TestParseMsgFlags(t *testing.T) {
 		}},
 		{name: "nudge rejects a second target", args: []string{"nudge", "71", "72"}, code: exitcode.Invocation},
 		{name: "nudge does not accept --to", args: []string{"nudge", "--to", "71"}, code: exitcode.Invocation},
-		{name: "nudge dry-run rejects json", args: []string{"nudge", "--dry-run", "--json", "71"}, code: exitcode.Invocation},
 		{name: "nudge accepts but does not require --self", args: []string{"nudge", "71", "--self", "5"}, code: exitcode.OK, want: func(t *testing.T, f *msgFlags) {
 			t.Helper()
 			if f.to != 71 || f.self != 5 {
@@ -282,81 +267,6 @@ func TestResolveMsgIdentity(t *testing.T) {
 	}
 }
 
-func TestMsgDryRunLines(t *testing.T) {
-	const now = "2026-06-13T00:00:00Z"
-	for _, tc := range []struct {
-		name  string
-		flags msgFlags
-		pane  msgstore.Peer
-		want  []string
-	}{
-		{
-			name:  "send",
-			flags: msgFlags{verb: "send", to: 71, kind: "note", body: "hello world"},
-			want: []string{
-				"# would INSERT INTO messages(parent, from_issue, to_issue, kind, body, created_at) VALUES ('68', 70, 71, 'note', 'hello world', '2026-06-13T00:00:00Z')",
-			},
-		},
-		{
-			name:  "post escapes quotes and newlines",
-			flags: msgFlags{verb: "post", kind: "blocker", body: "it's\nbroken"},
-			want: []string{
-				`# would INSERT INTO messages(parent, from_issue, to_issue, kind, body, created_at) VALUES ('68', 70, NULL, 'blocker', 'it''s\nbroken', '2026-06-13T00:00:00Z')`,
-			},
-		},
-		{
-			name:  "mark-read ids",
-			flags: msgFlags{verb: "mark-read", ids: []int64{3, 5}},
-			want: []string{
-				"# would UPDATE messages SET read_at = '2026-06-13T00:00:00Z' WHERE parent = '68' AND to_issue = 70 AND id IN (3, 5) AND read_at IS NULL",
-			},
-		},
-		{
-			name:  "mark-read all",
-			flags: msgFlags{verb: "mark-read", all: true},
-			want: []string{
-				"# would UPDATE messages SET read_at = '2026-06-13T00:00:00Z' WHERE parent = '68' AND to_issue = 70 AND read_at IS NULL",
-				"# would UPSERT board_cursors(issue=70, last_read_id=MAX(id) of board posts)",
-			},
-		},
-		{
-			name:  "register with pane",
-			flags: msgFlags{verb: "register"},
-			pane:  msgstore.Peer{Issue: 70, PaneID: "%1", Slug: "s-70", WorktreePath: "/tmp/wt", Agent: "claude", DisplayName: "name"},
-			want: []string{
-				"# would UPSERT INTO peers(issue, pane_id, slug, worktree_path, agent, display_name, joined_at, last_seen, task_id) VALUES (70, '%1', 's-70', '/tmp/wt', 'claude', 'name', '2026-06-13T00:00:00Z', '2026-06-13T00:00:00Z', NULL)",
-			},
-		},
-		{
-			name:  "register without pane",
-			flags: msgFlags{verb: "register"},
-			want: []string{
-				"# would UPSERT INTO peers(issue, pane_id, slug, worktree_path, agent, display_name, joined_at, last_seen, task_id) VALUES (70, '', '', '', '', '', '2026-06-13T00:00:00Z', '2026-06-13T00:00:00Z', NULL)",
-			},
-		},
-		{
-			name:  "register a plan task pane records the task id",
-			flags: msgFlags{verb: "register"},
-			pane:  msgstore.Peer{Issue: -42, TaskID: "api-client", Slug: "launch-plan-api-client"},
-			want: []string{
-				"# would UPSERT INTO peers(issue, pane_id, slug, worktree_path, agent, display_name, joined_at, last_seen, task_id) VALUES (70, '', 'launch-plan-api-client', '', '', '', '2026-06-13T00:00:00Z', '2026-06-13T00:00:00Z', 'api-client')",
-			},
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			got := msgDryRunLines(&tc.flags, 70, "68", tc.pane, now)
-			if len(got) != len(tc.want) {
-				t.Fatalf("lines = %q, want %q", got, tc.want)
-			}
-			for i := range got {
-				if got[i] != tc.want[i] {
-					t.Errorf("line %d = %q, want %q", i, got[i], tc.want[i])
-				}
-			}
-		})
-	}
-}
-
 func TestWriteMsgMessagesTable(t *testing.T) {
 	to := 70
 	read := "2026-06-13T00:00:00Z"
@@ -411,20 +321,6 @@ func TestWriteMsgMessagesTablePlanLabels(t *testing.T) {
 	}
 }
 
-func TestSQLLiteral(t *testing.T) {
-	for _, tc := range []struct{ in, want string }{
-		{"plain", "'plain'"},
-		{"it's", "'it''s'"},
-		{"a\nb", `'a\nb'`},
-		{"a\r\nb", `'a\r\nb'`},
-		{"", "''"},
-	} {
-		if got := sqlLiteral(tc.in); got != tc.want {
-			t.Errorf("sqlLiteral(%q) = %s, want %s", tc.in, got, tc.want)
-		}
-	}
-}
-
 func TestShouldNudge(t *testing.T) {
 	for _, tc := range []struct {
 		state string
@@ -439,39 +335,6 @@ func TestShouldNudge(t *testing.T) {
 		if got := shouldNudge(tc.state); got != tc.want {
 			t.Errorf("shouldNudge(%q) = %v, want %v", tc.state, got, tc.want)
 		}
-	}
-}
-
-func TestNudgeDryRunLine(t *testing.T) {
-	for _, tc := range []struct {
-		name   string
-		target string
-		paneID string
-		found  bool
-		want   string
-	}{
-		{
-			name: "resolved pane", target: "#70", paneID: "%1", found: true,
-			want: "# would send-keys -t %1 -l '[fanout] peer message in your inbox — run: fanout msg inbox' then Enter (target #70, only if agent is running)",
-		},
-		{
-			name: "unresolved recipient", target: "#99", paneID: "", found: false,
-			want: "# would send-keys -t <unknown> -l '[fanout] peer message in your inbox — run: fanout msg inbox' then Enter (target #99, only if agent is running)",
-		},
-		{
-			name: "found row but empty pane id", target: "#72", paneID: "", found: true,
-			want: "# would send-keys -t <unknown> -l '[fanout] peer message in your inbox — run: fanout msg inbox' then Enter (target #72, only if agent is running)",
-		},
-		{
-			name: "plan task recipient renders the task id", target: "api-client", paneID: "%3", found: true,
-			want: "# would send-keys -t %3 -l '[fanout] peer message in your inbox — run: fanout msg inbox' then Enter (target api-client, only if agent is running)",
-		},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := nudgeDryRunLine(tc.target, tc.paneID, tc.found); got != tc.want {
-				t.Errorf("nudgeDryRunLine() = %q, want %q", got, tc.want)
-			}
-		})
 	}
 }
 
@@ -551,14 +414,6 @@ func TestRunMsgNudge(t *testing.T) {
 		{
 			name: "recipient without a recorded pane is a no-op success", flags: msgFlags{verb: "nudge", to: 72}, store: noPaneID,
 			wantCode: exitcode.OK, wantStderr: "no recorded pane",
-		},
-		{
-			name: "dry-run prints the would-line and touches no tmux", flags: msgFlags{verb: "nudge", to: 71, dryRun: true}, store: withWorktree,
-			wantCode: exitcode.OK, wantStdout: "# would send-keys -t %5",
-		},
-		{
-			name: "dry-run for an unrecorded recipient prints <unknown> and touches no tmux", flags: msgFlags{verb: "nudge", to: 99, dryRun: true}, store: withWorktree,
-			wantCode: exitcode.OK, wantStdout: "# would send-keys -t <unknown>",
 		},
 		{
 			name: "state load failure is an invocation error", flags: msgFlags{verb: "nudge", to: 71}, storeErr: errors.New("bad path"),

--- a/codex/skills/fanout/SKILL.md
+++ b/codex/skills/fanout/SKILL.md
@@ -474,8 +474,7 @@ single-session) and works the same for `codex` and `claude` panes.
   board), `board [--all]`, `send --to <N> [--kind K] "<body>"`,
   `post [--kind K] "<body>"`, `mark-read [--id N ...|--all]`, `register`.
 - Common options: `--json`, `--self <N>` / `--parent <ref>` (override
-  detection), `--dry-run` (write verbs only; prints `# would ...`, not
-  combinable with `--json`). `kind` is a free-form label (default `note`).
+  detection). `kind` is a free-form label (default `note`).
   Exit codes: `0` ok, `2` bad invocation, `4` SQLite backend failure.
 - Coordination is pull-based — messages persist and siblings read them at their
   own checkpoints; there is no nudge. The DB is a plaintext SQLite file under

--- a/site/content/docs/cli.ja.md
+++ b/site/content/docs/cli.ja.md
@@ -290,7 +290,7 @@ parent ごとの SQLite メッセージバス上での兄弟協調です。fanou
 | `register` | このペインを peers テーブルに upsert する（`--team` が自動で行う。再 join に使う）。 |
 | `nudge` | `<N>` —— best-effort: peer `#N` の agent が running のときだけ、tmux 経由でそのペインに inbox の hint を送る。メッセージではなく通知専用 verb で、DB は触らない。対象の agent が running でない（ペイン消失 / 状態不明 / done）ときは何もせず success（no-op）。 |
 
-verb 共通のオプション: `--json`（機械可読出力）、`--self <N>` と `--parent <ref>`（ペイン検出を上書き）、`--dry-run`（write / notify verb のみ —— `# would ...` の書き込み内容を表示し何も触らない。`--json` とは併用不可）。
+verb 共通のオプション: `--json`（機械可読出力）、`--self <N>` と `--parent <ref>`（ペイン検出を上書き）。
 
 [`fanout plan --team`](#plan-fan-out-issue-less) の run では、peer は issue 番号ではなく **task ID** で指定します: `send --to <task-id>`、`peers` は現在の task ID 一覧を表示します。plan モードのペインの `--json` 出力には `selfTask` / `fromTask` / `toTask` フィールドが付き、合成 peer 番号から task ID を解決できます。issue / Project の JSON は変わりません。
 

--- a/site/content/docs/cli.md
+++ b/site/content/docs/cli.md
@@ -291,7 +291,7 @@ Sibling coordination over a per-parent SQLite message bus. Run from inside a fan
 | `register` | Upsert this pane into the peers table (auto-done by `--team`; use it to (re-)join). |
 | `nudge` | `<N>` — best-effort: drop an inbox hint into peer `#N`'s pane via tmux only when its agent is running. A notify verb, not a message: it never touches the DB and is a no-op success when the peer's agent is not running (pane gone, state unknown, or done). |
 
-Common options across verbs: `--json` (machine-readable output), `--self <N>` and `--parent <ref>` (override pane detection), and `--dry-run` (write/notify verbs only — prints the `# would ...` writes and touches nothing; not combinable with `--json`).
+Common options across verbs: `--json` (machine-readable output), `--self <N>` and `--parent <ref>` (override pane detection).
 
 Under a [`fanout plan --team`](#plan-fan-out-issue-less) run, peers are addressed by **task ID** rather than issue number: `send --to <task-id>`, and `peers` lists the live task IDs. The `--json` output of plan-mode panes adds `selfTask` / `fromTask` / `toTask` fields so automation can resolve task IDs from the synthetic peer numbers; issue / Project JSON is unchanged.
 

--- a/tests/bats/tier1_msg.bats
+++ b/tests/bats/tier1_msg.bats
@@ -97,20 +97,6 @@ msg_env() {
   [[ "$output" == *"pass either --id <n> (repeatable) or --all"* ]]
 }
 
-@test "msg inbox rejects --dry-run (read verb): exit 2" {
-  msg_env
-  run_fanout msg inbox --dry-run --self 70 --parent 68
-  [ "$status" -eq 2 ]
-  [[ "$output" == *"--dry-run is not supported"* ]]
-}
-
-@test "msg send rejects --dry-run with --json: exit 2" {
-  msg_env
-  run_fanout msg send --dry-run --json --to 71 --self 70 --parent 68 hello
-  [ "$status" -eq 2 ]
-  [[ "$output" == *"--dry-run cannot be combined with --json"* ]]
-}
-
 @test "msg peers rejects a verb-foreign flag: exit 2" {
   msg_env
   run_fanout msg peers --to 5 --parent 68
@@ -152,14 +138,6 @@ msg_env() {
   assert_success
   [[ "$output" == *"sent #1 to #71"* ]]
   [ -f "$BATS_TEST_TMPDIR/team.db" ]
-}
-
-@test "msg dry-run touches no DB file" {
-  msg_env
-  run_fanout msg send --dry-run --to 71 --self 70 --parent 68 hello
-  assert_success
-  [[ "$output" == *"# would INSERT INTO messages"* ]]
-  [ ! -e "$BATS_TEST_TMPDIR/team.db" ]
 }
 
 @test "msg send body may contain -h after the first body word (no silent help)" {
@@ -215,17 +193,6 @@ msg_env() {
   assert_success
   [[ "$output" == *'"nudged": false'* ]]
   [[ "$output" == *"not recorded"* ]]
-  [ ! -e "$BATS_TEST_TMPDIR/team.db" ]
-}
-
-@test "msg nudge --dry-run prints the would-line and touches no DB" {
-  msg_env
-  printf '%s\n' '{"schemaVersion":1,"panes":[{"parent":"68","issueNum":70,"slug":"s","branchName":"b","paneId":"%1","agent":"claude","displayName":"d","worktreePath":"","prompt":"[fanout #70 of #68] s","createdAt":"2026-06-13T00:00:00Z"}]}' \
-    > "$BATS_TEST_TMPDIR/state.json"
-  export FANOUT_STATE_PATH="$BATS_TEST_TMPDIR/state.json"
-  run_fanout msg nudge 70 --dry-run --parent 68
-  assert_success
-  [[ "$output" == *"# would send-keys -t %1 -l "* ]]
   [ ! -e "$BATS_TEST_TMPDIR/team.db" ]
 }
 

--- a/tests/bats/tier2_msg.bats
+++ b/tests/bats/tier2_msg.bats
@@ -1,11 +1,10 @@
 #!/usr/bin/env bats
-# Tier 2 goldens for `fanout msg` (#70): exact dry-run output for the write
-# verbs, and the read-path JSON/table views against a real SQLite DB. The DB
-# fixture is self-hosting — seeded through fanout's own write verbs instead
-# of a sqlite3 CLI (which is deliberately not a test dependency) — so the
-# write path is exercised by every read-path golden. FANOUT_FAKE_NOW freezes
-# created_at/read_at; ids are deterministic because each test starts from a
-# fresh DB (AUTOINCREMENT yields 1, 2, 3, ...).
+# Tier 2 goldens for `fanout msg` (#70): read-path JSON/table views against a
+# real SQLite DB. The DB fixture is self-hosting — seeded through fanout's own
+# write verbs instead of a sqlite3 CLI (which is deliberately not a test
+# dependency) — so the write path is exercised by every read-path golden.
+# FANOUT_FAKE_NOW freezes created_at/read_at; ids are deterministic because
+# each test starts from a fresh DB (AUTOINCREMENT yields 1, 2, 3, ...).
 
 load helpers
 
@@ -35,54 +34,6 @@ seed_msg_db() {
   assert_success
   run_fanout msg send --to 71 --self 70 --parent 68 reply meant for 71
   assert_success
-}
-
-@test "msg send --dry-run golden" {
-  msg_env
-  run_fanout msg send --dry-run --to 71 --self 70 --parent 68 hello world
-  assert_success
-  assert_golden msg-send
-}
-
-@test "msg post --dry-run --kind golden" {
-  msg_env
-  run_fanout msg post --dry-run --kind blocker --self 70 --parent 68 schema is not ready
-  assert_success
-  assert_golden msg-post-kind
-}
-
-@test "msg mark-read --dry-run --id golden" {
-  msg_env
-  run_fanout msg mark-read --dry-run --id 3 --id 5 --self 70 --parent 68
-  assert_success
-  assert_golden msg-mark-read-ids
-}
-
-@test "msg mark-read --dry-run --all golden" {
-  msg_env
-  run_fanout msg mark-read --dry-run --all --self 70 --parent 68
-  assert_success
-  assert_golden msg-mark-read-all
-}
-
-@test "msg register --dry-run with explicit identity golden (no pane fields)" {
-  msg_env
-  run_fanout msg register --dry-run --self 70 --parent 68
-  assert_success
-  assert_golden msg-register-bare
-}
-
-@test "msg nudge --dry-run golden (pane id resolved from state.json)" {
-  msg_env
-  # nudge resolves the recipient pane id from state.json (never the DB), so the
-  # dry-run line is deterministic given a fixed FANOUT_STATE_PATH. The agent
-  # state is read live only on the real path, never in dry-run.
-  printf '%s\n' '{"schemaVersion":1,"panes":[{"parent":"68","issueNum":70,"slug":"msg-cli-surface-70","branchName":"fanout/msg-cli-surface-70","paneId":"%1","agent":"claude","displayName":"msg cli surface","worktreePath":"","prompt":"[fanout #70 of #68] msg-cli-surface-70: msg CLI.","createdAt":"2026-06-13T00:00:00Z"}]}' \
-    > "$BATS_TEST_TMPDIR/state.json"
-  export FANOUT_STATE_PATH="$BATS_TEST_TMPDIR/state.json"
-  run_fanout msg nudge 70 --dry-run --parent 68
-  assert_success
-  assert_golden msg-nudge
 }
 
 @test "msg inbox --json golden: unread 1:1 + board union" {

--- a/tests/golden/msg-mark-read-all.dry-run.txt
+++ b/tests/golden/msg-mark-read-all.dry-run.txt
@@ -1,2 +1,0 @@
-# would UPDATE messages SET read_at = '2026-06-13T00:00:00Z' WHERE parent = '68' AND to_issue = 70 AND read_at IS NULL
-# would UPSERT board_cursors(issue=70, last_read_id=MAX(id) of board posts)

--- a/tests/golden/msg-mark-read-ids.dry-run.txt
+++ b/tests/golden/msg-mark-read-ids.dry-run.txt
@@ -1,1 +1,0 @@
-# would UPDATE messages SET read_at = '2026-06-13T00:00:00Z' WHERE parent = '68' AND to_issue = 70 AND id IN (3, 5) AND read_at IS NULL

--- a/tests/golden/msg-nudge.dry-run.txt
+++ b/tests/golden/msg-nudge.dry-run.txt
@@ -1,1 +1,0 @@
-# would send-keys -t %1 -l '[fanout] peer message in your inbox — run: fanout msg inbox' then Enter (target #70, only if agent is running)

--- a/tests/golden/msg-post-kind.dry-run.txt
+++ b/tests/golden/msg-post-kind.dry-run.txt
@@ -1,1 +1,0 @@
-# would INSERT INTO messages(parent, from_issue, to_issue, kind, body, created_at) VALUES ('68', 70, NULL, 'blocker', 'schema is not ready', '2026-06-13T00:00:00Z')

--- a/tests/golden/msg-register-bare.dry-run.txt
+++ b/tests/golden/msg-register-bare.dry-run.txt
@@ -1,1 +1,0 @@
-# would UPSERT INTO peers(issue, pane_id, slug, worktree_path, agent, display_name, joined_at, last_seen, task_id) VALUES (70, '', '', '', '', '', '2026-06-13T00:00:00Z', '2026-06-13T00:00:00Z', NULL)

--- a/tests/golden/msg-send.dry-run.txt
+++ b/tests/golden/msg-send.dry-run.txt
@@ -1,1 +1,0 @@
-# would INSERT INTO messages(parent, from_issue, to_issue, kind, body, created_at) VALUES ('68', 70, 71, 'note', 'hello world', '2026-06-13T00:00:00Z')


### PR DESCRIPTION
**TL;DR**
Remove the `fanout msg --dry-run` surface so msg write/notify verbs now reject the flag instead of printing preview lines. Review effort: 1

**Why**
Issue #277 asks to delete the isolated `fanout msg --dry-run` path for send/post/mark-read/register/nudge because it is not used by current skills/flows and msg writes are low-risk per-parent SQLite operations. Parent issue/project `--dry-run` and `fanout plan --dry-run` remain unchanged.

**Changes by file**
<details><summary>Changed files</summary>

| File | What changed | Why |
|---|---|---|
| `cmd/fanout/msg.go` | Removed msg `--dry-run` help text, flag state, allowlist entries, parser/validation branches, dry-run renderers, SQL literal helper, and nudge dry-run branch. | Make `fanout msg --dry-run` an unknown option and remove the unused preview path. |
| `cmd/fanout/msg_test.go` | Removed parser/helper/nudge unit tests for msg dry-run. | The deleted helpers and accepted flag no longer exist. |
| `claude/skills/fanout/SKILL.md` | Removed msg dry-run from the common options text. | Keep the source-of-truth installed Claude skill aligned with the CLI. |
| `codex/skills/fanout/SKILL.md` | Removed msg dry-run from the common options text. | Keep the source-of-truth installed Codex skill aligned with the CLI. |
| `site/content/docs/cli.md` | Removed msg dry-run from the English CLI reference. | Stop documenting a rejected msg option. |
| `site/content/docs/cli.ja.md` | Removed msg dry-run from the Japanese CLI reference. | Stop documenting a rejected msg option. |
| `tests/bats/tier1_msg.bats` | Removed Tier 1 black-box assertions for accepted msg dry-run behavior. | The old behavior is intentionally gone. |
| `tests/bats/tier2_msg.bats` | Removed six msg dry-run golden tests and updated the file comment. | Tier 2 msg coverage now covers real DB-backed read/write behavior only. |
| `tests/golden/msg-mark-read-all.dry-run.txt` | Deleted the msg mark-read all dry-run golden. | Removed obsolete fixture. |
| `tests/golden/msg-mark-read-ids.dry-run.txt` | Deleted the msg mark-read ids dry-run golden. | Removed obsolete fixture. |
| `tests/golden/msg-nudge.dry-run.txt` | Deleted the msg nudge dry-run golden. | Removed obsolete fixture. |
| `tests/golden/msg-post-kind.dry-run.txt` | Deleted the msg post dry-run golden. | Removed obsolete fixture. |
| `tests/golden/msg-register-bare.dry-run.txt` | Deleted the msg register dry-run golden. | Removed obsolete fixture. |
| `tests/golden/msg-send.dry-run.txt` | Deleted the msg send dry-run golden. | Removed obsolete fixture. |

</details>

**Risk**
> [!WARNING]
> Existing local scripts or stale agent notes that still call `fanout msg --dry-run` now fail with exit 2 and `unknown option: --dry-run`; this is the requested behavior change. Issue/project and plan `--dry-run` are unchanged.

**Test plan**
- `go test ./cmd/fanout/...` passed.
- `make build-go` passed.
- `./fanout-go msg send --to 1 --dry-run hi` exited 2 with `msg send: unknown option: --dry-run`.
- `make test` passed.
- `make lint` passed.
- `grep -rn "dry-run\|DryRun\|dryRun" cmd/fanout/msg.go cmd/fanout/msg_test.go tests/bats/tier2_msg.bats` returned no matches.
- Focused docs/skills search for `fanout msg` dry-run references returned no matches.
- `codex review --uncommitted` reported no actionable regressions after the skill-doc fix.

Closes #277
