### PR TITLE
[codex] Allow local fanout plans without origin

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -114,7 +114,9 @@ flag を生成します。詳しくは
 
 ## 前提条件
 
-- **git**、**tmux**、認証済みの **GitHub CLI(`gh`)**(`gh auth status`)。
+- **git** と **tmux**。GitHub issue / Project workflow、PR status、
+  cleanup/status view では認証済みの **GitHub CLI(`gh`)**(`gh auth status`)も
+  必要です。ローカルの `fanout plan` 実行や TUI の手動 pane では不要です。
 - 子を起動する agent CLI — **`claude`**(Claude Code)や **`codex`** — を、live
   実行では `PATH` に入れておくこと。インストールが配置するのは fanout 側の
   skill/command だけで、agent 本体はインストールしません(`--dry-run` や

--- a/README.md
+++ b/README.md
@@ -110,8 +110,9 @@ context. See the
 
 ## Prerequisites
 
-- **git**, **tmux**, and the **GitHub CLI (`gh`)**, authenticated
-  (`gh auth status`).
+- **git** and **tmux**. GitHub issue / Project workflows, PR status, and
+  cleanup/status views also need the **GitHub CLI (`gh`)**, authenticated
+  (`gh auth status`); local `fanout plan` runs and manual TUI panes do not.
 - The agent CLI you launch children with — **`claude`** (Claude Code) and/or
   **`codex`** — on your `PATH` for live runs. The install only bundles fanout's
   skills/commands for them; it does not install the agents themselves.

--- a/claude/skills/fanout-plan/SKILL.md
+++ b/claude/skills/fanout-plan/SKILL.md
@@ -67,8 +67,7 @@ Schema:
   "plan": {
     "slug": "launch-plan",
     "title": "Launch plan",
-    "source": "path-or-conversation-label",
-    "base_branch": "main"
+    "source": "path-or-conversation-label"
   },
   "tasks": [
     {
@@ -88,17 +87,18 @@ Schema:
 `source`, `base_branch`, `slug`, `display_name`, `branch`, `wave`, and
 `blocked_by` are optional except when the dependency graph requires
 `blocked_by`. Prefer `plan.base_branch` when the source plan names a base;
-otherwise let fanout resolve the repository default branch or let the user pass
-`--base-branch`.
+otherwise let fanout resolve the repository default branch, use the current
+local branch in repos without `origin`, or let the user pass `--base-branch`.
 Do not add an agent field to the JSON schema; per-task agent assignment belongs
 only in repeatable CLI flags such as `--agent base-types=codex`.
 
 ## CLI Surface
 
 Run from the target repository worktree. Task creation and dry-run modes need
-`git` and `tmux`; `gh` is additionally needed for `--unblocked-only` blocker
-completion checks. Read/lifecycle action modes need `git` but not tmux;
-`--status` and `--cleanup` also need `gh`. Use `--agent claude` unless the user
+`git` and `tmux`; `gh` is optional for `--unblocked-only` blocker completion
+checks, and unavailable PR lookups are treated as incomplete dependencies.
+Read/lifecycle action modes need `git` but not tmux; `--status` and `--cleanup`
+also need `gh`. Use `--agent claude` unless the user
 supplied `--agent` or `FANOUT_AGENT`; repeat `--agent task-id=name` for
 per-task overrides.
 

--- a/cmd/fanout/pane.go
+++ b/cmd/fanout/pane.go
@@ -100,11 +100,12 @@ func createPane(cfg *cliflags.Config, lg *log.Logger, info *fanoutruntime.Info, 
 	}
 
 	prepared, err := worktree.Prepare(worktree.Options{
-		ProjectRoot: info.ProjectRoot,
-		Slug:        req.Slug,
-		BranchName:  req.BranchName,
-		BaseBranch:  req.Worktree.BaseBranch,
-		NoRefresh:   cfg.NoRefresh,
+		ProjectRoot:        info.ProjectRoot,
+		Slug:               req.Slug,
+		BranchName:         req.BranchName,
+		BaseBranch:         req.Worktree.BaseBranch,
+		NoRefresh:          cfg.NoRefresh,
+		AllowMissingOrigin: req.Worktree.AllowMissingOrigin,
 	})
 	if err != nil {
 		lg.Err("%s: prepare worktree: %v", paneLogLabel(req), err)
@@ -289,11 +290,12 @@ func newTaskPaneRequest(cfg *cliflags.Config, projectRoot string, spec planspec.
 		BranchName:          branchName,
 		Agent:               agentName,
 		Worktree: worktree.BuildPlan(worktree.Options{
-			ProjectRoot: projectRoot,
-			Slug:        slug,
-			BranchName:  branchName,
-			BaseBranch:  cfg.BaseBranch,
-			NoRefresh:   cfg.NoRefresh,
+			ProjectRoot:        projectRoot,
+			Slug:               slug,
+			BranchName:         branchName,
+			BaseBranch:         cfg.BaseBranch,
+			NoRefresh:          cfg.NoRefresh,
+			AllowMissingOrigin: true,
 		}),
 	}
 	req.BriefingBody = briefing.RenderTask(spec.Plan.Slug, spec.Plan.Title, task.ID, task.Title, task.Briefing, agentName, req.Worktree.BaseBranch, resolvedSettings, teamCtx)
@@ -339,7 +341,7 @@ func newManualPaneRequest(cfg *cliflags.Config, projectRoot string, store state.
 		Agent:        agentName,
 		BriefingPath: briefingPath,
 		BriefingBody: briefingBody,
-		Worktree:     worktree.BuildPlan(worktree.Options{ProjectRoot: projectRoot, Slug: slug, BranchName: branchName, BaseBranch: cfg.BaseBranch, NoRefresh: cfg.NoRefresh}),
+		Worktree:     worktree.BuildPlan(worktree.Options{ProjectRoot: projectRoot, Slug: slug, BranchName: branchName, BaseBranch: cfg.BaseBranch, NoRefresh: cfg.NoRefresh, AllowMissingOrigin: true}),
 	}
 }
 
@@ -499,6 +501,9 @@ func logPaneRequest(req paneRequest, lg *log.Logger) {
 	lg.Dim("  worktree -> %s", req.Worktree.WorktreePath)
 	lg.Dim("  branch -> %s", req.BranchName)
 	lg.Dim("  base -> %s", req.Worktree.BaseBranch)
+	if req.Worktree.RefreshSkippedReason != "" {
+		lg.Dim("  refresh -> skipped (%s)", req.Worktree.RefreshSkippedReason)
+	}
 	if req.DisplayNameOverride != "" {
 		lg.Dim("  display-name -> %s", req.DisplayNameOverride)
 	}
@@ -522,6 +527,8 @@ func printPaneDryRun(req paneRequest, target string, lg *log.Logger, c log.Palet
 			fmt.Fprintf(lg.Stdout(), "    %s$ git -C %s branch -f %s %s%s\n", c.Dim, shellQuote(req.Worktree.ProjectRoot), shellQuote(details.LocalBranch), shellQuote(details.OriginRef), c.Reset)
 			fmt.Fprintf(lg.Stdout(), "    %s# if the base is checked out elsewhere, fanout uses merge --ff-only in that worktree%s\n", c.Dim, c.Reset)
 		}
+	} else if req.Worktree.RefreshSkippedReason != "" {
+		fmt.Fprintf(lg.Stdout(), "    %s# skip base refresh: %s%s\n", c.Dim, req.Worktree.RefreshSkippedReason, c.Reset)
 	}
 	fmt.Fprintf(lg.Stdout(), "    %s$ git -C %s worktree add -b %s %s %s%s\n",
 		c.Dim,

--- a/cmd/fanout/pane_test.go
+++ b/cmd/fanout/pane_test.go
@@ -151,6 +151,22 @@ func TestCreatePaneAcceptsManualRequestWithoutParentIssue(t *testing.T) {
 	}
 }
 
+func TestPlanAndManualPaneRequestsAllowMissingOrigin(t *testing.T) {
+	cfg := &cliflags.Config{Agent: "claude"}
+	spec := planspec.Spec{Plan: planspec.Plan{Slug: "launch-plan", Title: "Launch plan"}}
+	task := planspec.Task{ID: "api-client", Title: "Extract API client", Briefing: "Do it"}
+
+	taskReq := newTaskPaneRequest(cfg, "/repo", spec, task, settings.Defaults(), nil)
+	if !taskReq.Worktree.AllowMissingOrigin {
+		t.Fatal("task pane AllowMissingOrigin = false, want true")
+	}
+
+	manualReq := newManualPaneRequest(cfg, "/repo", state.Store{}, manualPaneOptions{Title: "Manual diagnostics"})
+	if !manualReq.Worktree.AllowMissingOrigin {
+		t.Fatal("manual pane AllowMissingOrigin = false, want true")
+	}
+}
+
 func TestCreatePaneIssueDryRunDoesNotWriteBriefing(t *testing.T) {
 	projectRoot := t.TempDir()
 	cfg := &cliflags.Config{ParentRef: "100", Agent: "claude", BaseBranch: "main", DryRun: true, NoRefresh: true}

--- a/cmd/fanout/plancmd.go
+++ b/cmd/fanout/plancmd.go
@@ -126,7 +126,7 @@ func cmdPlan(args []string, lg *log.Logger, commandName string) exitcode.Code {
 		return cmdPlanLifecycle(cfg, lg)
 	}
 
-	if missing := checkPlanDeps(cfg); len(missing) > 0 {
+	if missing := checkPlanDeps(); len(missing) > 0 {
 		lg.Err("missing dependencies:")
 		for _, d := range missing {
 			fmt.Fprintf(lg.Stderr(), "  - %s\n", d)
@@ -619,7 +619,7 @@ func parsePlanAgentArg(cfg *planCommandConfig, raw string) error {
 	return nil
 }
 
-func checkPlanDeps(cfg planCommandConfig) []string {
+func checkPlanDeps() []string {
 	var missing []string
 	check := func(cmd, hint string) {
 		if _, err := exec.LookPath(cmd); err != nil {
@@ -628,9 +628,6 @@ func checkPlanDeps(cfg planCommandConfig) []string {
 	}
 	check("git", "git")
 	check("tmux", "tmux (brew install tmux)")
-	if cfg.UnblockedOnly {
-		check("gh", "gh (brew install gh)")
-	}
 	return missing
 }
 
@@ -658,7 +655,7 @@ func resolvePlanBaseBranch(cfg planCommandConfig, spec planspec.Spec, projectRoo
 		}
 		return spec.Plan.BaseBranch, nil
 	}
-	return worktree.ResolveDefaultBranch(projectRoot), nil
+	return worktree.ResolveDefaultBranchAllowMissingOrigin(projectRoot), nil
 }
 
 func validatePlanBaseBranch(label, value string) error {

--- a/cmd/fanout/plancmd_test.go
+++ b/cmd/fanout/plancmd_test.go
@@ -81,6 +81,41 @@ func TestResolvePlanBaseBranchValidatesSpecBranchOnlyWhenUsed(t *testing.T) {
 	}
 }
 
+func TestResolvePlanBaseBranchUsesCurrentBranchWithoutOrigin(t *testing.T) {
+	repo := t.TempDir()
+	gitCmdTest(t, repo, "init", "-b", "trunk")
+	gitCmdTest(t, repo, "config", "user.email", "fanout@example.test")
+	gitCmdTest(t, repo, "config", "user.name", "Fanout Test")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("base\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmdTest(t, repo, "add", "README.md")
+	gitCmdTest(t, repo, "commit", "-m", "base")
+
+	got, err := resolvePlanBaseBranch(planCommandConfig{}, planspec.Spec{Plan: planspec.Plan{Slug: "launch-plan"}}, repo)
+	if err != nil {
+		t.Fatalf("resolvePlanBaseBranch() error = %v", err)
+	}
+	if got != "trunk" {
+		t.Fatalf("resolvePlanBaseBranch() = %q, want current branch trunk", got)
+	}
+}
+
+func TestCheckPlanDepsDoesNotRequireGhForUnblockedOnly(t *testing.T) {
+	binDir := t.TempDir()
+	for _, name := range []string{"git", "tmux"} {
+		path := filepath.Join(binDir, name)
+		if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("PATH", binDir)
+
+	if missing := checkPlanDeps(); len(missing) != 0 {
+		t.Fatalf("checkPlanDeps() missing = %v, want no gh requirement", missing)
+	}
+}
+
 func TestPlanRerunSpecArgUsesCopiedPlanSlugForLiveRuns(t *testing.T) {
 	spec := planspec.Spec{Plan: planspec.Plan{Slug: "launch-plan"}}
 

--- a/codex/skills/fanout-plan/SKILL.md
+++ b/codex/skills/fanout-plan/SKILL.md
@@ -69,8 +69,7 @@ Schema:
   "plan": {
     "slug": "launch-plan",
     "title": "Launch plan",
-    "source": "path-or-conversation-label",
-    "base_branch": "main"
+    "source": "path-or-conversation-label"
   },
   "tasks": [
     {
@@ -90,17 +89,18 @@ Schema:
 `source`, `base_branch`, `slug`, `display_name`, `branch`, `wave`, and
 `blocked_by` are optional except when the dependency graph requires
 `blocked_by`. Prefer `plan.base_branch` when the source plan names a base;
-otherwise let fanout resolve the repository default branch or let the user pass
-`--base-branch`.
+otherwise let fanout resolve the repository default branch, use the current
+local branch in repos without `origin`, or let the user pass `--base-branch`.
 Do not add an agent field to the JSON schema; per-task agent assignment belongs
 only in repeatable CLI flags such as `--agent base-types=claude`.
 
 ## CLI Surface
 
 Run from the target repository worktree. Task creation and dry-run modes need
-`git` and `tmux`; `gh` is additionally needed for `--unblocked-only` blocker
-completion checks. Read/lifecycle action modes need `git` but not tmux;
-`--status` and `--cleanup` also need `gh`. Use `--agent codex` unless the user
+`git` and `tmux`; `gh` is optional for `--unblocked-only` blocker completion
+checks, and unavailable PR lookups are treated as incomplete dependencies.
+Read/lifecycle action modes need `git` but not tmux; `--status` and `--cleanup`
+also need `gh`. Use `--agent codex` unless the user
 supplied `--agent` or `FANOUT_AGENT`; repeat `--agent task-id=name` for
 per-task overrides.
 

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -25,21 +25,24 @@ var localExcludePatterns = []string{
 }
 
 type Options struct {
-	ProjectRoot string
-	Slug        string
-	BranchName  string
-	BaseBranch  string
-	NoRefresh   bool
+	ProjectRoot        string
+	Slug               string
+	BranchName         string
+	BaseBranch         string
+	NoRefresh          bool
+	AllowMissingOrigin bool
 }
 
 type Plan struct {
-	ProjectRoot    string
-	WorktreePath   string
-	BranchName     string
-	BaseBranch     string
-	Refresh        bool
-	RefreshDetails RefreshDetails
-	RefreshError   error
+	ProjectRoot          string
+	WorktreePath         string
+	BranchName           string
+	BaseBranch           string
+	AllowMissingOrigin   bool
+	Refresh              bool
+	RefreshDetails       RefreshDetails
+	RefreshError         error
+	RefreshSkippedReason string
 }
 
 type Result struct {
@@ -50,19 +53,32 @@ type Result struct {
 
 // BuildPlan resolves deterministic worktree paths and the base branch.
 func BuildPlan(opts Options) Plan {
-	base := opts.BaseBranch
-	if base == "" {
-		base = ResolveDefaultBranch(opts.ProjectRoot)
+	base, missingOrigin := resolveBaseBranch(opts)
+	refresh := !opts.NoRefresh
+	refreshSkippedReason := ""
+	var refreshDetails RefreshDetails
+	var refreshErr error
+	if missingOrigin {
+		if originQualifiedBase(base) {
+			refreshErr = fmt.Errorf("base branch %q requires origin remote, but origin is not configured", base)
+			refresh = true
+		} else {
+			refresh = false
+			refreshSkippedReason = "origin remote is not configured; using local base without refresh"
+		}
+	} else {
+		refreshDetails, refreshErr = RefreshDetailsFor(base)
 	}
-	refreshDetails, refreshErr := RefreshDetailsFor(base)
 	return Plan{
-		ProjectRoot:    opts.ProjectRoot,
-		WorktreePath:   filepath.Join(opts.ProjectRoot, ".fanout", "worktrees", opts.Slug),
-		BranchName:     opts.BranchName,
-		BaseBranch:     base,
-		Refresh:        !opts.NoRefresh,
-		RefreshDetails: refreshDetails,
-		RefreshError:   refreshErr,
+		ProjectRoot:          opts.ProjectRoot,
+		WorktreePath:         filepath.Join(opts.ProjectRoot, ".fanout", "worktrees", opts.Slug),
+		BranchName:           opts.BranchName,
+		BaseBranch:           base,
+		AllowMissingOrigin:   opts.AllowMissingOrigin,
+		Refresh:              refresh,
+		RefreshDetails:       refreshDetails,
+		RefreshError:         refreshErr,
+		RefreshSkippedReason: refreshSkippedReason,
 	}
 }
 
@@ -80,6 +96,9 @@ func Prepare(opts Options) (Result, error) {
 		return Result{Plan: plan, AlreadyExists: true}, nil
 	}
 	if plan.Refresh {
+		if plan.RefreshError != nil {
+			return Result{Plan: plan}, plan.RefreshError
+		}
 		if err := RefreshBase(plan.ProjectRoot, plan.BaseBranch); err != nil {
 			return Result{Plan: plan}, err
 		}
@@ -187,6 +206,19 @@ func missingExcludePatterns(body []byte) []string {
 
 // ResolveDefaultBranch follows fanout's default branch fallback order.
 func ResolveDefaultBranch(root string) string {
+	return resolveDefaultBranch(root, false)
+}
+
+// ResolveDefaultBranchAllowMissingOrigin returns the current local branch when
+// no origin remote exists, for local-only plan/manual pane runs.
+func ResolveDefaultBranchAllowMissingOrigin(root string) string {
+	return resolveDefaultBranch(root, true)
+}
+
+func resolveDefaultBranch(root string, allowMissingOrigin bool) string {
+	if allowMissingOrigin && !hasOriginRemote(root) {
+		return localBaseRef(root)
+	}
 	cmd := exec.Command("gh", "repo", "view", "--json", "defaultBranchRef", "-q", ".defaultBranchRef.name")
 	cmd.Dir = root
 	if out, err := cmd.Output(); err == nil {
@@ -202,6 +234,34 @@ func ResolveDefaultBranch(root string) string {
 		}
 	}
 	return "main"
+}
+
+func resolveBaseBranch(opts Options) (string, bool) {
+	missingOrigin := opts.AllowMissingOrigin && !hasOriginRemote(opts.ProjectRoot)
+	base := opts.BaseBranch
+	if base == "" {
+		if missingOrigin {
+			return localBaseRef(opts.ProjectRoot), true
+		}
+		return ResolveDefaultBranch(opts.ProjectRoot), false
+	}
+	return base, missingOrigin
+}
+
+func hasOriginRemote(root string) bool {
+	_, err := git(root, "remote", "get-url", "origin")
+	return err == nil
+}
+
+func localBaseRef(root string) string {
+	if branch, err := gitTrim(root, "symbolic-ref", "--quiet", "--short", "HEAD"); err == nil && branch != "" {
+		return branch
+	}
+	return "HEAD"
+}
+
+func originQualifiedBase(base string) bool {
+	return strings.HasPrefix(base, "origin/") || strings.HasPrefix(base, "refs/remotes/origin/")
 }
 
 type RefreshDetails struct {

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -101,6 +101,70 @@ func TestPrepareSupportsOriginQualifiedBase(t *testing.T) {
 	}
 }
 
+func TestPrepareAllowsMissingOriginFromCurrentBranch(t *testing.T) {
+	repo := newCommittedRepoWithoutOrigin(t)
+	baseHead := gitOutput(t, repo, "rev-parse", "HEAD")
+
+	res, err := Prepare(Options{
+		ProjectRoot:        repo,
+		Slug:               "local-task",
+		BranchName:         "fanout/local-task",
+		AllowMissingOrigin: true,
+	})
+	if err != nil {
+		t.Fatalf("Prepare() failed without origin: %v", err)
+	}
+	if res.Refresh {
+		t.Fatal("Prepare() plan refresh = true, want false without origin")
+	}
+	if !strings.Contains(res.RefreshSkippedReason, "origin remote is not configured") {
+		t.Fatalf("RefreshSkippedReason = %q, want origin skip message", res.RefreshSkippedReason)
+	}
+	if res.BaseBranch != "main" {
+		t.Fatalf("BaseBranch = %q, want current branch main", res.BaseBranch)
+	}
+	if got := gitOutput(t, res.WorktreePath, "rev-parse", "HEAD"); got != baseHead {
+		t.Fatalf("worktree HEAD = %s, want local base %s", got, baseHead)
+	}
+}
+
+func TestPrepareAllowsMissingOriginWithExplicitLocalBase(t *testing.T) {
+	repo := newCommittedRepoWithoutOrigin(t)
+	baseHead := gitOutput(t, repo, "rev-parse", "main")
+
+	res, err := Prepare(Options{
+		ProjectRoot:        repo,
+		Slug:               "local-base-task",
+		BranchName:         "fanout/local-base-task",
+		BaseBranch:         "main",
+		AllowMissingOrigin: true,
+	})
+	if err != nil {
+		t.Fatalf("Prepare() failed with explicit local base and no origin: %v", err)
+	}
+	if res.Refresh {
+		t.Fatal("Prepare() plan refresh = true, want false without origin")
+	}
+	if got := gitOutput(t, res.WorktreePath, "rev-parse", "HEAD"); got != baseHead {
+		t.Fatalf("worktree HEAD = %s, want local base %s", got, baseHead)
+	}
+}
+
+func TestPrepareRejectsOriginQualifiedBaseWithoutOrigin(t *testing.T) {
+	repo := newCommittedRepoWithoutOrigin(t)
+
+	_, err := Prepare(Options{
+		ProjectRoot:        repo,
+		Slug:               "remote-base-task",
+		BranchName:         "fanout/remote-base-task",
+		BaseBranch:         "origin/main",
+		AllowMissingOrigin: true,
+	})
+	if err == nil || !strings.Contains(err.Error(), `base branch "origin/main" requires origin remote`) {
+		t.Fatalf("Prepare() error = %v, want origin-required error", err)
+	}
+}
+
 func TestPrepareSkipsExistingWorktreePath(t *testing.T) {
 	dir := t.TempDir()
 	gitTest(t, dir, "init")
@@ -403,4 +467,16 @@ func writeFile(t *testing.T, path, body string) {
 	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func newCommittedRepoWithoutOrigin(t *testing.T) string {
+	t.Helper()
+	repo := t.TempDir()
+	gitTest(t, "", "init", "-b", "main", repo)
+	gitTest(t, repo, "config", "user.name", "Fanout Test")
+	gitTest(t, repo, "config", "user.email", "fanout@example.test")
+	writeFile(t, filepath.Join(repo, "file.txt"), "base\n")
+	gitTest(t, repo, "add", "file.txt")
+	gitTest(t, repo, "commit", "-m", "base")
+	return repo
 }

--- a/site/content/docs/cli.ja.md
+++ b/site/content/docs/cli.ja.md
@@ -117,8 +117,7 @@ spec フォーマット:
   "plan": {
     "slug": "launch-plan",
     "title": "Launch plan",
-    "source": "docs/launch.md",
-    "base_branch": "main"
+    "source": "docs/launch.md"
   },
   "tasks": [
     {
@@ -151,7 +150,7 @@ spec フォーマット:
 | `--skip` | `<task-id[,id...]>` | 指定 task ID を除外する。`--only` とは併用不可。 |
 | `--limit` | `<N>` | 作成する task pane を N 件までに制限し、残りは task ID の再実行 hint として表示する。 |
 | `--unblocked-only` | — | `blocked_by` 依存 task の明示 branch または生成 branch に merge 済み PR がまだ無い task を deferred にする。 |
-| `--base-branch` | `<branch>` | `plan.base_branch` を上書きする。どちらも無い場合は repository default branch を解決する。 |
+| `--base-branch` | `<branch>` | `plan.base_branch` を上書きする。どちらも無い場合は repository default branch を解決し、`origin` remote が無い場合は現在の local branch / `HEAD` を使う。 |
 | `--branch-prefix` | `<prefix>` | 生成 task branch 名の prefix。 |
 | `--no-refresh` | — | task worktree 作成前の base branch refresh をスキップする。 |
 | `--team` | — | その plan run を兄弟協調に opt-in する。issue モードと同じだが、peer は issue 番号ではなく **task ID** で指定する（issue-less な plan task には `#N` が無い）。plan の per-parent peer レジストリに seed し、各 task briefing に roster 節を付ける。plan のバスは `/tmp/fanout-<repo>-plan-<slug>.db`。plan の read / lifecycle モード（`--status` / `--close` / `--merge` / `--cleanup`）とは併用不可。既定: off。 |

--- a/site/content/docs/cli.md
+++ b/site/content/docs/cli.md
@@ -117,8 +117,7 @@ Spec format:
   "plan": {
     "slug": "launch-plan",
     "title": "Launch plan",
-    "source": "docs/launch.md",
-    "base_branch": "main"
+    "source": "docs/launch.md"
   },
   "tasks": [
     {
@@ -151,7 +150,7 @@ generated branches use `fanout/<slug>` unless the task supplies `branch`.
 | `--skip` | `<task-id[,id...]>` | Exclude task IDs. Cannot be combined with `--only`. |
 | `--limit` | `<N>` | Create at most N task panes and print a task-ID rerun hint for the rest. |
 | `--unblocked-only` | — | Defer tasks whose `blocked_by` dependencies do not yet have a merged PR on their explicit or generated branch. |
-| `--base-branch` | `<branch>` | Override `plan.base_branch`; if neither is set, fanout resolves the repository default branch. |
+| `--base-branch` | `<branch>` | Override `plan.base_branch`; if neither is set, fanout resolves the repository default branch, or uses the current local branch/`HEAD` when no `origin` remote is configured. |
 | `--branch-prefix` | `<prefix>` | Prefix generated task branch names. |
 | `--no-refresh` | — | Skip base-branch refresh before creating task worktrees. |
 | `--team` | — | Opt the plan run into sibling coordination, exactly like issue mode — except peers are addressed by **task ID** (issue-less plan tasks have no `#N`). Seeds the plan's per-parent peer registry and appends the roster section to each task briefing. The plan bus lives at `/tmp/fanout-<repo>-plan-<slug>.db`. Not combinable with the plan read/lifecycle modes (`--status` / `--close` / `--merge` / `--cleanup`). Off by default. |

--- a/site/content/docs/installation.ja.md
+++ b/site/content/docs/installation.ja.md
@@ -9,7 +9,7 @@ yomi: install
 
 ## 前提ツール
 
-既定の fanout 作成フローでは、次のツールが `PATH` 上に必要です:
+既定の GitHub issue / Project fanout 作成フローでは、次のツールが `PATH` 上に必要です:
 
 | ツール | 用途 |
 |---|---|
@@ -18,6 +18,7 @@ yomi: install
 | `tmux` | 子ペイン |
 
 fanout は選択されたモードに必要な依存を起動時にチェックし、失敗時にはインストールのヒントを表示します。`--status` と `--cleanup` は `gh`/`git`、`--merge` と `--close` は `git` を使います。
+ローカルの `fanout plan` 実行と TUI から起動する手動 pane は、`git`/`tmux` と選択した agent があれば、`origin` remote や `gh` 認証が無い repository でも動作します。
 
 > **Project モード時のみ**: Project items を取得する GraphQL クエリのため、`gh` CLI に `read:project` スコープが必要です。`gh auth refresh -s read:project` で付与してください。issue モード(`fanout <N>`)では不要です。
 

--- a/site/content/docs/installation.md
+++ b/site/content/docs/installation.md
@@ -9,7 +9,7 @@ yomi: install
 
 ## Prerequisites
 
-The default pane-creation flow needs these tools on your `PATH`:
+The default GitHub issue / Project pane-creation flow needs these tools on your `PATH`:
 
 | Tool | Used for |
 |---|---|
@@ -18,6 +18,7 @@ The default pane-creation flow needs these tools on your `PATH`:
 | `tmux` | child panes |
 
 fanout checks the dependencies needed for the selected mode at startup and prints install hints on failure. `--status` and `--cleanup` use `gh`/`git`; `--merge` and `--close` use `git`.
+Local `fanout plan` runs and manual panes launched from the TUI need `git`/`tmux` and the selected agent, but they can run in repositories without an `origin` remote or `gh` authentication.
 
 > **Project mode only:** the `gh` CLI must have the `read:project` scope so the GraphQL query that lists Project items can succeed. Add it with `gh auth refresh -s read:project`. Issue mode (`fanout <N>`) does not need this scope.
 

--- a/site/content/docs/workflow.ja.md
+++ b/site/content/docs/workflow.ja.md
@@ -168,7 +168,7 @@ read / lifecycle モード（`--status` / `--close` / `--merge` / `--cleanup`）
 - `--name <NUM>=<slug>[|<display>[|<branch>]]` — 特定の子の worktree slug stem、pane タイトル、branch を直接指定する。pipe 区切りの 3 セグメントはそれぞれ空でよいが、最低 1 つは非空であること。slug stem に issue 番号 suffix が無ければ fanout が `-<NUM>` を付け、3 つ目のセグメントは生成 branch 名を上書きする。繰り返し指定可 — 対象ごとに 1 つ。
 - `--branch-prefix <prefix>` — run 全体の生成 branch 名の prefix を変える。
 - `--base-branch <branch>` — 子が分岐する base branch を上書きする。bare な local branch 名と `origin/<branch>` の両方に対応。
-- `--no-refresh` — base branch の refresh をスキップする。既定では、分岐前に `git fetch --quiet --no-tags` と fast-forward 更新で base を fresh 化する。
+- `--no-refresh` — base branch の refresh をスキップする。既定では、分岐前に `git fetch --quiet --no-tags` と fast-forward 更新で base を fresh 化する。ローカル plan / 手動 pane では `origin` remote が無い場合、自動的に refresh をスキップして現在の local branch / `HEAD` を使う。
 
 ```bash
 fanout 123 --name 4=fix-login-timeout --name 7='update-docs|Docs update'

--- a/site/content/docs/workflow.md
+++ b/site/content/docs/workflow.md
@@ -169,7 +169,7 @@ By default each child gets the worktree slug `slugify(title)-<issueNum>` and the
 - `--name <NUM>=<slug>[|<display>[|<branch>]]` — name one child's worktree slug stem, pane title, and branch directly. The three pipe-separated segments may each be empty, but at least one must be non-empty. fanout appends `-<NUM>` to slug stems that do not already carry it; the third segment overrides the generated branch name. Repeatable — one per target.
 - `--branch-prefix <prefix>` — change generated branch names for the whole run.
 - `--base-branch <branch>` — override the base branch the children branch from. Bare local branch names and `origin/<branch>` are both supported.
-- `--no-refresh` — skip the base-branch refresh. By default fanout refreshes the base with `git fetch --quiet --no-tags` plus a fast-forward update before branching.
+- `--no-refresh` — skip the base-branch refresh. By default fanout refreshes the base with `git fetch --quiet --no-tags` plus a fast-forward update before branching; local plan/manual panes automatically skip refresh and use the current local branch/`HEAD` when no `origin` remote exists.
 
 ```bash
 fanout 123 --name 4=fix-login-timeout --name 7='update-docs|Docs update'


### PR DESCRIPTION
## Summary

- Allow issue-less `fanout plan` task panes and manual TUI panes to prepare worktrees in repositories without an `origin` remote.
- Skip base refresh for local base refs when `origin` is absent, while still rejecting `origin/...` bases without a configured `origin`.
- Relax `fanout plan --unblocked-only` dependency checks so local plan fan-out does not require `gh` unless status/cleanup PR lookup modes need it.
- Update README, site docs, and Claude/Codex fanout-plan skills to describe the local no-origin path.

## Root Cause

Local plan/manual pane setup reused worktree base-resolution paths that assumed an `origin` remote and plan preflight still treated GitHub PR lookup as mandatory for `--unblocked-only`. That made issue-less fanout fail in local-only repositories even though no GitHub issue was involved.

## Validation

- `codex review --uncommitted`
- `make lint`
- `make test`
- `git diff --check`