### PR TITLE
docs(site): トップページを source 非依存に刷新し冗長な比喩を平易化

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -6,11 +6,11 @@
 [![Latest release](https://img.shields.io/github/v/release/butaosuinu/fanout)](https://github.com/butaosuinu/fanout/releases)
 [![Docs](https://img.shields.io/badge/docs-butaosuinu.github.io%2Ffanout-2b7a78)](https://butaosuinu.github.io/fanout/ja/)
 
-**tmux 向けの並列 issue オーケストレーター。** GitHub の親 issue の OPEN な
-サブ issue を、並列の tmux ペインへファンアウトします — 子ごとに 1 つの git
-worktree、1 つの agent CLI(Claude Code / Codex)、issue 単位の briefing から
-起動。再実行しても同じ子に 2 つ目のペインは作られません(`.fanout/state.json`
-が記憶します)。
+**tmux 向けの並列エージェントオーケストレーター。** GitHub の親 issue の OPEN な
+サブ issue、あるいはローカルの plan spec を渡すと、子 issue / タスクごとに tmux
+ペイン・git worktree・agent CLI(Claude Code / Codex)を立ち上げ、タスク単位の
+briefing から起動します。再実行しても同じ対象に 2 つ目のペインは作られません
+(`.fanout/state.json` が記憶します)。
 
 📖 **ドキュメント:** <https://butaosuinu.github.io/fanout/ja/> — インストール、
 クイックスタート、完全な CLI リファレンス、設定、トラブルシューティング(英語 /
@@ -67,14 +67,15 @@ fanout 123 --status     # ファンアウトした子の PR review + CI 状態�
 
 ## 仕組み
 
-3 幕構成 — **育てる → 開く → 収穫する**:
+3 手 — **用意 → 展開 → 片づけ**:
 
-1. **木を育てる。** 親 issue と OPEN な子 issue を作成します。同梱の
-   `fanout-issues` skill がブロッカーの wave を組み立ててくれます。
-2. **扇を開く。** `fanout 123` を一振り: 子 1 つ = worktree 1 つ = tmux ペイン
-   1 つ = agent 1 つ。
-3. **果実を収穫する。** TUI または `--status` で進捗を見守り、`--merge` /
-   `--cleanup` でペインを畳んで、次の wave を開きます。
+1. **用意する。** 親 issue と OPEN な子 issue を作る(同梱の `fanout-issues`
+   skill がブロッカーの wave を組み立ててくれます)か、issue を介さず plan spec
+   を書いて `fanout plan` に渡します。
+2. **展開する。** `fanout 123`(または `fanout plan spec.json`)を一回: 子 / タスク
+   1 つ = worktree 1 つ = tmux ペイン 1 つ = agent 1 つ。
+3. **片づける。** TUI または `--status` で進捗を見て、`--merge` / `--cleanup` で
+   ペインを畳み、次の wave を開きます。
 
 `fanout plan <spec>` は GitHub の子 issue ではなくローカルの plan spec を
 ファンアウトし、`--team` + `fanout msg` は兄弟ペインに軽量な peer messaging を

--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@
 [![Latest release](https://img.shields.io/github/v/release/butaosuinu/fanout)](https://github.com/butaosuinu/fanout/releases)
 [![Docs](https://img.shields.io/badge/docs-butaosuinu.github.io%2Ffanout-2b7a78)](https://butaosuinu.github.io/fanout/)
 
-**Parallel issue orchestrator for tmux.** Fan a GitHub parent issue's OPEN
-sub-issues out into parallel tmux panes — one git worktree, one agent CLI
-(Claude Code / Codex) per child, each launched from a per-issue briefing. Run it
-again and no child gets a second pane: `.fanout/state.json` remembers.
+**Parallel agent orchestrator for tmux.** Point fanout at a GitHub parent
+issue's OPEN sub-issues — or a local plan spec — and it fans each child or task
+out into its own tmux pane, git worktree and agent CLI (Claude Code / Codex),
+launched from a per-task briefing. Run it again and nothing gets a second pane:
+`.fanout/state.json` remembers.
 
 📖 **Full documentation:** <https://butaosuinu.github.io/fanout/> — installation,
 quickstart, the complete CLI reference, settings, and troubleshooting, in
@@ -65,14 +66,15 @@ for a guided first run.
 
 ## How it works
 
-Three acts — **grow → open → gather**:
+Three moves — **prepare → fan out → fold away**:
 
-1. **Grow the tree.** Create a parent issue and its OPEN child issues. The
-   bundled `fanout-issues` skill encodes blocker waves for you.
-2. **Open the fan.** One sweep of `fanout 123`: one child = one worktree = one
-   tmux pane = one agent.
-3. **Gather the fruit.** Watch progress through the TUI or `--status`, then fold
-   panes away with `--merge` / `--cleanup`, and open the next wave.
+1. **Prepare the work.** Create a parent issue and its OPEN child issues (the
+   bundled `fanout-issues` skill encodes blocker waves for you), or write a local
+   plan spec for `fanout plan` — no issues required.
+2. **Fan it out.** One run of `fanout 123` or `fanout plan spec.json`: one child
+   or task = one worktree = one tmux pane = one agent.
+3. **Merge and fold away.** Watch progress through the TUI or `--status`, then
+   `--merge` and `--cleanup` finished work, and open the next wave.
 
 `fanout plan <spec>` fans out a local plan spec instead of GitHub child issues,
 and `--team` + `fanout msg` give sibling panes lightweight peer messaging — both

--- a/site/content/_index.ja.md
+++ b/site/content/_index.ja.md
@@ -1,25 +1,25 @@
 ---
 title: fanout
-description: "GitHub 親 issue の OPEN なサブ issue を、子ごとに git worktree + tmux ペイン + エージェント CLI(Claude Code / Codex)へ扇状に並列展開するオーケストレーター。"
+description: "GitHub 親 issue の OPEN なサブ issue、あるいはローカルの plan spec を、子 issue / タスクごとに git worktree + tmux ペイン + エージェント CLI(Claude Code / Codex)へ並列展開するオーケストレーター。"
 hero:
-  kicker: "Parallel issue orchestrator for tmux"
-  tagline: "ひとつの親 issue を、<em>扇</em>のように。"
-  subcopy: "Fan a GitHub parent issue&rsquo;s OPEN sub-issues out into parallel tmux panes &mdash; one git worktree, one agent per child."
+  kicker: "Parallel agent orchestrator for tmux"
+  tagline: "issue でも <em>plan</em> でも、並列に展開する。"
+  subcopy: "GitHub の親 issue か、ローカルの plan spec を渡すだけ。子 issue / タスクごとに git worktree・tmux ペイン・エージェントが立ち上がる。"
   ctaNote: "tmux と git と GitHub CLI の上で動く、Go 製シングルバイナリ。Claude Code / Codex の skill も同梱。"
   ctaQuickstart: "クイックスタート"
   ctaInstall: "インストール"
 quickstart:
   title: "開くのは、一行。"
-  lede: "tmux の中で一度だけ。親 issue の OPEN な子 issue が、それぞれの worktree・pane・agent に展開される。"
+  lede: "tmux の中で一度だけ。親 issue の OPEN な子 issue が、それぞれの worktree・pane・agent で動き出す。"
   caption: "もう一度実行しても、同じ子に二度目のペインは作られない —— <code class=\"in\">.fanout/state.json</code> が覚えている。"
 features:
-  title: "静かな並列のための、六つの骨。"
-  lede: "扇がきれいに開くのは、骨が通っているから。fanout の機能はどれも「並列の手を止めない」ために通っている。"
+  title: "並列を止めないための、六つの機能。"
+  lede: "issue でも、ローカルの plan でも —— どの機能も並列の手を止めないために働く。"
   items:
     - no: "i"
       icon: "seal"
       title: "冪等なファンアウト"
-      body: "<code>.fanout/state.json</code> が (parent, issue) ごとにペインを記録。再実行しても重複しない。"
+      body: "<code>.fanout/state.json</code> が子 issue も plan タスクもペイン単位で記録。再実行しても重複しない。"
       link: "/docs/workflow"
     - no: "ii"
       icon: "waves"
@@ -47,20 +47,20 @@ features:
       body: "Claude Code / Codex の <code>/fanout</code> スラッシュコマンドと skill を同梱インストール。"
       link: "/docs/agents"
 workflow:
-  title: "育てて、開いて、収める。"
-  lede: "仕事は三幕。あとは風まかせ —— wave が終わるたび、また開けばいい。"
+  title: "用意して、展開して、片づける。"
+  lede: "基本はこの三手。wave が終わるたび、繰り返すだけ。"
   steps:
     - num: "一"
-      title: "木を育てる"
-      body: "fanout-issues skill で、親 issue と OPEN の子 issue ツリーを作る。blocker を書き込めば、wave の順番まで設計できる。"
-      chip: "fanout-issues skill"
+      title: "用意する"
+      body: "fanout-issues skill で親 issue と子 issue ツリーを作るか、issue を介さず plan spec を書いて <code>fanout plan</code> に渡す。blocker を書けば wave の順番も決まる。"
+      chip: "fanout-issues · fanout plan"
     - num: "二"
       title: "扇を開く"
-      body: "<code>fanout 123</code> の一振りで、1 子 = 1 worktree = 1 ペイン = 1 agent。何度振っても、開く骨は同じ。"
+      body: "<code>fanout 123</code>(または <code>fanout plan spec.json</code>)の一回で、1 子 / タスク = 1 worktree = 1 ペイン = 1 agent。何度実行しても、同じペインが開くだけで重複しない。"
       chip: "fanout 123 --agent claude"
     - num: "三"
-      title: "実を収める"
-      body: "TUI や <code>--status</code> で見届けて、<code>--merge</code> / <code>--cleanup</code> で畳む。次の wave へ。"
+      title: "片づける"
+      body: "TUI や <code>--status</code> で進捗を見て、<code>--merge</code> / <code>--cleanup</code> で畳む。そして次の wave へ。"
       chip: "--status → --merge → --cleanup"
 cli:
   title: "覚えるのは、これだけ。"
@@ -84,6 +84,6 @@ cli:
     - cmd: "fanout 123 --merge 4"
       desc: "子ブランチを ff-only でマージ。<code>--close</code> / <code>--cleanup</code> で静かに畳む"
 coda:
-  title: "次の親 issue を、開いてみる。"
+  title: "次の wave を、開いてみる。"
   docsLink: "ドキュメントを読む"
 ---

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -1,25 +1,25 @@
 ---
 title: fanout
-description: "Fan a GitHub parent issue's OPEN sub-issues out into parallel tmux panes — one git worktree, one agent CLI (Claude Code / Codex) per child, launched with a per-issue briefing."
+description: "Fan a GitHub parent issue's OPEN sub-issues — or a local plan spec — out into parallel tmux panes, one git worktree and agent CLI (Claude Code / Codex) per child or task."
 hero:
-  kicker: "Parallel issue orchestrator for tmux"
-  tagline: "One parent issue, opened like a <em>fan</em>."
-  subcopy: "Fan a GitHub parent issue&rsquo;s OPEN sub-issues out into parallel tmux panes &mdash; one git worktree, one agent per child."
+  kicker: "Parallel agent orchestrator for tmux"
+  tagline: "Issues or a plan, <em>fanned</em> out in parallel."
+  subcopy: "Point fanout at a GitHub parent issue or a local plan spec; each child or task gets its own git worktree, tmux pane and agent."
   ctaNote: "Runs on tmux + git + GitHub CLI. A single Go binary, with Claude Code / Codex skills bundled."
   ctaQuickstart: "Quickstart"
   ctaInstall: "Installation"
 quickstart:
   title: "One line to open."
-  lede: "Run it once inside tmux. Every OPEN child of the parent issue unfolds into its own worktree, pane and agent."
+  lede: "Run it once inside tmux. Every OPEN child of the parent issue gets its own worktree, pane and agent."
   caption: "Run it again and no child gets a second pane &mdash; <code class=\"in\">.fanout/state.json</code> remembers."
 features:
-  title: "Six ribs for quiet parallelism."
-  lede: "A fan opens cleanly because its ribs are true. Every fanout feature exists to keep parallel work moving."
+  title: "Six features that keep parallel work moving."
+  lede: "Whether you fan out GitHub issues or a local plan, every feature keeps parallel work moving."
   items:
     - no: "i"
       icon: "seal"
       title: "Idempotent fan-out"
-      body: "<code>.fanout/state.json</code> keys every (parent, issue) pane. Reruns never duplicate work."
+      body: "<code>.fanout/state.json</code> keys every pane &mdash; issue children or plan tasks alike. Reruns never duplicate work."
       link: "/docs/workflow"
     - no: "ii"
       icon: "waves"
@@ -47,20 +47,20 @@ features:
       body: "The <code>/fanout</code> slash command and skills for Claude Code &amp; Codex, bundled with the install."
       link: "/docs/agents"
 workflow:
-  title: "Grow, open, gather."
-  lede: "Three acts &mdash; then let the breeze do the rest. When a wave ends, just open again."
+  title: "Prepare, fan out, fold away."
+  lede: "Prepare the work, fan it out, fold finished panes away &mdash; then rerun for the next wave."
   steps:
     - num: "一"
-      title: "Grow the tree"
-      body: "Create the parent and its OPEN child issues with the fanout-issues skill. Write blockers in, and the waves are already designed."
-      chip: "fanout-issues skill"
+      title: "Prepare the work"
+      body: "Decompose into GitHub child issues with the fanout-issues skill, or write a local plan spec for <code>fanout plan</code> &mdash; no issues required. Note blockers and the waves fall out for you."
+      chip: "fanout-issues · fanout plan"
     - num: "二"
-      title: "Open the fan"
-      body: "One sweep of <code>fanout 123</code>: one child = one worktree = one pane = one agent. However often you swing it, the same ribs open."
+      title: "Fan it out"
+      body: "One run of <code>fanout 123</code> or <code>fanout plan spec.json</code>: one child or task = one worktree = one pane = one agent. Rerun anytime &mdash; the same panes open, never duplicated."
       chip: "fanout 123 --agent claude"
     - num: "三"
-      title: "Gather the fruit"
-      body: "Watch through the TUI or <code>--status</code>, then fold up with <code>--merge</code> / <code>--cleanup</code>. On to the next wave."
+      title: "Merge and fold away"
+      body: "Watch through the TUI or <code>--status</code>, then <code>--merge</code> and <code>--cleanup</code> finished work. On to the next wave."
       chip: "--status → --merge → --cleanup"
 cli:
   title: "All you need to remember."
@@ -84,6 +84,6 @@ cli:
     - cmd: "fanout 123 --merge 4"
       desc: "Fast-forward merge a child branch; <code>--close</code> / <code>--cleanup</code> fold panes away"
 coda:
-  title: "Open the next parent issue."
+  title: "Open the next wave."
   docsLink: "Read the docs"
 ---

--- a/site/hugo.toml
+++ b/site/hugo.toml
@@ -11,13 +11,13 @@ disableKinds = ["taxonomy", "term"]
     label = "English"
     weight = 1
     [languages.en.params]
-      tagline = "Fan a parent issue out into parallel panes — quietly."
+      tagline = "Fan GitHub issues or a local plan out into parallel panes — quietly."
   [languages.ja]
     locale = "ja"
     label = "日本語"
     weight = 2
     [languages.ja.params]
-      tagline = "ひとつの親 issue を、扇のように。"
+      tagline = "issue でも plan でも、並列に展開する。"
 
 [params]
   github = "https://github.com/butaosuinu/fanout"


### PR DESCRIPTION
## なぜ

`fanout plan`（issue-less fan-out）が追加され、fanout は GitHub issue に必ずしも紐づかずに並列オーケストレーションできるようになった。しかしドキュメントサイトのトップページは依然 issue 中心で、`fanout plan` は CLI 表の 1 行に埋もれていた。加えてトップのコピーは「扇 / breeze / 骨」のメタファーを過剰に押し出した、詩的すぎて不自然な（AI 臭い）文章になっていた。

## 何を

- **source 非依存の positioning** — hero kicker を `Parallel issue orchestrator` → `Parallel agent orchestrator`、tagline / subcopy / description を「issue でも plan でも並列展開する」表現に。`fanout plan` を workflow step 1（`fanout-issues · fanout plan`）・features lede / card i・CLI 例に組み込み、一級市民化。
- **脱 AI 臭** — `Six ribs / its ribs are true`・`Grow, open, gather` / `let the breeze do the rest`・`何度振っても、開く骨は同じ`・`果実を収穫する` 等の過剰な比喩を、`Six features that keep parallel work moving`・`Prepare, fan out, fold away`・`用意して、展開して、片づける` のような具体的で自然なコピーに置換。
- **周辺整合** — `site/hugo.toml` の footer tagline（EN/JA）と `README.md` / `README.ja.md` の冒頭リード文・How it works / 仕組みを同じトーンに揃えた。

## 維持したもの

- 扇 / 風のビジュアル（縦書き `扇`・`風`、breeze SVG、fan partial、装飾 kicker "One more breeze"）はブランドのビジュアルとして維持（`home.html` 無改修）。
- features は 6 枚維持（アイコン固定 6 種・「六つ」維持のため、plan 導線は lede と card i に通す）。step 二「扇を開く」は自然な軽い扇モチーフとして残置。

## 検証

- `hugo --gc` がエラー / 警告なくビルド成功。レンダリング後 HTML に新コピーが反映、旧文言は全ファイル 0 件。
- 新コピーの機能主張（plan タスクの state 記録・冪等性、issue-less な `fanout plan`、blocker/wave、1 タスク=1 worktree/pane/agent）を実装（`cmd/fanout/plancmd.go` / `internal/state` / `internal/planspec`）と突き合わせて正確性を確認。
- post-work-review（code-review + codex review ループ）を実施。codex 指摘の「裸 `fanout plan` 実行例」を `fanout plan spec.json` に修正し、再レビューで clean。

🤖 Generated with [Claude Code](https://claude.com/claude-code)