### PR TITLE
refactor(cmd): split run and add watch pane helper

### DIFF
--- a/cmd/fanout/main.go
+++ b/cmd/fanout/main.go
@@ -129,6 +129,10 @@ func run(cfg *cliflags.Config, lg *log.Logger, commandName string) exitcode.Code
 	if code != exitcode.OK {
 		return code
 	}
+	return runWithRuntime(cfg, lg, rt, commandName)
+}
+
+func runWithRuntime(cfg *cliflags.Config, lg *log.Logger, rt *runtimeInfo, commandName string) exitcode.Code {
 	resolvedSettings := settings.Resolve(rt.info.ProjectRoot, settings.CLIOverrides{
 		AutoPullRequest:    cfg.AutoPullRequest,
 		PRReviewGate:       cfg.PRReviewGate,

--- a/cmd/fanout/pane.go
+++ b/cmd/fanout/pane.go
@@ -27,6 +27,7 @@ import (
 
 const (
 	manualPaneParentRef        = "@manual"
+	watchPaneParentRef         = "@watch"
 	codexPlanTUIStartupTimeout = 30 * time.Second
 	codexPlanTUIStartupPoll    = 200 * time.Millisecond
 )
@@ -278,6 +279,13 @@ func newPaneRequest(cfg *cliflags.Config, projectRoot string, issue ghissue.Issu
 		req.CodexPlanStatusPath = codexPlanStatusPath(projectRoot, issue.Number, cfg.DryRun)
 	}
 	return req
+}
+
+func newWatchPaneRequest(cfg *cliflags.Config, projectRoot string, issue ghissue.Issue, resolvedSettings settings.Settings, hookConfig hooks.Config) paneRequest {
+	watchCfg := *cfg
+	watchCfg.ParentRef = watchPaneParentRef
+	watchCfg.CodexPlanMode = nil
+	return newPaneRequest(&watchCfg, projectRoot, issue, resolvedSettings, hookConfig, false, nil)
 }
 
 func newTaskPaneRequest(cfg *cliflags.Config, projectRoot string, spec planspec.Spec, task planspec.Task, resolvedSettings settings.Settings, hookConfig hooks.Config, teamCtx *briefing.TeamContext) paneRequest {

--- a/cmd/fanout/pane_test.go
+++ b/cmd/fanout/pane_test.go
@@ -290,6 +290,57 @@ func TestNewPaneRequestUsesIssueAgentOverride(t *testing.T) {
 	}
 }
 
+func TestNewWatchPaneRequestUsesReservedParentAndIssueBriefing(t *testing.T) {
+	codexPlanMode := true
+	cfg := &cliflags.Config{
+		ParentRef:     "220",
+		Agent:         "codex",
+		BaseBranch:    "main",
+		BranchPrefix:  "watch/",
+		CodexPlanMode: &codexPlanMode,
+	}
+	issue := ghissue.Issue{Number: 223, Title: "Watch runtime helper", Body: "body"}
+
+	got := newWatchPaneRequest(cfg, "/repo", issue, settings.Defaults(), hooks.EmptyConfig())
+
+	if got.ParentRef != watchPaneParentRef || got.Number != 223 || got.TaskID != "" {
+		t.Fatalf("watch identity = parent %q number %d task %q, want %q/223 with no task", got.ParentRef, got.Number, got.TaskID, watchPaneParentRef)
+	}
+	if got.Slug != "watch-runtime-helper-223" || got.BranchName != "watch/watch-runtime-helper-223" {
+		t.Fatalf("slug/branch = %q/%q", got.Slug, got.BranchName)
+	}
+	if got.Worktree.WorktreePath != "/repo/.fanout/worktrees/watch-runtime-helper-223" {
+		t.Fatalf("worktree path = %q", got.Worktree.WorktreePath)
+	}
+	if got.BriefingPath != "/tmp/fanout-repo-223.md" {
+		t.Fatalf("briefing path = %q", got.BriefingPath)
+	}
+	wantPrompt := "[fanout #223 of #@watch] watch-runtime-helper-223: Watch runtime helper. read /tmp/fanout-repo-223.md and begin."
+	if got.Prompt != wantPrompt {
+		t.Fatalf("prompt = %q, want %q", got.Prompt, wantPrompt)
+	}
+	if got.CodexPlanMode || got.CodexPlanStatusPath != "" {
+		t.Fatalf("codex plan mode = %t status %q, want disabled for watch work pane", got.CodexPlanMode, got.CodexPlanStatusPath)
+	}
+	for _, want := range []string{
+		"You are assigned GitHub issue #223",
+		`Open a pull request with "Closes #223"`,
+		"Closes #223",
+	} {
+		if !strings.Contains(got.BriefingBody, want) {
+			t.Fatalf("briefing missing %q:\n%s", want, got.BriefingBody)
+		}
+	}
+	if strings.Contains(got.BriefingBody, "<proposed_plan>") {
+		t.Fatalf("watch briefing used Codex Plan Mode body:\n%s", got.BriefingBody)
+	}
+
+	pane := statePane(got, "%42", got.Worktree.WorktreePath, time.Date(2026, 6, 20, 1, 2, 3, 0, time.UTC))
+	if pane.Parent != watchPaneParentRef || pane.IssueNum != 223 {
+		t.Fatalf("state key = %q/%d, want %q/223", pane.Parent, pane.IssueNum, watchPaneParentRef)
+	}
+}
+
 func TestNewPaneRequestPassesResolvedSettingsAgentAndTeamToBriefing(t *testing.T) {
 	cfg := &cliflags.Config{
 		ParentRef:  "100",


### PR DESCRIPTION
## TL;DR
Split `run()` so watcher code can reuse the post-runtime execution path, and add the `@watch` standalone issue pane request helper. Review effort: 2

## Why
Issue #223 asks for a behavior-preserving command refactor plus a helper for future TUI watcher launches. The intent is to let watcher code launch parent fan-out in process and record standalone issue panes under `(@watch, N)` instead of a self-parent key.

## Changes by file
<details><summary>Changed files</summary>

| File | What changed | Why |
|---|---|---|
| `cmd/fanout/main.go` | Kept `run()` as runtime resolution and moved the existing execution body to `runWithRuntime(cfg, lg, rt, commandName)`. | Lets future watcher code reuse `loadChildren`, `buildPlan`, `executePlan`, and state locking after supplying a runtime. |
| `cmd/fanout/pane.go` | Added `watchPaneParentRef` and `newWatchPaneRequest()`, reusing the issue pane builder with parent `@watch`. | Records standalone issue panes with idempotency key `(@watch, N)` while keeping issue briefing and prompt shape. |
| `cmd/fanout/pane_test.go` | Added unit coverage for `newWatchPaneRequest()`. | Verifies the `@watch` state key, prompt, issue briefing with `Closes #N`, and worktree naming. |

</details>

## Risk
> [!WARNING]
> `newWatchPaneRequest()` deliberately clears Codex Plan Mode so standalone watch panes always get an issue work briefing with `Closes #N`. A future caller that wants watch-launched Plan Mode panes needs a separate opt-in path.

## Test plan
- `go test ./cmd/fanout -run 'TestNewWatchPaneRequestUsesReservedParentAndIssueBriefing|TestExecutePlanSleepsBetweenDryRunIssues'` passed.
- `make test` passed, including Tier 2 goldens without `FANOUT_GOLDEN_UPDATE`.
- `make lint` passed.
- `codex review --uncommitted` passed with no findings.

Closes #223