### PR TITLE
docs(site): cut v0.7.0 changelog and fill in missing entries

### DIFF
--- a/site/content/docs/changelog.ja.md
+++ b/site/content/docs/changelog.ja.md
@@ -9,10 +9,15 @@ yomi: changelog
 
 リリースのハイライトを新しい順に並べています。各タグには完全なコミット一覧とビルド済みバイナリ（darwin / linux × amd64 / arm64）を含む [GitHub release](https://github.com/butaosuinu/fanout/releases) があります。バージョンは git タグから ldflags 経由で埋め込まれます — `fanout --check-update` で自分の版を確認できます。
 
-## Unreleased
+## v0.7.0 — 2026-06-21
 
+- **ライフサイクルフック。** worktree・pane・merge イベントの前後でユーザーの shell hook を実行するようになりました。`$XDG_CONFIG_HOME/fanout/hooks.json`(Codex 形式の `hooks` オブジェクト)で設定します。常時有効で、ファイルが無い場合やコマンドの無いイベントは no-op です。[CLI Reference]({{< relref "/docs/cli" >}}) を参照。
 - **TUI shell terminal。** 常駐コンソールで、選択行の worktree に `A`、project root に `t` で plain shell を開けます。shell 行は focus / peek 用に manual entry として記録され、close は tmux pane と state 行だけを消します。[Monitoring]({{< relref "/docs/monitoring" >}}) を参照。
+- **コンパクトな Session ナビゲーター。** 常駐コンソールに、セッション間を移動するためのコンパクトな Session ナビゲーターが加わりました(既存の focus / peek / lifecycle キーはそのままです)。[Monitoring]({{< relref "/docs/monitoring" >}}) を参照。
+- **`origin` なしの `fanout plan`。** plan 実行に `origin` remote が不要になりました。base branch 解決は現在のローカルブランチや `HEAD` にフォールバックするため、ローカルだけのリポジトリでも plan を fan out できます。[CLI Reference]({{< relref "/docs/cli" >}}) を参照。
 - **dry-run の整理。** issue / Project と `fanout plan` の dry-run は pane 作成前の安全な preview として残しつつ、issue / Project dry-run は `/tmp` briefing file を書かなくなりました。未使用だった `fanout msg --dry-run` surface は削除されました。
+
+[リリースノート →](https://github.com/butaosuinu/fanout/releases/tag/v0.7.0)
 
 ## v0.6.0 — 2026-06-15
 

--- a/site/content/docs/changelog.md
+++ b/site/content/docs/changelog.md
@@ -9,10 +9,15 @@ yomi: changelog
 
 Release highlights, newest first. Every tag also has a [GitHub release](https://github.com/butaosuinu/fanout/releases) with the full commit list and prebuilt binaries (darwin / linux × amd64 / arm64). Versions come from git tags via ldflags — check yours with `fanout --check-update`.
 
-## Unreleased
+## v0.7.0 — 2026-06-21
 
+- **Lifecycle hooks.** fanout now runs user shell hooks around worktree, pane, and merge events. Configure them in `$XDG_CONFIG_HOME/fanout/hooks.json` (a Codex-style `hooks` object); they are always enabled, and a missing file or an event with no commands is a no-op. See [CLI Reference]({{< relref "/docs/cli" >}}).
 - **TUI shell terminals.** The persistent console can now open a plain shell in the selected row's worktree with `A`, or at the project root with `t`. Shell rows are recorded as manual entries for focus / peek, and close removes only the tmux pane and state row. See [Monitoring]({{< relref "/docs/monitoring" >}}).
+- **Compact Session navigator.** The persistent console gained a compact Session navigator for jumping between sessions, alongside the existing focus / peek / lifecycle keys. See [Monitoring]({{< relref "/docs/monitoring" >}}).
+- **`fanout plan` without `origin`.** Plan runs no longer require an `origin` remote — base branch resolution falls back to the current local branch or `HEAD`, so a local-only repo can still fan out a plan. See [CLI Reference]({{< relref "/docs/cli" >}}).
 - **Cleaner dry-run semantics.** Issue / Project and `fanout plan` dry-runs remain the safety previews for pane creation, but issue / Project dry-runs no longer write `/tmp` briefing files. The unused `fanout msg --dry-run` surface was removed.
+
+[Release notes →](https://github.com/butaosuinu/fanout/releases/tag/v0.7.0)
 
 ## v0.6.0 — 2026-06-15
 


### PR DESCRIPTION
## What

Promote the docs-site changelog `Unreleased` section to **v0.7.0 — 2026-06-21** and add the entries that were missing for changes merged since v0.6.0.

Newly documented (were missing from the changelog, already covered in body docs):
- **Lifecycle hooks** (#295) — user shell hooks around worktree / pane / merge events via `hooks.json`.
- **Compact Session navigator** (#293) — TUI console session jump.
- **`fanout plan` without `origin`** (#294) — base branch falls back to local branch / `HEAD`.

Already in `Unreleased`, carried into v0.7.0:
- TUI shell terminals (#296), cleaner dry-run semantics (#282/#283/#284).

EN (`changelog.md`) and JA (`changelog.ja.md`) kept in sync.

## Why

Cutting the v0.7.0 release. Per the established flow (v0.6.0 via #279), the changelog lands on `main` before the tag is pushed.

## Notes

Docs-only change, no code. Created with `FANOUT_SKIP_PR_REVIEW=1` (the documented escape hatch) since there is no implementation to review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)