### PR TITLE
[codex] feat(settings): add watcher settings

### DIFF
--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -1,11 +1,12 @@
-// Package settings resolves fanout's opinionated-behavior switches from
-// layered defaults, config files, environment variables, and CLI overrides.
+// Package settings resolves fanout settings from layered defaults, config
+// files, environment variables, and CLI overrides.
 package settings
 
 import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -14,17 +15,23 @@ const (
 	userConfigRelPath = "fanout/config.json"
 )
 
-// Settings contains the fully resolved behavior switches.
+// Settings contains the fully resolved settings.
 type Settings struct {
-	AutoPullRequest    bool
-	PRReviewGate       bool
-	BriefingCodeReview bool
-	AgentTeamsHint     bool
-	PRVisualization    bool
-	DashboardKeybind   bool
-	Notifications      string
-	NtfyURL            string
-	SlackWebhookURL    string
+	AutoPullRequest        bool
+	PRReviewGate           bool
+	BriefingCodeReview     bool
+	AgentTeamsHint         bool
+	PRVisualization        bool
+	DashboardKeybind       bool
+	Watcher                bool
+	WatcherTriggerLabel    string
+	WatcherRunningLabel    string
+	WatcherIntervalSeconds int
+	WatcherAgent           string
+	WatcherMaxSessions     int
+	Notifications          string
+	NtfyURL                string
+	SlackWebhookURL        string
 }
 
 // CLIOverrides holds tri-state command-line overrides. nil means the flag was
@@ -39,15 +46,21 @@ type CLIOverrides struct {
 }
 
 type overrides struct {
-	AutoPullRequest    *bool
-	PRReviewGate       *bool
-	BriefingCodeReview *bool
-	AgentTeamsHint     *bool
-	PRVisualization    *bool
-	DashboardKeybind   *bool
-	Notifications      *string
-	NtfyURL            *string
-	SlackWebhookURL    *string
+	AutoPullRequest        *bool
+	PRReviewGate           *bool
+	BriefingCodeReview     *bool
+	AgentTeamsHint         *bool
+	PRVisualization        *bool
+	DashboardKeybind       *bool
+	Watcher                *bool
+	WatcherTriggerLabel    *string
+	WatcherRunningLabel    *string
+	WatcherIntervalSeconds *int
+	WatcherAgent           *string
+	WatcherMaxSessions     *int
+	Notifications          *string
+	NtfyURL                *string
+	SlackWebhookURL        *string
 }
 
 // WarnFunc receives tolerant-parse diagnostics. Nil suppresses warnings.
@@ -56,13 +69,17 @@ type WarnFunc func(format string, a ...any)
 // Defaults returns the built-in settings.
 func Defaults() Settings {
 	return Settings{
-		AutoPullRequest:    true,
-		PRReviewGate:       true,
-		BriefingCodeReview: true,
-		AgentTeamsHint:     true,
-		PRVisualization:    true,
-		DashboardKeybind:   true,
-		Notifications:      "bell",
+		AutoPullRequest:        true,
+		PRReviewGate:           true,
+		BriefingCodeReview:     true,
+		AgentTeamsHint:         true,
+		PRVisualization:        true,
+		DashboardKeybind:       true,
+		WatcherTriggerLabel:    "fanout:auto",
+		WatcherRunningLabel:    "fanout:running",
+		WatcherIntervalSeconds: 60,
+		WatcherMaxSessions:     4,
+		Notifications:          "bell",
 	}
 }
 
@@ -116,6 +133,24 @@ func apply(s *Settings, o overrides) {
 	if o.DashboardKeybind != nil {
 		s.DashboardKeybind = *o.DashboardKeybind
 	}
+	if o.Watcher != nil {
+		s.Watcher = *o.Watcher
+	}
+	if o.WatcherTriggerLabel != nil {
+		s.WatcherTriggerLabel = *o.WatcherTriggerLabel
+	}
+	if o.WatcherRunningLabel != nil {
+		s.WatcherRunningLabel = *o.WatcherRunningLabel
+	}
+	if o.WatcherIntervalSeconds != nil {
+		s.WatcherIntervalSeconds = clampWatcherIntervalSeconds(*o.WatcherIntervalSeconds)
+	}
+	if o.WatcherAgent != nil {
+		s.WatcherAgent = *o.WatcherAgent
+	}
+	if o.WatcherMaxSessions != nil {
+		s.WatcherMaxSessions = *o.WatcherMaxSessions
+	}
 	if o.Notifications != nil {
 		s.Notifications = *o.Notifications
 	}
@@ -140,6 +175,10 @@ func cliOverrides(cli CLIOverrides) overrides {
 
 func repoOverrides(path string, warnf WarnFunc) overrides {
 	out := loadFile(path, warnf)
+	if out.Watcher != nil {
+		warn(warnf, "settings %s: watcher is ignored in repo config; use user config or FANOUT_WATCHER", path)
+		out.Watcher = nil
+	}
 	if out.NtfyURL != nil {
 		warn(warnf, "settings %s: ntfyURL is ignored in repo config; use user config or FANOUT_NTFY_URL", path)
 		out.NtfyURL = nil
@@ -215,11 +254,19 @@ func loadFile(path string, warnf WarnFunc) overrides {
 		"agentTeamsHint":     func(v *bool) { out.AgentTeamsHint = v },
 		"prVisualization":    func(v *bool) { out.PRVisualization = v },
 		"dashboardKeybind":   func(v *bool) { out.DashboardKeybind = v },
+		"watcher":            func(v *bool) { out.Watcher = v },
 	}
 	stringKeys := map[string]func(*string){
-		"notifications":   func(v *string) { out.Notifications = v },
-		"ntfyURL":         func(v *string) { out.NtfyURL = v },
-		"slackWebhookURL": func(v *string) { out.SlackWebhookURL = v },
+		"watcherTriggerLabel": func(v *string) { out.WatcherTriggerLabel = v },
+		"watcherRunningLabel": func(v *string) { out.WatcherRunningLabel = v },
+		"watcherAgent":        func(v *string) { out.WatcherAgent = v },
+		"notifications":       func(v *string) { out.Notifications = v },
+		"ntfyURL":             func(v *string) { out.NtfyURL = v },
+		"slackWebhookURL":     func(v *string) { out.SlackWebhookURL = v },
+	}
+	intKeys := map[string]func(*int){
+		"watcherIntervalSeconds": func(v *int) { out.WatcherIntervalSeconds = v },
+		"watcherMaxSessions":     func(v *int) { out.WatcherMaxSessions = v },
 	}
 	for key, raw := range root {
 		if set, ok := boolKeys[key]; ok {
@@ -243,6 +290,19 @@ func loadFile(path string, warnf WarnFunc) overrides {
 			var v string
 			if err := json.Unmarshal(raw, &v); err != nil {
 				warn(warnf, "settings %s: %s must be a string (ignored)", path, key)
+				continue
+			}
+			set(&v)
+			continue
+		}
+		if set, ok := intKeys[key]; ok {
+			if strings.TrimSpace(string(raw)) == "null" {
+				warn(warnf, "settings %s: %s must be an integer (ignored)", path, key)
+				continue
+			}
+			var v int
+			if err := json.Unmarshal(raw, &v); err != nil {
+				warn(warnf, "settings %s: %s must be an integer (ignored)", path, key)
 				continue
 			}
 			set(&v)
@@ -273,6 +333,7 @@ func envOverrides(warnf WarnFunc) overrides {
 	read("FANOUT_AGENT_TEAMS_HINT", func(v *bool) { out.AgentTeamsHint = v })
 	read("FANOUT_PR_VISUALIZATION", func(v *bool) { out.PRVisualization = v })
 	read("FANOUT_DASHBOARD_KEYBIND", func(v *bool) { out.DashboardKeybind = v })
+	read("FANOUT_WATCHER", func(v *bool) { out.Watcher = v })
 	readString := func(name string, set func(*string)) {
 		raw, ok := os.LookupEnv(name)
 		if !ok {
@@ -280,9 +341,26 @@ func envOverrides(warnf WarnFunc) overrides {
 		}
 		set(&raw)
 	}
+	readString("FANOUT_WATCHER_TRIGGER_LABEL", func(v *string) { out.WatcherTriggerLabel = v })
+	readString("FANOUT_WATCHER_RUNNING_LABEL", func(v *string) { out.WatcherRunningLabel = v })
+	readString("FANOUT_WATCHER_AGENT", func(v *string) { out.WatcherAgent = v })
 	readString("FANOUT_NOTIFICATIONS", func(v *string) { out.Notifications = v })
 	readString("FANOUT_NTFY_URL", func(v *string) { out.NtfyURL = v })
 	readString("FANOUT_SLACK_WEBHOOK_URL", func(v *string) { out.SlackWebhookURL = v })
+	readInt := func(name string, set func(*int)) {
+		raw, ok := os.LookupEnv(name)
+		if !ok {
+			return
+		}
+		v, err := strconv.Atoi(strings.TrimSpace(raw))
+		if err != nil {
+			warn(warnf, "settings env %s: invalid integer %q (ignored)", name, raw)
+			return
+		}
+		set(&v)
+	}
+	readInt("FANOUT_WATCHER_INTERVAL_SECONDS", func(v *int) { out.WatcherIntervalSeconds = v })
+	readInt("FANOUT_WATCHER_MAX_SESSIONS", func(v *int) { out.WatcherMaxSessions = v })
 	return out
 }
 
@@ -295,6 +373,13 @@ func parseBool(raw string) (bool, bool) {
 	default:
 		return false, false
 	}
+}
+
+func clampWatcherIntervalSeconds(v int) int {
+	if v < 20 {
+		return 20
+	}
+	return v
 }
 
 func warn(warnf WarnFunc, format string, a ...any) {

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -51,15 +51,19 @@ func TestResolvePriorityCLIEnvRepoUserBuiltin(t *testing.T) {
 	}, t.Fatalf)
 
 	want := Settings{
-		AutoPullRequest:    true,
-		PRReviewGate:       false,
-		BriefingCodeReview: false,
-		AgentTeamsHint:     true,
-		PRVisualization:    false,
-		DashboardKeybind:   true,
-		Notifications:      "bell,ntfy",
-		NtfyURL:            "https://ntfy-user.example/topic",
-		SlackWebhookURL:    "https://hooks.example/slack",
+		AutoPullRequest:        true,
+		PRReviewGate:           false,
+		BriefingCodeReview:     false,
+		AgentTeamsHint:         true,
+		PRVisualization:        false,
+		DashboardKeybind:       true,
+		WatcherTriggerLabel:    "fanout:auto",
+		WatcherRunningLabel:    "fanout:running",
+		WatcherIntervalSeconds: 60,
+		WatcherMaxSessions:     4,
+		Notifications:          "bell,ntfy",
+		NtfyURL:                "https://ntfy-user.example/topic",
+		SlackWebhookURL:        "https://hooks.example/slack",
 	}
 	if got != want {
 		t.Fatalf("Resolve() = %#v, want %#v", got, want)
@@ -86,6 +90,96 @@ func TestResolvePriorityCLIEnvRepoUserBuiltin(t *testing.T) {
 	if got.NtfyURL != "https://ntfy-user.example/topic" {
 		t.Fatalf("NtfyURL = %q, want user override", got.NtfyURL)
 	}
+}
+
+func TestResolveWatcherSettingsPriority(t *testing.T) {
+	repo := t.TempDir()
+	xdg := setEmptyUserConfig(t)
+	clearEnv(t)
+	writeConfig(t, filepath.Join(xdg, "fanout", "config.json"), `{
+  "watcher": true,
+  "watcherTriggerLabel": "fanout:user",
+  "watcherRunningLabel": "fanout:user-running",
+  "watcherIntervalSeconds": 45,
+  "watcherAgent": "claude",
+  "watcherMaxSessions": 2
+}`)
+	writeConfig(t, RepoConfigPath(repo), `{
+  "watcher": false,
+  "watcherTriggerLabel": "fanout:repo",
+  "watcherRunningLabel": "fanout:repo-running",
+  "watcherIntervalSeconds": 30,
+  "watcherAgent": "codex",
+  "watcherMaxSessions": 3
+}`)
+	t.Setenv("FANOUT_WATCHER", "off")
+	t.Setenv("FANOUT_WATCHER_TRIGGER_LABEL", "fanout:env")
+	t.Setenv("FANOUT_WATCHER_INTERVAL_SECONDS", "10")
+	t.Setenv("FANOUT_WATCHER_MAX_SESSIONS", "0")
+
+	got := Resolve(repo, CLIOverrides{}, nil)
+
+	if got.Watcher {
+		t.Fatalf("Watcher = true, want env override false")
+	}
+	if got.WatcherTriggerLabel != "fanout:env" {
+		t.Fatalf("WatcherTriggerLabel = %q, want env override", got.WatcherTriggerLabel)
+	}
+	if got.WatcherRunningLabel != "fanout:repo-running" {
+		t.Fatalf("WatcherRunningLabel = %q, want repo override", got.WatcherRunningLabel)
+	}
+	if got.WatcherIntervalSeconds != 20 {
+		t.Fatalf("WatcherIntervalSeconds = %d, want env override clamped to 20", got.WatcherIntervalSeconds)
+	}
+	if got.WatcherAgent != "codex" {
+		t.Fatalf("WatcherAgent = %q, want repo override", got.WatcherAgent)
+	}
+	if got.WatcherMaxSessions != 0 {
+		t.Fatalf("WatcherMaxSessions = %d, want env override", got.WatcherMaxSessions)
+	}
+
+	for _, name := range []string{
+		"FANOUT_WATCHER",
+		"FANOUT_WATCHER_TRIGGER_LABEL",
+		"FANOUT_WATCHER_INTERVAL_SECONDS",
+		"FANOUT_WATCHER_MAX_SESSIONS",
+	} {
+		if err := os.Unsetenv(name); err != nil {
+			t.Fatalf("Unsetenv(%s): %v", name, err)
+		}
+	}
+	got = Resolve(repo, CLIOverrides{}, nil)
+	if !got.Watcher {
+		t.Fatalf("Watcher = false, want user config because repo watcher is ignored")
+	}
+	if got.WatcherTriggerLabel != "fanout:repo" {
+		t.Fatalf("WatcherTriggerLabel = %q, want repo override", got.WatcherTriggerLabel)
+	}
+	if got.WatcherIntervalSeconds != 30 {
+		t.Fatalf("WatcherIntervalSeconds = %d, want repo override", got.WatcherIntervalSeconds)
+	}
+	if got.WatcherMaxSessions != 3 {
+		t.Fatalf("WatcherMaxSessions = %d, want repo override", got.WatcherMaxSessions)
+	}
+}
+
+func TestRepoConfigCannotEnableWatcher(t *testing.T) {
+	repo := t.TempDir()
+	setEmptyUserConfig(t)
+	clearEnv(t)
+	writeConfig(t, RepoConfigPath(repo), `{
+  "watcher": true
+}`)
+
+	var warnings []string
+	got := Resolve(repo, CLIOverrides{}, func(format string, a ...any) {
+		warnings = append(warnings, fmt.Sprintf(format, a...))
+	})
+
+	if got.Watcher {
+		t.Fatal("Watcher = true, want repo config watcher ignored")
+	}
+	assertWarningContains(t, warnings, "watcher is ignored in repo config")
 }
 
 func TestRepoConfigCannotEnableHTTPNotifications(t *testing.T) {
@@ -172,6 +266,47 @@ func TestResolveWarnsAndIgnoresInvalidInputs(t *testing.T) {
 	assertWarningContains(t, warnings, "settings env FANOUT_AGENT_TEAMS_HINT: invalid boolean \"sometimes\"")
 }
 
+func TestResolveWarnsAndIgnoresInvalidWatcherInts(t *testing.T) {
+	repo := t.TempDir()
+	xdg := setEmptyUserConfig(t)
+	clearEnv(t)
+	writeConfig(t, filepath.Join(xdg, "fanout", "config.json"), `{
+  "watcherIntervalSeconds": "fast",
+  "watcherMaxSessions": null
+}`)
+	t.Setenv("FANOUT_WATCHER_INTERVAL_SECONDS", "soon")
+	t.Setenv("FANOUT_WATCHER_MAX_SESSIONS", "many")
+
+	var warnings []string
+	got := Resolve(repo, CLIOverrides{}, func(format string, a ...any) {
+		warnings = append(warnings, fmt.Sprintf(format, a...))
+	})
+
+	if got.WatcherIntervalSeconds != 60 {
+		t.Fatalf("WatcherIntervalSeconds = %d, want default", got.WatcherIntervalSeconds)
+	}
+	if got.WatcherMaxSessions != 4 {
+		t.Fatalf("WatcherMaxSessions = %d, want default", got.WatcherMaxSessions)
+	}
+	assertWarningContains(t, warnings, "watcherIntervalSeconds must be an integer")
+	assertWarningContains(t, warnings, "watcherMaxSessions must be an integer")
+	assertWarningContains(t, warnings, "settings env FANOUT_WATCHER_INTERVAL_SECONDS: invalid integer \"soon\"")
+	assertWarningContains(t, warnings, "settings env FANOUT_WATCHER_MAX_SESSIONS: invalid integer \"many\"")
+}
+
+func TestResolveClampsWatcherIntervalSeconds(t *testing.T) {
+	repo := t.TempDir()
+	setEmptyUserConfig(t)
+	clearEnv(t)
+	t.Setenv("FANOUT_WATCHER_INTERVAL_SECONDS", "5")
+
+	got := Resolve(repo, CLIOverrides{}, t.Fatalf)
+
+	if got.WatcherIntervalSeconds != 20 {
+		t.Fatalf("WatcherIntervalSeconds = %d, want 20", got.WatcherIntervalSeconds)
+	}
+}
+
 func TestUserConfigPathHonorsXDGConfigHome(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", "/tmp/fanout-xdg")
 
@@ -198,6 +333,12 @@ func clearEnv(t *testing.T) {
 		"FANOUT_AGENT_TEAMS_HINT",
 		"FANOUT_PR_VISUALIZATION",
 		"FANOUT_DASHBOARD_KEYBIND",
+		"FANOUT_WATCHER",
+		"FANOUT_WATCHER_TRIGGER_LABEL",
+		"FANOUT_WATCHER_RUNNING_LABEL",
+		"FANOUT_WATCHER_INTERVAL_SECONDS",
+		"FANOUT_WATCHER_AGENT",
+		"FANOUT_WATCHER_MAX_SESSIONS",
 		"FANOUT_NOTIFICATIONS",
 		"FANOUT_NTFY_URL",
 		"FANOUT_SLACK_WEBHOOK_URL",

--- a/site/content/docs/cli.ja.md
+++ b/site/content/docs/cli.ja.md
@@ -380,13 +380,19 @@ fanout check-update
 | `FANOUT_AGENT_TEAMS_HINT` | Claude Agent Teams ヒント（`agentTeamsHint`）の環境変数レイヤ。 |
 | `FANOUT_PR_VISUALIZATION` | 構造化 PR 本文とゲート付き Mermaid 指示（`prVisualization`）の環境変数レイヤ。 |
 | `FANOUT_DASHBOARD_KEYBIND` | ダッシュボード `prefix + D` tmux キーバインド（`dashboardKeybind`）の環境変数レイヤ。 |
+| `FANOUT_WATCHER` | watcher opt-in（`watcher`）の環境変数レイヤ。 |
+| `FANOUT_WATCHER_TRIGGER_LABEL` | watcher trigger label（`watcherTriggerLabel`）の環境変数レイヤ。 |
+| `FANOUT_WATCHER_RUNNING_LABEL` | watcher running label（`watcherRunningLabel`）の環境変数レイヤ。 |
+| `FANOUT_WATCHER_INTERVAL_SECONDS` | watcher interval（`watcherIntervalSeconds`）の環境変数レイヤ。 |
+| `FANOUT_WATCHER_AGENT` | watcher child agent（`watcherAgent`）の環境変数レイヤ。 |
+| `FANOUT_WATCHER_MAX_SESSIONS` | watcher session 上限（`watcherMaxSessions`）の環境変数レイヤ。 |
 | `FANOUT_NOTIFICATIONS` | TUI 遷移通知チャネル（`notifications`）の環境変数レイヤ。[設定]({{< relref "/docs/settings" >}})を参照。 |
 | `FANOUT_NTFY_URL` | ntfy POST URL（`ntfyURL`）の環境変数レイヤ。 |
 | `FANOUT_SLACK_WEBHOOK_URL` | Slack webhook POST URL（`slackWebhookURL`）の環境変数レイヤ。 |
 | `FANOUT_DB_PATH` | `--team` と `fanout msg` が使う parent ごとの peer messaging SQLite パスを上書きする。既定: `/tmp/fanout-<repo>-<parent>.db`。 |
 | `FANOUT_SKIP_PR_REVIEW` | PR レビューゲート hook の 1 回限りのバイパス: `gh pr create` の先頭に `FANOUT_SKIP_PR_REVIEW=1` を付ける。[トラブルシューティング]({{< relref "/docs/troubleshooting" >}})を参照。 |
 
-bool の settings 変数は `1/true/yes/on` と `0/false/no/off` を受け付けます（大小文字は無視）。不正な値は warn して無視されます。settings の解決順序では CLI flag と設定ファイルの間に位置します。
+bool の settings 変数は `1/true/yes/on` と `0/false/no/off` を受け付けます（大小文字は無視）。integer の watcher 変数は 10 進整数を受け付けます。不正な値は warn して無視されます。settings の解決順序では CLI flag と設定ファイルの間に位置します。
 
 ## Exit codes
 

--- a/site/content/docs/cli.md
+++ b/site/content/docs/cli.md
@@ -381,13 +381,19 @@ Read-only: fetches the latest release tag from `butaosuinu/fanout`, compares it 
 | `FANOUT_AGENT_TEAMS_HINT` | Environment layer for the Claude Agent Teams hint (`agentTeamsHint`). |
 | `FANOUT_PR_VISUALIZATION` | Environment layer for the structured PR-body and gated Mermaid guidance (`prVisualization`). |
 | `FANOUT_DASHBOARD_KEYBIND` | Environment layer for the dashboard `prefix + D` tmux keybinding (`dashboardKeybind`). |
+| `FANOUT_WATCHER` | Environment layer for watcher opt-in (`watcher`). |
+| `FANOUT_WATCHER_TRIGGER_LABEL` | Environment layer for the watcher trigger label (`watcherTriggerLabel`). |
+| `FANOUT_WATCHER_RUNNING_LABEL` | Environment layer for the watcher running label (`watcherRunningLabel`). |
+| `FANOUT_WATCHER_INTERVAL_SECONDS` | Environment layer for the watcher interval (`watcherIntervalSeconds`). |
+| `FANOUT_WATCHER_AGENT` | Environment layer for the watcher child agent (`watcherAgent`). |
+| `FANOUT_WATCHER_MAX_SESSIONS` | Environment layer for the watcher session cap (`watcherMaxSessions`). |
 | `FANOUT_NOTIFICATIONS` | Environment layer for the TUI transition notification channels (`notifications`); see [Settings]({{< relref "/docs/settings" >}}). |
 | `FANOUT_NTFY_URL` | Environment layer for the ntfy POST URL (`ntfyURL`). |
 | `FANOUT_SLACK_WEBHOOK_URL` | Environment layer for the Slack webhook POST URL (`slackWebhookURL`). |
 | `FANOUT_DB_PATH` | Override the per-parent peer-messaging SQLite path used by `--team` and `fanout msg`. Default: `/tmp/fanout-<repo>-<parent>.db`. |
 | `FANOUT_SKIP_PR_REVIEW` | One-shot bypass of the PR review-gate hook: prefix `gh pr create` with `FANOUT_SKIP_PR_REVIEW=1`. See [Troubleshooting]({{< relref "/docs/troubleshooting" >}}). |
 
-The boolean settings variables accept `1/true/yes/on` and `0/false/no/off`, case-insensitive. Invalid values are warned and ignored. They sit between CLI flags and the config files in the settings resolution order.
+The boolean settings variables accept `1/true/yes/on` and `0/false/no/off`, case-insensitive. Integer watcher variables accept base-10 integers. Invalid values are warned and ignored. They sit between CLI flags and the config files in the settings resolution order.
 
 ## Exit codes
 

--- a/site/content/docs/settings.ja.md
+++ b/site/content/docs/settings.ja.md
@@ -1,13 +1,13 @@
 ---
 title: 設定
 linkTitle: 設定
-description: "オン/オフできる opinionated な挙動トグルと TUI 通知 channel、そしてその背後にある flag > env > repo > user > default の解決順序。"
+description: "オン/オフできる opinionated な挙動トグル、watcher 制御、TUI 通知 channel、そして flag > env > repo > user > default の解決順序。"
 weight: 60
 kanji: 整
 yomi: settings
 ---
 
-fanout は opinionated な 6 つの挙動(briefing の 5 トグル、ダッシュボードの tmux キーバインド)をオン/オフでき、TUI 通知 channel も選択できます。bool 既定値は `true` です。通知の既定値は `bell` です。
+fanout は briefing トグル、ダッシュボードの tmux キーバインド、watcher 制御、TUI 通知 channel を同じ設定スタックで解決します。briefing/dashboard の bool 既定値は `true`、watcher は既定で off、通知の既定値は `bell` です。
 
 ## 解決順序
 
@@ -26,15 +26,21 @@ fanout は opinionated な 6 つの挙動(briefing の 5 トグル、ダッシ�
 | Claude Agent Teams ヒント | `agentTeamsHint` | `FANOUT_AGENT_TEAMS_HINT` | `--agent-teams-hint` / `--no-agent-teams-hint` | `true` |
 | 構造化 PR 本文とゲート付き Mermaid の briefing 指示 | `prVisualization` | `FANOUT_PR_VISUALIZATION` | `--pr-visualization` / `--no-pr-visualization` | `true` |
 | ダッシュボード `prefix + D` tmux キーバインド | `dashboardKeybind` | `FANOUT_DASHBOARD_KEYBIND` | `--dashboard-keybind` / `--no-dashboard-keybind` | `true` |
+| watcher opt-in | `watcher` | `FANOUT_WATCHER` | n/a | `false` |
+| watcher trigger label | `watcherTriggerLabel` | `FANOUT_WATCHER_TRIGGER_LABEL` | n/a | `fanout:auto` |
+| watcher running label | `watcherRunningLabel` | `FANOUT_WATCHER_RUNNING_LABEL` | n/a | `fanout:running` |
+| watcher interval 秒 | `watcherIntervalSeconds` | `FANOUT_WATCHER_INTERVAL_SECONDS` | n/a | `60` |
+| watcher child agent | `watcherAgent` | `FANOUT_WATCHER_AGENT` | n/a | 未設定 |
+| watcher 最大 session 数 | `watcherMaxSessions` | `FANOUT_WATCHER_MAX_SESSIONS` | n/a | `4` |
 | TUI 状態遷移通知 | `notifications` | `FANOUT_NOTIFICATIONS` | n/a | `bell` |
 | ntfy POST URL | `ntfyURL` | `FANOUT_NTFY_URL` | n/a | 未設定 |
 | Slack webhook POST URL | `slackWebhookURL` | `FANOUT_SLACK_WEBHOOK_URL` | n/a | 未設定 |
 
-これらの flag ペアは [CLI リファレンス]({{< relref "/docs/cli" >}})にも載っています（CLI リファレンスには、設定ではなく起動フラグである `--codex-plan-mode` も含まれます）。通知設定に CLI flag はありません。
+これらの flag ペアは [CLI リファレンス]({{< relref "/docs/cli" >}})にも載っています（CLI リファレンスには、設定ではなく起動フラグである `--codex-plan-mode` も含まれます）。watcher と通知設定に CLI flag はありません。
 
 ## config.json サンプル
 
-リポジトリ設定とユーザー設定はどちらも同じ形で、bool のトグルに加えて 3 つの string な通知キーを持つフラットな JSON オブジェクトです:
+リポジトリ設定とユーザー設定はどちらも同じ形で、bool、string、integer のキーを持つフラットな JSON オブジェクトです:
 
 ```json
 {
@@ -44,6 +50,12 @@ fanout は opinionated な 6 つの挙動(briefing の 5 トグル、ダッシ�
   "agentTeamsHint": false,
   "prVisualization": true,
   "dashboardKeybind": true,
+  "watcher": false,
+  "watcherTriggerLabel": "fanout:auto",
+  "watcherRunningLabel": "fanout:running",
+  "watcherIntervalSeconds": 60,
+  "watcherAgent": "codex",
+  "watcherMaxSessions": 4,
   "notifications": "bell",
   "ntfyURL": "https://ntfy.sh/my-topic",
   "slackWebhookURL": "https://hooks.slack.com/services/..."
@@ -51,14 +63,19 @@ fanout は opinionated な 6 つの挙動(briefing の 5 トグル、ダッシ�
 ```
 
 bool の環境変数は `1/true/yes/on` と `0/false/no/off` を受け付けます(大小文字は無視)。
+integer の環境変数は 10 進整数を受け付けます。`watcherIntervalSeconds` は最低 `20` に解決され、`watcherMaxSessions=0` は無制限を意味します。
 
 ## 通知 channel
 
 `notifications` は comma または空白区切りの selector です。指定できる値は `bell`、`tmux`、`ntfy`、`slack`、`none` です。`ntfy` は `ntfyURL`、`slack` は `slackWebhookURL` が必要です。どちらの HTTP channel も outbound POST のみで、inbound socket は開きません。repository-controlled な外部送信を避けるため、repo config で選択できるのは `bell`、`tmux`、`none` だけです。`ntfy`、`slack`、`ntfyURL`、`slackWebhookURL` は user config または環境変数からだけ有効になります。
 
+## watcher の安全制約
+
+repo config では watcher を opt-in できません。`<project_root>/.fanout/config.json` が `watcher` を設定している場合、fanout は警告してそのキーを無視します。user config または `FANOUT_WATCHER` を使ってください。repo config では `watcherTriggerLabel`、`watcherRunningLabel`、`watcherIntervalSeconds`、`watcherAgent`、`watcherMaxSessions` は設定できます。
+
 ## 前方互換
 
-不正な bool env 値、設定ファイル内の未知キー、JSON type が合わない値は warn して無視します。将来の設定追加で古い fanout バイナリが壊れないようにするためです。
+不正な bool / integer env 値、設定ファイル内の未知キー、JSON type が合わない値は warn して無視します。将来の設定追加で古い fanout バイナリが壊れないようにするためです。
 
 Lifecycle hook は常に有効で、別の `hooks.json` で設定します。詳細は [CLI リファレンス]({{< relref "/docs/cli" >}})を参照してください。
 

--- a/site/content/docs/settings.md
+++ b/site/content/docs/settings.md
@@ -1,13 +1,13 @@
 ---
 title: Settings
 linkTitle: Settings
-description: "Opinionated behavior toggles plus TUI notification channels — and the flag > env > repo > user > default resolution order behind them."
+description: "Opinionated behavior toggles, watcher controls, TUI notification channels, and the flag > env > repo > user > default resolution order behind them."
 weight: 60
 kanji: 整
 yomi: settings
 ---
 
-fanout can turn six opinionated behaviors on or off — five briefing toggles and the dashboard tmux keybinding — and select TUI notification channels. Boolean defaults are `true`. Notifications default to `bell`.
+fanout resolves briefing toggles, the dashboard tmux keybinding, watcher controls, and TUI notification channels from the same settings stack. The briefing/dashboard booleans default to `true`, the watcher defaults to off, and notifications default to `bell`.
 
 ## Resolution order
 
@@ -26,15 +26,21 @@ Each setting resolves as: **CLI flag > environment variable > repo config file >
 | Claude Agent Teams hint | `agentTeamsHint` | `FANOUT_AGENT_TEAMS_HINT` | `--agent-teams-hint` / `--no-agent-teams-hint` | `true` |
 | Structured PR body and gated Mermaid briefing guidance | `prVisualization` | `FANOUT_PR_VISUALIZATION` | `--pr-visualization` / `--no-pr-visualization` | `true` |
 | Dashboard `prefix + D` tmux keybinding | `dashboardKeybind` | `FANOUT_DASHBOARD_KEYBIND` | `--dashboard-keybind` / `--no-dashboard-keybind` | `true` |
+| Watcher opt-in | `watcher` | `FANOUT_WATCHER` | n/a | `false` |
+| Watcher trigger label | `watcherTriggerLabel` | `FANOUT_WATCHER_TRIGGER_LABEL` | n/a | `fanout:auto` |
+| Watcher running label | `watcherRunningLabel` | `FANOUT_WATCHER_RUNNING_LABEL` | n/a | `fanout:running` |
+| Watcher interval seconds | `watcherIntervalSeconds` | `FANOUT_WATCHER_INTERVAL_SECONDS` | n/a | `60` |
+| Watcher child agent | `watcherAgent` | `FANOUT_WATCHER_AGENT` | n/a | unset |
+| Watcher max sessions | `watcherMaxSessions` | `FANOUT_WATCHER_MAX_SESSIONS` | n/a | `4` |
 | TUI transition notifications | `notifications` | `FANOUT_NOTIFICATIONS` | n/a | `bell` |
 | ntfy POST URL | `ntfyURL` | `FANOUT_NTFY_URL` | n/a | unset |
 | Slack webhook POST URL | `slackWebhookURL` | `FANOUT_SLACK_WEBHOOK_URL` | n/a | unset |
 
-These flag pairs are also listed in the [CLI Reference]({{< relref "/docs/cli" >}}) (which also covers `--codex-plan-mode`, a launch flag rather than a resolved setting); the notification settings have no CLI flag.
+These flag pairs are also listed in the [CLI Reference]({{< relref "/docs/cli" >}}) (which also covers `--codex-plan-mode`, a launch flag rather than a resolved setting); the watcher and notification settings have no CLI flag.
 
 ## Sample config.json
 
-Both config files share the same shape — a flat JSON object of boolean toggles plus the three string notification keys:
+Both config files share the same shape: a flat JSON object of booleans, strings, and integer keys:
 
 ```json
 {
@@ -44,6 +50,12 @@ Both config files share the same shape — a flat JSON object of boolean toggles
   "agentTeamsHint": false,
   "prVisualization": true,
   "dashboardKeybind": true,
+  "watcher": false,
+  "watcherTriggerLabel": "fanout:auto",
+  "watcherRunningLabel": "fanout:running",
+  "watcherIntervalSeconds": 60,
+  "watcherAgent": "codex",
+  "watcherMaxSessions": 4,
   "notifications": "bell",
   "ntfyURL": "https://ntfy.sh/my-topic",
   "slackWebhookURL": "https://hooks.slack.com/services/..."
@@ -51,14 +63,19 @@ Both config files share the same shape — a flat JSON object of boolean toggles
 ```
 
 Boolean environment values accept `1/true/yes/on` and `0/false/no/off` (case-insensitive).
+Integer environment values accept base-10 integers. `watcherIntervalSeconds` resolves to at least `20`; `watcherMaxSessions=0` means unlimited.
 
 ## Notification channels
 
 `notifications` is a comma- or space-separated selector. Supported values are `bell`, `tmux`, `ntfy`, `slack`, and `none`. `ntfy` requires `ntfyURL`; `slack` requires `slackWebhookURL`. Both HTTP channels only send outbound POST requests and never open inbound sockets. To avoid repository-controlled exfiltration, repo config may only select `bell`, `tmux`, or `none`; `ntfy`, `slack`, `ntfyURL`, and `slackWebhookURL` are honored only from user config or environment variables.
 
+## Watcher safety
+
+Repo config cannot opt into the watcher. If `<project_root>/.fanout/config.json` sets `watcher`, fanout warns and ignores that key; use user config or `FANOUT_WATCHER` instead. Repo config may still set `watcherTriggerLabel`, `watcherRunningLabel`, `watcherIntervalSeconds`, `watcherAgent`, and `watcherMaxSessions`.
+
 ## Forward compatibility
 
-Invalid boolean env values, unknown file keys, and file values with the wrong JSON type are warned and ignored, so future settings additions do not break older fanout binaries.
+Invalid boolean or integer env values, unknown file keys, and file values with the wrong JSON type are warned and ignored, so future settings additions do not break older fanout binaries.
 
 Lifecycle hooks are always enabled and configured separately in `hooks.json`; see [CLI Reference]({{< relref "/docs/cli" >}}).
 


### PR DESCRIPTION
**TL;DR**
Adds the six watcher settings keys to `internal/settings`, including int parsing, interval clamping, env overrides, and the repo-config guard for `watcher`. Review effort: 2

**Why**
Issue #222 asks for watcher keys in the existing layered settings resolver: defaults -> user config -> repo config -> env -> CLI. It also requires repo config `watcher` to be ignored with a warning while label, interval, agent, and session-limit knobs remain repo-configurable.

```mermaid
flowchart LR
  defaults["Defaults()"] --> user["loadFile(user config)"]
  user --> repo["repoOverrides(repo config)"]
  repo --> env["envOverrides()"]
  env --> cli["cliOverrides()"]
  cli --> resolved["Settings"]
  repo -. "warn + drop watcher" .-> warn["WarnFunc"]
```

**Changes by file**
<details><summary>Changed files</summary>

| File | What changed | Why |
|---|---|---|
| `internal/settings/settings.go` | Added watcher fields/defaults (`Settings`, `overrides`, `Defaults()`), apply plumbing, file/env key parsing, repo-config `watcher` warning/drop, and 20-second interval clamp. See `internal/settings/settings.go:19`, `internal/settings/settings.go:70`, `internal/settings/settings.go:117`, `internal/settings/settings.go:176`, `internal/settings/settings.go:250`, `internal/settings/settings.go:316`, `internal/settings/settings.go:378`. | Implements the requested settings resolver surface without adding CLI flags. |
| `internal/settings/settings_test.go` | Added watcher priority, repo `watcher=true` ignore warning, invalid int parsing, and interval clamp coverage. See `internal/settings/settings_test.go:95`, `internal/settings/settings_test.go:166`, `internal/settings/settings_test.go:269`, `internal/settings/settings_test.go:297`. | Covers the acceptance criteria for the new keys and int plumbing. |
| `site/content/docs/settings.md` | Documented watcher keys, defaults, env names, config sample, integer env behavior, and repo-config safety. See `site/content/docs/settings.md:21`, `site/content/docs/settings.md:43`, `site/content/docs/settings.md:65`, `site/content/docs/settings.md:72`. | Keeps the settings reference aligned with the resolved schema. |
| `site/content/docs/settings.ja.md` | Mirrored the watcher settings reference in Japanese. | Keeps paired docs in sync. |
| `site/content/docs/cli.md` | Added watcher env vars to the CLI environment variable reference. See `site/content/docs/cli.md:384`. | The CLI reference says it lists environment variables. |
| `site/content/docs/cli.ja.md` | Mirrored watcher env vars in the Japanese CLI reference. See `site/content/docs/cli.ja.md:383`. | Keeps paired docs in sync. |

</details>

**Risk**
> [!WARNING]
> This PR only adds settings plumbing. Until the watcher runtime/TUI wiring lands from sibling work, `watcher=true` can resolve through user config or env but does not start a watcher by itself.

**Test plan**
- `go test ./...` - passed
- `make test` - passed
- `make lint` - passed
- `codex review --uncommitted` - clean, no actionable issues

Closes #222