### PR TITLE
feat(watch): add watcher planner engine

### DIFF
--- a/internal/watch/engine.go
+++ b/internal/watch/engine.go
@@ -1,0 +1,453 @@
+// Package watch plans and runs one repository watcher cycle from labeled
+// GitHub issues to fanout launches. All external effects are dependency
+// injected so the planner can be tested without gh, tmux, git, or settings.
+package watch
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/butaosuinu/fanout/internal/ghissue"
+	"github.com/butaosuinu/fanout/internal/state"
+)
+
+const (
+	defaultBackoffBase          = 60 * time.Second
+	defaultDisableAfterFailures = 3
+)
+
+// LaunchKind classifies the launch fanout should perform for one labeled issue.
+type LaunchKind string
+
+const (
+	LaunchStandalone LaunchKind = "standalone"
+	LaunchParent     LaunchKind = "parent"
+)
+
+// SkipReason explains why a labeled issue was not eligible this cycle.
+type SkipReason string
+
+const (
+	SkipClosed         SkipReason = "closed"
+	SkipAlreadyRunning SkipReason = "already_running"
+	SkipAlreadyFanned  SkipReason = "already_fanned"
+	SkipDisabled       SkipReason = "disabled"
+)
+
+// DeferReason explains why an otherwise eligible issue should be retried in a
+// later watcher cycle.
+type DeferReason string
+
+const (
+	DeferBackoff     DeferReason = "backoff"
+	DeferMaxSessions DeferReason = "max_sessions"
+)
+
+// FailureStage identifies the effect that failed during a cycle.
+type FailureStage string
+
+const (
+	FailureCountChildren FailureStage = "count_open_children"
+	FailureSwapLabels    FailureStage = "swap_labels"
+	FailureLaunch        FailureStage = "launch"
+)
+
+// Config is the settings-shaped input for Engine. TUI/settings code maps its
+// own config into this small struct; this package does not import settings.
+type Config struct {
+	TriggerLabel string
+	RunningLabel string
+	// MaxSessions is a repo-wide live pane budget. A value <= 0 means unlimited.
+	MaxSessions int
+	// BackoffBase defaults to 60s. Launch failures wait BackoffBase, then double
+	// after each consecutive failure.
+	BackoffBase time.Duration
+	// DisableAfterFailures defaults to 3 consecutive launch failures for the
+	// lifetime of this Engine.
+	DisableAfterFailures int
+	Now                  func() time.Time
+}
+
+// IO is the watcher's complete external boundary. Tests should provide fakes;
+// production code wires these to ghissue/state/tmux/cmd fanout helpers.
+type IO struct {
+	ListLabeled       func(label string) ([]ghissue.Issue, error)
+	CountOpenChildren func(issue ghissue.Issue) (int, error)
+	SwapLabels        func(issue ghissue.Issue, removeLabel, addLabel string) error
+	LoadState         func() (state.Store, error)
+	PaneAlive         func(pane state.Pane) (bool, error)
+	LaunchStandalone  func(issue ghissue.Issue) error
+	LaunchParent      func(issue ghissue.Issue, limit int) error
+}
+
+// Engine keeps process-local launch failure state between cycles.
+type Engine struct {
+	cfg      Config
+	io       IO
+	failures map[int]failureState
+}
+
+type failureState struct {
+	Attempts    int
+	NextRetryAt time.Time
+	Disabled    bool
+}
+
+// NewEngine returns a watcher engine with process-local failure memory.
+func NewEngine(cfg Config, io IO) *Engine {
+	return &Engine{
+		cfg:      cfg,
+		io:       io,
+		failures: map[int]failureState{},
+	}
+}
+
+// Action is one launch the watcher should perform after acquiring the running
+// label.
+type Action struct {
+	Issue        ghissue.Issue
+	Kind         LaunchKind
+	OpenChildren int
+	// Limit is non-zero only when MaxSessions is finite and this is a parent
+	// fan-out. The caller should pass it through as fanout's --limit value.
+	Limit int
+}
+
+// Skip is a candidate removed by idempotency or an already-terminal condition.
+type Skip struct {
+	Issue  ghissue.Issue
+	Reason SkipReason
+}
+
+// Deferred is a candidate left for a later cycle.
+type Deferred struct {
+	Issue      ghissue.Issue
+	Reason     DeferReason
+	RetryAfter time.Duration
+	RetryAt    time.Time
+}
+
+// Failure records a per-issue cycle failure. RunCycle uses it for swap/launch
+// failures; PlanCycle uses it for child-count failures.
+type Failure struct {
+	Issue       ghissue.Issue
+	Stage       FailureStage
+	Err         error
+	RevertErr   error
+	Attempts    int
+	NextRetryAt time.Time
+	Disabled    bool
+}
+
+// Report is the full outcome of one planned or executed watcher cycle.
+type Report struct {
+	Candidates        int
+	RunningSessions   int
+	MaxSessions       int
+	RemainingSessions int
+	Actions           []Action
+	Launched          []Action
+	Skipped           []Skip
+	Deferred          []Deferred
+	Failures          []Failure
+}
+
+// PlanCycle reads candidates and state, then returns the launch actions for one
+// cycle. It does not mutate labels or launch panes.
+func (e *Engine) PlanCycle() (Report, error) {
+	if e == nil {
+		return Report{}, errors.New("watch engine is nil")
+	}
+	cfg := normalizeConfig(e.cfg)
+	if err := validatePlanConfig(cfg); err != nil {
+		return Report{}, err
+	}
+	if err := validatePlanIO(e.io); err != nil {
+		return Report{}, err
+	}
+
+	candidates, err := e.io.ListLabeled(cfg.TriggerLabel)
+	if err != nil {
+		return Report{}, fmt.Errorf("list labeled issues %q: %w", cfg.TriggerLabel, err)
+	}
+	store, err := e.io.LoadState()
+	if err != nil {
+		return Report{}, fmt.Errorf("load fanout state: %w", err)
+	}
+	running, err := countLivePanes(store, e.io.PaneAlive)
+	if err != nil {
+		return Report{}, err
+	}
+
+	remaining := unlimitedSessions
+	if cfg.MaxSessions > 0 {
+		remaining = max(cfg.MaxSessions-running, 0)
+	}
+	report := Report{
+		Candidates:        len(candidates),
+		RunningSessions:   running,
+		MaxSessions:       cfg.MaxSessions,
+		RemainingSessions: reportRemaining(remaining),
+	}
+	now := cfg.Now()
+
+	for _, issue := range candidates {
+		if strings.ToUpper(strings.TrimSpace(issue.State)) != "OPEN" {
+			report.Skipped = append(report.Skipped, Skip{Issue: issue, Reason: SkipClosed})
+			continue
+		}
+		if hasLabel(issue, cfg.RunningLabel) {
+			report.Skipped = append(report.Skipped, Skip{Issue: issue, Reason: SkipAlreadyRunning})
+			continue
+		}
+		if alreadyFanned(store, issue.Number) {
+			report.Skipped = append(report.Skipped, Skip{Issue: issue, Reason: SkipAlreadyFanned})
+			continue
+		}
+		if failure := e.failures[issue.Number]; failure.Disabled {
+			report.Skipped = append(report.Skipped, Skip{Issue: issue, Reason: SkipDisabled})
+			continue
+		} else if !failure.NextRetryAt.IsZero() && now.Before(failure.NextRetryAt) {
+			report.Deferred = append(report.Deferred, Deferred{
+				Issue:      issue,
+				Reason:     DeferBackoff,
+				RetryAfter: failure.NextRetryAt.Sub(now),
+				RetryAt:    failure.NextRetryAt,
+			})
+			continue
+		}
+		if remaining == 0 {
+			report.Deferred = append(report.Deferred, Deferred{Issue: issue, Reason: DeferMaxSessions})
+			continue
+		}
+
+		openChildren, err := e.io.CountOpenChildren(issue)
+		if err != nil {
+			report.Failures = append(report.Failures, Failure{Issue: issue, Stage: FailureCountChildren, Err: err})
+			continue
+		}
+		if openChildren < 0 {
+			openChildren = 0
+		}
+		action := Action{Issue: issue, Kind: LaunchStandalone, OpenChildren: openChildren}
+		consumes := 1
+		if openChildren > 0 {
+			action.Kind = LaunchParent
+			consumes = openChildren
+			if remaining > 0 {
+				action.Limit = remaining
+				consumes = min(openChildren, remaining)
+			}
+		}
+		report.Actions = append(report.Actions, action)
+		if remaining > 0 {
+			remaining = max(remaining-consumes, 0)
+		}
+	}
+	report.RemainingSessions = reportRemaining(remaining)
+	return report, nil
+}
+
+// RunCycle executes a planned cycle. It swaps trigger->running before launching
+// and fails closed when the label swap cannot be applied.
+func (e *Engine) RunCycle() (Report, error) {
+	if e == nil {
+		return Report{}, errors.New("watch engine is nil")
+	}
+	cfg := normalizeConfig(e.cfg)
+	if err := validateRunIO(e.io); err != nil {
+		return Report{}, err
+	}
+	report, err := e.PlanCycle()
+	if err != nil {
+		return report, err
+	}
+
+	for _, action := range report.Actions {
+		if err := e.io.SwapLabels(action.Issue, cfg.TriggerLabel, cfg.RunningLabel); err != nil {
+			report.Failures = append(report.Failures, Failure{Issue: action.Issue, Stage: FailureSwapLabels, Err: err})
+			continue
+		}
+
+		var launchErr error
+		switch action.Kind {
+		case LaunchParent:
+			launchErr = e.io.LaunchParent(action.Issue, action.Limit)
+		default:
+			launchErr = e.io.LaunchStandalone(action.Issue)
+		}
+		if launchErr != nil {
+			revertErr := e.io.SwapLabels(action.Issue, cfg.RunningLabel, cfg.TriggerLabel)
+			failure := e.recordLaunchFailure(action.Issue.Number, cfg.Now())
+			report.Failures = append(report.Failures, Failure{
+				Issue:       action.Issue,
+				Stage:       FailureLaunch,
+				Err:         launchErr,
+				RevertErr:   revertErr,
+				Attempts:    failure.Attempts,
+				NextRetryAt: failure.NextRetryAt,
+				Disabled:    failure.Disabled,
+			})
+			continue
+		}
+		delete(e.failures, action.Issue.Number)
+		report.Launched = append(report.Launched, action)
+	}
+	return report, nil
+}
+
+func normalizeConfig(cfg Config) Config {
+	if cfg.BackoffBase <= 0 {
+		cfg.BackoffBase = defaultBackoffBase
+	}
+	if cfg.DisableAfterFailures <= 0 {
+		cfg.DisableAfterFailures = defaultDisableAfterFailures
+	}
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
+	return cfg
+}
+
+func validatePlanConfig(cfg Config) error {
+	switch {
+	case strings.TrimSpace(cfg.TriggerLabel) == "":
+		return errors.New("watch trigger label is required")
+	case strings.TrimSpace(cfg.RunningLabel) == "":
+		return errors.New("watch running label is required")
+	case cfg.TriggerLabel == cfg.RunningLabel:
+		return errors.New("watch trigger and running labels must differ")
+	default:
+		return nil
+	}
+}
+
+func validatePlanIO(io IO) error {
+	switch {
+	case io.ListLabeled == nil:
+		return errors.New("watch IO ListLabeled is required")
+	case io.CountOpenChildren == nil:
+		return errors.New("watch IO CountOpenChildren is required")
+	case io.LoadState == nil:
+		return errors.New("watch IO LoadState is required")
+	case io.PaneAlive == nil:
+		return errors.New("watch IO PaneAlive is required")
+	default:
+		return nil
+	}
+}
+
+func validateRunIO(io IO) error {
+	if err := validatePlanIO(io); err != nil {
+		return err
+	}
+	switch {
+	case io.SwapLabels == nil:
+		return errors.New("watch IO SwapLabels is required")
+	case io.LaunchStandalone == nil:
+		return errors.New("watch IO LaunchStandalone is required")
+	case io.LaunchParent == nil:
+		return errors.New("watch IO LaunchParent is required")
+	default:
+		return nil
+	}
+}
+
+func countLivePanes(store state.Store, alive func(state.Pane) (bool, error)) (int, error) {
+	count := 0
+	for _, pane := range store.Panes {
+		ok, err := alive(pane)
+		if err != nil {
+			return 0, fmt.Errorf("check pane %s alive: %w", pane.PaneID, err)
+		}
+		if ok {
+			count++
+		}
+	}
+	return count, nil
+}
+
+func (e *Engine) recordLaunchFailure(issueNum int, now time.Time) failureState {
+	cfg := normalizeConfig(e.cfg)
+	failure := e.failures[issueNum]
+	failure.Attempts++
+	if failure.Attempts >= cfg.DisableAfterFailures {
+		failure.Disabled = true
+		failure.NextRetryAt = time.Time{}
+	} else {
+		failure.NextRetryAt = now.Add(backoffDelay(cfg.BackoffBase, failure.Attempts))
+	}
+	e.failures[issueNum] = failure
+	return failure
+}
+
+func backoffDelay(base time.Duration, attempts int) time.Duration {
+	if attempts <= 1 {
+		return base
+	}
+	shift := min(attempts-1, 30)
+	return base * time.Duration(1<<shift)
+}
+
+const unlimitedSessions = -1
+
+func reportRemaining(remaining int) int {
+	if remaining == unlimitedSessions {
+		return 0
+	}
+	return remaining
+}
+
+func alreadyFanned(store state.Store, issueNum int) bool {
+	if issueNum <= 0 {
+		return false
+	}
+	for _, pane := range store.Panes {
+		if pane.IssueNum == issueNum {
+			return true
+		}
+		if pane.IssueNum > 0 && paneWorktreeMatchesIssue(pane, issueNum) {
+			return true
+		}
+	}
+	return false
+}
+
+func paneWorktreeMatchesIssue(pane state.Pane, issueNum int) bool {
+	for _, name := range []string{pane.Slug, filepath.Base(strings.TrimSpace(pane.WorktreePath))} {
+		if worktreeNameMatchesIssue(name, issueNum) {
+			return true
+		}
+	}
+	return false
+}
+
+func worktreeNameMatchesIssue(name string, issueNum int) bool {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return false
+	}
+	num := strconv.Itoa(issueNum)
+	if name == num {
+		return true
+	}
+	for _, sep := range []string{"-", "_"} {
+		if strings.HasSuffix(name, sep+num) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasLabel(issue ghissue.Issue, name string) bool {
+	for _, label := range issue.Labels {
+		if label.Name == name {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/watch/engine.go
+++ b/internal/watch/engine.go
@@ -81,7 +81,7 @@ type IO struct {
 	LoadState         func() (state.Store, error)
 	PaneAlive         func(pane state.Pane) (bool, error)
 	LaunchStandalone  func(issue ghissue.Issue) error
-	LaunchParent      func(issue ghissue.Issue, limit int) error
+	LaunchParent      func(issue ghissue.Issue, limit int) (ParentLaunchResult, error)
 }
 
 // Engine keeps process-local launch failure state between cycles.
@@ -104,6 +104,12 @@ func NewEngine(cfg Config, io IO) *Engine {
 		io:       io,
 		failures: map[int]failureState{},
 	}
+}
+
+// ParentLaunchResult reports whether the underlying parent fan-out left more
+// children for a later watcher cycle.
+type ParentLaunchResult struct {
+	Deferred bool
 }
 
 // Action is one launch the watcher should perform after acquiring the running
@@ -204,10 +210,6 @@ func (e *Engine) PlanCycle() (Report, error) {
 			report.Skipped = append(report.Skipped, Skip{Issue: issue, Reason: SkipAlreadyRunning})
 			continue
 		}
-		if alreadyFanned(store, issue.Number) {
-			report.Skipped = append(report.Skipped, Skip{Issue: issue, Reason: SkipAlreadyFanned})
-			continue
-		}
 		if failure := e.failures[issue.Number]; failure.Disabled {
 			report.Skipped = append(report.Skipped, Skip{Issue: issue, Reason: SkipDisabled})
 			continue
@@ -238,10 +240,14 @@ func (e *Engine) PlanCycle() (Report, error) {
 		if openChildren > 0 {
 			action.Kind = LaunchParent
 			consumes = openChildren
-			if remaining > 0 {
-				action.Limit = remaining
-				consumes = min(openChildren, remaining)
-			}
+		}
+		if alreadyFanned(store, action) {
+			report.Skipped = append(report.Skipped, Skip{Issue: issue, Reason: SkipAlreadyFanned})
+			continue
+		}
+		if action.Kind == LaunchParent && remaining > 0 {
+			action.Limit = remaining
+			consumes = min(openChildren, remaining)
 		}
 		report.Actions = append(report.Actions, action)
 		if remaining > 0 {
@@ -274,9 +280,10 @@ func (e *Engine) RunCycle() (Report, error) {
 		}
 
 		var launchErr error
+		var parentResult ParentLaunchResult
 		switch action.Kind {
 		case LaunchParent:
-			launchErr = e.io.LaunchParent(action.Issue, action.Limit)
+			parentResult, launchErr = e.io.LaunchParent(action.Issue, action.Limit)
 		default:
 			launchErr = e.io.LaunchStandalone(action.Issue)
 		}
@@ -293,6 +300,12 @@ func (e *Engine) RunCycle() (Report, error) {
 				Disabled:    failure.Disabled,
 			})
 			continue
+		}
+		if action.Kind == LaunchParent && parentResult.Deferred {
+			report.Deferred = append(report.Deferred, Deferred{Issue: action.Issue, Reason: DeferMaxSessions})
+			if err := e.io.SwapLabels(action.Issue, cfg.RunningLabel, cfg.TriggerLabel); err != nil {
+				report.Failures = append(report.Failures, Failure{Issue: action.Issue, Stage: FailureSwapLabels, Err: err})
+			}
 		}
 		delete(e.failures, action.Issue.Number)
 		report.Launched = append(report.Launched, action)
@@ -402,15 +415,18 @@ func reportRemaining(remaining int) int {
 	return remaining
 }
 
-func alreadyFanned(store state.Store, issueNum int) bool {
-	if issueNum <= 0 {
+func alreadyFanned(store state.Store, action Action) bool {
+	if action.Issue.Number <= 0 {
+		return false
+	}
+	if action.Kind == LaunchParent {
 		return false
 	}
 	for _, pane := range store.Panes {
-		if pane.IssueNum == issueNum {
+		if pane.IssueNum == action.Issue.Number {
 			return true
 		}
-		if pane.IssueNum > 0 && paneWorktreeMatchesIssue(pane, issueNum) {
+		if pane.IssueNum > 0 && paneWorktreeMatchesIssue(pane, action.Issue.Number) {
 			return true
 		}
 	}

--- a/internal/watch/engine.go
+++ b/internal/watch/engine.go
@@ -86,9 +86,10 @@ type IO struct {
 
 // Engine keeps process-local launch failure state between cycles.
 type Engine struct {
-	cfg      Config
-	io       IO
-	failures map[int]failureState
+	cfg           Config
+	io            IO
+	failures      map[int]failureState
+	parentRetries map[int]ghissue.Issue
 }
 
 type failureState struct {
@@ -100,9 +101,10 @@ type failureState struct {
 // NewEngine returns a watcher engine with process-local failure memory.
 func NewEngine(cfg Config, io IO) *Engine {
 	return &Engine{
-		cfg:      cfg,
-		io:       io,
-		failures: map[int]failureState{},
+		cfg:           cfg,
+		io:            io,
+		failures:      map[int]failureState{},
+		parentRetries: map[int]ghissue.Issue{},
 	}
 }
 
@@ -118,6 +120,9 @@ type Action struct {
 	Issue        ghissue.Issue
 	Kind         LaunchKind
 	OpenChildren int
+	// RetryRunningParent means a deferred parent is already on the running label
+	// after a failed requeue swap, so RunCycle should not acquire it again.
+	RetryRunningParent bool
 	// Limit is non-zero only when MaxSessions is finite and this is a parent
 	// fan-out. The caller should pass it through as fanout's --limit value.
 	Limit int
@@ -180,6 +185,13 @@ func (e *Engine) PlanCycle() (Report, error) {
 	if err != nil {
 		return Report{}, fmt.Errorf("list labeled issues %q: %w", cfg.TriggerLabel, err)
 	}
+	var runningCandidates []ghissue.Issue
+	if len(e.parentRetries) > 0 {
+		runningCandidates, err = e.io.ListLabeled(cfg.RunningLabel)
+		if err != nil {
+			return Report{}, fmt.Errorf("list labeled issues %q: %w", cfg.RunningLabel, err)
+		}
+	}
 	store, err := e.io.LoadState()
 	if err != nil {
 		return Report{}, fmt.Errorf("load fanout state: %w", err)
@@ -193,20 +205,25 @@ func (e *Engine) PlanCycle() (Report, error) {
 	if cfg.MaxSessions > 0 {
 		remaining = max(cfg.MaxSessions-running, 0)
 	}
+	plannedCandidates := e.planCandidates(candidates, runningCandidates)
 	report := Report{
-		Candidates:        len(candidates),
+		Candidates:        len(plannedCandidates),
 		RunningSessions:   running,
 		MaxSessions:       cfg.MaxSessions,
 		RemainingSessions: reportRemaining(remaining),
 	}
 	now := cfg.Now()
 
-	for _, issue := range candidates {
+	for _, candidate := range plannedCandidates {
+		issue := candidate.issue
 		if strings.ToUpper(strings.TrimSpace(issue.State)) != "OPEN" {
+			if candidate.retryParent {
+				delete(e.parentRetries, issue.Number)
+			}
 			report.Skipped = append(report.Skipped, Skip{Issue: issue, Reason: SkipClosed})
 			continue
 		}
-		if hasLabel(issue, cfg.RunningLabel) {
+		if hasLabel(issue, cfg.RunningLabel) && !candidate.retryParent {
 			report.Skipped = append(report.Skipped, Skip{Issue: issue, Reason: SkipAlreadyRunning})
 			continue
 		}
@@ -235,9 +252,14 @@ func (e *Engine) PlanCycle() (Report, error) {
 		if openChildren < 0 {
 			openChildren = 0
 		}
-		action := Action{Issue: issue, Kind: LaunchStandalone, OpenChildren: openChildren}
+		action := Action{
+			Issue:              issue,
+			Kind:               LaunchStandalone,
+			OpenChildren:       openChildren,
+			RetryRunningParent: candidate.retryRunningParent,
+		}
 		consumes := 1
-		if openChildren > 0 {
+		if openChildren > 0 || candidate.retryParent {
 			action.Kind = LaunchParent
 			consumes = openChildren
 		}
@@ -274,9 +296,11 @@ func (e *Engine) RunCycle() (Report, error) {
 	}
 
 	for _, action := range report.Actions {
-		if err := e.io.SwapLabels(action.Issue, cfg.TriggerLabel, cfg.RunningLabel); err != nil {
-			report.Failures = append(report.Failures, Failure{Issue: action.Issue, Stage: FailureSwapLabels, Err: err})
-			continue
+		if !action.RetryRunningParent {
+			if err := e.io.SwapLabels(action.Issue, cfg.TriggerLabel, cfg.RunningLabel); err != nil {
+				report.Failures = append(report.Failures, Failure{Issue: action.Issue, Stage: FailureSwapLabels, Err: err})
+				continue
+			}
 		}
 
 		var launchErr error
@@ -289,6 +313,11 @@ func (e *Engine) RunCycle() (Report, error) {
 		}
 		if launchErr != nil {
 			revertErr := e.io.SwapLabels(action.Issue, cfg.RunningLabel, cfg.TriggerLabel)
+			if action.Kind == LaunchParent && revertErr != nil {
+				e.parentRetries[action.Issue.Number] = action.Issue
+			} else {
+				delete(e.parentRetries, action.Issue.Number)
+			}
 			failure := e.recordLaunchFailure(action.Issue.Number, cfg.Now())
 			report.Failures = append(report.Failures, Failure{
 				Issue:       action.Issue,
@@ -304,13 +333,50 @@ func (e *Engine) RunCycle() (Report, error) {
 		if action.Kind == LaunchParent && parentResult.Deferred {
 			report.Deferred = append(report.Deferred, Deferred{Issue: action.Issue, Reason: DeferMaxSessions})
 			if err := e.io.SwapLabels(action.Issue, cfg.RunningLabel, cfg.TriggerLabel); err != nil {
+				e.parentRetries[action.Issue.Number] = action.Issue
 				report.Failures = append(report.Failures, Failure{Issue: action.Issue, Stage: FailureSwapLabels, Err: err})
+			} else {
+				delete(e.parentRetries, action.Issue.Number)
 			}
+		} else {
+			delete(e.parentRetries, action.Issue.Number)
 		}
 		delete(e.failures, action.Issue.Number)
 		report.Launched = append(report.Launched, action)
 	}
 	return report, nil
+}
+
+type planCandidate struct {
+	issue              ghissue.Issue
+	retryParent        bool
+	retryRunningParent bool
+}
+
+func (e *Engine) planCandidates(triggered, running []ghissue.Issue) []planCandidate {
+	candidates := make([]planCandidate, 0, len(triggered)+len(running))
+	seen := map[int]bool{}
+	for _, issue := range triggered {
+		_, retry := e.parentRetries[issue.Number]
+		candidates = append(candidates, planCandidate{issue: issue, retryParent: retry})
+		seen[issue.Number] = true
+	}
+	for _, issue := range running {
+		if _, retry := e.parentRetries[issue.Number]; retry && !seen[issue.Number] {
+			candidates = append(candidates, planCandidate{
+				issue:              issue,
+				retryParent:        true,
+				retryRunningParent: true,
+			})
+			seen[issue.Number] = true
+		}
+	}
+	for num := range e.parentRetries {
+		if !seen[num] {
+			delete(e.parentRetries, num)
+		}
+	}
+	return candidates
 }
 
 func normalizeConfig(cfg Config) Config {

--- a/internal/watch/engine.go
+++ b/internal/watch/engine.go
@@ -189,12 +189,9 @@ func (e *Engine) PlanCycle() (Report, error) {
 	if err != nil {
 		return Report{}, fmt.Errorf("list labeled issues %q: %w", cfg.TriggerLabel, err)
 	}
-	var runningCandidates []ghissue.Issue
-	if len(e.runningRetries) > 0 {
-		runningCandidates, err = e.io.ListLabeled(cfg.RunningLabel)
-		if err != nil {
-			return Report{}, fmt.Errorf("list labeled issues %q: %w", cfg.RunningLabel, err)
-		}
+	runningCandidates, err := e.io.ListLabeled(cfg.RunningLabel)
+	if err != nil {
+		return Report{}, fmt.Errorf("list labeled issues %q: %w", cfg.RunningLabel, err)
 	}
 	store, err := e.io.LoadState()
 	if err != nil {
@@ -227,7 +224,7 @@ func (e *Engine) PlanCycle() (Report, error) {
 			report.Skipped = append(report.Skipped, Skip{Issue: issue, Reason: SkipClosed})
 			continue
 		}
-		if hasLabel(issue, cfg.RunningLabel) && candidate.retryKind == "" {
+		if hasLabel(issue, cfg.RunningLabel) && candidate.retryKind == "" && !candidate.recoverRunning {
 			report.Skipped = append(report.Skipped, Skip{Issue: issue, Reason: SkipAlreadyRunning})
 			continue
 		}
@@ -256,6 +253,20 @@ func (e *Engine) PlanCycle() (Report, error) {
 		if openChildren < 0 {
 			openChildren = 0
 		}
+		if candidate.recoverRunning && openChildren == 0 && hasPaneForParent(store, issue.Number) {
+			report.Skipped = append(report.Skipped, Skip{Issue: issue, Reason: SkipAlreadyRunning})
+			continue
+		}
+		if candidate.recoverRunning && openChildren > 0 {
+			liveParent, err := hasLivePaneForParent(store, issue.Number, e.io.PaneAlive)
+			if err != nil {
+				return Report{}, err
+			}
+			if liveParent {
+				report.Skipped = append(report.Skipped, Skip{Issue: issue, Reason: SkipAlreadyRunning})
+				continue
+			}
+		}
 		action := Action{
 			Issue:        issue,
 			Kind:         LaunchStandalone,
@@ -272,8 +283,8 @@ func (e *Engine) PlanCycle() (Report, error) {
 			continue
 		}
 		if action.Kind == LaunchParent && remaining > 0 {
-			action.Limit = remaining
 			consumes = min(openChildren, remaining)
+			action.Limit = consumes
 		}
 		report.Actions = append(report.Actions, action)
 		if remaining > 0 {
@@ -352,28 +363,37 @@ func (e *Engine) RunCycle() (Report, error) {
 }
 
 type planCandidate struct {
-	issue        ghissue.Issue
-	retryKind    LaunchKind
-	retryRunning bool
+	issue          ghissue.Issue
+	retryKind      LaunchKind
+	retryRunning   bool
+	recoverRunning bool
 }
 
 func (e *Engine) planCandidates(triggered, running []ghissue.Issue) []planCandidate {
 	candidates := make([]planCandidate, 0, len(triggered)+len(running))
 	seen := map[int]bool{}
+	index := map[int]int{}
 	for _, issue := range triggered {
 		retry := e.runningRetries[issue.Number]
 		candidates = append(candidates, planCandidate{issue: issue, retryKind: retry.kind})
 		seen[issue.Number] = true
+		index[issue.Number] = len(candidates) - 1
 	}
 	for _, issue := range running {
-		if retry, ok := e.runningRetries[issue.Number]; ok && !seen[issue.Number] {
-			candidates = append(candidates, planCandidate{
-				issue:        issue,
-				retryKind:    retry.kind,
-				retryRunning: true,
-			})
-			seen[issue.Number] = true
+		if seen[issue.Number] {
+			if _, retrying := e.runningRetries[issue.Number]; !retrying {
+				candidates[index[issue.Number]].recoverRunning = true
+			}
+			continue
 		}
+		retry, retrying := e.runningRetries[issue.Number]
+		candidates = append(candidates, planCandidate{
+			issue:          issue,
+			retryKind:      retry.kind,
+			retryRunning:   true,
+			recoverRunning: !retrying,
+		})
+		seen[issue.Number] = true
 	}
 	for num := range e.runningRetries {
 		if !seen[num] {
@@ -504,6 +524,26 @@ func alreadyFanned(store state.Store, action Action) bool {
 		}
 	}
 	return false
+}
+
+func hasPaneForParent(store state.Store, issueNum int) bool {
+	return len(store.PanesForParent(strconv.Itoa(issueNum))) > 0
+}
+
+func hasLivePaneForParent(store state.Store, issueNum int, alive func(state.Pane) (bool, error)) (bool, error) {
+	for _, pane := range store.PanesForParent(strconv.Itoa(issueNum)) {
+		if pane.Kind == state.PaneKindShell {
+			continue
+		}
+		ok, err := alive(pane)
+		if err != nil {
+			return false, fmt.Errorf("check pane %s alive: %w", pane.PaneID, err)
+		}
+		if ok {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func paneWorktreeMatchesIssue(pane state.Pane, issueNum int) bool {

--- a/internal/watch/engine.go
+++ b/internal/watch/engine.go
@@ -86,10 +86,10 @@ type IO struct {
 
 // Engine keeps process-local launch failure state between cycles.
 type Engine struct {
-	cfg           Config
-	io            IO
-	failures      map[int]failureState
-	parentRetries map[int]ghissue.Issue
+	cfg            Config
+	io             IO
+	failures       map[int]failureState
+	runningRetries map[int]runningRetry
 }
 
 type failureState struct {
@@ -98,13 +98,17 @@ type failureState struct {
 	Disabled    bool
 }
 
+type runningRetry struct {
+	kind LaunchKind
+}
+
 // NewEngine returns a watcher engine with process-local failure memory.
 func NewEngine(cfg Config, io IO) *Engine {
 	return &Engine{
-		cfg:           cfg,
-		io:            io,
-		failures:      map[int]failureState{},
-		parentRetries: map[int]ghissue.Issue{},
+		cfg:            cfg,
+		io:             io,
+		failures:       map[int]failureState{},
+		runningRetries: map[int]runningRetry{},
 	}
 }
 
@@ -120,9 +124,9 @@ type Action struct {
 	Issue        ghissue.Issue
 	Kind         LaunchKind
 	OpenChildren int
-	// RetryRunningParent means a deferred parent is already on the running label
-	// after a failed requeue swap, so RunCycle should not acquire it again.
-	RetryRunningParent bool
+	// RetryRunning means the issue is already on the running label after a failed
+	// requeue swap, so RunCycle should not acquire it again.
+	RetryRunning bool
 	// Limit is non-zero only when MaxSessions is finite and this is a parent
 	// fan-out. The caller should pass it through as fanout's --limit value.
 	Limit int
@@ -186,7 +190,7 @@ func (e *Engine) PlanCycle() (Report, error) {
 		return Report{}, fmt.Errorf("list labeled issues %q: %w", cfg.TriggerLabel, err)
 	}
 	var runningCandidates []ghissue.Issue
-	if len(e.parentRetries) > 0 {
+	if len(e.runningRetries) > 0 {
 		runningCandidates, err = e.io.ListLabeled(cfg.RunningLabel)
 		if err != nil {
 			return Report{}, fmt.Errorf("list labeled issues %q: %w", cfg.RunningLabel, err)
@@ -217,13 +221,13 @@ func (e *Engine) PlanCycle() (Report, error) {
 	for _, candidate := range plannedCandidates {
 		issue := candidate.issue
 		if strings.ToUpper(strings.TrimSpace(issue.State)) != "OPEN" {
-			if candidate.retryParent {
-				delete(e.parentRetries, issue.Number)
+			if candidate.retryKind != "" {
+				delete(e.runningRetries, issue.Number)
 			}
 			report.Skipped = append(report.Skipped, Skip{Issue: issue, Reason: SkipClosed})
 			continue
 		}
-		if hasLabel(issue, cfg.RunningLabel) && !candidate.retryParent {
+		if hasLabel(issue, cfg.RunningLabel) && candidate.retryKind == "" {
 			report.Skipped = append(report.Skipped, Skip{Issue: issue, Reason: SkipAlreadyRunning})
 			continue
 		}
@@ -253,13 +257,13 @@ func (e *Engine) PlanCycle() (Report, error) {
 			openChildren = 0
 		}
 		action := Action{
-			Issue:              issue,
-			Kind:               LaunchStandalone,
-			OpenChildren:       openChildren,
-			RetryRunningParent: candidate.retryRunningParent,
+			Issue:        issue,
+			Kind:         LaunchStandalone,
+			OpenChildren: openChildren,
+			RetryRunning: candidate.retryRunning,
 		}
 		consumes := 1
-		if openChildren > 0 || candidate.retryParent {
+		if openChildren > 0 || candidate.retryKind == LaunchParent {
 			action.Kind = LaunchParent
 			consumes = openChildren
 		}
@@ -296,7 +300,7 @@ func (e *Engine) RunCycle() (Report, error) {
 	}
 
 	for _, action := range report.Actions {
-		if !action.RetryRunningParent {
+		if !action.RetryRunning {
 			if err := e.io.SwapLabels(action.Issue, cfg.TriggerLabel, cfg.RunningLabel); err != nil {
 				report.Failures = append(report.Failures, Failure{Issue: action.Issue, Stage: FailureSwapLabels, Err: err})
 				continue
@@ -313,10 +317,10 @@ func (e *Engine) RunCycle() (Report, error) {
 		}
 		if launchErr != nil {
 			revertErr := e.io.SwapLabels(action.Issue, cfg.RunningLabel, cfg.TriggerLabel)
-			if action.Kind == LaunchParent && revertErr != nil {
-				e.parentRetries[action.Issue.Number] = action.Issue
+			if revertErr != nil {
+				e.runningRetries[action.Issue.Number] = runningRetry{kind: action.Kind}
 			} else {
-				delete(e.parentRetries, action.Issue.Number)
+				delete(e.runningRetries, action.Issue.Number)
 			}
 			failure := e.recordLaunchFailure(action.Issue.Number, cfg.Now())
 			report.Failures = append(report.Failures, Failure{
@@ -333,13 +337,13 @@ func (e *Engine) RunCycle() (Report, error) {
 		if action.Kind == LaunchParent && parentResult.Deferred {
 			report.Deferred = append(report.Deferred, Deferred{Issue: action.Issue, Reason: DeferMaxSessions})
 			if err := e.io.SwapLabels(action.Issue, cfg.RunningLabel, cfg.TriggerLabel); err != nil {
-				e.parentRetries[action.Issue.Number] = action.Issue
+				e.runningRetries[action.Issue.Number] = runningRetry{kind: LaunchParent}
 				report.Failures = append(report.Failures, Failure{Issue: action.Issue, Stage: FailureSwapLabels, Err: err})
 			} else {
-				delete(e.parentRetries, action.Issue.Number)
+				delete(e.runningRetries, action.Issue.Number)
 			}
 		} else {
-			delete(e.parentRetries, action.Issue.Number)
+			delete(e.runningRetries, action.Issue.Number)
 		}
 		delete(e.failures, action.Issue.Number)
 		report.Launched = append(report.Launched, action)
@@ -348,32 +352,32 @@ func (e *Engine) RunCycle() (Report, error) {
 }
 
 type planCandidate struct {
-	issue              ghissue.Issue
-	retryParent        bool
-	retryRunningParent bool
+	issue        ghissue.Issue
+	retryKind    LaunchKind
+	retryRunning bool
 }
 
 func (e *Engine) planCandidates(triggered, running []ghissue.Issue) []planCandidate {
 	candidates := make([]planCandidate, 0, len(triggered)+len(running))
 	seen := map[int]bool{}
 	for _, issue := range triggered {
-		_, retry := e.parentRetries[issue.Number]
-		candidates = append(candidates, planCandidate{issue: issue, retryParent: retry})
+		retry := e.runningRetries[issue.Number]
+		candidates = append(candidates, planCandidate{issue: issue, retryKind: retry.kind})
 		seen[issue.Number] = true
 	}
 	for _, issue := range running {
-		if _, retry := e.parentRetries[issue.Number]; retry && !seen[issue.Number] {
+		if retry, ok := e.runningRetries[issue.Number]; ok && !seen[issue.Number] {
 			candidates = append(candidates, planCandidate{
-				issue:              issue,
-				retryParent:        true,
-				retryRunningParent: true,
+				issue:        issue,
+				retryKind:    retry.kind,
+				retryRunning: true,
 			})
 			seen[issue.Number] = true
 		}
 	}
-	for num := range e.parentRetries {
+	for num := range e.runningRetries {
 		if !seen[num] {
-			delete(e.parentRetries, num)
+			delete(e.runningRetries, num)
 		}
 	}
 	return candidates
@@ -439,6 +443,9 @@ func validateRunIO(io IO) error {
 func countLivePanes(store state.Store, alive func(state.Pane) (bool, error)) (int, error) {
 	count := 0
 	for _, pane := range store.Panes {
+		if pane.Kind == state.PaneKindShell {
+			continue
+		}
 		ok, err := alive(pane)
 		if err != nil {
 			return 0, fmt.Errorf("check pane %s alive: %w", pane.PaneID, err)

--- a/internal/watch/engine_test.go
+++ b/internal/watch/engine_test.go
@@ -232,7 +232,7 @@ func TestRunCycleTableDriven(t *testing.T) {
 			},
 		},
 		{
-			name: "parent fanout gets remaining budget as limit",
+			name: "parent fanout gets reserved budget as limit",
 			cfg:  Config{MaxSessions: 5},
 			fake: &fakeWatchIO{
 				issues:       []ghissue.Issue{issue(201)},
@@ -242,10 +242,10 @@ func TestRunCycleTableDriven(t *testing.T) {
 			},
 			check: func(t *testing.T, report Report, fake *fakeWatchIO) {
 				t.Helper()
-				if len(report.Actions) != 1 || report.Actions[0].Kind != LaunchParent || report.Actions[0].Limit != 4 {
-					t.Fatalf("actions = %#v, want parent with limit 4", report.Actions)
+				if len(report.Actions) != 1 || report.Actions[0].Kind != LaunchParent || report.Actions[0].Limit != 3 {
+					t.Fatalf("actions = %#v, want parent with limit 3", report.Actions)
 				}
-				if got, want := fake.parents, []parentLaunch{{num: 201, limit: 4}}; !slices.Equal(got, want) {
+				if got, want := fake.parents, []parentLaunch{{num: 201, limit: 3}}; !slices.Equal(got, want) {
 					t.Fatalf("parent launches = %#v, want %#v", got, want)
 				}
 			},
@@ -303,6 +303,130 @@ func TestRunCycleTableDriven(t *testing.T) {
 	}
 }
 
+func TestRunCycleRecoversStandaloneRunningRetryAfterRestart(t *testing.T) {
+	fake := &fakeWatchIO{
+		runningIssues: []ghissue.Issue{issue(101, runningLabel)},
+		openChildren:  map[int]int{101: 0},
+	}
+	engine := NewEngine(Config{
+		TriggerLabel: triggerLabel,
+		RunningLabel: runningLabel,
+		Now:          (&fakeClock{now: time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)}).Now,
+	}, fake.IO())
+
+	report, err := engine.RunCycle()
+	if err != nil {
+		t.Fatalf("RunCycle error = %v", err)
+	}
+	assertInts(t, "count calls", fake.countCalls, []int{101})
+	assertSwaps(t, fake.swaps, nil)
+	assertInts(t, "standalone launches", fake.standalone, []int{101})
+	if len(report.Actions) != 1 || !report.Actions[0].RetryRunning {
+		t.Fatalf("actions = %#v, want recovered running-label standalone", report.Actions)
+	}
+}
+
+func TestRunCycleRecoversParentRunningRetryAfterRestart(t *testing.T) {
+	fake := &fakeWatchIO{
+		runningIssues: []ghissue.Issue{issue(301, runningLabel)},
+		openChildren:  map[int]int{301: 1},
+	}
+	engine := NewEngine(Config{
+		TriggerLabel: triggerLabel,
+		RunningLabel: runningLabel,
+		Now:          (&fakeClock{now: time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)}).Now,
+	}, fake.IO())
+
+	report, err := engine.RunCycle()
+	if err != nil {
+		t.Fatalf("RunCycle error = %v", err)
+	}
+	assertInts(t, "count calls", fake.countCalls, []int{301})
+	assertSwaps(t, fake.swaps, nil)
+	if got, want := fake.parents, []parentLaunch{{num: 301, limit: 0}}; !slices.Equal(got, want) {
+		t.Fatalf("parent launches = %#v, want %#v", got, want)
+	}
+	if len(report.Actions) != 1 || !report.Actions[0].RetryRunning || report.Actions[0].Kind != LaunchParent {
+		t.Fatalf("actions = %#v, want recovered running-label parent", report.Actions)
+	}
+}
+
+func TestRunCycleSkipsRecoveredRunningParentWithLiveChildren(t *testing.T) {
+	fake := &fakeWatchIO{
+		runningIssues: []ghissue.Issue{issue(301, runningLabel)},
+		openChildren:  map[int]int{301: 2},
+		store: state.Store{Panes: []state.Pane{
+			{Parent: "301", IssueNum: 401, PaneID: "%child"},
+		}},
+		alive: map[string]bool{"%child": true},
+	}
+	engine := NewEngine(Config{
+		TriggerLabel: triggerLabel,
+		RunningLabel: runningLabel,
+		Now:          (&fakeClock{now: time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)}).Now,
+	}, fake.IO())
+
+	report, err := engine.RunCycle()
+	if err != nil {
+		t.Fatalf("RunCycle error = %v", err)
+	}
+	assertInts(t, "count calls", fake.countCalls, []int{301})
+	if len(fake.parents) != 0 || len(report.Actions) != 0 {
+		t.Fatalf("report=%#v parents=%#v, want live parent skipped", report, fake.parents)
+	}
+	assertSkipReasons(t, report, []SkipReason{SkipAlreadyRunning})
+}
+
+func TestRunCycleRecoversBothLabeledRunningRetryAfterRestart(t *testing.T) {
+	fake := &fakeWatchIO{
+		issues:        []ghissue.Issue{issue(101, runningLabel)},
+		runningIssues: []ghissue.Issue{issue(101, runningLabel)},
+		openChildren:  map[int]int{101: 0},
+	}
+	engine := NewEngine(Config{
+		TriggerLabel: triggerLabel,
+		RunningLabel: runningLabel,
+		Now:          (&fakeClock{now: time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)}).Now,
+	}, fake.IO())
+
+	report, err := engine.RunCycle()
+	if err != nil {
+		t.Fatalf("RunCycle error = %v", err)
+	}
+	assertInts(t, "count calls", fake.countCalls, []int{101})
+	assertSwaps(t, fake.swaps, []swapCall{{num: 101, remove: triggerLabel, add: runningLabel}})
+	assertInts(t, "standalone launches", fake.standalone, []int{101})
+	if len(report.Actions) != 1 || report.Actions[0].RetryRunning {
+		t.Fatalf("actions = %#v, want recovered trigger acquisition", report.Actions)
+	}
+}
+
+func TestRunCycleSkipsRecoveredRunningParentWithoutOpenChildren(t *testing.T) {
+	fake := &fakeWatchIO{
+		runningIssues: []ghissue.Issue{issue(301, runningLabel)},
+		openChildren:  map[int]int{301: 0},
+		store: state.Store{Panes: []state.Pane{
+			{Parent: "301", IssueNum: 401, PaneID: "%child"},
+		}},
+	}
+	engine := NewEngine(Config{
+		TriggerLabel: triggerLabel,
+		RunningLabel: runningLabel,
+		Now:          (&fakeClock{now: time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)}).Now,
+	}, fake.IO())
+
+	report, err := engine.RunCycle()
+	if err != nil {
+		t.Fatalf("RunCycle error = %v", err)
+	}
+	assertInts(t, "count calls", fake.countCalls, []int{301})
+	assertInts(t, "standalone launches", fake.standalone, nil)
+	if len(fake.parents) != 0 || len(report.Actions) != 0 {
+		t.Fatalf("report=%#v parents=%#v, want recovered parent skipped", report, fake.parents)
+	}
+	assertSkipReasons(t, report, []SkipReason{SkipAlreadyRunning})
+}
+
 func TestRunCycleRetriesStandaloneWhenRequeueSwapFails(t *testing.T) {
 	baseNow := time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)
 	clock := &fakeClock{now: baseNow}
@@ -356,15 +480,17 @@ func TestRunCycleRetriesStandaloneWhenRequeueSwapFails(t *testing.T) {
 
 	fake.countCalls = nil
 	fake.standalone = nil
+	fake.store = state.Store{Panes: []state.Pane{{IssueNum: 101, PaneID: "%new"}}}
 
 	third, err := engine.RunCycle()
 	if err != nil {
 		t.Fatalf("third RunCycle error = %v", err)
 	}
-	if len(third.Actions) != 0 || len(fake.standalone) != 0 || len(fake.countCalls) != 0 {
-		t.Fatalf("third retry persisted: report=%#v standalone=%#v countCalls=%#v",
-			third, fake.standalone, fake.countCalls)
+	if len(third.Actions) != 0 || len(fake.standalone) != 0 {
+		t.Fatalf("third retry persisted: report=%#v standalone=%#v", third, fake.standalone)
 	}
+	assertInts(t, "count calls after state record", fake.countCalls, []int{101})
+	assertSkipReasons(t, third, []SkipReason{SkipAlreadyFanned})
 }
 
 func TestRunCycleRetriesDeferredParentWhenRequeueSwapFails(t *testing.T) {
@@ -423,6 +549,8 @@ func TestRunCycleRetriesDeferredParentWhenRequeueSwapFails(t *testing.T) {
 
 	fake.countCalls = nil
 	fake.parents = nil
+	fake.openChildren[301] = 0
+	fake.store = state.Store{Panes: []state.Pane{{Parent: "301", IssueNum: 401, PaneID: "%new"}}}
 
 	third, err := engine.RunCycle()
 	if err != nil {

--- a/internal/watch/engine_test.go
+++ b/internal/watch/engine_test.go
@@ -200,6 +200,26 @@ func TestRunCycleTableDriven(t *testing.T) {
 			},
 		},
 		{
+			name: "max sessions ignores shell panes",
+			cfg:  Config{MaxSessions: 1},
+			fake: &fakeWatchIO{
+				issues:       []ghissue.Issue{issue(101)},
+				openChildren: map[int]int{101: 0},
+				store: state.Store{Panes: []state.Pane{
+					{IssueNum: -1, Kind: state.PaneKindShell, PaneID: "%shell"},
+				}},
+				alive: map[string]bool{"%shell": true},
+			},
+			check: func(t *testing.T, report Report, fake *fakeWatchIO) {
+				t.Helper()
+				if report.RunningSessions != 0 || report.RemainingSessions != 0 {
+					t.Fatalf("budget = running %d remaining %d, want shell excluded",
+						report.RunningSessions, report.RemainingSessions)
+				}
+				assertInts(t, "standalone launches", fake.standalone, []int{101})
+			},
+		},
+		{
 			name: "running label skips launch",
 			fake: &fakeWatchIO{
 				issues: []ghissue.Issue{issue(101, runningLabel)},
@@ -283,6 +303,70 @@ func TestRunCycleTableDriven(t *testing.T) {
 	}
 }
 
+func TestRunCycleRetriesStandaloneWhenRequeueSwapFails(t *testing.T) {
+	baseNow := time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)
+	clock := &fakeClock{now: baseNow}
+	fake := &fakeWatchIO{
+		issues:        []ghissue.Issue{issue(101)},
+		openChildren:  map[int]int{101: 0},
+		standaloneErr: map[int]error{101: errors.New("launch failed")},
+		swapErr: map[swapKey]error{
+			{num: 101, remove: runningLabel, add: triggerLabel}: errors.New("requeue failed"),
+		},
+	}
+	engine := NewEngine(Config{
+		TriggerLabel: triggerLabel,
+		RunningLabel: runningLabel,
+		Now:          clock.Now,
+	}, fake.IO())
+
+	first, err := engine.RunCycle()
+	if err != nil {
+		t.Fatalf("first RunCycle error = %v", err)
+	}
+	assertInts(t, "first standalone launches", fake.standalone, []int{101})
+	assertSwaps(t, fake.swaps, []swapCall{
+		{num: 101, remove: triggerLabel, add: runningLabel},
+		{num: 101, remove: runningLabel, add: triggerLabel},
+	})
+	assertFailure(t, first, 101, FailureLaunch, 1, false)
+
+	clock.Advance(60 * time.Second)
+	fake.issues = nil
+	fake.runningIssues = []ghissue.Issue{issue(101, runningLabel)}
+	fake.standaloneErr = nil
+	fake.swapErr = nil
+	fake.countCalls = nil
+	fake.swaps = nil
+	fake.standalone = nil
+
+	second, err := engine.RunCycle()
+	if err != nil {
+		t.Fatalf("second RunCycle error = %v", err)
+	}
+	assertInts(t, "count calls on retry", fake.countCalls, []int{101})
+	assertSwaps(t, fake.swaps, nil)
+	assertInts(t, "standalone retry launches", fake.standalone, []int{101})
+	if len(second.Actions) != 1 || !second.Actions[0].RetryRunning {
+		t.Fatalf("second actions = %#v, want running-label retry", second.Actions)
+	}
+	if len(second.Failures) != 0 || len(second.Deferred) != 0 || len(second.Launched) != 1 {
+		t.Fatalf("second report = %#v, want one clean launch", second)
+	}
+
+	fake.countCalls = nil
+	fake.standalone = nil
+
+	third, err := engine.RunCycle()
+	if err != nil {
+		t.Fatalf("third RunCycle error = %v", err)
+	}
+	if len(third.Actions) != 0 || len(fake.standalone) != 0 || len(fake.countCalls) != 0 {
+		t.Fatalf("third retry persisted: report=%#v standalone=%#v countCalls=%#v",
+			third, fake.standalone, fake.countCalls)
+	}
+}
+
 func TestRunCycleRetriesDeferredParentWhenRequeueSwapFails(t *testing.T) {
 	baseNow := time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)
 	fake := &fakeWatchIO{
@@ -330,7 +414,7 @@ func TestRunCycleRetriesDeferredParentWhenRequeueSwapFails(t *testing.T) {
 	if got, want := fake.parents, []parentLaunch{{num: 301, limit: 0}}; !slices.Equal(got, want) {
 		t.Fatalf("parent retry launches = %#v, want %#v", got, want)
 	}
-	if len(second.Actions) != 1 || !second.Actions[0].RetryRunningParent {
+	if len(second.Actions) != 1 || !second.Actions[0].RetryRunning {
 		t.Fatalf("second actions = %#v, want running-label retry", second.Actions)
 	}
 	if len(second.Failures) != 0 || len(second.Deferred) != 0 || len(second.Launched) != 1 {
@@ -384,7 +468,7 @@ func TestRunCycleAcquiresTriggerLabeledParentRetry(t *testing.T) {
 	if got, want := fake.parents, []parentLaunch{{num: 301, limit: 0}}; !slices.Equal(got, want) {
 		t.Fatalf("parent retry launches = %#v, want %#v", got, want)
 	}
-	if len(second.Actions) != 1 || second.Actions[0].RetryRunningParent {
+	if len(second.Actions) != 1 || second.Actions[0].RetryRunning {
 		t.Fatalf("second actions = %#v, want normal trigger acquisition", second.Actions)
 	}
 }
@@ -424,7 +508,7 @@ func TestRunCycleAcquiresBothLabeledParentRetry(t *testing.T) {
 	if got, want := fake.parents, []parentLaunch{{num: 301, limit: 0}}; !slices.Equal(got, want) {
 		t.Fatalf("parent retry launches = %#v, want %#v", got, want)
 	}
-	if len(second.Skipped) != 0 || len(second.Actions) != 1 || second.Actions[0].RetryRunningParent {
+	if len(second.Skipped) != 0 || len(second.Actions) != 1 || second.Actions[0].RetryRunning {
 		t.Fatalf("second report = %#v, want normal acquisition retry", second)
 	}
 }

--- a/internal/watch/engine_test.go
+++ b/internal/watch/engine_test.go
@@ -1,0 +1,371 @@
+package watch
+
+import (
+	"errors"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/butaosuinu/fanout/internal/ghissue"
+	"github.com/butaosuinu/fanout/internal/state"
+)
+
+const (
+	triggerLabel = "fanout:ready"
+	runningLabel = "fanout:running"
+)
+
+type fakeClock struct {
+	now time.Time
+}
+
+func (c *fakeClock) Now() time.Time {
+	return c.now
+}
+
+func (c *fakeClock) Advance(d time.Duration) {
+	c.now = c.now.Add(d)
+}
+
+type fakeWatchIO struct {
+	issues       []ghissue.Issue
+	store        state.Store
+	openChildren map[int]int
+	alive        map[string]bool
+
+	swapErr       map[swapKey]error
+	standaloneErr map[int]error
+	parentErr     map[int]error
+
+	countCalls []int
+	swaps      []swapCall
+	standalone []int
+	parents    []parentLaunch
+}
+
+type swapKey struct {
+	num    int
+	remove string
+	add    string
+}
+
+type swapCall struct {
+	num    int
+	remove string
+	add    string
+}
+
+type parentLaunch struct {
+	num   int
+	limit int
+}
+
+func (f *fakeWatchIO) IO() IO {
+	return IO{
+		ListLabeled: func(label string) ([]ghissue.Issue, error) {
+			if label != triggerLabel {
+				return nil, errors.New("unexpected label")
+			}
+			return slices.Clone(f.issues), nil
+		},
+		CountOpenChildren: func(issue ghissue.Issue) (int, error) {
+			f.countCalls = append(f.countCalls, issue.Number)
+			return f.openChildren[issue.Number], nil
+		},
+		SwapLabels: func(issue ghissue.Issue, removeLabel, addLabel string) error {
+			f.swaps = append(f.swaps, swapCall{num: issue.Number, remove: removeLabel, add: addLabel})
+			return f.swapErr[swapKey{num: issue.Number, remove: removeLabel, add: addLabel}]
+		},
+		LoadState: func() (state.Store, error) {
+			return f.store, nil
+		},
+		PaneAlive: func(pane state.Pane) (bool, error) {
+			return f.alive[pane.PaneID], nil
+		},
+		LaunchStandalone: func(issue ghissue.Issue) error {
+			f.standalone = append(f.standalone, issue.Number)
+			return f.standaloneErr[issue.Number]
+		},
+		LaunchParent: func(issue ghissue.Issue, limit int) error {
+			f.parents = append(f.parents, parentLaunch{num: issue.Number, limit: limit})
+			return f.parentErr[issue.Number]
+		},
+	}
+}
+
+func TestRunCycleTableDriven(t *testing.T) {
+	baseNow := time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)
+	launchErr := errors.New("launch failed")
+
+	tests := []struct {
+		name      string
+		cfg       Config
+		fake      *fakeWatchIO
+		check     func(t *testing.T, report Report, fake *fakeWatchIO)
+		wantError bool
+	}{
+		{
+			name: "swap failure stops launch fail closed",
+			fake: &fakeWatchIO{
+				issues:       []ghissue.Issue{issue(101)},
+				openChildren: map[int]int{101: 0},
+				swapErr: map[swapKey]error{
+					{num: 101, remove: triggerLabel, add: runningLabel}: errors.New("swap failed"),
+				},
+			},
+			check: func(t *testing.T, report Report, fake *fakeWatchIO) {
+				t.Helper()
+				assertInts(t, "standalone launches", fake.standalone, nil)
+				assertFailure(t, report, 101, FailureSwapLabels, 0, false)
+			},
+		},
+		{
+			name: "launch failure reverts label and backs off",
+			fake: &fakeWatchIO{
+				issues:        []ghissue.Issue{issue(101)},
+				openChildren:  map[int]int{101: 0},
+				standaloneErr: map[int]error{101: launchErr},
+			},
+			check: func(t *testing.T, report Report, fake *fakeWatchIO) {
+				t.Helper()
+				assertInts(t, "standalone launches", fake.standalone, []int{101})
+				assertSwaps(t, fake.swaps, []swapCall{
+					{num: 101, remove: triggerLabel, add: runningLabel},
+					{num: 101, remove: runningLabel, add: triggerLabel},
+				})
+				failure := assertFailure(t, report, 101, FailureLaunch, 1, false)
+				if got, want := failure.NextRetryAt, baseNow.Add(60*time.Second); !got.Equal(want) {
+					t.Fatalf("next retry = %s, want %s", got, want)
+				}
+			},
+		},
+		{
+			name: "idempotency skips issue number and issue-backed worktree fallback",
+			fake: &fakeWatchIO{
+				issues:       []ghissue.Issue{issue(101), issue(102), issue(103)},
+				openChildren: map[int]int{103: 0},
+				store: state.Store{Panes: []state.Pane{
+					{Parent: "900", IssueNum: 101, PaneID: "%1"},
+					{Parent: "901", IssueNum: 999, Slug: "api-client-102", WorktreePath: "/repo/.fanout/worktrees/api-client-102"},
+					{Parent: "plan:tasks", IssueNum: 0, TaskID: "migration-103", Slug: "migration-103", WorktreePath: "/repo/.fanout/worktrees/migration-103"},
+				}},
+			},
+			check: func(t *testing.T, report Report, fake *fakeWatchIO) {
+				t.Helper()
+				assertInts(t, "count calls", fake.countCalls, []int{103})
+				assertInts(t, "standalone launches", fake.standalone, []int{103})
+				assertSkipReasons(t, report, []SkipReason{SkipAlreadyFanned, SkipAlreadyFanned})
+			},
+		},
+		{
+			name: "max sessions reached defers without counting children",
+			cfg:  Config{MaxSessions: 1},
+			fake: &fakeWatchIO{
+				issues: []ghissue.Issue{issue(101)},
+				store:  state.Store{Panes: []state.Pane{{IssueNum: 900, PaneID: "%live"}}},
+				alive:  map[string]bool{"%live": true},
+			},
+			check: func(t *testing.T, report Report, fake *fakeWatchIO) {
+				t.Helper()
+				assertInts(t, "count calls", fake.countCalls, nil)
+				if len(report.Deferred) != 1 || report.Deferred[0].Reason != DeferMaxSessions {
+					t.Fatalf("deferred = %#v, want max_sessions", report.Deferred)
+				}
+			},
+		},
+		{
+			name: "running label skips launch",
+			fake: &fakeWatchIO{
+				issues: []ghissue.Issue{issue(101, runningLabel)},
+			},
+			check: func(t *testing.T, report Report, fake *fakeWatchIO) {
+				t.Helper()
+				assertInts(t, "count calls", fake.countCalls, nil)
+				assertSkipReasons(t, report, []SkipReason{SkipAlreadyRunning})
+				assertInts(t, "standalone launches", fake.standalone, nil)
+			},
+		},
+		{
+			name: "parent fanout gets remaining budget as limit",
+			cfg:  Config{MaxSessions: 5},
+			fake: &fakeWatchIO{
+				issues:       []ghissue.Issue{issue(201)},
+				openChildren: map[int]int{201: 3},
+				store:        state.Store{Panes: []state.Pane{{IssueNum: 900, PaneID: "%live"}}},
+				alive:        map[string]bool{"%live": true},
+			},
+			check: func(t *testing.T, report Report, fake *fakeWatchIO) {
+				t.Helper()
+				if len(report.Actions) != 1 || report.Actions[0].Kind != LaunchParent || report.Actions[0].Limit != 4 {
+					t.Fatalf("actions = %#v, want parent with limit 4", report.Actions)
+				}
+				if got, want := fake.parents, []parentLaunch{{num: 201, limit: 4}}; !slices.Equal(got, want) {
+					t.Fatalf("parent launches = %#v, want %#v", got, want)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			clock := &fakeClock{now: baseNow}
+			cfg := Config{
+				TriggerLabel: triggerLabel,
+				RunningLabel: runningLabel,
+				Now:          clock.Now,
+				MaxSessions:  tt.cfg.MaxSessions,
+			}
+			engine := NewEngine(cfg, tt.fake.IO())
+			report, err := engine.RunCycle()
+			if tt.wantError && err == nil {
+				t.Fatal("RunCycle error = nil, want error")
+			}
+			if !tt.wantError && err != nil {
+				t.Fatalf("RunCycle error = %v", err)
+			}
+			tt.check(t, report, tt.fake)
+		})
+	}
+}
+
+func TestRunCycleDisablesAfterThreeConsecutiveLaunchFailures(t *testing.T) {
+	baseNow := time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)
+	clock := &fakeClock{now: baseNow}
+	fake := &fakeWatchIO{
+		issues:        []ghissue.Issue{issue(101)},
+		openChildren:  map[int]int{101: 0},
+		standaloneErr: map[int]error{101: errors.New("launch failed")},
+	}
+	engine := NewEngine(Config{
+		TriggerLabel: triggerLabel,
+		RunningLabel: runningLabel,
+		Now:          clock.Now,
+	}, fake.IO())
+
+	first, err := engine.RunCycle()
+	if err != nil {
+		t.Fatalf("first RunCycle error = %v", err)
+	}
+	assertFailure(t, first, 101, FailureLaunch, 1, false)
+
+	clock.Advance(60 * time.Second)
+	second, err := engine.RunCycle()
+	if err != nil {
+		t.Fatalf("second RunCycle error = %v", err)
+	}
+	assertFailure(t, second, 101, FailureLaunch, 2, false)
+
+	clock.Advance(120 * time.Second)
+	third, err := engine.RunCycle()
+	if err != nil {
+		t.Fatalf("third RunCycle error = %v", err)
+	}
+	assertFailure(t, third, 101, FailureLaunch, 3, true)
+
+	clock.Advance(time.Hour)
+	fake.standalone = nil
+	fake.swaps = nil
+	fourth, err := engine.RunCycle()
+	if err != nil {
+		t.Fatalf("fourth RunCycle error = %v", err)
+	}
+	assertSkipReasons(t, fourth, []SkipReason{SkipDisabled})
+	assertInts(t, "standalone launches after disable", fake.standalone, nil)
+	assertSwaps(t, fake.swaps, nil)
+}
+
+func TestPlanCycleDefersDuringBackoff(t *testing.T) {
+	baseNow := time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)
+	clock := &fakeClock{now: baseNow}
+	fake := &fakeWatchIO{
+		issues:        []ghissue.Issue{issue(101)},
+		openChildren:  map[int]int{101: 0},
+		standaloneErr: map[int]error{101: errors.New("launch failed")},
+	}
+	engine := NewEngine(Config{
+		TriggerLabel: triggerLabel,
+		RunningLabel: runningLabel,
+		Now:          clock.Now,
+	}, fake.IO())
+
+	if _, err := engine.RunCycle(); err != nil {
+		t.Fatalf("RunCycle error = %v", err)
+	}
+	fake.standalone = nil
+	fake.swaps = nil
+
+	report, err := engine.PlanCycle()
+	if err != nil {
+		t.Fatalf("PlanCycle error = %v", err)
+	}
+	if len(report.Deferred) != 1 || report.Deferred[0].Reason != DeferBackoff {
+		t.Fatalf("deferred = %#v, want one backoff", report.Deferred)
+	}
+	if got, want := report.Deferred[0].RetryAfter, 60*time.Second; got != want {
+		t.Fatalf("retry after = %s, want %s", got, want)
+	}
+	assertInts(t, "standalone launches during backoff", fake.standalone, nil)
+	assertSwaps(t, fake.swaps, nil)
+}
+
+func issue(num int, labels ...string) ghissue.Issue {
+	issue := ghissue.Issue{Number: num, Title: "issue", State: "OPEN"}
+	for _, label := range labels {
+		issue.Labels = append(issue.Labels, ghissue.Label{Name: label})
+	}
+	return issue
+}
+
+func assertFailure(t *testing.T, report Report, num int, stage FailureStage, attempts int, disabled bool) Failure {
+	t.Helper()
+	for _, failure := range report.Failures {
+		if failure.Issue.Number == num && failure.Stage == stage {
+			if failure.Attempts != attempts {
+				t.Fatalf("failure attempts = %d, want %d in %#v", failure.Attempts, attempts, failure)
+			}
+			if failure.Disabled != disabled {
+				t.Fatalf("failure disabled = %v, want %v in %#v", failure.Disabled, disabled, failure)
+			}
+			return failure
+		}
+	}
+	t.Fatalf("missing failure issue #%d stage %s in %#v", num, stage, report.Failures)
+	return Failure{}
+}
+
+func assertInts(t *testing.T, name string, got, want []int) {
+	t.Helper()
+	if got == nil {
+		got = []int{}
+	}
+	if want == nil {
+		want = []int{}
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("%s = %#v, want %#v", name, got, want)
+	}
+}
+
+func assertSwaps(t *testing.T, got, want []swapCall) {
+	t.Helper()
+	if got == nil {
+		got = []swapCall{}
+	}
+	if want == nil {
+		want = []swapCall{}
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("swaps = %#v, want %#v", got, want)
+	}
+}
+
+func assertSkipReasons(t *testing.T, report Report, want []SkipReason) {
+	t.Helper()
+	got := make([]SkipReason, len(report.Skipped))
+	for i, skip := range report.Skipped {
+		got[i] = skip.Reason
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("skip reasons = %#v, want %#v", got, want)
+	}
+}

--- a/internal/watch/engine_test.go
+++ b/internal/watch/engine_test.go
@@ -28,10 +28,11 @@ func (c *fakeClock) Advance(d time.Duration) {
 }
 
 type fakeWatchIO struct {
-	issues       []ghissue.Issue
-	store        state.Store
-	openChildren map[int]int
-	alive        map[string]bool
+	issues        []ghissue.Issue
+	runningIssues []ghissue.Issue
+	store         state.Store
+	openChildren  map[int]int
+	alive         map[string]bool
 
 	swapErr        map[swapKey]error
 	standaloneErr  map[int]error
@@ -64,10 +65,14 @@ type parentLaunch struct {
 func (f *fakeWatchIO) IO() IO {
 	return IO{
 		ListLabeled: func(label string) ([]ghissue.Issue, error) {
-			if label != triggerLabel {
+			switch label {
+			case triggerLabel:
+				return slices.Clone(f.issues), nil
+			case runningLabel:
+				return slices.Clone(f.runningIssues), nil
+			default:
 				return nil, errors.New("unexpected label")
 			}
-			return slices.Clone(f.issues), nil
 		},
 		CountOpenChildren: func(issue ghissue.Issue) (int, error) {
 			f.countCalls = append(f.countCalls, issue.Number)
@@ -275,6 +280,191 @@ func TestRunCycleTableDriven(t *testing.T) {
 			}
 			tt.check(t, report, tt.fake)
 		})
+	}
+}
+
+func TestRunCycleRetriesDeferredParentWhenRequeueSwapFails(t *testing.T) {
+	baseNow := time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)
+	fake := &fakeWatchIO{
+		issues:         []ghissue.Issue{issue(301)},
+		openChildren:   map[int]int{301: 3},
+		parentDeferred: map[int]bool{301: true},
+		swapErr: map[swapKey]error{
+			{num: 301, remove: runningLabel, add: triggerLabel}: errors.New("requeue failed"),
+		},
+	}
+	engine := NewEngine(Config{
+		TriggerLabel: triggerLabel,
+		RunningLabel: runningLabel,
+		Now:          (&fakeClock{now: baseNow}).Now,
+	}, fake.IO())
+
+	first, err := engine.RunCycle()
+	if err != nil {
+		t.Fatalf("first RunCycle error = %v", err)
+	}
+	assertSwaps(t, fake.swaps, []swapCall{
+		{num: 301, remove: triggerLabel, add: runningLabel},
+		{num: 301, remove: runningLabel, add: triggerLabel},
+	})
+	if len(first.Deferred) != 1 || first.Deferred[0].Reason != DeferMaxSessions {
+		t.Fatalf("first deferred = %#v, want max_sessions", first.Deferred)
+	}
+	assertFailure(t, first, 301, FailureSwapLabels, 0, false)
+
+	fake.issues = nil
+	fake.runningIssues = []ghissue.Issue{issue(301, runningLabel)}
+	fake.openChildren[301] = 1
+	fake.parentDeferred[301] = false
+	fake.swapErr = nil
+	fake.countCalls = nil
+	fake.swaps = nil
+	fake.parents = nil
+
+	second, err := engine.RunCycle()
+	if err != nil {
+		t.Fatalf("second RunCycle error = %v", err)
+	}
+	assertInts(t, "count calls on retry", fake.countCalls, []int{301})
+	assertSwaps(t, fake.swaps, nil)
+	if got, want := fake.parents, []parentLaunch{{num: 301, limit: 0}}; !slices.Equal(got, want) {
+		t.Fatalf("parent retry launches = %#v, want %#v", got, want)
+	}
+	if len(second.Actions) != 1 || !second.Actions[0].RetryRunningParent {
+		t.Fatalf("second actions = %#v, want running-label retry", second.Actions)
+	}
+	if len(second.Failures) != 0 || len(second.Deferred) != 0 || len(second.Launched) != 1 {
+		t.Fatalf("second report = %#v, want one clean launch", second)
+	}
+
+	fake.countCalls = nil
+	fake.parents = nil
+
+	third, err := engine.RunCycle()
+	if err != nil {
+		t.Fatalf("third RunCycle error = %v", err)
+	}
+	if len(third.Actions) != 0 || len(fake.parents) != 0 {
+		t.Fatalf("third retry persisted: report=%#v parents=%#v", third, fake.parents)
+	}
+}
+
+func TestRunCycleAcquiresTriggerLabeledParentRetry(t *testing.T) {
+	baseNow := time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)
+	fake := &fakeWatchIO{
+		issues:         []ghissue.Issue{issue(301)},
+		openChildren:   map[int]int{301: 3},
+		parentDeferred: map[int]bool{301: true},
+		swapErr: map[swapKey]error{
+			{num: 301, remove: runningLabel, add: triggerLabel}: errors.New("requeue failed"),
+		},
+	}
+	engine := NewEngine(Config{
+		TriggerLabel: triggerLabel,
+		RunningLabel: runningLabel,
+		Now:          (&fakeClock{now: baseNow}).Now,
+	}, fake.IO())
+
+	if _, err := engine.RunCycle(); err != nil {
+		t.Fatalf("first RunCycle error = %v", err)
+	}
+
+	fake.issues = []ghissue.Issue{issue(301)}
+	fake.openChildren[301] = 1
+	fake.parentDeferred[301] = false
+	fake.swapErr = nil
+	fake.swaps = nil
+	fake.parents = nil
+
+	second, err := engine.RunCycle()
+	if err != nil {
+		t.Fatalf("second RunCycle error = %v", err)
+	}
+	assertSwaps(t, fake.swaps, []swapCall{{num: 301, remove: triggerLabel, add: runningLabel}})
+	if got, want := fake.parents, []parentLaunch{{num: 301, limit: 0}}; !slices.Equal(got, want) {
+		t.Fatalf("parent retry launches = %#v, want %#v", got, want)
+	}
+	if len(second.Actions) != 1 || second.Actions[0].RetryRunningParent {
+		t.Fatalf("second actions = %#v, want normal trigger acquisition", second.Actions)
+	}
+}
+
+func TestRunCycleAcquiresBothLabeledParentRetry(t *testing.T) {
+	baseNow := time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)
+	fake := &fakeWatchIO{
+		issues:         []ghissue.Issue{issue(301)},
+		openChildren:   map[int]int{301: 3},
+		parentDeferred: map[int]bool{301: true},
+		swapErr: map[swapKey]error{
+			{num: 301, remove: runningLabel, add: triggerLabel}: errors.New("requeue failed"),
+		},
+	}
+	engine := NewEngine(Config{
+		TriggerLabel: triggerLabel,
+		RunningLabel: runningLabel,
+		Now:          (&fakeClock{now: baseNow}).Now,
+	}, fake.IO())
+
+	if _, err := engine.RunCycle(); err != nil {
+		t.Fatalf("first RunCycle error = %v", err)
+	}
+
+	fake.issues = []ghissue.Issue{issue(301, runningLabel)}
+	fake.openChildren[301] = 1
+	fake.parentDeferred[301] = false
+	fake.swapErr = nil
+	fake.swaps = nil
+	fake.parents = nil
+
+	second, err := engine.RunCycle()
+	if err != nil {
+		t.Fatalf("second RunCycle error = %v", err)
+	}
+	assertSwaps(t, fake.swaps, []swapCall{{num: 301, remove: triggerLabel, add: runningLabel}})
+	if got, want := fake.parents, []parentLaunch{{num: 301, limit: 0}}; !slices.Equal(got, want) {
+		t.Fatalf("parent retry launches = %#v, want %#v", got, want)
+	}
+	if len(second.Skipped) != 0 || len(second.Actions) != 1 || second.Actions[0].RetryRunningParent {
+		t.Fatalf("second report = %#v, want normal acquisition retry", second)
+	}
+}
+
+func TestRunCycleIgnoresStaleHiddenParentRetry(t *testing.T) {
+	baseNow := time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)
+	fake := &fakeWatchIO{
+		issues:         []ghissue.Issue{issue(301)},
+		openChildren:   map[int]int{301: 3},
+		parentDeferred: map[int]bool{301: true},
+		swapErr: map[swapKey]error{
+			{num: 301, remove: runningLabel, add: triggerLabel}: errors.New("requeue failed"),
+		},
+	}
+	engine := NewEngine(Config{
+		TriggerLabel: triggerLabel,
+		RunningLabel: runningLabel,
+		Now:          (&fakeClock{now: baseNow}).Now,
+	}, fake.IO())
+
+	if _, err := engine.RunCycle(); err != nil {
+		t.Fatalf("first RunCycle error = %v", err)
+	}
+
+	fake.issues = nil
+	fake.runningIssues = nil
+	fake.openChildren[301] = 1
+	fake.parentDeferred[301] = false
+	fake.swapErr = nil
+	fake.countCalls = nil
+	fake.swaps = nil
+	fake.parents = nil
+
+	second, err := engine.RunCycle()
+	if err != nil {
+		t.Fatalf("second RunCycle error = %v", err)
+	}
+	if len(second.Actions) != 0 || len(fake.parents) != 0 || len(fake.countCalls) != 0 || len(fake.swaps) != 0 {
+		t.Fatalf("second report = %#v calls=%#v swaps=%#v parents=%#v, want stale retry ignored",
+			second, fake.countCalls, fake.swaps, fake.parents)
 	}
 }
 

--- a/internal/watch/engine_test.go
+++ b/internal/watch/engine_test.go
@@ -33,9 +33,10 @@ type fakeWatchIO struct {
 	openChildren map[int]int
 	alive        map[string]bool
 
-	swapErr       map[swapKey]error
-	standaloneErr map[int]error
-	parentErr     map[int]error
+	swapErr        map[swapKey]error
+	standaloneErr  map[int]error
+	parentErr      map[int]error
+	parentDeferred map[int]bool
 
 	countCalls []int
 	swaps      []swapCall
@@ -86,9 +87,9 @@ func (f *fakeWatchIO) IO() IO {
 			f.standalone = append(f.standalone, issue.Number)
 			return f.standaloneErr[issue.Number]
 		},
-		LaunchParent: func(issue ghissue.Issue, limit int) error {
+		LaunchParent: func(issue ghissue.Issue, limit int) (ParentLaunchResult, error) {
 			f.parents = append(f.parents, parentLaunch{num: issue.Number, limit: limit})
-			return f.parentErr[issue.Number]
+			return ParentLaunchResult{Deferred: f.parentDeferred[issue.Number]}, f.parentErr[issue.Number]
 		},
 	}
 }
@@ -140,10 +141,10 @@ func TestRunCycleTableDriven(t *testing.T) {
 			},
 		},
 		{
-			name: "idempotency skips issue number and issue-backed worktree fallback",
+			name: "idempotency skips standalone rows across all parents",
 			fake: &fakeWatchIO{
-				issues:       []ghissue.Issue{issue(101), issue(102), issue(103)},
-				openChildren: map[int]int{103: 0},
+				issues:       []ghissue.Issue{issue(101), issue(102), issue(103), issue(104)},
+				openChildren: map[int]int{101: 0, 102: 0, 103: 0, 104: 0},
 				store: state.Store{Panes: []state.Pane{
 					{Parent: "900", IssueNum: 101, PaneID: "%1"},
 					{Parent: "901", IssueNum: 999, Slug: "api-client-102", WorktreePath: "/repo/.fanout/worktrees/api-client-102"},
@@ -152,9 +153,29 @@ func TestRunCycleTableDriven(t *testing.T) {
 			},
 			check: func(t *testing.T, report Report, fake *fakeWatchIO) {
 				t.Helper()
-				assertInts(t, "count calls", fake.countCalls, []int{103})
-				assertInts(t, "standalone launches", fake.standalone, []int{103})
+				assertInts(t, "count calls", fake.countCalls, []int{101, 102, 103, 104})
+				assertInts(t, "standalone launches", fake.standalone, []int{103, 104})
 				assertSkipReasons(t, report, []SkipReason{SkipAlreadyFanned, SkipAlreadyFanned})
+			},
+		},
+		{
+			name: "parent fanout ignores child issue false positive",
+			fake: &fakeWatchIO{
+				issues:       []ghissue.Issue{issue(201), issue(202)},
+				openChildren: map[int]int{201: 2, 202: 2},
+				store: state.Store{Panes: []state.Pane{
+					{Parent: "0201", IssueNum: 301, PaneID: "%1"},
+					{Parent: "201", IssueNum: 302, PaneID: "%2"},
+					{Parent: "900", IssueNum: 202, PaneID: "%3"},
+				}},
+			},
+			check: func(t *testing.T, report Report, fake *fakeWatchIO) {
+				t.Helper()
+				assertInts(t, "count calls", fake.countCalls, []int{201, 202})
+				if got, want := fake.parents, []parentLaunch{{num: 201, limit: 0}, {num: 202, limit: 0}}; !slices.Equal(got, want) {
+					t.Fatalf("parent launches = %#v, want %#v", got, want)
+				}
+				assertSkipReasons(t, report, nil)
 			},
 		},
 		{
@@ -204,17 +225,46 @@ func TestRunCycleTableDriven(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "parent exceeding remaining budget launches limited batch and keeps trigger label",
+			cfg:  Config{MaxSessions: 3},
+			fake: &fakeWatchIO{
+				issues:         []ghissue.Issue{issue(301)},
+				openChildren:   map[int]int{301: 3},
+				parentDeferred: map[int]bool{301: true},
+				store: state.Store{Panes: []state.Pane{
+					{Parent: "301", IssueNum: 401, PaneID: "%old"},
+					{Parent: "900", IssueNum: 900, PaneID: "%live"},
+				}},
+				alive: map[string]bool{"%live": true},
+			},
+			check: func(t *testing.T, report Report, fake *fakeWatchIO) {
+				t.Helper()
+				assertInts(t, "count calls", fake.countCalls, []int{301})
+				assertSwaps(t, fake.swaps, []swapCall{
+					{num: 301, remove: triggerLabel, add: runningLabel},
+					{num: 301, remove: runningLabel, add: triggerLabel},
+				})
+				if len(report.Deferred) != 1 || report.Deferred[0].Reason != DeferMaxSessions {
+					t.Fatalf("deferred = %#v, want max_sessions", report.Deferred)
+				}
+				if len(report.Actions) != 1 || report.Actions[0].Limit != 2 {
+					t.Fatalf("actions = %#v, want one parent launch with limit 2", report.Actions)
+				}
+				if got, want := fake.parents, []parentLaunch{{num: 301, limit: 2}}; !slices.Equal(got, want) {
+					t.Fatalf("parent launches = %#v, want %#v", got, want)
+				}
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			clock := &fakeClock{now: baseNow}
-			cfg := Config{
-				TriggerLabel: triggerLabel,
-				RunningLabel: runningLabel,
-				Now:          clock.Now,
-				MaxSessions:  tt.cfg.MaxSessions,
-			}
+			cfg := tt.cfg
+			cfg.TriggerLabel = triggerLabel
+			cfg.RunningLabel = runningLabel
+			cfg.Now = clock.Now
 			engine := NewEngine(cfg, tt.fake.IO())
 			report, err := engine.RunCycle()
 			if tt.wantError && err == nil {


### PR DESCRIPTION
**TL;DR**
Adds `internal/watch` as a pure planner and IO-injected watcher engine for trigger-label polling, launch planning, and launch execution. Review effort: 3.

```mermaid
flowchart LR
  A[ListLabeled] --> B[Engine.PlanCycle]
  C[LoadState + PaneAlive] --> B
  D[CountOpenChildren] --> B
  B --> E[SwapLabels trigger to running]
  E --> F{launch kind}
  F -->|standalone| G[LaunchStandalone]
  F -->|parent| H[LaunchParent with Limit]
  G --> I[Report]
  H --> I[Report]
```

**Why**
Issue #224 needs a watcher core that can be tested without tmux, GitHub, or settings dependencies. The engine keeps classification, idempotency, backoff, and max-session planning in a package that later CLI/TUI plumbing can call through injected IO.

**Changes by file**
<details>
<summary>Changed files</summary>

| File | What changed | Why |
| --- | --- | --- |
| `internal/watch/engine.go` | Adds `Config`, `IO`, `Engine`, `Report`, `PlanCycle`, and `RunCycle` with label swap, launch, revert, backoff, disable, idempotency, and max-session handling. | Provides the pure watcher planner/executor requested by #224 while depending only on `ghissue.Issue` and `state.Store`. |
| `internal/watch/engine_test.go` | Adds table-driven and focused unit tests for fail-closed swaps, launch rollback, parent versus standalone planning, state idempotency, worktree-name fallback, max-session deferral, backoff, and disable after repeated failures. | Locks the engine behavior before it is wired into runtime code. |

</details>

**Test plan**
- `go test ./internal/watch` passed.
- `make lint` passed.
- `make test` passed.
- `codex review --uncommitted` passed with no findings after the idempotency fallback fix.

Closes #224