### PR TITLE
feat(ghissue): add label issue APIs

### DIFF
--- a/internal/ghissue/ghissue.go
+++ b/internal/ghissue/ghissue.go
@@ -224,11 +224,77 @@ func (r Runner) IssueDetail(num int) (Issue, error) {
 	if err := json.Unmarshal(out, &d); err != nil {
 		return Issue{}, fmt.Errorf("parse gh issue view %d: %w", num, err)
 	}
-	d.State = strings.ToUpper(d.State)
-	if d.Labels == nil {
-		d.Labels = []Label{}
-	}
+	normalizeIssue(&d)
 	return d, nil
+}
+
+// ListOpenIssuesWithLabel returns up to 100 OPEN issues that carry the
+// requested label. `gh issue list` lists issues, not pull requests; watcher
+// label scans rely on that command boundary so same-label PRs do not enter the
+// issue work queue.
+func (r Runner) ListOpenIssuesWithLabel(label string) ([]Issue, error) {
+	out, err := r.gh(
+		"issue", "list",
+		"--state", "open",
+		"--label", label,
+		"--limit", "100",
+		"--json", "number,title,state,body,labels",
+	)
+	if err != nil {
+		return nil, err
+	}
+	issues, err := parseIssueList(out)
+	if err != nil {
+		return nil, fmt.Errorf("parse gh issue list --label %q: %w", label, err)
+	}
+	return issues, nil
+}
+
+// SwapIssueLabels moves one issue from remove to add with one `gh issue edit`
+// call so GitHub observes a single label mutation round.
+func (r Runner) SwapIssueLabels(num int, remove, add string) error {
+	_, err := r.gh("issue", "edit", strconv.Itoa(num), "--remove-label", remove, "--add-label", add)
+	return err
+}
+
+// EnsureLabel creates name when it is absent from the repository labels.
+func (r Runner) EnsureLabel(name string) error {
+	out, err := r.gh("label", "list", "--search", name, "--limit", "100", "--json", "name")
+	if err != nil {
+		return err
+	}
+	var labels []Label
+	if unmarshalErr := json.Unmarshal(out, &labels); unmarshalErr != nil {
+		return fmt.Errorf("parse gh label list --search %q: %w", name, unmarshalErr)
+	}
+	for _, label := range labels {
+		if strings.EqualFold(strings.TrimSpace(label.Name), strings.TrimSpace(name)) {
+			return nil
+		}
+	}
+	_, err = r.gh("label", "create", name)
+	return err
+}
+
+func parseIssueList(out []byte) ([]Issue, error) {
+	var issues []Issue
+	if err := json.Unmarshal(out, &issues); err != nil {
+		return nil, err
+	}
+	if issues == nil {
+		return []Issue{}, nil
+	}
+	for i := range issues {
+		normalizeIssue(&issues[i])
+	}
+	return issues, nil
+}
+
+func normalizeIssue(issue *Issue) {
+	issue.State = strings.ToUpper(issue.State)
+	if issue.Labels == nil {
+		issue.Labels = []Label{}
+	}
 }
 
 // IssueState fetches just `.state` for blocker resolution.

--- a/internal/ghissue/ghissue_test.go
+++ b/internal/ghissue/ghissue_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -73,6 +74,185 @@ func TestSummarizeCI(t *testing.T) {
 				t.Fatalf("SummarizeCI(%#v) = %q, want %q", tc.prs, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestParseIssueListFixture(t *testing.T) {
+	fixture := `[
+  {
+    "number": 221,
+    "title": "label watcher API",
+    "state": "open",
+    "body": "body",
+    "labels": [{"name": "fanout:queued"}]
+  },
+  {
+    "number": 222,
+    "title": "missing labels normalizes empty",
+    "state": "OPEN",
+    "body": "",
+    "labels": null
+  }
+]`
+
+	got, err := parseIssueList([]byte(fixture))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []Issue{
+		{Number: 221, Title: "label watcher API", State: "OPEN", Body: "body", Labels: []Label{{Name: "fanout:queued"}}},
+		{Number: 222, Title: "missing labels normalizes empty", State: "OPEN", Body: "", Labels: []Label{}},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseIssueList() = %#v, want %#v", got, want)
+	}
+}
+
+func TestParseIssueListRejectsInvalidJSON(t *testing.T) {
+	got, err := parseIssueList([]byte(`{"number":221}`))
+	if err == nil {
+		t.Fatalf("parseIssueList() = %#v, want error", got)
+	}
+}
+
+func TestListOpenIssuesWithLabelRunsGHIssueList(t *testing.T) {
+	argsPath := installFakeGH(t, `[{"number":221,"title":"queued","state":"OPEN","body":"body","labels":[{"name":"fanout:queued"}]}]`)
+
+	got, err := (Runner{}).ListOpenIssuesWithLabel("fanout:queued")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []Issue{{Number: 221, Title: "queued", State: "OPEN", Body: "body", Labels: []Label{{Name: "fanout:queued"}}}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ListOpenIssuesWithLabel() = %#v, want %#v", got, want)
+	}
+	assertFakeGHArgs(t, argsPath, []string{
+		"issue", "list",
+		"--state", "open",
+		"--label", "fanout:queued",
+		"--limit", "100",
+		"--json", "number,title,state,body,labels",
+	})
+}
+
+func TestListOpenIssuesWithLabelReturnsParseError(t *testing.T) {
+	installFakeGH(t, `not-json`)
+
+	got, err := (Runner{}).ListOpenIssuesWithLabel("fanout:queued")
+	if err == nil {
+		t.Fatalf("ListOpenIssuesWithLabel() = %#v, want error", got)
+	}
+	if !strings.Contains(err.Error(), `parse gh issue list --label "fanout:queued"`) {
+		t.Fatalf("ListOpenIssuesWithLabel() error = %v", err)
+	}
+}
+
+func TestSwapIssueLabelsRunsSingleEdit(t *testing.T) {
+	argsPath := installFakeGH(t, ``)
+
+	if err := (Runner{}).SwapIssueLabels(221, "fanout:queued", "fanout:running"); err != nil {
+		t.Fatal(err)
+	}
+
+	assertFakeGHArgs(t, argsPath, []string{
+		"issue", "edit", "221",
+		"--remove-label", "fanout:queued",
+		"--add-label", "fanout:running",
+	})
+}
+
+func TestSwapIssueLabelsReturnsGHError(t *testing.T) {
+	installFakeGHWithResult(t, ``, `missing label`, 1)
+
+	err := (Runner{}).SwapIssueLabels(221, "fanout:queued", "fanout:running")
+	if err == nil {
+		t.Fatal("SwapIssueLabels() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "missing label") {
+		t.Fatalf("SwapIssueLabels() error = %v", err)
+	}
+}
+
+func TestEnsureLabelSkipsCreateWhenPresent(t *testing.T) {
+	argsPath := installFakeGH(t, `[{"name":"fanout:running"}]`)
+
+	if err := (Runner{}).EnsureLabel("fanout:running"); err != nil {
+		t.Fatal(err)
+	}
+
+	assertFakeGHArgs(t, argsPath, []string{
+		"label", "list",
+		"--search", "fanout:running",
+		"--limit", "100",
+		"--json", "name",
+	})
+}
+
+func TestEnsureLabelCreatesMissingLabel(t *testing.T) {
+	argsPath := installFakeGHScript(t, `
+args="$*"
+printf '%s\n' "$args" >> "$GH_FAKE_ARGS"
+case "$args" in
+"label list --search fanout:running --limit 100 --json name")
+  printf '[{"name":"fanout:queued"}]'
+  ;;
+"label create fanout:running")
+  ;;
+*)
+  printf 'unexpected gh args: %s\n' "$args" >&2
+  exit 64
+  ;;
+esac
+`)
+
+	if err := (Runner{}).EnsureLabel("fanout:running"); err != nil {
+		t.Fatal(err)
+	}
+
+	assertFakeGHCommandLines(t, argsPath, []string{
+		"label list --search fanout:running --limit 100 --json name",
+		"label create fanout:running",
+	})
+}
+
+func TestEnsureLabelReturnsParseError(t *testing.T) {
+	installFakeGH(t, `not-json`)
+
+	err := (Runner{}).EnsureLabel("fanout:running")
+	if err == nil {
+		t.Fatal("EnsureLabel() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), `parse gh label list --search "fanout:running"`) {
+		t.Fatalf("EnsureLabel() error = %v", err)
+	}
+}
+
+func TestEnsureLabelReturnsCreateError(t *testing.T) {
+	installFakeGHScript(t, `
+args="$*"
+case "$args" in
+"label list --search fanout:running --limit 100 --json name")
+  printf '[]'
+  ;;
+"label create fanout:running")
+  printf 'create failed' >&2
+  exit 1
+  ;;
+*)
+  printf 'unexpected gh args: %s\n' "$args" >&2
+  exit 64
+  ;;
+esac
+`)
+
+	err := (Runner{}).EnsureLabel("fanout:running")
+	if err == nil {
+		t.Fatal("EnsureLabel() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "create failed") {
+		t.Fatalf("EnsureLabel() error = %v", err)
 	}
 }
 
@@ -181,12 +361,21 @@ func TestNormalizeCIStatus(t *testing.T) {
 
 func installFakeGH(t *testing.T, output string) string {
 	t.Helper()
+	return installFakeGHWithResult(t, output, "", 0)
+}
+
+func installFakeGHWithResult(t *testing.T, output, stderr string, exitCode int) string {
+	t.Helper()
 	dir := t.TempDir()
 	argsPath := filepath.Join(dir, "args")
 	script := filepath.Join(dir, "gh")
 	body := `#!/usr/bin/env bash
 set -euo pipefail
 printf '%s\n' "$@" > "$GH_FAKE_ARGS"
+if [[ "$GH_FAKE_EXIT" != "0" ]]; then
+  printf '%s' "$GH_FAKE_STDERR" >&2
+  exit "$GH_FAKE_EXIT"
+fi
 printf '%s' "$GH_FAKE_OUTPUT"
 `
 	if err := os.WriteFile(script, []byte(body), 0o755); err != nil {
@@ -194,6 +383,22 @@ printf '%s' "$GH_FAKE_OUTPUT"
 	}
 	t.Setenv("GH_FAKE_ARGS", argsPath)
 	t.Setenv("GH_FAKE_OUTPUT", output)
+	t.Setenv("GH_FAKE_STDERR", stderr)
+	t.Setenv("GH_FAKE_EXIT", strconv.Itoa(exitCode))
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return argsPath
+}
+
+func installFakeGHScript(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	argsPath := filepath.Join(dir, "args")
+	script := filepath.Join(dir, "gh")
+	fullBody := "#!/usr/bin/env bash\nset -euo pipefail\n" + body
+	if err := os.WriteFile(script, []byte(fullBody), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GH_FAKE_ARGS", argsPath)
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	return argsPath
 }
@@ -207,6 +412,18 @@ func assertFakeGHArgs(t *testing.T, argsPath string, want []string) {
 	got := strings.Split(strings.TrimSuffix(string(data), "\n"), "\n")
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("gh args = %#v, want %#v", got, want)
+	}
+}
+
+func assertFakeGHCommandLines(t *testing.T, argsPath string, want []string) {
+	t.Helper()
+	data, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := strings.Split(strings.TrimSuffix(string(data), "\n"), "\n")
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("gh command lines = %#v, want %#v", got, want)
 	}
 }
 


### PR DESCRIPTION
## TL;DR

Adds `internal/ghissue.Runner` APIs for watcher label queues: list up to 100 OPEN issues by label, swap issue labels in one edit call, and ensure a label exists before watcher startup. Review effort: 2

## Why

Issue #221 asks for the ghissue boundary needed by the watcher: a label-scoped OPEN issue list plus label mutation/existence helpers. The brief specifies the exact `gh issue list`, `gh issue edit`, and `gh label create` shapes, so this PR keeps the scope inside `internal/ghissue`.

```mermaid
flowchart TD
  A[ListOpenIssuesWithLabel] --> B[gh issue list --state open --label X --limit 100 --json number,title,state,body,labels]
  C[EnsureLabel] --> D[gh label list --search name --limit 100 --json name]
  D --> E{exact label match?}
  E -- no --> F[gh label create name]
  E -- yes --> G[return]
  H[SwapIssueLabels] --> I[gh issue edit N --remove-label X --add-label Y]
```

## Changes by file

<details><summary>Changed files</summary>

| File | What changed | Why |
|---|---|---|
| `internal/ghissue/ghissue.go` | Added `ListOpenIssuesWithLabel`, `SwapIssueLabels`, `EnsureLabel`, and shared issue normalization/parse helpers at `internal/ghissue/ghissue.go:231`, `internal/ghissue/ghissue.go:255`, `internal/ghissue/ghissue.go:261`, and `internal/ghissue/ghissue.go:279`. | Provides watcher-facing label queue and label mutation API on the existing gh runner boundary. |
| `internal/ghissue/ghissue_test.go` | Added fixture JSON parse coverage plus fake-`gh` command and error tests for all new APIs at `internal/ghissue/ghissue_test.go:80`, `internal/ghissue/ghissue_test.go:119`, `internal/ghissue/ghissue_test.go:152`, and `internal/ghissue/ghissue_test.go:178`. | Locks the JSON mapping and exact CLI argument contracts without live GitHub access. |

</details>

## Risk

> [!WARNING]
> `ListOpenIssuesWithLabel` intentionally mirrors the requested `gh issue list --limit 100` contract, so callers that need more than 100 matching OPEN issues need a separate pagination or limit design.

## Test plan

- `go test ./internal/ghissue` - pass
- `make lint` - pass
- `codex review --uncommitted` - pass after documenting the 100-issue cap
- `make test` - pass

Closes #221