### PR TITLE
[codex] Add TUI shell terminals

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -25,8 +25,8 @@ briefing から起動します。再実行しても同じ対象に 2 つ目の�
 - **Wave 進行** — `--unblocked-only` がブロッカーを読み取り、unblock 済みの子
   だけをファンアウト。PR が merge されたら再実行すれば次の wave が開きます。
 - **常駐 TUI コンソール** — 引数なしの `fanout` で、ペイン / issue / PR を
-  ライブ表示し、コンパクトな Session ナビゲータと focus・peek・lifecycle キーを
-  備えたコンソールを開きます。
+  ライブ表示し、コンパクトな Session ナビゲータと focus・peek・terminal・lifecycle
+  キーを備えたコンソールを開きます。
 - **Web ダッシュボード** — localhost で動く read-only のダッシュボード(ライブ
   更新)。どのペインからでも `prefix + D` でポップできます。
 - **状態確認とレポート** — `--status` の JSON / table で PR review・CI 状態を
@@ -94,7 +94,7 @@ fanout 123 --status     # ファンアウトした子の PR review + CI 状態�
 | `fanout 123 --unblocked-only` | ブロッカーが closed の子だけをファンアウト — 次の wave |
 | `fanout 123 --dry-run` | git / tmux / state / briefing file を変更せず計画だけ表示 |
 | `fanout plan spec.json --agent claude` | GitHub の子 issue でなくローカル plan spec をファンアウト |
-| `fanout` | 常駐 TUI コンソールを起動(Session ジャンプ・focus・peek・lifecycle キー) |
+| `fanout` | 常駐 TUI コンソールを起動(Session ジャンプ・focus・peek・terminal・lifecycle キー) |
 | `fanout 123 --status` | ペイン・PR review・CI 状態を JSON または table で |
 | `fanout dashboard --web` | localhost で read-only Web ダッシュボードを配信 |
 | `fanout 123 --merge 4` | 子 branch を fast-forward merge(`--close` / `--cleanup` でペインを畳む) |

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ English and 日本語.
   unblocked children; rerun as PRs merge and the next wave opens.
 - **Persistent TUI console** — run `fanout` with no arguments for a live
   pane / issue / PR view with a compact Session navigator plus focus, peek,
-  and lifecycle keys.
+  terminal, and lifecycle keys.
 - **Web dashboard** — a read-only localhost dashboard with live updates; pop it
   from any pane with `prefix + D`.
 - **Status & reporting** — `--status` JSON / table with PR review and CI state,
@@ -91,7 +91,7 @@ detailed in the [workflow docs](https://butaosuinu.github.io/fanout/docs/workflo
 | `fanout 123 --unblocked-only` | Fan out only children whose blockers are closed — the next wave |
 | `fanout 123 --dry-run` | Print the plan without modifying git, tmux, state, or briefing files |
 | `fanout plan spec.json --agent claude` | Fan out a local plan spec instead of GitHub child issues |
-| `fanout` | Start the persistent TUI console (Session jump, focus, peek, lifecycle keys) |
+| `fanout` | Start the persistent TUI console (Session jump, focus, peek, terminal, lifecycle keys) |
 | `fanout 123 --status` | Pane, PR review, and CI state as JSON or a table |
 | `fanout dashboard --web` | Serve the read-only web dashboard on localhost |
 | `fanout 123 --merge 4` | Fast-forward merge a child branch (`--close` / `--cleanup` fold panes away) |

--- a/cmd/fanout/lifecycle_test.go
+++ b/cmd/fanout/lifecycle_test.go
@@ -111,10 +111,7 @@ printf '\n' >> "$GIT_LOG"
 exit 99
 `)
 	t.Setenv("GIT_LOG", gitLog)
-	tmuxLog := installLifecycleScript(t, "tmux", `#!/bin/sh
-printf '%s ' "$@" >> "$TMUX_LOG"
-printf '\n' >> "$TMUX_LOG"
-`)
+	tmuxLog := installLifecycleLivePaneTmuxScript(t, "%77", repo, "root terminal", "shell-root")
 	t.Setenv("TMUX_LOG", tmuxLog)
 	writeLifecycleState(t, repo, state.Pane{
 		Parent:       "@manual",
@@ -122,6 +119,7 @@ printf '\n' >> "$TMUX_LOG"
 		Kind:         state.PaneKindShell,
 		Slug:         "terminal-root-1",
 		PaneID:       "%77",
+		ShellKey:     "shell-root",
 		Agent:        "shell",
 		DisplayName:  "root terminal",
 		WorktreePath: repo,
@@ -142,6 +140,56 @@ printf '\n' >> "$TMUX_LOG"
 	}
 	if body, err := os.ReadFile(tmuxLog); err != nil || !strings.Contains(string(body), "kill-pane -t %77") {
 		t.Fatalf("tmux log = %q err=%v, want kill-pane for %%77", body, err)
+	}
+	if body, err := os.ReadFile(gitLog); err == nil && strings.TrimSpace(string(body)) != "" {
+		t.Fatalf("git was called for shell close:\n%s", body)
+	}
+}
+
+func TestCmdCloseShellPaneSkipsKillWhenShellKeyDiffers(t *testing.T) {
+	repo := initLifecycleRepo(t)
+	gitLog := installLifecycleScript(t, "git", `#!/bin/sh
+printf '%s ' "$@" >> "$GIT_LOG"
+printf '\n' >> "$GIT_LOG"
+exit 99
+`)
+	t.Setenv("GIT_LOG", gitLog)
+	tmuxLog := installLifecycleLivePaneTmuxScript(t, "%77", repo, "reused pane", "other-shell")
+	t.Setenv("TMUX_LOG", tmuxLog)
+	writeLifecycleState(t, repo, state.Pane{
+		Parent:       "@manual",
+		IssueNum:     -1,
+		Kind:         state.PaneKindShell,
+		Slug:         "terminal-root-1",
+		PaneID:       "%77",
+		ShellKey:     "shell-root",
+		Agent:        "shell",
+		DisplayName:  "root terminal",
+		WorktreePath: repo,
+	})
+	t.Setenv(fanoutStatePathEnv, state.Path(repo))
+
+	code := cmdClose(&cliflags.Config{ParentRef: "@manual", CloseNum: -1}, discardLogger())
+
+	if code != exitcode.OK {
+		t.Fatalf("cmdClose shell code = %d, want %d", code, exitcode.OK)
+	}
+	loaded, err := state.LoadProject(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded.Panes) != 0 {
+		t.Fatalf("state panes = %+v, want empty", loaded.Panes)
+	}
+	body, err := os.ReadFile(tmuxLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(body), "kill-pane -t %77") {
+		t.Fatalf("tmux log = %q, did not want kill-pane for reused %%77", body)
+	}
+	if !strings.Contains(string(body), "list-panes -a -F") {
+		t.Fatalf("tmux log = %q, want live pane revalidation", body)
 	}
 	if body, err := os.ReadFile(gitLog); err == nil && strings.TrimSpace(string(body)) != "" {
 		t.Fatalf("git was called for shell close:\n%s", body)
@@ -624,6 +672,37 @@ func installLifecycleScript(t *testing.T, name, script string) string {
 	}
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	logPath := filepath.Join(t.TempDir(), name+".log")
+	return logPath
+}
+
+func installLifecycleLivePaneTmuxScript(t *testing.T, paneID, path, title, shellKey string) string {
+	t.Helper()
+	logPath := installLifecycleScript(t, "tmux", `#!/bin/sh
+printf '%s ' "$@" >> "$TMUX_LOG"
+printf '\n' >> "$TMUX_LOG"
+case "$1 $2 $3" in
+"list-panes -a -F")
+	case "$4" in
+	*pane_current_path*)
+		printf '%s\t%s\n' "$TMUX_LIVE_PANE_ID" "$TMUX_LIVE_PATH"
+		;;
+	*pane_title*)
+		printf '%s\t%s\n' "$TMUX_LIVE_PANE_ID" "$TMUX_LIVE_TITLE"
+		;;
+	*fanout_agent_state*)
+		printf '%s\t\n' "$TMUX_LIVE_PANE_ID"
+		;;
+	*fanout_shell_key*)
+		printf '%s\t%s\n' "$TMUX_LIVE_PANE_ID" "$TMUX_LIVE_SHELL_KEY"
+		;;
+	esac
+	;;
+esac
+`)
+	t.Setenv("TMUX_LIVE_PANE_ID", paneID)
+	t.Setenv("TMUX_LIVE_PATH", path)
+	t.Setenv("TMUX_LIVE_TITLE", title)
+	t.Setenv("TMUX_LIVE_SHELL_KEY", shellKey)
 	return logPath
 }
 

--- a/cmd/fanout/lifecycle_test.go
+++ b/cmd/fanout/lifecycle_test.go
@@ -103,6 +103,51 @@ printf '\n' >> "$TMUX_LOG"
 	}
 }
 
+func TestCmdCloseShellPaneSkipsGitWorktreeRemoval(t *testing.T) {
+	repo := initLifecycleRepo(t)
+	gitLog := installLifecycleScript(t, "git", `#!/bin/sh
+printf '%s ' "$@" >> "$GIT_LOG"
+printf '\n' >> "$GIT_LOG"
+exit 99
+`)
+	t.Setenv("GIT_LOG", gitLog)
+	tmuxLog := installLifecycleScript(t, "tmux", `#!/bin/sh
+printf '%s ' "$@" >> "$TMUX_LOG"
+printf '\n' >> "$TMUX_LOG"
+`)
+	t.Setenv("TMUX_LOG", tmuxLog)
+	writeLifecycleState(t, repo, state.Pane{
+		Parent:       "@manual",
+		IssueNum:     -1,
+		Kind:         state.PaneKindShell,
+		Slug:         "terminal-root-1",
+		PaneID:       "%77",
+		Agent:        "shell",
+		DisplayName:  "root terminal",
+		WorktreePath: repo,
+	})
+	t.Setenv(fanoutStatePathEnv, state.Path(repo))
+
+	code := cmdClose(&cliflags.Config{ParentRef: "@manual", CloseNum: -1}, discardLogger())
+
+	if code != exitcode.OK {
+		t.Fatalf("cmdClose shell code = %d, want %d", code, exitcode.OK)
+	}
+	loaded, err := state.LoadProject(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded.Panes) != 0 {
+		t.Fatalf("state panes = %+v, want empty", loaded.Panes)
+	}
+	if body, err := os.ReadFile(tmuxLog); err != nil || !strings.Contains(string(body), "kill-pane -t %77") {
+		t.Fatalf("tmux log = %q err=%v, want kill-pane for %%77", body, err)
+	}
+	if body, err := os.ReadFile(gitLog); err == nil && strings.TrimSpace(string(body)) != "" {
+		t.Fatalf("git was called for shell close:\n%s", body)
+	}
+}
+
 func TestCmdMergeFastForwardsRecordedBranch(t *testing.T) {
 	repo := initLifecycleRepo(t)
 	baseHead := gitTrimTest(t, repo, "rev-parse", "HEAD")

--- a/cmd/fanout/tui.go
+++ b/cmd/fanout/tui.go
@@ -151,8 +151,8 @@ func launchShellPaneFromTUI(projectRoot, session string, req fanouttui.ShellLaun
 		return fmt.Errorf("terminal path is not a directory: %s", targetPath)
 	}
 
-	if err := worktree.EnsureLocalExclude(projectRoot); err != nil {
-		return fmt.Errorf("prepare local git exclude: %w", err)
+	if excludeErr := worktree.EnsureLocalExclude(projectRoot); excludeErr != nil {
+		return fmt.Errorf("prepare local git exclude: %w", excludeErr)
 	}
 
 	recorder, err := state.LockProject(projectRoot)

--- a/cmd/fanout/tui.go
+++ b/cmd/fanout/tui.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"crypto/rand"
 	"crypto/sha1"
 	"encoding/hex"
 	"fmt"
@@ -166,8 +167,16 @@ func launchShellPaneFromTUI(projectRoot, session string, req fanouttui.ShellLaun
 	number := nextSyntheticPaneNumber(recorder.Store, manualPaneParentRef)
 	slug := shellPaneSlug(targetPath, req.Root, number)
 	title := shellPaneTitle(targetPath, req.Root)
+	shellKey, err := newShellPaneKey()
+	if err != nil {
+		return err
+	}
 	paneID, err := tmuxrun.SplitPane(tuiLaunchTarget(session), targetPath)
 	if err != nil {
+		return err
+	}
+	if err := tmuxrun.SetPaneShellKey(paneID, shellKey); err != nil {
+		_ = tmuxrun.KillPane(paneID)
 		return err
 	}
 	// Shell pane ergonomics are best-effort; the recorded pane id is enough to
@@ -181,6 +190,7 @@ func launchShellPaneFromTUI(projectRoot, session string, req fanouttui.ShellLaun
 		Kind:         state.PaneKindShell,
 		Slug:         slug,
 		PaneID:       paneID,
+		ShellKey:     shellKey,
 		Agent:        state.PaneKindShell,
 		DisplayName:  title,
 		WorktreePath: targetPath,
@@ -190,6 +200,14 @@ func launchShellPaneFromTUI(projectRoot, session string, req fanouttui.ShellLaun
 		return fmt.Errorf("write fanout state: %w", err)
 	}
 	return nil
+}
+
+func newShellPaneKey() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", fmt.Errorf("generate terminal identity: %w", err)
+	}
+	return "shell-" + hex.EncodeToString(b[:]), nil
 }
 
 func shellPaneSlug(targetPath string, root bool, number int) string {

--- a/cmd/fanout/tui.go
+++ b/cmd/fanout/tui.go
@@ -18,8 +18,10 @@ import (
 	fanoutnotify "github.com/butaosuinu/fanout/internal/notify"
 	fanoutruntime "github.com/butaosuinu/fanout/internal/runtime"
 	"github.com/butaosuinu/fanout/internal/settings"
+	"github.com/butaosuinu/fanout/internal/state"
 	"github.com/butaosuinu/fanout/internal/tmuxrun"
 	fanouttui "github.com/butaosuinu/fanout/internal/tui"
+	"github.com/butaosuinu/fanout/internal/worktree"
 )
 
 const tuiPaneTitle = "fanout tui"
@@ -67,6 +69,7 @@ func cmdTUI(commandName string, lg *log.Logger) exitcode.Code {
 		DefaultAgent:  defaultTUIAgent(),
 		Hooks:         hookConfig,
 		LaunchPane:    newTUILaunchPaneFunc(projectRoot, session, commandName, hookConfig),
+		LaunchShell:   newTUILaunchShellFunc(projectRoot, session),
 		Notifier:      notifier,
 	}); err != nil {
 		lg.Err("tui: %v", err)
@@ -124,6 +127,95 @@ func launchManualPaneFromTUI(projectRoot, session, commandName string, hookConfi
 		return bufferedLaunchError(stdout, stderr, "create pane")
 	}
 	return nil
+}
+
+func newTUILaunchShellFunc(projectRoot, session string) fanouttui.ShellLaunchFunc {
+	return func(req fanouttui.ShellLaunchRequest) error {
+		return launchShellPaneFromTUI(projectRoot, session, req)
+	}
+}
+
+func launchShellPaneFromTUI(projectRoot, session string, req fanouttui.ShellLaunchRequest) error {
+	rawPath := strings.TrimSpace(req.TargetPath)
+	if rawPath == "" {
+		return fmt.Errorf("terminal path is required")
+	}
+	targetPath, err := filepath.Abs(rawPath)
+	if err != nil {
+		return fmt.Errorf("resolve terminal path: %w", err)
+	}
+	st, statErr := os.Stat(targetPath)
+	if statErr != nil {
+		return fmt.Errorf("terminal path: %w", statErr)
+	} else if !st.IsDir() {
+		return fmt.Errorf("terminal path is not a directory: %s", targetPath)
+	}
+
+	if err := worktree.EnsureLocalExclude(projectRoot); err != nil {
+		return fmt.Errorf("prepare local git exclude: %w", err)
+	}
+
+	recorder, err := state.LockProject(projectRoot)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = recorder.Unlock()
+	}()
+
+	number := nextSyntheticPaneNumber(recorder.Store, manualPaneParentRef)
+	slug := shellPaneSlug(targetPath, req.Root, number)
+	title := shellPaneTitle(targetPath, req.Root)
+	paneID, err := tmuxrun.SplitPane(tuiLaunchTarget(session), targetPath)
+	if err != nil {
+		return err
+	}
+	// Shell pane ergonomics are best-effort; the recorded pane id is enough to
+	// keep the terminal usable when tmux metadata/layout updates fail.
+	_ = tmuxrun.SetPaneTitle(paneID, title)
+	_ = tmuxrun.SetPaneProjectRoot(paneID, projectRoot)
+	_ = tmuxrun.SelectTiled(tuiLaunchTarget(session))
+	if err := recorder.RecordPane(state.Pane{
+		Parent:       manualPaneParentRef,
+		IssueNum:     number,
+		Kind:         state.PaneKindShell,
+		Slug:         slug,
+		PaneID:       paneID,
+		Agent:        state.PaneKindShell,
+		DisplayName:  title,
+		WorktreePath: targetPath,
+		CreatedAt:    time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		_ = tmuxrun.KillPane(paneID)
+		return fmt.Errorf("write fanout state: %w", err)
+	}
+	return nil
+}
+
+func shellPaneSlug(targetPath string, root bool, number int) string {
+	base := "root"
+	if !root {
+		base = sanitizeSessionPart(filepath.Base(targetPath))
+	}
+	if base == "" {
+		base = "terminal"
+	}
+	n := number
+	if n < 0 {
+		n = -n
+	}
+	return fmt.Sprintf("terminal-%s-%d", base, n)
+}
+
+func shellPaneTitle(targetPath string, root bool) string {
+	if root {
+		return "root terminal"
+	}
+	base := strings.TrimSpace(filepath.Base(targetPath))
+	if base == "" || base == "." || base == string(filepath.Separator) {
+		base = "worktree"
+	}
+	return "terminal " + base
 }
 
 func manualPaneOptionsForTUI(prompt, slug, agentName string) manualPaneOptions {

--- a/cmd/fanout/tui_test.go
+++ b/cmd/fanout/tui_test.go
@@ -130,6 +130,9 @@ func TestLaunchShellPaneFromTUIRecordsShellState(t *testing.T) {
 	if got.Kind != state.PaneKindShell || got.Agent != "shell" || got.PaneID != "%77" {
 		t.Fatalf("shell state = %+v, want shell kind/agent/pane", got)
 	}
+	if !strings.HasPrefix(got.ShellKey, "shell-") {
+		t.Fatalf("shell key = %q, want generated shell key", got.ShellKey)
+	}
 	if got.Parent != manualPaneParentRef || got.IssueNum != -1 {
 		t.Fatalf("shell identity = %s/%d, want @manual/-1", got.Parent, got.IssueNum)
 	}

--- a/cmd/fanout/tui_test.go
+++ b/cmd/fanout/tui_test.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/butaosuinu/fanout/internal/hooks"
+	"github.com/butaosuinu/fanout/internal/state"
 	fanouttui "github.com/butaosuinu/fanout/internal/tui"
 )
 
@@ -102,4 +104,78 @@ func TestLaunchManualPaneFromTUIChecksAgentBeforeState(t *testing.T) {
 	if _, statErr := os.Stat(filepath.Join(repo, ".fanout")); !os.IsNotExist(statErr) {
 		t.Fatalf(".fanout state was touched before agent validation: %v", statErr)
 	}
+}
+
+func TestLaunchShellPaneFromTUIRecordsShellState(t *testing.T) {
+	repo := t.TempDir()
+	initTUITestGitRepo(t, repo)
+	installTUITmuxShim(t, "%77")
+
+	err := launchShellPaneFromTUI(repo, "fanout-test", fanouttui.ShellLaunchRequest{
+		TargetPath: repo,
+		Root:       true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := state.LoadProject(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(store.Panes) != 1 {
+		t.Fatalf("state panes = %+v, want one shell pane", store.Panes)
+	}
+	got := store.Panes[0]
+	if got.Kind != state.PaneKindShell || got.Agent != "shell" || got.PaneID != "%77" {
+		t.Fatalf("shell state = %+v, want shell kind/agent/pane", got)
+	}
+	if got.Parent != manualPaneParentRef || got.IssueNum != -1 {
+		t.Fatalf("shell identity = %s/%d, want @manual/-1", got.Parent, got.IssueNum)
+	}
+	if got.WorktreePath != repo || got.DisplayName != "root terminal" || got.Slug != "terminal-root-1" {
+		t.Fatalf("shell path/name/slug = %q/%q/%q", got.WorktreePath, got.DisplayName, got.Slug)
+	}
+
+	body, err := os.ReadFile(filepath.Join(repo, ".git", "info", "exclude"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, pattern := range []string{".fanout/state.json", ".fanout/state.json.lock"} {
+		if !strings.Contains(string(body), pattern) {
+			t.Fatalf("git exclude missing %q:\n%s", pattern, body)
+		}
+	}
+}
+
+func initTUITestGitRepo(t *testing.T, dir string) {
+	t.Helper()
+	cmd := exec.Command("git", "init")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init failed: %v\n%s", err, out)
+	}
+}
+
+func installTUITmuxShim(t *testing.T, paneID string) {
+	t.Helper()
+	dir := t.TempDir()
+	script := `#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+  split-window)
+    printf '%s\n' "$TMUX_SHIM_PANE_ID"
+    ;;
+  select-pane|set-option|select-layout|kill-pane)
+    ;;
+  *)
+    ;;
+esac
+`
+	path := filepath.Join(dir, "tmux")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("TMUX_SHIM_PANE_ID", paneID)
 }

--- a/internal/dashboard/peek.go
+++ b/internal/dashboard/peek.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/butaosuinu/fanout/internal/sessionview"
+	"github.com/butaosuinu/fanout/internal/state"
 	"github.com/butaosuinu/fanout/internal/tmuxrun"
 )
 
@@ -49,11 +50,10 @@ func (p *poller) livePaneView(paneID string) (sessionview.PaneView, bool) {
 
 // requireLivePane is the request-validation chain GET /api/peek and
 // GET /api/plan share: pane-id shape (400), snapshot liveness via livePaneView
-// (404), and recorded-worktree presence (404 — legacy/hand-written rows
-// without a worktree are alive on an id-only basis, which cannot survive tmux
-// pane-id reuse; without a path to verify against, capture could read an
-// unrelated pane, so refuse). On ok=false the JSON error response has already
-// been written.
+// (404), and a recorded identity usable for request-time verification. Agent
+// rows need a worktree path; shell rows need a shellKey because their
+// WorktreePath can be the broad project root. On ok=false the JSON error
+// response has already been written.
 func (s *Server) requireLivePane(w http.ResponseWriter, paneID string) (sessionview.PaneView, bool) {
 	if !paneIDRe.MatchString(paneID) {
 		peekError(w, http.StatusBadRequest, fmt.Sprintf("invalid pane id %q: want a tmux pane id like %%5", paneID))
@@ -63,6 +63,13 @@ func (s *Server) requireLivePane(w http.ResponseWriter, paneID string) (sessionv
 	if !ok {
 		peekError(w, http.StatusNotFound, fmt.Sprintf("pane %s is not live in the current sessions", paneID))
 		return sessionview.PaneView{}, false
+	}
+	if pv.Kind == state.PaneKindShell {
+		if strings.TrimSpace(pv.ShellKey) == "" {
+			peekError(w, http.StatusNotFound, fmt.Sprintf("pane %s has no recorded shell key to verify against", paneID))
+			return sessionview.PaneView{}, false
+		}
+		return pv, true
 	}
 	if pv.WorktreePath == "" {
 		peekError(w, http.StatusNotFound, fmt.Sprintf("pane %s has no recorded worktree to verify against", paneID))
@@ -75,20 +82,20 @@ func (s *Server) requireLivePane(w http.ResponseWriter, paneID string) (sessionv
 // GET /api/plan: response headers, the HEAD early-return (getOnly permits
 // HEAD; answer it before running tmux — mirrors handleStream's HEAD
 // early-return — so a probe never triggers a capture), and the request-time
-// tmux revalidation. The snapshot check in requireLivePane can be a
-// cheap-tick stale, which is enough for a tmux restart to hand the id to an
-// unrelated pane; verifying id+path right before reading shrinks that reuse
+// tmux revalidation. The snapshot check in requireLivePane can be a cheap-tick
+// stale, which is enough for a tmux restart to hand the id to an unrelated
+// pane; verifying the row identity right before reading shrinks that reuse
 // window to the instant before capture. A false return means the response is
-// complete (HEAD answered, or verify failed with 404) and the handler must
-// not capture.
-func (s *Server) beginPaneCapture(w http.ResponseWriter, r *http.Request, paneID, worktree string) bool {
+// complete (HEAD answered, or verify failed with 404) and the handler must not
+// capture.
+func (s *Server) beginPaneCapture(w http.ResponseWriter, r *http.Request, pv sessionview.PaneView) bool {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Cache-Control", "no-store")
 	if r.Method == http.MethodHead {
 		w.WriteHeader(http.StatusOK)
 		return false
 	}
-	if err := s.verifyPane(paneID, worktree); err != nil {
+	if err := s.verifyPane(pv); err != nil {
 		peekError(w, http.StatusNotFound, err.Error())
 		return false
 	}
@@ -96,27 +103,42 @@ func (s *Server) beginPaneCapture(w http.ResponseWriter, r *http.Request, paneID
 }
 
 // verifyLivePane is the default Options.VerifyPane: it re-resolves the pane id
-// against tmux at request time and requires the pane's current path to sit
-// at/under the recorded worktree (same rule as sessionview's paneAlive). The
-// snapshot's Alive flag can be up to one cheap-tick stale, which is enough for
-// a tmux restart to hand %N to an unrelated pane; this check shrinks that
-// reuse window from seconds to the instant before capture.
-func verifyLivePane(paneID, worktree string) error {
+// against tmux at request time. Agent panes require the pane's current path to
+// sit at/under the recorded worktree; shell panes require the recorded
+// @fanout_shell_key. The snapshot's Alive flag can be up to one cheap-tick
+// stale, which is enough for a tmux restart to hand %N to an unrelated pane;
+// this check shrinks that reuse window from seconds to the instant before
+// capture.
+func verifyLivePane(pv sessionview.PaneView) error {
 	panes, err := tmuxrun.ListLivePanes()
 	if err != nil {
 		return fmt.Errorf("tmux list-panes: %w", err)
 	}
+	return verifyPaneAgainstLive(pv, panes)
+}
+
+func verifyPaneAgainstLive(pv sessionview.PaneView, panes []tmuxrun.LivePane) error {
 	for _, pane := range panes {
-		if pane.ID != paneID {
+		if pane.ID != pv.PaneID {
 			continue
 		}
+		if pv.Kind == state.PaneKindShell {
+			if strings.TrimSpace(pv.ShellKey) == "" {
+				return fmt.Errorf("pane %s has no recorded shell key", pv.PaneID)
+			}
+			if pane.ShellKey != pv.ShellKey {
+				return fmt.Errorf("pane %s is no longer the recorded shell terminal", pv.PaneID)
+			}
+			return nil
+		}
+		worktree := pv.WorktreePath
 		if worktree == "" || (pane.CurrentPath != worktree &&
 			!strings.HasPrefix(pane.CurrentPath, worktree+string(filepath.Separator))) {
-			return fmt.Errorf("pane %s is no longer at its recorded worktree", paneID)
+			return fmt.Errorf("pane %s is no longer at its recorded worktree", pv.PaneID)
 		}
 		return nil
 	}
-	return fmt.Errorf("pane %s is gone", paneID)
+	return fmt.Errorf("pane %s is gone", pv.PaneID)
 }
 
 // peekResponse is the GET /api/peek wire contract the SPA consumes.
@@ -146,7 +168,7 @@ func (s *Server) handlePeek(w http.ResponseWriter, r *http.Request) {
 		}
 		lines = min(max(n, 1), peekMaxLines)
 	}
-	if !s.beginPaneCapture(w, r, paneID, pv.WorktreePath) {
+	if !s.beginPaneCapture(w, r, pv) {
 		return
 	}
 	out, err := s.capturePane(paneID, lines)

--- a/internal/dashboard/peek_test.go
+++ b/internal/dashboard/peek_test.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	"github.com/butaosuinu/fanout/internal/sessionview"
+	"github.com/butaosuinu/fanout/internal/state"
+	"github.com/butaosuinu/fanout/internal/tmuxrun"
 )
 
 // errPaneGone simulates capture-pane failing on a stale pane / dead tmux server.
@@ -90,7 +92,7 @@ func newPeekServer(t *testing.T, token string, capture *fakeCapture) *Server {
 		CapturePane: capture.capture,
 		// Request-time revalidation is exercised by TestPeekVerifyFailureIs404;
 		// everywhere else a no-op keeps the fixture's liveness authoritative.
-		VerifyPane: func(string, string) error { return nil },
+		VerifyPane: func(sessionview.PaneView) error { return nil },
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)
@@ -329,11 +331,11 @@ func TestPeekVerifyFailureIs404AndSkipsCapture(t *testing.T) {
 		Token:       "",
 		ResolveGH:   func() (string, GHProvider, error) { return "o/n", fakeGH{}, nil },
 		CapturePane: fake.capture,
-		VerifyPane: func(paneID, worktree string) error {
-			if worktree != "/wt/child" {
-				t.Errorf("VerifyPane worktree = %q, want recorded /wt/child", worktree)
+		VerifyPane: func(pv sessionview.PaneView) error {
+			if pv.WorktreePath != "/wt/child" {
+				t.Errorf("VerifyPane worktree = %q, want recorded /wt/child", pv.WorktreePath)
 			}
-			return fmt.Errorf("pane %s is no longer at its recorded worktree", paneID)
+			return fmt.Errorf("pane %s is no longer at its recorded worktree", pv.PaneID)
 		},
 	})
 	if err != nil {
@@ -367,5 +369,66 @@ func TestPeekRowWithoutWorktreeIs404(t *testing.T) {
 	}
 	if calls, _, _ := fake.snapshot(); calls != 0 {
 		t.Fatalf("capture calls = %d, want 0 (no worktree to verify against)", calls)
+	}
+}
+
+func TestPeekShellPanePassesShellIdentityToVerifier(t *testing.T) {
+	t.Parallel()
+	fake := &fakeCapture{out: "shell output"}
+	seen := make(chan sessionview.PaneView, 1)
+	srv, err := New(Options{
+		ProjectRoot: t.TempDir(),
+		Port:        0,
+		Token:       "",
+		ResolveGH:   func() (string, GHProvider, error) { return "o/n", fakeGH{}, nil },
+		CapturePane: fake.capture,
+		VerifyPane: func(pv sessionview.PaneView) error {
+			seen <- pv
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	snap := peekSnapshot(true)
+	pv := &snap.Sessions[0].Panes[0]
+	pv.Kind = state.PaneKindShell
+	pv.Agent = "shell"
+	pv.ShellKey = "shell-root"
+	pv.WorktreePath = ""
+	publishSnapshot(srv, snap)
+	go func() { _ = srv.httpServer.Serve(srv.listener) }()
+	t.Cleanup(func() { _ = srv.httpServer.Close() })
+	waitReady(t, srv.base)
+
+	status, _, body := getPeek(t, peekURL(srv.base, map[string]string{"pane": "%5"}))
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body %s", status, body)
+	}
+	got := <-seen
+	if got.Kind != state.PaneKindShell || got.ShellKey != "shell-root" || got.WorktreePath != "" {
+		t.Fatalf("VerifyPane saw %+v, want shell identity without requiring worktree", got)
+	}
+}
+
+func TestVerifyPaneAgainstLiveUsesShellKeyForShellRows(t *testing.T) {
+	shell := sessionview.PaneView{
+		Kind:         state.PaneKindShell,
+		PaneID:       "%5",
+		ShellKey:     "shell-root",
+		WorktreePath: "/repo",
+	}
+	live := []tmuxrun.LivePane{{
+		ID:          "%5",
+		CurrentPath: "/elsewhere",
+		ShellKey:    "shell-root",
+	}}
+	if err := verifyPaneAgainstLive(shell, live); err != nil {
+		t.Fatalf("matching shell key with changed cwd failed: %v", err)
+	}
+
+	shell.ShellKey = "shell-stale"
+	if err := verifyPaneAgainstLive(shell, live); err == nil || !strings.Contains(err.Error(), "recorded shell terminal") {
+		t.Fatalf("mismatched shell key err = %v, want recorded shell terminal error", err)
 	}
 }

--- a/internal/dashboard/plan.go
+++ b/internal/dashboard/plan.go
@@ -46,7 +46,7 @@ func (s *Server) handlePlan(w http.ResponseWriter, r *http.Request) {
 		peekError(w, http.StatusNotFound, fmt.Sprintf("pane %s is not a codex plan-mode pane", paneID))
 		return
 	}
-	if !s.beginPaneCapture(w, r, paneID, pv.WorktreePath) {
+	if !s.beginPaneCapture(w, r, pv) {
 		return
 	}
 	out, err := s.capturePlan(paneID, planCaptureLines)

--- a/internal/dashboard/plan_test.go
+++ b/internal/dashboard/plan_test.go
@@ -38,7 +38,7 @@ func newPlanServer(t *testing.T, token string, capture *fakeCapture) *Server {
 		// Request-time revalidation is exercised by
 		// TestPlanVerifyFailureIs404AndSkipsCapture; everywhere else a no-op
 		// keeps the fixture's liveness authoritative.
-		VerifyPane: func(string, string) error { return nil },
+		VerifyPane: func(sessionview.PaneView) error { return nil },
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)
@@ -183,11 +183,11 @@ func TestPlanVerifyFailureIs404AndSkipsCapture(t *testing.T) {
 		Token:       "",
 		ResolveGH:   func() (string, GHProvider, error) { return "o/n", fakeGH{}, nil },
 		CapturePlan: fake.capture,
-		VerifyPane: func(paneID, worktree string) error {
-			if worktree != "/wt/child" {
-				t.Errorf("VerifyPane worktree = %q, want recorded /wt/child", worktree)
+		VerifyPane: func(pv sessionview.PaneView) error {
+			if pv.WorktreePath != "/wt/child" {
+				t.Errorf("VerifyPane worktree = %q, want recorded /wt/child", pv.WorktreePath)
 			}
-			return fmt.Errorf("pane %s is no longer at its recorded worktree", paneID)
+			return fmt.Errorf("pane %s is no longer at its recorded worktree", pv.PaneID)
 		},
 	})
 	if err != nil {

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -17,6 +17,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/butaosuinu/fanout/internal/sessionview"
 	"github.com/butaosuinu/fanout/internal/tmuxrun"
 )
 
@@ -47,10 +48,11 @@ type Options struct {
 	// plus alternate screen, wrapped lines joined). nil defaults to
 	// tmuxrun.CapturePlanSource; tests inject a fake.
 	CapturePlan func(paneID string, lines int) (string, error)
-	// VerifyPane re-checks, at request time, that paneID is still a live tmux
-	// pane sitting at/under the recorded worktree. nil defaults to a
+	// VerifyPane re-checks, at request time, that the snapshot pane is still
+	// the same live tmux pane. Agent panes verify paneID + worktree path; shell
+	// panes verify paneID + shellKey. nil defaults to a
 	// tmuxrun.ListLivePanes-backed check; tests inject a fake.
-	VerifyPane func(paneID, worktree string) error
+	VerifyPane func(sessionview.PaneView) error
 }
 
 // Server is a bound, ready-to-run dashboard. New binds the listener (so a
@@ -66,7 +68,7 @@ type Server struct {
 	serveErr    chan error
 	capturePane func(paneID string, lines int) (string, error)
 	capturePlan func(paneID string, lines int) (string, error)
-	verifyPane  func(paneID, worktree string) error
+	verifyPane  func(sessionview.PaneView) error
 }
 
 // New binds the loopback listener and assembles the handler. The returned

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -43,7 +43,7 @@ type statusChild struct {
 // Close removes the recorded worktree(s), best-effort kills tmux pane(s), and
 // removes all state rows matching parent and issueNum.
 func Close(opts Options, parent string, issueNum int, lg Logger) exitcode.Code {
-	locked, code := lockState("--close", opts, lg)
+	locked, code := lockStateOnly("--close", opts, lg)
 	if code != exitcode.OK {
 		return code
 	}
@@ -54,6 +54,12 @@ func Close(opts Options, parent string, issueNum int, lg Logger) exitcode.Code {
 		lg.Err("--close: #%d is not recorded for parent %s in %s", issueNum, parent, opts.StatePath)
 		return exitcode.Invocation
 	}
+	if hasManagedWorktree(panes) {
+		if err := worktree.EnsureLocalExclude(opts.ProjectRoot); err != nil {
+			lg.Err("--close: prepare local git exclude: %v", err)
+			return exitcode.Env
+		}
+	}
 	if !cleanupPaneRecords(opts, panes, lg) {
 		return exitcode.Env
 	}
@@ -61,17 +67,21 @@ func Close(opts Options, parent string, issueNum int, lg Logger) exitcode.Code {
 		lg.Err("#%d: remove fanout state: %v", issueNum, err)
 		return exitcode.Env
 	}
-	if !pruneWorktrees(opts.ProjectRoot, lg) {
+	if hasManagedWorktree(panes) && !pruneWorktrees(opts.ProjectRoot, lg) {
 		return exitcode.Env
 	}
-	lg.Ok("#%d: closed fanout worktree and removed state", issueNum)
+	if hasManagedWorktree(panes) {
+		lg.Ok("#%d: closed fanout worktree and removed state", issueNum)
+	} else {
+		lg.Ok("#%d: closed shell terminal and removed state", issueNum)
+	}
 	return exitcode.OK
 }
 
 // CloseTask removes the recorded worktree(s), best-effort kills tmux pane(s),
 // and removes all task state rows matching parent and taskID.
 func CloseTask(opts Options, parent, taskID string, lg Logger) exitcode.Code {
-	locked, code := lockState("--close", opts, lg)
+	locked, code := lockStateOnly("--close", opts, lg)
 	if code != exitcode.OK {
 		return code
 	}
@@ -82,6 +92,12 @@ func CloseTask(opts Options, parent, taskID string, lg Logger) exitcode.Code {
 		lg.Err("--close: task %s is not recorded for parent %s in %s", taskID, parent, opts.StatePath)
 		return exitcode.Invocation
 	}
+	if hasManagedWorktree(panes) {
+		if err := worktree.EnsureLocalExclude(opts.ProjectRoot); err != nil {
+			lg.Err("--close: prepare local git exclude: %v", err)
+			return exitcode.Env
+		}
+	}
 	if !cleanupPaneRecords(opts, panes, lg) {
 		return exitcode.Env
 	}
@@ -89,10 +105,14 @@ func CloseTask(opts Options, parent, taskID string, lg Logger) exitcode.Code {
 		lg.Err("%s: remove fanout state: %v", taskID, err)
 		return exitcode.Env
 	}
-	if !pruneWorktrees(opts.ProjectRoot, lg) {
+	if hasManagedWorktree(panes) && !pruneWorktrees(opts.ProjectRoot, lg) {
 		return exitcode.Env
 	}
-	lg.Ok("%s: closed fanout worktree and removed state", taskID)
+	if hasManagedWorktree(panes) {
+		lg.Ok("%s: closed fanout worktree and removed state", taskID)
+	} else {
+		lg.Ok("%s: closed shell terminal and removed state", taskID)
+	}
 	return exitcode.OK
 }
 
@@ -169,7 +189,7 @@ func Cleanup(opts Options, parent string, lg Logger) exitcode.Code {
 	}
 	defer unlockState("--cleanup", locked, lg)
 
-	panes := locked.PanesForParent(parent)
+	panes := cleanupIssuePanes(locked.PanesForParent(parent))
 	if len(panes) == 0 {
 		lg.Info("--cleanup: no recorded panes for parent %s", parent)
 		return exitcode.OK
@@ -314,6 +334,14 @@ func lockState(mode string, opts Options, lg Logger) (*state.LockedStore, exitco
 		lg.Err("%s: prepare local git exclude: %v", mode, err)
 		return nil, exitcode.Env
 	}
+	return lockStateOnly(mode, opts, lg)
+}
+
+func lockStateOnly(mode string, opts Options, lg Logger) (*state.LockedStore, exitcode.Code) {
+	if opts.ProjectRoot == "" || !dirExists(opts.ProjectRoot) {
+		lg.Err("%s: project_root is not a directory: %s (state=%s)", mode, emptyLabel(opts.ProjectRoot), opts.StatePath)
+		return nil, exitcode.Invocation
+	}
 	locked, err := state.Lock(opts.StatePath)
 	if err != nil {
 		lg.Err("%s: %v", mode, err)
@@ -363,6 +391,12 @@ func statusChildren(projectRoot string, nums []int, mode string, lg Logger) ([]s
 func cleanupPaneRecords(opts Options, panes []state.Pane, lg Logger) bool {
 	ok := true
 	for _, pane := range panes {
+		if pane.IsShell() {
+			runBackgroundHook(hooks.BeforePaneClose, opts, pane, "", lg)
+			killPaneBestEffort(pane, lg)
+			runBackgroundHook(hooks.PaneClosed, opts, pane, "", lg)
+			continue
+		}
 		hadWorktree := recordedWorktreeExists(pane)
 		if hadWorktree && !runBlockingHook(hooks.BeforeWorktreeRemove, opts, pane, "", lg) {
 			ok = false
@@ -380,6 +414,26 @@ func cleanupPaneRecords(opts Options, panes []state.Pane, lg Logger) bool {
 		runBackgroundHook(hooks.PaneClosed, opts, pane, "", lg)
 	}
 	return ok
+}
+
+func hasManagedWorktree(panes []state.Pane) bool {
+	for _, pane := range panes {
+		if !pane.IsShell() {
+			return true
+		}
+	}
+	return false
+}
+
+func cleanupIssuePanes(panes []state.Pane) []state.Pane {
+	var out []state.Pane
+	for _, pane := range panes {
+		if pane.IsShell() || pane.IssueNum <= 0 {
+			continue
+		}
+		out = append(out, pane)
+	}
+	return out
 }
 
 func removeWorktree(projectRoot string, pane state.Pane, lg Logger) bool {

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -393,7 +393,7 @@ func cleanupPaneRecords(opts Options, panes []state.Pane, lg Logger) bool {
 	for _, pane := range panes {
 		if pane.IsShell() {
 			runBackgroundHook(hooks.BeforePaneClose, opts, pane, "", lg)
-			killPaneBestEffort(pane, lg)
+			killShellPaneBestEffort(pane, lg)
 			runBackgroundHook(hooks.PaneClosed, opts, pane, "", lg)
 			continue
 		}
@@ -464,6 +464,35 @@ func killPaneBestEffort(pane state.Pane, lg Logger) {
 	if err := tmuxrun.KillPane(pane.PaneID); err != nil {
 		lg.Warn("%s: tmux kill-pane %s failed; treating pane as stale: %v", paneLabel(pane), pane.PaneID, err)
 	}
+}
+
+func killShellPaneBestEffort(pane state.Pane, lg Logger) {
+	if strings.TrimSpace(pane.PaneID) == "" {
+		lg.Warn("%s: no paneId recorded; skipping tmux kill-pane", paneLabel(pane))
+		return
+	}
+	shellKey := strings.TrimSpace(pane.ShellKey)
+	if shellKey == "" {
+		lg.Warn("%s: no shellKey recorded; skipping tmux kill-pane to avoid pane id reuse", paneLabel(pane))
+		return
+	}
+	live, err := tmuxrun.ListLivePanes()
+	if err != nil {
+		lg.Warn("%s: tmux list-panes failed; skipping shell pane kill: %v", paneLabel(pane), err)
+		return
+	}
+	for _, cur := range live {
+		if cur.ID != pane.PaneID {
+			continue
+		}
+		if cur.ShellKey != shellKey {
+			lg.Warn("%s: shell pane %s identity changed; skipping tmux kill-pane to avoid pane id reuse", paneLabel(pane), pane.PaneID)
+			return
+		}
+		killPaneBestEffort(pane, lg)
+		return
+	}
+	lg.Warn("%s: shell pane %s is gone; skipping tmux kill-pane", paneLabel(pane), pane.PaneID)
 }
 
 func pruneWorktrees(projectRoot string, lg Logger) bool {

--- a/internal/sessionview/aggregate.go
+++ b/internal/sessionview/aggregate.go
@@ -26,6 +26,8 @@ type LivePaneInfo struct {
 	// "done")。fanout の起動ラッパーが agent 実行前後に設定する。未設定
 	// (旧版 fanout やラッパー外で起動した pane)や取得失敗時は ""。
 	AgentState string
+	// ShellKey is @fanout_shell_key for TUI shell panes.
+	ShellKey string
 }
 
 // Collectors are the injectable IO boundary. The web dashboard's poller and the
@@ -222,7 +224,7 @@ func Build(repo, projectRoot string, c Collectors) Snapshot {
 		for _, p := range panes {
 			issueState, prs := fetchPanePRs(p)
 			worktreeStat, worktreeErr := fetchWorktree(p.WorktreePath, p.BaseBranch)
-			alive := paneAlive(live, p.PaneID, p.WorktreePath)
+			alive := paneAlive(live, p)
 			wi := graph.Info[p.IssueNum]
 			pv := PaneView{
 				IssueNum:     p.IssueNum,
@@ -468,19 +470,22 @@ func SyntheticTmuxState(issueState string, blocked bool) string {
 	}
 }
 
-// paneAlive reports whether a recorded pane is live: a tmux pane with its id
-// must exist AND be sitting at/under the recorded worktree. Requiring the path
-// match defends against tmux reusing a %N id for an unrelated pane after a
-// server restart. A row without a recorded worktree (legacy) falls back to an
-// id-only match.
-func paneAlive(live map[string]LivePaneInfo, paneID, worktree string) bool {
-	if paneID == "" {
+// paneAlive reports whether a recorded pane is live. Agent panes match on both
+// pane id and cwd at/under their recorded worktree. Shell panes match on pane
+// id plus @fanout_shell_key instead: root terminals record the repo root as
+// WorktreePath, which is too broad to protect against tmux pane id reuse.
+func paneAlive(live map[string]LivePaneInfo, pane state.Pane) bool {
+	if pane.PaneID == "" {
 		return false
 	}
-	cur, ok := live[paneID]
+	cur, ok := live[pane.PaneID]
 	if !ok {
 		return false
 	}
+	if pane.IsShell() {
+		return pane.ShellKey != "" && cur.ShellKey == pane.ShellKey
+	}
+	worktree := pane.WorktreePath
 	if strings.TrimSpace(worktree) == "" {
 		return true
 	}

--- a/internal/sessionview/aggregate.go
+++ b/internal/sessionview/aggregate.go
@@ -235,6 +235,7 @@ func Build(repo, projectRoot string, c Collectors) Snapshot {
 				Agent:        p.Agent,
 				BranchName:   p.BranchName,
 				PaneID:       p.PaneID,
+				ShellKey:     p.ShellKey,
 				WorktreePath: p.WorktreePath,
 				CreatedAt:    p.CreatedAt,
 				Alive:        alive,

--- a/internal/sessionview/aggregate.go
+++ b/internal/sessionview/aggregate.go
@@ -227,6 +227,7 @@ func Build(repo, projectRoot string, c Collectors) Snapshot {
 			pv := PaneView{
 				IssueNum:     p.IssueNum,
 				TaskID:       p.TaskID,
+				Kind:         p.Kind,
 				Slug:         p.Slug,
 				DisplayName:  p.DisplayName,
 				Agent:        p.Agent,
@@ -317,7 +318,7 @@ func Build(repo, projectRoot string, c Collectors) Snapshot {
 		snap.Sessions = append(snap.Sessions, session)
 
 		for _, pv := range session.Panes {
-			if countsInRollup(pv) {
+			if countsInRollup(pv) || pv.Kind == state.PaneKindShell {
 				accumulate(&snap.Rollup, pv)
 			}
 		}
@@ -557,6 +558,9 @@ func hasMergedPR(prs []ghissue.PRRef) bool {
 // に到達できなくなるため。merged PR を持つ CLOSED 子は「pane なしで完了した
 // 作業」として Total / Merged に算入する。記録 pane は従来どおり常に算入。
 func countsInRollup(pv PaneView) bool {
+	if pv.Kind == state.PaneKindShell {
+		return false
+	}
 	if !pv.NotStarted {
 		return true
 	}
@@ -571,6 +575,12 @@ func countsInRollup(pv PaneView) bool {
 }
 
 func accumulate(r *Rollup, pv PaneView) {
+	if pv.Kind == state.PaneKindShell {
+		if pv.Alive {
+			r.Live++
+		}
+		return
+	}
 	r.Total++
 	if pv.HasMergedPR {
 		r.Merged++
@@ -639,6 +649,7 @@ func DerivePane(projectRoot, parent string, pv PaneView) PaneDerived {
 	filterText := strings.ToLower(strings.Join([]string{
 		parent,
 		pv.TaskID,
+		pv.Kind,
 		"#" + strconv.Itoa(pv.IssueNum),
 		strconv.Itoa(pv.IssueNum),
 		name,

--- a/internal/sessionview/aggregate_test.go
+++ b/internal/sessionview/aggregate_test.go
@@ -186,7 +186,7 @@ func TestBuildShellPaneCountsLiveButNotProgressRollup(t *testing.T) {
 			}
 		}
 	}
-	if shell.Kind != state.PaneKindShell || !shell.Alive || shell.Derived.Name != "root terminal" {
+	if shell.Kind != state.PaneKindShell || shell.ShellKey != "shell-root" || !shell.Alive || shell.Derived.Name != "root terminal" {
 		t.Fatalf("shell pane = %+v, want live shell row", shell)
 	}
 }

--- a/internal/sessionview/aggregate_test.go
+++ b/internal/sessionview/aggregate_test.go
@@ -153,6 +153,7 @@ func TestBuildShellPaneCountsLiveButNotProgressRollup(t *testing.T) {
 		Kind:         state.PaneKindShell,
 		Slug:         "terminal-root-1",
 		PaneID:       "%2",
+		ShellKey:     "shell-root",
 		Agent:        "shell",
 		DisplayName:  "root terminal",
 		WorktreePath: "/repo",
@@ -163,7 +164,7 @@ func TestBuildShellPaneCountsLiveButNotProgressRollup(t *testing.T) {
 		LoadState: storeOf(agentPane, shellPane),
 		LivePanes: livePanesWith(map[string]LivePaneInfo{
 			"%1": {Path: "/wt/%1"},
-			"%2": {Path: "/repo", Title: "root terminal"},
+			"%2": {Path: "/repo", Title: "root terminal", ShellKey: "shell-root"},
 		}),
 		IssuePRs: func(num int) (string, []ghissue.PRRef, error) {
 			return "OPEN", nil, nil
@@ -187,6 +188,40 @@ func TestBuildShellPaneCountsLiveButNotProgressRollup(t *testing.T) {
 	}
 	if shell.Kind != state.PaneKindShell || !shell.Alive || shell.Derived.Name != "root terminal" {
 		t.Fatalf("shell pane = %+v, want live shell row", shell)
+	}
+}
+
+func TestBuildShellPaneRequiresShellKeyForLiveness(t *testing.T) {
+	shellPane := state.Pane{
+		Parent:       "@manual",
+		IssueNum:     -1,
+		Kind:         state.PaneKindShell,
+		Slug:         "terminal-root-1",
+		PaneID:       "%2",
+		ShellKey:     "shell-root",
+		Agent:        "shell",
+		DisplayName:  "root terminal",
+		WorktreePath: "/repo",
+		CreatedAt:    "2026-06-04T00:00:00Z",
+	}
+	snap := Build("owner/name", "/repo", Collectors{
+		Now:       fixedNow,
+		LoadState: storeOf(shellPane),
+		LivePanes: livePanesWith(map[string]LivePaneInfo{
+			"%2": {Path: "/repo/subdir", Title: "reused id", ShellKey: "other-shell"},
+		}),
+		IssuePRs: func(num int) (string, []ghissue.PRRef, error) {
+			return "OPEN", nil, nil
+		},
+		Waves: wavesNone,
+		WorktreeStat: func(path, baseRef string) (WorktreeStat, error) {
+			return WorktreeStat{DiffSummary: "+0/-0", DirtyState: "clean"}, nil
+		},
+	})
+
+	got := snap.Sessions[0].Panes[0]
+	if got.Alive || got.TmuxState != "stale" {
+		t.Fatalf("shell pane alive=%v tmux=%q, want stale when shell key differs", got.Alive, got.TmuxState)
 	}
 }
 

--- a/internal/sessionview/aggregate_test.go
+++ b/internal/sessionview/aggregate_test.go
@@ -145,6 +145,51 @@ func TestBuildGroupsByParentSortedAndComputesRollups(t *testing.T) {
 	}
 }
 
+func TestBuildShellPaneCountsLiveButNotProgressRollup(t *testing.T) {
+	agentPane := pane("100", 101, "%1")
+	shellPane := state.Pane{
+		Parent:       "@manual",
+		IssueNum:     -1,
+		Kind:         state.PaneKindShell,
+		Slug:         "terminal-root-1",
+		PaneID:       "%2",
+		Agent:        "shell",
+		DisplayName:  "root terminal",
+		WorktreePath: "/repo",
+		CreatedAt:    "2026-06-04T00:00:00Z",
+	}
+	snap := Build("owner/name", "/repo", Collectors{
+		Now:       fixedNow,
+		LoadState: storeOf(agentPane, shellPane),
+		LivePanes: livePanesWith(map[string]LivePaneInfo{
+			"%1": {Path: "/wt/%1"},
+			"%2": {Path: "/repo", Title: "root terminal"},
+		}),
+		IssuePRs: func(num int) (string, []ghissue.PRRef, error) {
+			return "OPEN", nil, nil
+		},
+		Waves: wavesNone,
+		WorktreeStat: func(path, baseRef string) (WorktreeStat, error) {
+			return WorktreeStat{DiffSummary: "+0/-0", DirtyState: "clean"}, nil
+		},
+	})
+
+	if snap.Rollup.Total != 1 || snap.Rollup.Pending != 1 || snap.Rollup.Live != 2 {
+		t.Fatalf("repo rollup = %+v, want progress total 1 and live 2", snap.Rollup)
+	}
+	var shell PaneView
+	for _, session := range snap.Sessions {
+		for _, pane := range session.Panes {
+			if pane.Kind == state.PaneKindShell {
+				shell = pane
+			}
+		}
+	}
+	if shell.Kind != state.PaneKindShell || !shell.Alive || shell.Derived.Name != "root terminal" {
+		t.Fatalf("shell pane = %+v, want live shell row", shell)
+	}
+}
+
 func TestBuildAddsDerivedDisplayFilterAndSortFields(t *testing.T) {
 	c := Collectors{
 		Now:       fixedNow,

--- a/internal/sessionview/collect.go
+++ b/internal/sessionview/collect.go
@@ -31,7 +31,7 @@ func LivePanes() func() (map[string]LivePaneInfo, error) {
 		}
 		m := make(map[string]LivePaneInfo, len(panes))
 		for _, p := range panes {
-			m[p.ID] = LivePaneInfo{Path: p.CurrentPath, Title: p.Title, AgentState: p.AgentState}
+			m[p.ID] = LivePaneInfo{Path: p.CurrentPath, Title: p.Title, AgentState: p.AgentState, ShellKey: p.ShellKey}
 		}
 		return m, nil
 	}

--- a/internal/sessionview/model.go
+++ b/internal/sessionview/model.go
@@ -52,6 +52,7 @@ type PaneView struct {
 	Agent        string          `json:"agent"`
 	BranchName   string          `json:"branchName"`
 	PaneID       string          `json:"paneId"`
+	ShellKey     string          `json:"shellKey,omitempty"`
 	WorktreePath string          `json:"worktreePath"`
 	CreatedAt    string          `json:"createdAt"`
 	Alive        bool            `json:"alive"`      // PaneID is among the live tmux panes

--- a/internal/sessionview/model.go
+++ b/internal/sessionview/model.go
@@ -46,6 +46,7 @@ type WorktreeStat struct {
 type PaneView struct {
 	IssueNum     int             `json:"issueNum"`
 	TaskID       string          `json:"taskId,omitempty"`
+	Kind         string          `json:"kind,omitempty"`
 	Slug         string          `json:"slug"`
 	DisplayName  string          `json:"displayName"`
 	Agent        string          `json:"agent"`

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -37,7 +37,11 @@ type Pane struct {
 	// (e.g. "main"). Legacy rows recorded before this field load as "".
 	BaseBranch string `json:"baseBranch,omitempty"`
 	PaneID     string `json:"paneId"`
-	Agent      string `json:"agent"`
+	// ShellKey is a tmux pane user-option token for TUI shell terminals. Shell
+	// panes can share WorktreePath with the repo root or an agent worktree, so
+	// liveness uses this marker instead of path-prefix matching.
+	ShellKey string `json:"shellKey,omitempty"`
+	Agent    string `json:"agent"`
 	// CodexPlanMode は --codex-plan-mode(app-server Plan turn + 対話 Codex TUI)
 	// で起動したペインかどうか。ダッシュボードの GET /api/plan が plan 抽出の
 	// 対象ペインを限定するために参照する。additive なフィールドなので

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -14,6 +14,8 @@ import (
 
 const SchemaVersion = 1
 
+const PaneKindShell = "shell"
+
 type Store struct {
 	SchemaVersion int    `json:"schemaVersion"`
 	Panes         []Pane `json:"panes"`
@@ -28,6 +30,7 @@ type Pane struct {
 	Parent     string `json:"parent"`
 	IssueNum   int    `json:"issueNum"`
 	TaskID     string `json:"taskId,omitempty"`
+	Kind       string `json:"kind,omitempty"`
 	Slug       string `json:"slug"`
 	BranchName string `json:"branchName"`
 	// BaseBranch is the resolved base branch the worktree branched from
@@ -49,6 +52,10 @@ type Pane struct {
 	// 表示側は tmux の動的判定(起動ラッパーが設定する pane user option
 	// @fanout_agent_state)を優先し、tmux 不通時のみこの記録値に fallback する。
 	AgentStatus string `json:"agentStatus,omitempty"`
+}
+
+func (p Pane) IsShell() bool {
+	return p.Kind == PaneKindShell
 }
 
 // LockedStore holds .fanout/state.json.lock while fanout plans and launches.

--- a/internal/team/detect.go
+++ b/internal/team/detect.go
@@ -52,11 +52,13 @@ var (
 // IdentifyPane is the pure detection core: it resolves the invoking pane
 // against an already-loaded state store. worktree, when non-empty, is the
 // fanout child worktree the caller runs in and is the primary key: a
-// WorktreePath match identifies the pane even after tmux restarts. paneID is
-// the fallback; rows whose recorded WorktreePath conflicts with the live
-// worktree are skipped because tmux reuses pane ids across server restarts
-// and such a row belongs to a dead pane. Rows are scanned newest-first
-// (state appends in launch order). The matched row's recorded
+// WorktreePath match identifies the managed issue/task pane even after tmux
+// restarts. Shell terminal rows can share the same worktree, so the worktree
+// match skips them and lets pane id fallback identify the shell only when no
+// managed row owns that worktree. Rows whose recorded WorktreePath conflicts
+// with the live worktree are skipped because tmux reuses pane ids across
+// server restarts and such a row belongs to a dead pane. Rows are scanned
+// newest-first (state appends in launch order). The matched row's recorded
 // IssueNum/Parent are authoritative; the prompt-tag parse only fills fields
 // a degenerate row is missing. A missing state file yields ErrPaneNotFound
 // because state.Load returns an empty store for absent files.
@@ -66,7 +68,7 @@ func IdentifyPane(paneID, worktree string, st state.Store) (Identity, error) {
 	}
 	if worktree != "" {
 		for _, pane := range slices.Backward(st.Panes) {
-			if pane.WorktreePath == worktree {
+			if pane.WorktreePath == worktree && !pane.IsShell() {
 				return paneIdentity(pane), nil
 			}
 		}

--- a/internal/team/detect_test.go
+++ b/internal/team/detect_test.go
@@ -92,6 +92,13 @@ func TestIdentifyPane(t *testing.T) {
 		WorktreePath: "/repo/.fanout/worktrees/msg-cli-70",
 		Prompt:       "[fanout #70 of #68] msg-cli-70: t. read /tmp/y.md and begin.",
 	}
+	shellInWorktree := state.Pane{
+		Parent:       "@manual",
+		IssueNum:     -1,
+		Kind:         state.PaneKindShell,
+		PaneID:       "%shell",
+		WorktreePath: "/repo/.fanout/worktrees/msg-cli-70",
+	}
 
 	tests := []struct {
 		name       string
@@ -152,6 +159,22 @@ func TestIdentifyPane(t *testing.T) {
 			store:      state.Store{Panes: []state.Pane{recorded, inWorktree}},
 			wantIssue:  70,
 			wantParent: "68",
+		},
+		{
+			name:       "shell row does not shadow managed worktree identity",
+			paneID:     "%2",
+			worktree:   "/repo/.fanout/worktrees/msg-cli-70",
+			store:      state.Store{Panes: []state.Pane{inWorktree, shellInWorktree}},
+			wantIssue:  70,
+			wantParent: "68",
+		},
+		{
+			name:       "shell pane id still identifies shell without managed worktree row",
+			paneID:     "%shell",
+			worktree:   "/repo/.fanout/worktrees/msg-cli-70",
+			store:      state.Store{Panes: []state.Pane{shellInWorktree}},
+			wantIssue:  -1,
+			wantParent: "@manual",
 		},
 		{
 			name:       "worktree alone identifies without pane id",

--- a/internal/tmuxrun/tmuxrun.go
+++ b/internal/tmuxrun/tmuxrun.go
@@ -24,8 +24,10 @@ const (
 	// tmux 3.6a/macOS; Linux resolves the foreground pgrp leader the same way).
 	// Pane user options die with the pane, matching the liveness boundary.
 	agentStateOption         = "@fanout_agent_state"
+	shellKeyOption           = "@fanout_shell_key"
 	projectRootOption        = "@fanout_project_root"
 	livePaneAgentStateFormat = "#{pane_id}\t#{" + agentStateOption + "}"
+	livePaneShellKeyFormat   = "#{pane_id}\t#{" + shellKeyOption + "}"
 	paneAlternateFormat      = "#{alternate_on}"
 )
 
@@ -112,6 +114,9 @@ type LivePane struct {
 	// "done" を設定する。旧版 fanout やラッパー外で起動した pane では未設定で
 	// ""。listing が失敗したとき・join 済み id に対応する行が無いときも空。
 	AgentState string
+	// ShellKey is @fanout_shell_key for TUI shell panes. It lets callers match
+	// shell rows without trusting broad repo-root WorktreePath prefixes.
+	ShellKey string
 }
 
 // ListLivePanes returns every live tmux pane across all sessions with its
@@ -121,10 +126,11 @@ type LivePane struct {
 // row live when an unrelated new pane reuses the same %N. An error (e.g. tmux
 // absent) lets callers degrade.
 //
-// It issues three list-panes calls (livePanePathFormat, livePaneTitleFormat,
-// then livePaneAgentStateFormat) so each variable-content field is last on its
-// line and survives strings.Cut with embedded tabs intact — both pane paths
-// and pane titles may legally contain tabs.
+// It issues four list-panes calls (livePanePathFormat, livePaneTitleFormat,
+// livePaneAgentStateFormat, then livePaneShellKeyFormat) so each
+// variable-content field is last on its line and survives strings.Cut with
+// embedded tabs intact — both pane paths and pane titles may legally contain
+// tabs.
 //
 // Injection defense: pane_current_path is just a directory name, so a crafted
 // path containing a newline can forge whole extra lines in the path listing.
@@ -163,6 +169,10 @@ func ListLivePanes() ([]LivePane, error) {
 	if stateOut, err := exec.Command("tmux", "list-panes", "-a", "-F", livePaneAgentStateFormat).Output(); err == nil {
 		agentStates = parseLivePaneField(string(stateOut))
 	}
+	shellKeys := map[string]string{}
+	if shellKeyOut, err := exec.Command("tmux", "list-panes", "-a", "-F", livePaneShellKeyFormat).Output(); err == nil {
+		shellKeys = parseLivePaneField(string(shellKeyOut))
+	}
 	// A real tmux listing emits each pane id exactly once; a duplicate means a
 	// newline-bearing pane_current_path forged an extra row reusing a REAL id
 	// (which would pass the title-listing check below). Conservatively drop
@@ -184,6 +194,7 @@ func ListLivePanes() ([]LivePane, error) {
 		}
 		pane.Title = title
 		pane.AgentState = agentStates[pane.ID]
+		pane.ShellKey = shellKeys[pane.ID]
 		joined = append(joined, pane)
 	}
 	return joined, nil
@@ -298,6 +309,20 @@ func SetPaneProjectRoot(paneID, projectRoot string) error {
 	}
 	if err := exec.Command("tmux", "set-option", "-p", "-t", paneID, projectRootOption, projectRoot).Run(); err != nil {
 		return fmt.Errorf("tmux set-option %s: %w", projectRootOption, err)
+	}
+	return nil
+}
+
+// SetPaneShellKey records a shell-pane liveness token on a tmux pane.
+func SetPaneShellKey(paneID, shellKey string) error {
+	if strings.TrimSpace(paneID) == "" {
+		return fmt.Errorf("pane id is required")
+	}
+	if strings.TrimSpace(shellKey) == "" {
+		return fmt.Errorf("shell key is required")
+	}
+	if err := exec.Command("tmux", "set-option", "-p", "-t", paneID, shellKeyOption, shellKey).Run(); err != nil {
+		return fmt.Errorf("tmux set-option %s: %w", shellKeyOption, err)
 	}
 	return nil
 }

--- a/internal/tmuxrun/tmuxrun_test.go
+++ b/internal/tmuxrun/tmuxrun_test.go
@@ -106,13 +106,18 @@ printf '%%43\n'
 	}
 }
 
-// installLivePanesShim installs a tmux shim that answers the three
+// installLivePanesShim installs a tmux shim that answers the four
 // `list-panes -a -F <format>` calls ListLivePanes makes, dispatching on the
 // format argument ($4): pathBody for livePanePathFormat, titleBody for
-// livePaneTitleFormat, agentStateBody for livePaneAgentStateFormat. Each argv
-// is appended to the args file separated by "---" lines.
-func installLivePanesShim(t *testing.T, pathBody, titleBody, agentStateBody string) string {
+// livePaneTitleFormat, agentStateBody for livePaneAgentStateFormat, and an
+// optional shellKeyBody for livePaneShellKeyFormat. Each argv is appended to
+// the args file separated by "---" lines.
+func installLivePanesShim(t *testing.T, pathBody, titleBody, agentStateBody string, shellKeyBody ...string) string {
 	t.Helper()
+	shellBody := `printf ''`
+	if len(shellKeyBody) > 0 {
+		shellBody = shellKeyBody[0]
+	}
 	script := `printf '%s\n' "$@" >> "$TMUXRUN_ARGS"
 printf '%s\n' '---' >> "$TMUXRUN_ARGS"
 case "$4" in
@@ -121,6 +126,9 @@ case "$4" in
 	;;
 *fanout_agent_state*)
 	` + agentStateBody + `
+	;;
+*fanout_shell_key*)
+	` + shellBody + `
 	;;
 *pane_title*)
 	` + titleBody + `
@@ -138,14 +146,15 @@ func TestListLivePanesJoinsPathTitleAndAgentStateOutputsByID(t *testing.T) {
 	argsPath := installLivePanesShim(t,
 		`printf '%%9\t/wt/nine\n%%10\t/wt/ten\twith\ttabs\n%%11\t/wt/eleven\n\n'`,
 		`printf '%%9\tnine: child\n%%10\ttitle\twith\ttabs\n%%11\t\n'`,
-		`printf '%%9\trunning\n%%10\tdone\n'`)
+		`printf '%%9\trunning\n%%10\tdone\n'`,
+		`printf '%%9\tshell-nine\n'`)
 
 	panes, err := ListLivePanes()
 	if err != nil {
 		t.Fatalf("ListLivePanes() failed: %v", err)
 	}
 	want := []LivePane{
-		{ID: "%9", CurrentPath: "/wt/nine", Title: "nine: child", AgentState: "running"},
+		{ID: "%9", CurrentPath: "/wt/nine", Title: "nine: child", AgentState: "running", ShellKey: "shell-nine"},
 		{ID: "%10", CurrentPath: "/wt/ten\twith\ttabs", Title: "title\twith\ttabs", AgentState: "done"},
 		{ID: "%11", CurrentPath: "/wt/eleven", Title: "", AgentState: ""},
 	}
@@ -157,6 +166,7 @@ func TestListLivePanesJoinsPathTitleAndAgentStateOutputsByID(t *testing.T) {
 		"list-panes", "-a", "-F", "#{pane_id}\t#{pane_current_path}", "---",
 		"list-panes", "-a", "-F", "#{pane_id}\t#{pane_title}", "---",
 		"list-panes", "-a", "-F", "#{pane_id}\t#{@fanout_agent_state}", "---",
+		"list-panes", "-a", "-F", "#{pane_id}\t#{@fanout_shell_key}", "---",
 	})
 }
 
@@ -424,6 +434,19 @@ func TestSetPaneProjectRoot(t *testing.T) {
 
 	assertTmuxArgs(t, argsPath, []string{
 		"set-option", "-p", "-t", "%42", "@fanout_project_root", "/tmp/My Repo",
+	})
+}
+
+func TestSetPaneShellKey(t *testing.T) {
+	argsPath := installTmuxShim(t, `printf '%s\n' "$@" > "$TMUXRUN_ARGS"
+`)
+
+	if err := SetPaneShellKey("%42", "shell-token"); err != nil {
+		t.Fatalf("SetPaneShellKey() failed: %v", err)
+	}
+
+	assertTmuxArgs(t, argsPath, []string{
+		"set-option", "-p", "-t", "%42", "@fanout_shell_key", "shell-token",
 	})
 }
 

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"maps"
 	"os"
+	"path/filepath"
 	"slices"
 	"strconv"
 	"strings"
@@ -53,6 +54,7 @@ type Options struct {
 	DefaultAgent      string
 	Hooks             hooks.Config
 	LaunchPane        LaunchFunc
+	LaunchShell       ShellLaunchFunc
 	FocusPane         func(string) error
 	PaneAlive         func(string) bool
 	CapturePaneOutput func(string, int) (string, error)
@@ -76,6 +78,16 @@ type LaunchRequest struct {
 
 // LaunchFunc creates a manual fanout pane for a TUI request.
 type LaunchFunc func(LaunchRequest) error
+
+// ShellLaunchRequest describes one shell terminal launch requested from the TUI.
+type ShellLaunchRequest struct {
+	TargetPath string
+	Root       bool
+	Source     string
+}
+
+// ShellLaunchFunc creates a shell terminal pane for a TUI request.
+type ShellLaunchFunc func(ShellLaunchRequest) error
 
 type issueStatus struct {
 	Title           string
@@ -110,6 +122,7 @@ type paneView struct {
 	Parent       string
 	IssueNum     int
 	TaskID       string
+	Kind         string
 	Name         string
 	PaneID       string
 	TmuxState    string
@@ -129,6 +142,7 @@ type paneView struct {
 	WorktreeErr  string
 	BranchName   string
 	WorktreePath string
+	worktreeAbs  string
 	Agent        string
 	CreatedAt    string
 	Prompt       string
@@ -296,6 +310,10 @@ type (
 	stateTickMsg  time.Time
 	ghTickMsg     time.Time
 	launchPaneMsg struct {
+		err error
+	}
+	launchShellMsg struct {
+		req ShellLaunchRequest
 		err error
 	}
 )
@@ -534,6 +552,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "n":
 			m.openNewPaneForm()
 			return m, nil
+		case "A":
+			return m, m.openSelectedWorktreeShellCmd()
+		case "t":
+			return m, m.openProjectRootShellCmd()
 		case "enter", "o":
 			cmd := m.focusSelectedCmd()
 			return m, cmd
@@ -636,6 +658,20 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.mode = modeMonitor
 		m.notice = "created new agent pane"
+		return m, m.loadStateCmd(false)
+	case launchShellMsg:
+		if msg.err != nil {
+			m.notice = fmt.Sprintf("terminal: %v", msg.err)
+			return m, nil
+		}
+		switch {
+		case msg.req.Root:
+			m.notice = "opened project root terminal"
+		case msg.req.Source != "":
+			m.notice = fmt.Sprintf("opened terminal for %s", msg.req.Source)
+		default:
+			m.notice = "opened worktree terminal"
+		}
 		return m, m.loadStateCmd(false)
 	case paneFocusedMsg:
 		if msg.keyboardPaused {
@@ -1041,6 +1077,10 @@ func (m model) startPendingAction(action lifecycleAction) (tea.Model, tea.Cmd) {
 		m.actionMessage = "no pane selected"
 		return m, nil
 	}
+	if pane.isShell() && action != actionClose {
+		m.actionMessage = fmt.Sprintf("%s unavailable for shell terminal", action)
+		return m, nil
+	}
 	m.pendingAction = &pendingLifecycleAction{action: action, pane: pane}
 	m.actionMessage = confirmMessage(action, pane)
 	return m, nil
@@ -1362,7 +1402,7 @@ func (m model) detailContent() string {
 	}
 	lines := []string{
 		fmt.Sprintf("%s %s  %s", pane.Parent, pane.itemLabel(), pane.Name),
-		fmt.Sprintf("pane=%s tmux=%s title=%s agent=%s", dash(pane.PaneID), pane.TmuxState, dash(pane.TmuxTitle), dash(pane.Agent)),
+		fmt.Sprintf("pane=%s tmux=%s title=%s kind=%s agent=%s", dash(pane.PaneID), pane.TmuxState, dash(pane.TmuxTitle), dash(pane.Kind), dash(pane.Agent)),
 		fmt.Sprintf("issue=%s pr=%s ci=%s branch=%s", dash(pane.IssueState), dash(pane.PRSummary), dash(pane.CIStatus), dash(pane.BranchName)),
 		fmt.Sprintf("wave=%s blockers=%s", dash(pane.waveText()), dash(pane.Blockers)),
 		fmt.Sprintf("worktree=%s diff=%s dirty=%s", dash(pane.WorktreePath), dash(pane.DiffSummary), dash(pane.DirtyState)),
@@ -1388,6 +1428,60 @@ func (m model) selectedPane() (paneView, bool) {
 		idx = 0
 	}
 	return m.panes[idx], true
+}
+
+func (m *model) openSelectedWorktreeShellCmd() tea.Cmd {
+	pane, ok := m.selectedPane()
+	if !ok {
+		m.notice = "no pane selected"
+		return nil
+	}
+	targetPath := pane.absoluteWorktreePath(m.opts.ProjectRoot)
+	if targetPath == "" {
+		m.notice = fmt.Sprintf("terminal skipped for %s: no worktree path", pane.identityLabel())
+		return nil
+	}
+	return m.launchShellCmd(ShellLaunchRequest{
+		TargetPath: targetPath,
+		Source:     pane.identityLabel(),
+	})
+}
+
+func (m *model) openProjectRootShellCmd() tea.Cmd {
+	projectRoot := strings.TrimSpace(m.opts.ProjectRoot)
+	if projectRoot == "" {
+		m.notice = "terminal skipped: project root is unknown"
+		return nil
+	}
+	return m.launchShellCmd(ShellLaunchRequest{
+		TargetPath: projectRoot,
+		Root:       true,
+		Source:     "project root",
+	})
+}
+
+func (m *model) launchShellCmd(req ShellLaunchRequest) tea.Cmd {
+	req.TargetPath = strings.TrimSpace(req.TargetPath)
+	if req.TargetPath == "" {
+		m.notice = "terminal skipped: target path is empty"
+		return nil
+	}
+	if m.opts.LaunchShell == nil {
+		m.notice = "terminal launcher is not configured"
+		return nil
+	}
+	switch {
+	case req.Root:
+		m.notice = "opening project root terminal..."
+	case req.Source != "":
+		m.notice = fmt.Sprintf("opening terminal for %s...", req.Source)
+	default:
+		m.notice = "opening worktree terminal..."
+	}
+	launch := m.opts.LaunchShell
+	return func() tea.Msg {
+		return launchShellMsg{req: req, err: launch(req)}
+	}
 }
 
 func (m *model) focusSelectedCmd() tea.Cmd {
@@ -2013,6 +2107,7 @@ func paneViewsFromSnapshot(projectRoot string, snap sessionview.Snapshot) []pane
 				Parent:       parent,
 				IssueNum:     pv.IssueNum,
 				TaskID:       pv.TaskID,
+				Kind:         pv.Kind,
 				Name:         derived.Name,
 				PaneID:       pv.PaneID,
 				TmuxState:    pv.TmuxState,
@@ -2032,6 +2127,7 @@ func paneViewsFromSnapshot(projectRoot string, snap sessionview.Snapshot) []pane
 				WorktreeErr:  pv.WorktreeErr,
 				BranchName:   pv.BranchName,
 				WorktreePath: firstNonEmpty(derived.WorktreeRelative, sessionview.RelativePath(projectRoot, pv.WorktreePath)),
+				worktreeAbs:  pv.WorktreePath,
 				Agent:        pv.Agent,
 				CreatedAt:    pv.CreatedAt,
 				Prompt:       pv.Prompt,
@@ -2096,6 +2192,7 @@ func derivePaneView(projectRoot string, view paneView, prs []ghissue.PRRef, bloc
 	return sessionview.DerivePane(projectRoot, view.Parent, sessionview.PaneView{
 		IssueNum:     view.IssueNum,
 		TaskID:       view.TaskID,
+		Kind:         view.Kind,
 		DisplayName:  view.Name,
 		Agent:        view.Agent,
 		BranchName:   view.BranchName,
@@ -2173,6 +2270,25 @@ func (p paneView) canPeek() bool {
 	return p.canFocus()
 }
 
+func (p paneView) isShell() bool {
+	return p.Kind == state.PaneKindShell
+}
+
+func (p paneView) absoluteWorktreePath(projectRoot string) string {
+	path := strings.TrimSpace(firstNonEmpty(p.worktreeAbs, p.WorktreePath))
+	if path == "" {
+		return ""
+	}
+	if filepath.IsAbs(path) {
+		return path
+	}
+	projectRoot = strings.TrimSpace(projectRoot)
+	if projectRoot == "" {
+		return path
+	}
+	return filepath.Join(projectRoot, path)
+}
+
 func columnsForWidth(width int) []table.Column {
 	nameWidth := clampInt(width/7, 12, 20)
 	blockerWidth := clampInt(width/8, 10, 16)
@@ -2196,7 +2312,7 @@ func columnsForWidth(width int) []table.Column {
 }
 
 func (m model) footerText() string {
-	parts := []string{"q quit", "n new", "j/k move", "[/] session", "/ filter", "enter/o focus", "p peek", "c close", "m merge", "x cleanup"}
+	parts := []string{"q quit", "n new", "A terminal", "t root", "j/k move", "[/] session", "/ filter", "enter/o focus", "p peek", "c close", "m merge", "x cleanup"}
 	if m.filterEditing {
 		parts = append(parts, "typing")
 	}
@@ -2337,6 +2453,7 @@ func (p paneView) matchesFilter(filter paneFilter) bool {
 	searchText := strings.ToLower(strings.Join([]string{
 		p.Parent,
 		p.TaskID,
+		p.Kind,
 		p.itemLabel(),
 		"#" + strconv.Itoa(p.IssueNum),
 		strconv.Itoa(p.IssueNum),
@@ -2459,6 +2576,15 @@ func (p paneView) identityLabel() string {
 	if p.isTask() {
 		return p.TaskID
 	}
+	if p.isShell() {
+		if label := strings.TrimSpace(firstNonEmpty(p.Name, p.Derived.Name, p.TmuxTitle)); label != "" && label != "-" {
+			return label
+		}
+		if slug := strings.TrimSpace(p.Derived.Name); slug != "" && slug != "-" {
+			return slug
+		}
+		return "shell"
+	}
 	return "#" + strconv.Itoa(p.IssueNum)
 }
 
@@ -2513,6 +2639,9 @@ func (p paneView) itemLabel() string {
 	if strings.TrimSpace(p.TaskID) != "" {
 		return p.TaskID
 	}
+	if p.isShell() {
+		return "shell"
+	}
 	return "#" + strconv.Itoa(p.IssueNum)
 }
 
@@ -2537,8 +2666,12 @@ func cloneIssueStatuses(in map[issueKey]issueStatus) map[issueKey]issueStatus {
 }
 
 func summarizeHUD(panes []paneView) hudSummary {
-	summary := hudSummary{Total: len(panes)}
+	summary := hudSummary{}
 	for _, pane := range panes {
+		if pane.isShell() {
+			continue
+		}
+		summary.Total++
 		if pane.HasMergedPR {
 			summary.Merged++
 		}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -57,6 +57,7 @@ type Options struct {
 	LaunchShell       ShellLaunchFunc
 	FocusPane         func(string) error
 	PaneAlive         func(string) bool
+	ShellPaneAlive    func(paneID, shellKey string) bool
 	CapturePaneOutput func(string, int) (string, error)
 	Notifier          transitionNotifier
 	lifecycle         lifecycleRunner
@@ -125,6 +126,7 @@ type paneView struct {
 	Kind         string
 	Name         string
 	PaneID       string
+	ShellKey     string
 	TmuxState    string
 	TmuxTitle    string
 	AgentState   string
@@ -450,6 +452,9 @@ func normalizeOptions(opts Options) Options {
 	if opts.PaneAlive == nil {
 		opts.PaneAlive = tmuxrun.IsPaneAlive
 	}
+	if opts.ShellPaneAlive == nil {
+		opts.ShellPaneAlive = shellPaneAliveByKey
+	}
 	if opts.CapturePaneOutput == nil {
 		opts.CapturePaneOutput = tmuxrun.CapturePaneOutput
 	}
@@ -693,6 +698,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if msg.err != nil {
 			m.peek = panePeek{PaneID: msg.paneID, At: msg.at, Err: msg.err.Error()}
+			if errors.Is(msg.err, errPaneNotAlive) {
+				m.markPaneStale(msg.paneID)
+				m.refreshRows()
+			}
 		} else {
 			m.peek = panePeek{PaneID: msg.paneID, Output: msg.output, At: msg.at}
 		}
@@ -1497,11 +1506,12 @@ func (m *model) focusSelectedCmd() tea.Cmd {
 
 	paneID := pane.PaneID
 	alive := m.opts.PaneAlive
+	shellAlive := m.opts.ShellPaneAlive
 	focus := m.opts.FocusPane
 	keyboard := m.opts.keyboard
 	m.notice = fmt.Sprintf("focusing %s...", paneID)
 	return func() tea.Msg {
-		if !alive(paneID) {
+		if !paneAliveForAction(pane, alive, shellAlive) {
 			return paneFocusedMsg{paneID: paneID, err: errPaneNotAlive}
 		}
 		keyboard.Disable()
@@ -1536,9 +1546,13 @@ func (m *model) peekSelectedCmd(force bool) tea.Cmd {
 	}
 
 	paneID := pane.PaneID
+	shellAlive := m.opts.ShellPaneAlive
 	capture := m.opts.CapturePaneOutput
 	m.peek = panePeek{PaneID: paneID, Loading: true}
 	return func() tea.Msg {
+		if pane.isShell() && !shellAlive(pane.PaneID, pane.ShellKey) {
+			return panePeekLoadedMsg{paneID: paneID, at: time.Now(), err: errPaneNotAlive}
+		}
 		out, err := capture(paneID, peekLines)
 		return panePeekLoadedMsg{paneID: paneID, output: out, at: time.Now(), err: err}
 	}
@@ -2094,6 +2108,31 @@ func errFromString(s string) error {
 	return errors.New(s)
 }
 
+func paneAliveForAction(pane paneView, paneAlive func(string) bool, shellPaneAlive func(string, string) bool) bool {
+	if pane.isShell() {
+		return shellPaneAlive(pane.PaneID, pane.ShellKey)
+	}
+	return paneAlive(pane.PaneID)
+}
+
+func shellPaneAliveByKey(paneID, shellKey string) bool {
+	paneID = strings.TrimSpace(paneID)
+	shellKey = strings.TrimSpace(shellKey)
+	if paneID == "" || shellKey == "" {
+		return false
+	}
+	panes, err := tmuxrun.ListLivePanes()
+	if err != nil {
+		return false
+	}
+	for _, pane := range panes {
+		if pane.ID == paneID && pane.ShellKey == shellKey {
+			return true
+		}
+	}
+	return false
+}
+
 func paneViewsFromSnapshot(projectRoot string, snap sessionview.Snapshot) []paneView {
 	out := []paneView{}
 	for _, session := range snap.Sessions {
@@ -2110,6 +2149,7 @@ func paneViewsFromSnapshot(projectRoot string, snap sessionview.Snapshot) []pane
 				Kind:         pv.Kind,
 				Name:         derived.Name,
 				PaneID:       pv.PaneID,
+				ShellKey:     pv.ShellKey,
 				TmuxState:    pv.TmuxState,
 				TmuxTitle:    pv.TmuxTitle,
 				AgentState:   pv.AgentState,
@@ -2197,6 +2237,7 @@ func derivePaneView(projectRoot string, view paneView, prs []ghissue.PRRef, bloc
 		Agent:        view.Agent,
 		BranchName:   view.BranchName,
 		PaneID:       view.PaneID,
+		ShellKey:     view.ShellKey,
 		WorktreePath: view.WorktreePath,
 		CreatedAt:    view.CreatedAt,
 		Alive:        view.TmuxState == "live",

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -1383,6 +1383,32 @@ func TestLifecycleKeysRoutePlanTaskRows(t *testing.T) {
 	}
 }
 
+func TestLifecycleMergeAndCleanupSkipShellRows(t *testing.T) {
+	for _, key := range []string{"m", "x"} {
+		t.Run(key, func(t *testing.T) {
+			runner := &fakeLifecycleRunner{code: exitcode.OK}
+			m := newModel(Options{ProjectRoot: "/repo", lifecycle: runner})
+			m.allPanes = []paneView{{Parent: "@manual", IssueNum: -1, Kind: state.PaneKindShell, Name: "root terminal"}}
+			m.refreshRows()
+
+			updated, cmd := m.Update(keyRunes(key))
+			m = updated.(model)
+			if cmd != nil {
+				t.Fatalf("Update(%q) returned command for shell row, want nil", key)
+			}
+			if m.pendingAction != nil {
+				t.Fatalf("pendingAction = %#v, want nil", m.pendingAction)
+			}
+			if !strings.Contains(m.actionMessage, "unavailable for shell terminal") {
+				t.Fatalf("actionMessage = %q, want shell unavailable", m.actionMessage)
+			}
+			if runner.mergeTaskID != "" || runner.cleanupParent != "" || runner.cleanupPlanParent != "" {
+				t.Fatalf("lifecycle runner was called: %+v", runner)
+			}
+		})
+	}
+}
+
 func TestLifecycleCleanupUsesSelectedParent(t *testing.T) {
 	runner := &fakeLifecycleRunner{code: exitcode.OK}
 	m := newModel(Options{ProjectRoot: "/repo", lifecycle: runner})
@@ -1579,6 +1605,88 @@ func TestNewPaneKeyOpensForm(t *testing.T) {
 	}
 	if got.newPane.agent != "codex" {
 		t.Fatalf("default agent = %q, want codex", got.newPane.agent)
+	}
+}
+
+func TestShellTerminalKeysLaunchRootAndSelectedWorktree(t *testing.T) {
+	var got []ShellLaunchRequest
+	m := newModel(Options{
+		ProjectRoot: "/repo",
+		LaunchShell: func(req ShellLaunchRequest) error {
+			got = append(got, req)
+			return nil
+		},
+	})
+	m.allPanes = []paneView{{
+		Parent:       "100",
+		IssueNum:     101,
+		Name:         "child",
+		WorktreePath: ".fanout/worktrees/child",
+		worktreeAbs:  "/repo/.fanout/worktrees/child",
+	}}
+	m.refreshRows()
+
+	updated, cmd := m.Update(keyRunes("A"))
+	m = updated.(model)
+	if cmd == nil {
+		t.Fatal("A returned nil command, want shell launch")
+	}
+	msg, ok := cmd().(launchShellMsg)
+	if !ok {
+		t.Fatalf("A command returned %T, want launchShellMsg", msg)
+	}
+	if msg.err != nil {
+		t.Fatalf("A launch error = %v", msg.err)
+	}
+	if len(got) != 1 || got[0].TargetPath != "/repo/.fanout/worktrees/child" || got[0].Root || got[0].Source != "#101" {
+		t.Fatalf("worktree shell request = %#v", got)
+	}
+
+	updated, cmd = m.Update(msg)
+	m = updated.(model)
+	if !strings.Contains(m.notice, "opened terminal for #101") {
+		t.Fatalf("notice after worktree shell = %q", m.notice)
+	}
+	if cmd == nil {
+		t.Fatal("shell success returned nil command, want state reload")
+	}
+
+	updated, cmd = m.Update(keyRunes("t"))
+	if cmd == nil {
+		t.Fatal("t returned nil command, want shell launch")
+	}
+	m = updated.(model)
+	msg, ok = cmd().(launchShellMsg)
+	if !ok {
+		t.Fatalf("t command returned %T, want launchShellMsg", msg)
+	}
+	if len(got) != 2 || got[1].TargetPath != "/repo" || !got[1].Root {
+		t.Fatalf("root shell request = %#v", got)
+	}
+}
+
+func TestShellTerminalKeyRequiresSelectedWorktree(t *testing.T) {
+	called := false
+	m := newModel(Options{
+		ProjectRoot: "/repo",
+		LaunchShell: func(ShellLaunchRequest) error {
+			called = true
+			return nil
+		},
+	})
+	m.allPanes = []paneView{{Parent: "100", IssueNum: 101, Name: "queued"}}
+	m.refreshRows()
+
+	updated, cmd := m.Update(keyRunes("A"))
+	m = updated.(model)
+	if cmd != nil {
+		t.Fatal("A returned command for row without worktree, want nil")
+	}
+	if called {
+		t.Fatal("LaunchShell was called for row without worktree")
+	}
+	if !strings.Contains(m.notice, "no worktree path") {
+		t.Fatalf("notice = %q, want no worktree path", m.notice)
 	}
 }
 

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -997,6 +997,57 @@ func TestFocusSelectedPaneMarksDeadPaneStale(t *testing.T) {
 	}
 }
 
+func TestFocusSelectedShellPaneRevalidatesShellKey(t *testing.T) {
+	focusCalled := false
+	paneAliveCalled := false
+	var gotPaneID, gotShellKey string
+	m := newModel(Options{
+		FocusPane: func(string) error {
+			focusCalled = true
+			return nil
+		},
+		PaneAlive: func(string) bool {
+			paneAliveCalled = true
+			return true
+		},
+		ShellPaneAlive: func(paneID, shellKey string) bool {
+			gotPaneID = paneID
+			gotShellKey = shellKey
+			return false
+		},
+	})
+	m.allPanes = []paneView{{
+		IssueNum:  -1,
+		Kind:      state.PaneKindShell,
+		Name:      "root terminal",
+		PaneID:    "%1",
+		ShellKey:  "shell-root",
+		TmuxState: "live",
+	}}
+	m.refreshRows()
+
+	cmd := m.focusSelectedCmd()
+	if cmd == nil {
+		t.Fatalf("focusSelectedCmd() returned nil, want shell identity check command")
+	}
+	msg := cmd()
+	next, _ := m.Update(msg)
+	m = next.(model)
+
+	if gotPaneID != "%1" || gotShellKey != "shell-root" {
+		t.Fatalf("ShellPaneAlive saw (%q, %q), want (%%1, shell-root)", gotPaneID, gotShellKey)
+	}
+	if focusCalled {
+		t.Fatal("FocusPane was called after shell key revalidation failed")
+	}
+	if paneAliveCalled {
+		t.Fatal("PaneAlive was called for a shell row; want shell-key revalidation")
+	}
+	if m.panes[0].TmuxState != "stale" {
+		t.Fatalf("TmuxState = %q, want stale", m.panes[0].TmuxState)
+	}
+}
+
 type fakeKeyboardProtocols struct {
 	enableCount  int
 	disableCount int
@@ -1048,6 +1099,68 @@ func TestPeekSelectedPaneLoadsOutputIntoDetail(t *testing.T) {
 	}
 }
 
+func TestPeekSelectedShellPaneRevalidatesShellKey(t *testing.T) {
+	captureCalled := false
+	paneAliveCalled := false
+	var gotPaneID, gotShellKey string
+	m := newModel(Options{
+		CapturePaneOutput: func(string, int) (string, error) {
+			captureCalled = true
+			return "wrong pane output", nil
+		},
+		PaneAlive: func(string) bool {
+			paneAliveCalled = true
+			return true
+		},
+		ShellPaneAlive: func(paneID, shellKey string) bool {
+			gotPaneID = paneID
+			gotShellKey = shellKey
+			return false
+		},
+	})
+	m.detail.Width = 80
+	m.detail.Height = 9
+	m.allPanes = []paneView{{
+		IssueNum:  -1,
+		Kind:      state.PaneKindShell,
+		Name:      "root terminal",
+		PaneID:    "%1",
+		ShellKey:  "shell-root",
+		TmuxState: "live",
+	}}
+	m.refreshRows()
+
+	cmd := m.peekSelectedCmd(true)
+	if cmd == nil {
+		t.Fatalf("peekSelectedCmd() returned nil, want shell identity check command")
+	}
+	msg, ok := cmd().(panePeekLoadedMsg)
+	if !ok {
+		t.Fatalf("peekSelectedCmd() msg = %T, want panePeekLoadedMsg", msg)
+	}
+	if !errors.Is(msg.err, errPaneNotAlive) {
+		t.Fatalf("peek err = %v, want errPaneNotAlive", msg.err)
+	}
+	next, _ := m.Update(msg)
+	m = next.(model)
+
+	if gotPaneID != "%1" || gotShellKey != "shell-root" {
+		t.Fatalf("ShellPaneAlive saw (%q, %q), want (%%1, shell-root)", gotPaneID, gotShellKey)
+	}
+	if captureCalled {
+		t.Fatal("CapturePaneOutput was called after shell key revalidation failed")
+	}
+	if paneAliveCalled {
+		t.Fatal("PaneAlive was called for a shell row; want shell-key revalidation")
+	}
+	if m.panes[0].TmuxState != "stale" {
+		t.Fatalf("TmuxState = %q, want stale", m.panes[0].TmuxState)
+	}
+	if !strings.Contains(m.peek.Err, errPaneNotAlive.Error()) {
+		t.Fatalf("peek err = %q, want errPaneNotAlive", m.peek.Err)
+	}
+}
+
 func TestKeySelectionChangeStartsPeekCapture(t *testing.T) {
 	var capturedPane string
 	m := newModel(Options{
@@ -1073,6 +1186,33 @@ func TestKeySelectionChangeStartsPeekCapture(t *testing.T) {
 	}
 	if capturedPane != "%2" {
 		t.Fatalf("captured pane = %q, want %%2", capturedPane)
+	}
+}
+
+func TestPaneViewsFromSnapshotCarriesShellKey(t *testing.T) {
+	snap := sessionview.Snapshot{
+		Sessions: []sessionview.Session{{
+			Parent: "@manual",
+			Panes: []sessionview.PaneView{{
+				Kind:         state.PaneKindShell,
+				DisplayName:  "root terminal",
+				Agent:        "shell",
+				PaneID:       "%9",
+				ShellKey:     "shell-root",
+				WorktreePath: "/repo",
+				TmuxState:    "live",
+				Derived:      sessionview.PaneDerived{Name: "root terminal"},
+			}},
+		}},
+	}
+
+	got := paneViewsFromSnapshot("/repo", snap)
+
+	if len(got) != 1 {
+		t.Fatalf("paneViewsFromSnapshot len = %d, want 1", len(got))
+	}
+	if got[0].ShellKey != "shell-root" {
+		t.Fatalf("ShellKey = %q, want shell-root", got[0].ShellKey)
 	}
 }
 

--- a/site/content/docs/changelog.ja.md
+++ b/site/content/docs/changelog.ja.md
@@ -11,6 +11,7 @@ yomi: changelog
 
 ## Unreleased
 
+- **TUI shell terminal。** 常駐コンソールで、選択行の worktree に `A`、project root に `t` で plain shell を開けます。shell 行は focus / peek 用に manual entry として記録され、close は tmux pane と state 行だけを消します。[Monitoring]({{< relref "/docs/monitoring" >}}) を参照。
 - **dry-run の整理。** issue / Project と `fanout plan` の dry-run は pane 作成前の安全な preview として残しつつ、issue / Project dry-run は `/tmp` briefing file を書かなくなりました。未使用だった `fanout msg --dry-run` surface は削除されました。
 
 ## v0.6.0 — 2026-06-15

--- a/site/content/docs/changelog.md
+++ b/site/content/docs/changelog.md
@@ -11,6 +11,7 @@ Release highlights, newest first. Every tag also has a [GitHub release](https://
 
 ## Unreleased
 
+- **TUI shell terminals.** The persistent console can now open a plain shell in the selected row's worktree with `A`, or at the project root with `t`. Shell rows are recorded as manual entries for focus / peek, and close removes only the tmux pane and state row. See [Monitoring]({{< relref "/docs/monitoring" >}}).
 - **Cleaner dry-run semantics.** Issue / Project and `fanout plan` dry-runs remain the safety previews for pane creation, but issue / Project dry-runs no longer write `/tmp` briefing files. The unused `fanout msg --dry-run` surface was removed.
 
 ## v0.6.0 — 2026-06-15

--- a/site/content/docs/monitoring.ja.md
+++ b/site/content/docs/monitoring.ja.md
@@ -28,6 +28,8 @@ fanout   # start the persistent tmux console
 | キー | 動作 |
 |---|---|
 | `n` | modal を開き、複数行の必須 prompt、`claude` / `codex` の agent 選択、任意 slug を指定して manual agent pane を作成する。prompt 欄では `Shift+Enter` で改行（`Shift+Enter` を区別できない terminal 向けの fallback として `Ctrl+J` も使える）、`Enter` で pane を作成する。manual pane は synthetic な `@manual` state entry として記録され、起動後に一覧へ表示される。 |
+| `A` | 選択中の行に記録された worktree で shell terminal を開く。shell 行は `@manual` entry として記録され、focus / peek できるが merge 進捗には数えない。 |
+| `t` | project root で shell terminal を開く。close は tmux pane と state 行だけを消し、git worktree は削除しない。 |
 | `Enter` / `o` | 選択中の live 行の pane にフォーカスする。 |
 | `p` | detail panel の read-only 出力スナップショットを更新する。 |
 | `c` | 選択中の pane を close する — 確認を挟み、`--close` と同じコア処理を使う。 |

--- a/site/content/docs/monitoring.md
+++ b/site/content/docs/monitoring.md
@@ -28,6 +28,8 @@ For recorded issue parents the console also reloads the parent's child set and s
 | Key | Action |
 |---|---|
 | `n` | Open a modal to create a manual agent pane from a required **multi-line** prompt, a `claude` / `codex` agent choice, and an optional slug. In the prompt field, `Shift+Enter` inserts a newline (`Ctrl+J` is a fallback for terminals that do not distinguish `Shift+Enter`); `Enter` creates the pane. Manual panes are recorded as synthetic `@manual` state entries and appear in the list after launch. |
+| `A` | Open a shell terminal in the selected row's recorded worktree. Shell rows are recorded as `@manual` entries, can be focused and peeked, and do not count toward merge progress. |
+| `t` | Open a shell terminal at the project root. Closing it kills the tmux pane and removes the state row; it never removes a git worktree. |
 | `Enter` / `o` | Focus the selected live row's pane. |
 | `p` | Refresh the read-only output snapshot shown in the detail panel. |
 | `c` | Close the selected pane — confirmation prompt, then the same core path as `--close`. |

--- a/site/content/docs/troubleshooting.ja.md
+++ b/site/content/docs/troubleshooting.ja.md
@@ -102,7 +102,7 @@ state・ロック・pane 作成について「なぜそうなっているのか�
 
 ### `state.json` のスキーマ
 
-`.fanout/state.json` には `schemaVersion` と、pane ごとに 1 行 — `parent` / `issueNum` / 任意の `taskId` / `kind` / `slug` / `branchName` / `paneId` / `agent` / `displayName` / `worktreePath` / `prompt` / `createdAt` を持つ行 — を保存します。TUI の shell terminal は `kind: "shell"` を使うため、close は tmux pane と state 行だけを消します。`--status` と lifecycle コマンドはこの行を対象に動作します。
+`.fanout/state.json` には `schemaVersion` と、pane ごとに 1 行 — `parent` / `issueNum` / 任意の `taskId` / `kind` / `shellKey` / `slug` / `branchName` / `paneId` / `agent` / `displayName` / `worktreePath` / `prompt` / `createdAt` を持つ行 — を保存します。TUI の shell terminal は `kind: "shell"` を使うため、close は tmux pane と state 行だけを消します。`shellKey` は、その行と live tmux pane を結びつけます。`--status` と lifecycle コマンドはこの行を対象に動作します。
 
 ### atomic 書き込みとロック
 

--- a/site/content/docs/troubleshooting.ja.md
+++ b/site/content/docs/troubleshooting.ja.md
@@ -102,7 +102,7 @@ state・ロック・pane 作成について「なぜそうなっているのか�
 
 ### `state.json` のスキーマ
 
-`.fanout/state.json` には `schemaVersion` と、pane ごとに 1 行 — `parent` / `issueNum` / `slug` / `branchName` / `paneId` / `agent` / `displayName` / `worktreePath` / `prompt` / `createdAt` を持つ行 — を保存します。`--status` と lifecycle コマンドはこの行を対象に動作します。
+`.fanout/state.json` には `schemaVersion` と、pane ごとに 1 行 — `parent` / `issueNum` / 任意の `taskId` / `kind` / `slug` / `branchName` / `paneId` / `agent` / `displayName` / `worktreePath` / `prompt` / `createdAt` を持つ行 — を保存します。TUI の shell terminal は `kind: "shell"` を使うため、close は tmux pane と state 行だけを消します。`--status` と lifecycle コマンドはこの行を対象に動作します。
 
 ### atomic 書き込みとロック
 

--- a/site/content/docs/troubleshooting.md
+++ b/site/content/docs/troubleshooting.md
@@ -102,7 +102,7 @@ The "why does it work that way" answers behind state, locking and pane creation.
 
 ### The `state.json` schema
 
-`.fanout/state.json` stores `schemaVersion` plus one row per pane, each carrying `parent`, `issueNum`, `slug`, `branchName`, `paneId`, `agent`, `displayName`, `worktreePath`, `prompt`, and `createdAt`. `--status` and the lifecycle commands operate on these rows.
+`.fanout/state.json` stores `schemaVersion` plus one row per pane, each carrying `parent`, `issueNum`, optional `taskId` / `kind`, `slug`, `branchName`, `paneId`, `agent`, `displayName`, `worktreePath`, `prompt`, and `createdAt`. TUI shell terminals use `kind: "shell"` so close can kill only the tmux pane and state row. `--status` and lifecycle commands operate on these rows.
 
 ### Atomic writes and locking
 

--- a/site/content/docs/troubleshooting.md
+++ b/site/content/docs/troubleshooting.md
@@ -102,7 +102,7 @@ The "why does it work that way" answers behind state, locking and pane creation.
 
 ### The `state.json` schema
 
-`.fanout/state.json` stores `schemaVersion` plus one row per pane, each carrying `parent`, `issueNum`, optional `taskId` / `kind`, `slug`, `branchName`, `paneId`, `agent`, `displayName`, `worktreePath`, `prompt`, and `createdAt`. TUI shell terminals use `kind: "shell"` so close can kill only the tmux pane and state row. `--status` and lifecycle commands operate on these rows.
+`.fanout/state.json` stores `schemaVersion` plus one row per pane, each carrying `parent`, `issueNum`, optional `taskId` / `kind` / `shellKey`, `slug`, `branchName`, `paneId`, `agent`, `displayName`, `worktreePath`, `prompt`, and `createdAt`. TUI shell terminals use `kind: "shell"` so close can kill only the tmux pane and state row; `shellKey` ties that row to its live tmux pane. `--status` and lifecycle commands operate on these rows.
 
 ### Atomic writes and locking
 

--- a/web/src/lib/pane.ts
+++ b/web/src/lib/pane.ts
@@ -65,6 +65,7 @@ export function blockersAllClosed(p: PaneView): boolean {
 }
 
 export function paneLabel(p: PaneView): string {
+  if (p.kind === "shell") return "shell";
   return p.taskId || `#${p.issueNum}`;
 }
 

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -23,6 +23,7 @@ export interface Session {
 export interface PaneView {
   issueNum: number;
   taskId?: string;
+  kind?: string;
   slug: string;
   displayName: string;
   agent: string;

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -29,6 +29,7 @@ export interface PaneView {
   agent: string;
   branchName: string;
   paneId: string;
+  shellKey?: string;
   worktreePath: string;
   createdAt: string;
   alive: boolean;


### PR DESCRIPTION
## Summary

- Add TUI shortcuts for plain shell terminals: `A` opens a terminal in the selected row's recorded worktree, and `t` opens one at the project root.
- Record shell panes as `kind: "shell"` manual state rows so they can be focused, peeked, listed in the TUI, and shown in the web dashboard.
- Keep shell lifecycle separate from managed worktrees: close kills only the tmux pane and removes state, while merge and cleanup are unavailable for shell rows.
- Update README/site docs and add tests for shell launch, state recording, rollups, lifecycle behavior, and team pane identity.

## Why

This brings the fanout TUI closer to dmux's terminal workflow: users can quickly open a plain terminal beside existing session panes, either in the selected worktree or at the project root, without launching an agent.

## Validation

- `GOCACHE=$(pwd)/.cache/go-build make test`
- `make lint` passed earlier in the implementation pass
- `make lint-web` passed earlier in the implementation pass
- `codex review --uncommitted` passed with no findings after the review fixes