### PR TITLE
feat(lifecycle): clear watcher running labels

### DIFF
--- a/cmd/fanout/lifecycle.go
+++ b/cmd/fanout/lifecycle.go
@@ -3,13 +3,15 @@ package main
 import (
 	"github.com/butaosuinu/fanout/internal/cliflags"
 	"github.com/butaosuinu/fanout/internal/exitcode"
+	"github.com/butaosuinu/fanout/internal/ghissue"
 	"github.com/butaosuinu/fanout/internal/hooks"
 	"github.com/butaosuinu/fanout/internal/lifecycle"
 	"github.com/butaosuinu/fanout/internal/log"
+	"github.com/butaosuinu/fanout/internal/settings"
 )
 
 func cmdClose(cfg *cliflags.Config, lg *log.Logger) exitcode.Code {
-	opts, code := lifecycleOptions("--close", lg)
+	opts, code := lifecycleOptions("--close", true, lg)
 	if code != exitcode.OK {
 		return code
 	}
@@ -17,7 +19,7 @@ func cmdClose(cfg *cliflags.Config, lg *log.Logger) exitcode.Code {
 }
 
 func cmdMerge(cfg *cliflags.Config, lg *log.Logger) exitcode.Code {
-	opts, code := lifecycleOptions("--merge", lg)
+	opts, code := lifecycleOptions("--merge", true, lg)
 	if code != exitcode.OK {
 		return code
 	}
@@ -25,21 +27,28 @@ func cmdMerge(cfg *cliflags.Config, lg *log.Logger) exitcode.Code {
 }
 
 func cmdCleanup(cfg *cliflags.Config, lg *log.Logger) exitcode.Code {
-	opts, code := lifecycleOptions("--cleanup", lg)
+	opts, code := lifecycleOptions("--cleanup", true, lg)
 	if code != exitcode.OK {
 		return code
 	}
 	return lifecycle.Cleanup(opts, cfg.ParentRef, lg)
 }
 
-func lifecycleOptions(mode string, lg *log.Logger) (lifecycle.Options, exitcode.Code) {
+func lifecycleOptions(mode string, removeWatcherRunningLabel bool, lg *log.Logger) (lifecycle.Options, exitcode.Code) {
 	rt, code := resolveStateRuntimeForMode(mode, lg)
 	if code != exitcode.OK {
 		return lifecycle.Options{}, code
 	}
-	return lifecycle.Options{
+	opts := lifecycle.Options{
 		ProjectRoot: rt.projectRoot,
 		StatePath:   rt.statePath,
 		Hooks:       hooks.LoadUserConfig(lg),
-	}, exitcode.OK
+	}
+	if removeWatcherRunningLabel {
+		resolvedSettings := settings.Resolve(rt.projectRoot, settings.CLIOverrides{}, lg.Warn)
+		gh := ghissue.Runner{Cwd: rt.projectRoot}
+		opts.WatcherRunningLabel = resolvedSettings.WatcherRunningLabel
+		opts.RemoveIssueLabel = gh.RemoveIssueLabel
+	}
+	return opts, exitcode.OK
 }

--- a/cmd/fanout/lifecycle_test.go
+++ b/cmd/fanout/lifecycle_test.go
@@ -103,6 +103,162 @@ printf '\n' >> "$TMUX_LOG"
 	}
 }
 
+func TestCmdCloseWarnsButKeepsOKWhenRunningLabelRemovalFails(t *testing.T) {
+	repo := initLifecycleRepo(t)
+	worktreePath := filepath.Join(repo, ".fanout", "worktrees", "close-child-101")
+	gitCmdTest(t, repo, "worktree", "add", "-b", "fanout/close-child-101", worktreePath, "HEAD")
+	tmuxLog := installLifecycleScript(t, "tmux", `#!/bin/sh
+printf '%s ' "$@" >> "$TMUX_LOG"
+printf '\n' >> "$TMUX_LOG"
+`)
+	ghLog := installFailingLabelRemovalGH(t)
+	t.Setenv("TMUX_LOG", tmuxLog)
+	t.Setenv("GH_LOG", ghLog)
+	t.Setenv("FANOUT_WATCHER_RUNNING_LABEL", "fanout:test-running")
+	writeLifecycleState(t, repo, state.Pane{
+		Parent:       "84",
+		IssueNum:     101,
+		Slug:         "close-child-101",
+		BranchName:   "fanout/close-child-101",
+		PaneID:       "%42",
+		WorktreePath: worktreePath,
+	})
+	t.Setenv(fanoutStatePathEnv, state.Path(repo))
+	var stderr bytes.Buffer
+	lg := log.NewWith(io.Discard, &stderr, false)
+
+	code := cmdClose(&cliflags.Config{ParentRef: "84", CloseNum: 101}, lg)
+
+	if code != exitcode.OK {
+		t.Fatalf("cmdClose code = %d, want %d; stderr=%s", code, exitcode.OK, stderr.String())
+	}
+	assertLifecycleGHLog(t, ghLog, "issue edit 84 --remove-label fanout:test-running")
+	if !strings.Contains(stderr.String(), `remove watcher running label "fanout:test-running"`) {
+		t.Fatalf("stderr = %q, want running label removal warning", stderr.String())
+	}
+}
+
+func TestCmdCloseWatcherStandaloneRemovesChildRunningLabel(t *testing.T) {
+	repo := initLifecycleRepo(t)
+	worktreePath := filepath.Join(repo, ".fanout", "worktrees", "close-child-101")
+	gitCmdTest(t, repo, "worktree", "add", "-b", "fanout/close-child-101", worktreePath, "HEAD")
+	tmuxLog := installLifecycleScript(t, "tmux", `#!/bin/sh
+printf '%s ' "$@" >> "$TMUX_LOG"
+printf '\n' >> "$TMUX_LOG"
+`)
+	ghLog := installFailingLabelRemovalGH(t)
+	t.Setenv("TMUX_LOG", tmuxLog)
+	t.Setenv("GH_LOG", ghLog)
+	t.Setenv("FANOUT_WATCHER_RUNNING_LABEL", "fanout:test-running")
+	writeLifecycleState(t, repo, state.Pane{
+		Parent:       "@watch",
+		IssueNum:     101,
+		Slug:         "close-child-101",
+		BranchName:   "fanout/close-child-101",
+		PaneID:       "%42",
+		WorktreePath: worktreePath,
+	})
+	t.Setenv(fanoutStatePathEnv, state.Path(repo))
+	var stderr bytes.Buffer
+	lg := log.NewWith(io.Discard, &stderr, false)
+
+	code := cmdClose(&cliflags.Config{ParentRef: "@watch", CloseNum: 101}, lg)
+
+	if code != exitcode.OK {
+		t.Fatalf("cmdClose code = %d, want %d; stderr=%s", code, exitcode.OK, stderr.String())
+	}
+	assertLifecycleGHLog(t, ghLog, "issue edit 101 --remove-label fanout:test-running")
+	if !strings.Contains(stderr.String(), `remove watcher running label "fanout:test-running"`) {
+		t.Fatalf("stderr = %q, want running label removal warning", stderr.String())
+	}
+}
+
+func TestCmdCloseKeepsParentRunningLabelWhenSiblingPaneRemains(t *testing.T) {
+	repo := initLifecycleRepo(t)
+	closedPath := filepath.Join(repo, ".fanout", "worktrees", "close-child-101")
+	openPath := filepath.Join(repo, ".fanout", "worktrees", "open-child-102")
+	gitCmdTest(t, repo, "worktree", "add", "-b", "fanout/close-child-101", closedPath, "HEAD")
+	gitCmdTest(t, repo, "worktree", "add", "-b", "fanout/open-child-102", openPath, "HEAD")
+	tmuxLog := installLifecycleScript(t, "tmux", `#!/bin/sh
+printf '%s ' "$@" >> "$TMUX_LOG"
+printf '\n' >> "$TMUX_LOG"
+`)
+	ghLog := installLifecycleScript(t, "gh", `#!/bin/sh
+printf '%s\n' "$*" >> "$GH_LOG"
+printf 'unexpected gh command: %s\n' "$*" >&2
+exit 64
+`)
+	t.Setenv("TMUX_LOG", tmuxLog)
+	t.Setenv("GH_LOG", ghLog)
+	t.Setenv("FANOUT_WATCHER_RUNNING_LABEL", "fanout:test-running")
+	writeLifecycleState(t, repo,
+		state.Pane{Parent: "84", IssueNum: 101, BranchName: "fanout/close-child-101", PaneID: "%101", WorktreePath: closedPath},
+		state.Pane{Parent: "84", IssueNum: 102, BranchName: "fanout/open-child-102", PaneID: "%102", WorktreePath: openPath},
+	)
+	t.Setenv(fanoutStatePathEnv, state.Path(repo))
+
+	code := cmdClose(&cliflags.Config{ParentRef: "84", CloseNum: 101}, discardLogger())
+
+	if code != exitcode.OK {
+		t.Fatalf("cmdClose code = %d, want %d", code, exitcode.OK)
+	}
+	if body, err := os.ReadFile(ghLog); err == nil && strings.TrimSpace(string(body)) != "" {
+		t.Fatalf("gh log = %q, want no label removal while sibling remains", body)
+	} else if err != nil && !os.IsNotExist(err) {
+		t.Fatalf("read gh log: %v", err)
+	}
+}
+
+func TestCmdCloseRemovesRunningLabelWhenPruneFails(t *testing.T) {
+	repo := initLifecycleRepo(t)
+	gitLog := installLifecycleScript(t, "git", `#!/bin/sh
+printf '%s\n' "$*" >> "$GIT_LOG"
+if [ "$1" = "-C" ]; then
+  shift 2
+fi
+case "$1 $2" in
+  "rev-parse --git-path")
+    printf '.git/info/exclude\n'
+    ;;
+  "worktree prune")
+    printf 'prune failed\n' >&2
+    exit 9
+    ;;
+  *)
+    printf 'unexpected git command: %s\n' "$*" >&2
+    exit 64
+    ;;
+esac
+`)
+	ghLog := installLifecycleScript(t, "gh", `#!/bin/sh
+printf '%s\n' "$*" >> "$GH_LOG"
+`)
+	t.Setenv("GIT_LOG", gitLog)
+	t.Setenv("GH_LOG", ghLog)
+	t.Setenv("FANOUT_WATCHER_RUNNING_LABEL", "fanout:test-running")
+	writeLifecycleState(t, repo, state.Pane{
+		Parent:     "84",
+		IssueNum:   101,
+		Slug:       "close-child-101",
+		BranchName: "fanout/close-child-101",
+	})
+	t.Setenv(fanoutStatePathEnv, state.Path(repo))
+
+	code := cmdClose(&cliflags.Config{ParentRef: "84", CloseNum: 101}, discardLogger())
+
+	if code != exitcode.Env {
+		t.Fatalf("cmdClose code = %d, want %d", code, exitcode.Env)
+	}
+	assertLifecycleGHLog(t, ghLog, "issue edit 84 --remove-label fanout:test-running")
+	loaded, err := state.LoadProject(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := loaded.Find("84", 101); ok {
+		t.Fatalf("closed issue #101 still present in state: %+v", loaded.Panes)
+	}
+}
+
 func TestCmdCloseShellPaneSkipsGitWorktreeRemoval(t *testing.T) {
 	repo := initLifecycleRepo(t)
 	gitLog := installLifecycleScript(t, "git", `#!/bin/sh
@@ -286,6 +442,42 @@ func TestCmdMergePreMergeHookBlocksFastForward(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "pre merge blocked") {
 		t.Fatalf("stderr = %q, want hook output", stderr.String())
+	}
+}
+
+func TestCmdMergeWarnsButKeepsOKWhenRunningLabelRemovalFails(t *testing.T) {
+	repo := initLifecycleRepo(t)
+	baseHead := gitTrimTest(t, repo, "rev-parse", "HEAD")
+	gitCmdTest(t, repo, "switch", "-c", "fanout/merge-child-101")
+	if err := os.WriteFile(filepath.Join(repo, "child.txt"), []byte("child\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmdTest(t, repo, "add", "child.txt")
+	gitCmdTest(t, repo, "commit", "-m", "child")
+	childHead := gitTrimTest(t, repo, "rev-parse", "HEAD")
+	gitCmdTest(t, repo, "switch", "main")
+	if got := gitTrimTest(t, repo, "rev-parse", "HEAD"); got != baseHead {
+		t.Fatalf("main HEAD before merge = %s, want base %s", got, baseHead)
+	}
+	ghLog := installFailingLabelRemovalGH(t)
+	t.Setenv("GH_LOG", ghLog)
+	t.Setenv("FANOUT_WATCHER_RUNNING_LABEL", "fanout:test-running")
+	writeLifecycleState(t, repo, state.Pane{Parent: "84", IssueNum: 101, BranchName: "fanout/merge-child-101"})
+	t.Setenv(fanoutStatePathEnv, state.Path(repo))
+	var stderr bytes.Buffer
+	lg := log.NewWith(io.Discard, &stderr, false)
+
+	code := cmdMerge(&cliflags.Config{ParentRef: "84", MergeNum: 101}, lg)
+
+	if code != exitcode.OK {
+		t.Fatalf("cmdMerge code = %d, want %d; stderr=%s", code, exitcode.OK, stderr.String())
+	}
+	if got := gitTrimTest(t, repo, "rev-parse", "HEAD"); got != childHead {
+		t.Fatalf("main HEAD after merge = %s, want child %s", got, childHead)
+	}
+	assertLifecycleGHLog(t, ghLog, "issue edit 84 --remove-label fanout:test-running")
+	if !strings.Contains(stderr.String(), `remove watcher running label "fanout:test-running"`) {
+		t.Fatalf("stderr = %q, want running label removal warning", stderr.String())
 	}
 }
 
@@ -555,6 +747,58 @@ esac
 	}
 }
 
+func TestCmdCleanupWarnsButKeepsOKWhenRunningLabelRemovalFails(t *testing.T) {
+	repo := initLifecycleRepo(t)
+	closedPath := filepath.Join(repo, ".fanout", "worktrees", "closed-child-101")
+	gitCmdTest(t, repo, "worktree", "add", "-b", "fanout/closed-child-101", closedPath, "HEAD")
+	tmuxLog := installLifecycleScript(t, "tmux", `#!/bin/sh
+printf '%s ' "$@" >> "$TMUX_LOG"
+printf '\n' >> "$TMUX_LOG"
+`)
+	ghLog := installLifecycleScript(t, "gh", `#!/bin/sh
+printf '%s\n' "$*" >> "$GH_LOG"
+case "$1 $2" in
+  "repo view")
+    printf 'butaosuinu/fanout\n'
+    ;;
+  "api graphql")
+    printf '{"state":"OPEN","closedByPullRequestsReferences":{"pageInfo":{"hasNextPage":false,"endCursor":""},"nodes":[{"state":"MERGED"}]}}\n'
+    ;;
+  "issue edit")
+    printf 'label removal failed\n' >&2
+    exit 7
+    ;;
+  *)
+    printf 'unexpected gh command: %s\n' "$*" >&2
+    exit 64
+    ;;
+esac
+`)
+	t.Setenv("TMUX_LOG", tmuxLog)
+	t.Setenv("GH_LOG", ghLog)
+	t.Setenv("FANOUT_WATCHER_RUNNING_LABEL", "fanout:test-running")
+	writeLifecycleState(t, repo, state.Pane{
+		Parent:       "84",
+		IssueNum:     101,
+		BranchName:   "fanout/closed-child-101",
+		PaneID:       "%101",
+		WorktreePath: closedPath,
+	})
+	t.Setenv(fanoutStatePathEnv, state.Path(repo))
+	var stderr bytes.Buffer
+	lg := log.NewWith(io.Discard, &stderr, false)
+
+	code := cmdCleanup(&cliflags.Config{ParentRef: "84", CleanupMode: true}, lg)
+
+	if code != exitcode.OK {
+		t.Fatalf("cmdCleanup code = %d, want %d; stderr=%s", code, exitcode.OK, stderr.String())
+	}
+	assertLifecycleGHLog(t, ghLog, "issue edit 84 --remove-label fanout:test-running")
+	if !strings.Contains(stderr.String(), `remove watcher running label "fanout:test-running"`) {
+		t.Fatalf("stderr = %q, want running label removal warning", stderr.String())
+	}
+}
+
 func TestLifecycleCleanupPlanClosesOnlyTasksWithMergedBranchPR(t *testing.T) {
 	repo := initLifecycleRepo(t)
 	mergedPath := filepath.Join(repo, ".fanout", "worktrees", "api-client")
@@ -623,6 +867,7 @@ exit 1
 
 func initLifecycleRepo(t *testing.T) string {
 	t.Helper()
+	t.Setenv("FANOUT_WATCHER_RUNNING_LABEL", "")
 	repo := t.TempDir()
 	gitCmdTest(t, repo, "init", "-b", "main")
 	gitCmdTest(t, repo, "config", "user.email", "fanout@example.invalid")
@@ -673,6 +918,30 @@ func installLifecycleScript(t *testing.T, name, script string) string {
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	logPath := filepath.Join(t.TempDir(), name+".log")
 	return logPath
+}
+
+func installFailingLabelRemovalGH(t *testing.T) string {
+	t.Helper()
+	return installLifecycleScript(t, "gh", `#!/bin/sh
+printf '%s\n' "$*" >> "$GH_LOG"
+if [ "$1 $2" = "issue edit" ]; then
+  printf 'label removal failed\n' >&2
+  exit 7
+fi
+printf 'unexpected gh command: %s\n' "$*" >&2
+exit 64
+`)
+}
+
+func assertLifecycleGHLog(t *testing.T, path, want string) {
+	t.Helper()
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), want) {
+		t.Fatalf("gh log = %q, want %q", body, want)
+	}
 }
 
 func installLifecycleLivePaneTmuxScript(t *testing.T, paneID, path, title, shellKey string) string {

--- a/cmd/fanout/tui.go
+++ b/cmd/fanout/tui.go
@@ -63,15 +63,16 @@ func cmdTUI(commandName string, lg *log.Logger) exitcode.Code {
 	restoreTitle := markTUIRunning(projectRoot)
 	defer restoreTitle()
 	if err := fanouttui.Run(fanouttui.Options{
-		ProjectRoot:   projectRoot,
-		Session:       session,
-		StateInterval: 2 * time.Second,
-		GHInterval:    20 * time.Second,
-		DefaultAgent:  defaultTUIAgent(),
-		Hooks:         hookConfig,
-		LaunchPane:    newTUILaunchPaneFunc(projectRoot, session, commandName, hookConfig),
-		LaunchShell:   newTUILaunchShellFunc(projectRoot, session),
-		Notifier:      notifier,
+		ProjectRoot:         projectRoot,
+		Session:             session,
+		StateInterval:       2 * time.Second,
+		GHInterval:          20 * time.Second,
+		DefaultAgent:        defaultTUIAgent(),
+		WatcherRunningLabel: resolvedSettings.WatcherRunningLabel,
+		Hooks:               hookConfig,
+		LaunchPane:          newTUILaunchPaneFunc(projectRoot, session, commandName, hookConfig),
+		LaunchShell:         newTUILaunchShellFunc(projectRoot, session),
+		Notifier:            notifier,
 	}); err != nil {
 		lg.Err("tui: %v", err)
 		return exitcode.Env

--- a/internal/ghissue/ghissue.go
+++ b/internal/ghissue/ghissue.go
@@ -257,6 +257,12 @@ func (r Runner) SwapIssueLabels(num int, remove, add string) error {
 	return err
 }
 
+// RemoveIssueLabel removes label from one issue.
+func (r Runner) RemoveIssueLabel(num int, label string) error {
+	_, err := r.gh("issue", "edit", strconv.Itoa(num), "--remove-label", label)
+	return err
+}
+
 // EnsureLabel creates name when it is absent from the repository labels.
 func (r Runner) EnsureLabel(name string) error {
 	out, err := r.gh("label", "list", "--search", name, "--limit", "100", "--json", "name")

--- a/internal/ghissue/ghissue_test.go
+++ b/internal/ghissue/ghissue_test.go
@@ -175,6 +175,31 @@ func TestSwapIssueLabelsReturnsGHError(t *testing.T) {
 	}
 }
 
+func TestRemoveIssueLabelRunsSingleEdit(t *testing.T) {
+	argsPath := installFakeGH(t, ``)
+
+	if err := (Runner{}).RemoveIssueLabel(226, "fanout:running"); err != nil {
+		t.Fatal(err)
+	}
+
+	assertFakeGHArgs(t, argsPath, []string{
+		"issue", "edit", "226",
+		"--remove-label", "fanout:running",
+	})
+}
+
+func TestRemoveIssueLabelReturnsGHError(t *testing.T) {
+	installFakeGHWithResult(t, ``, `missing label`, 1)
+
+	err := (Runner{}).RemoveIssueLabel(226, "fanout:running")
+	if err == nil {
+		t.Fatal("RemoveIssueLabel() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "missing label") {
+		t.Fatalf("RemoveIssueLabel() error = %v", err)
+	}
+}
+
 func TestEnsureLabelSkipsCreateWhenPresent(t *testing.T) {
 	argsPath := installFakeGH(t, `[{"name":"fanout:running"}]`)
 

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/butaosuinu/fanout/internal/exitcode"
@@ -20,9 +21,11 @@ import (
 
 // Options points lifecycle operations at a concrete fanout state file.
 type Options struct {
-	ProjectRoot string
-	StatePath   string
-	Hooks       hooks.Config
+	ProjectRoot         string
+	StatePath           string
+	Hooks               hooks.Config
+	WatcherRunningLabel string
+	RemoveIssueLabel    func(issueNum int, label string) error
 }
 
 // Logger is the narrow logging surface lifecycle operations need.
@@ -39,6 +42,8 @@ type statusChild struct {
 	State       string
 	HasMergedPR bool
 }
+
+const watcherStandaloneParent = "@watch"
 
 // Close removes the recorded worktree(s), best-effort kills tmux pane(s), and
 // removes all state rows matching parent and issueNum.
@@ -67,6 +72,7 @@ func Close(opts Options, parent string, issueNum int, lg Logger) exitcode.Code {
 		lg.Err("#%d: remove fanout state: %v", issueNum, err)
 		return exitcode.Env
 	}
+	removeWatcherRunningLabelBestEffort(opts, parent, issueNum, locked.PanesForParent(parent), lg)
 	if hasManagedWorktree(panes) && !pruneWorktrees(opts.ProjectRoot, lg) {
 		return exitcode.Env
 	}
@@ -145,6 +151,7 @@ func Merge(opts Options, parent string, issueNum int, lg Logger) exitcode.Code {
 	}
 	runBackgroundHook(hooks.PostMerge, opts, pane, targetBranch, lg)
 	lg.Ok("#%d: merged %s with --ff-only", pane.IssueNum, pane.BranchName)
+	removeWatcherRunningLabelBestEffort(opts, parent, pane.IssueNum, remainingIssuePanesAfter(store.PanesForParent(parent), pane.IssueNum), lg)
 	return exitcode.OK
 }
 
@@ -231,6 +238,7 @@ func Cleanup(opts Options, parent string, lg Logger) exitcode.Code {
 			continue
 		}
 		closed++
+		removeWatcherRunningLabelBestEffort(opts, parent, issueNum, locked.PanesForParent(parent), lg)
 	}
 	if !pruneWorktrees(opts.ProjectRoot, lg) {
 		failed++
@@ -609,6 +617,58 @@ func taskPanesForParent(panes []state.Pane) []state.Pane {
 func branchHasMergedPR(prs []ghissue.PRRef) bool {
 	for _, pr := range prs {
 		if strings.EqualFold(pr.State, "MERGED") || pr.MergedAt != nil {
+			return true
+		}
+	}
+	return false
+}
+
+func removeWatcherRunningLabelBestEffort(opts Options, parent string, issueNum int, remainingParentPanes []state.Pane, lg Logger) {
+	issueNum, ok := watcherRunningLabelTarget(parent, issueNum, remainingParentPanes)
+	if !ok {
+		return
+	}
+	label := strings.TrimSpace(opts.WatcherRunningLabel)
+	remove := opts.RemoveIssueLabel
+	if label == "" || remove == nil {
+		return
+	}
+	if err := remove(issueNum, label); err != nil {
+		lg.Warn("#%d: remove watcher running label %q: %v", issueNum, label, err)
+	}
+}
+
+func watcherRunningLabelTarget(parent string, issueNum int, remainingParentPanes []state.Pane) (int, bool) {
+	if issueNum <= 0 {
+		return 0, false
+	}
+	if strings.TrimSpace(parent) == watcherStandaloneParent {
+		return issueNum, true
+	}
+	parentNum, err := strconv.Atoi(strings.TrimSpace(parent))
+	if err != nil || parentNum <= 0 {
+		return 0, false
+	}
+	if hasIssuePanes(remainingParentPanes) {
+		return 0, false
+	}
+	return parentNum, true
+}
+
+func remainingIssuePanesAfter(panes []state.Pane, issueNum int) []state.Pane {
+	remaining := make([]state.Pane, 0, len(panes))
+	for _, pane := range panes {
+		if pane.IssueNum == issueNum {
+			continue
+		}
+		remaining = append(remaining, pane)
+	}
+	return remaining
+}
+
+func hasIssuePanes(panes []state.Pane) bool {
+	for _, pane := range panes {
+		if pane.IssueNum > 0 {
 			return true
 		}
 	}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -47,21 +47,22 @@ const (
 
 // Options configures the TUI monitor.
 type Options struct {
-	ProjectRoot       string
-	Session           string
-	StateInterval     time.Duration
-	GHInterval        time.Duration
-	DefaultAgent      string
-	Hooks             hooks.Config
-	LaunchPane        LaunchFunc
-	LaunchShell       ShellLaunchFunc
-	FocusPane         func(string) error
-	PaneAlive         func(string) bool
-	ShellPaneAlive    func(paneID, shellKey string) bool
-	CapturePaneOutput func(string, int) (string, error)
-	Notifier          transitionNotifier
-	lifecycle         lifecycleRunner
-	keyboard          keyboardProtocols
+	ProjectRoot         string
+	Session             string
+	StateInterval       time.Duration
+	GHInterval          time.Duration
+	DefaultAgent        string
+	WatcherRunningLabel string
+	Hooks               hooks.Config
+	LaunchPane          LaunchFunc
+	LaunchShell         ShellLaunchFunc
+	FocusPane           func(string) error
+	PaneAlive           func(string) bool
+	ShellPaneAlive      func(paneID, shellKey string) bool
+	CapturePaneOutput   func(string, int) (string, error)
+	Notifier            transitionNotifier
+	lifecycle           lifecycleRunner
+	keyboard            keyboardProtocols
 }
 
 type issueKey struct {
@@ -1097,9 +1098,11 @@ func (m model) startPendingAction(action lifecycleAction) (tea.Model, tea.Cmd) {
 
 func (m model) lifecycleCmd(pending pendingLifecycleAction) tea.Cmd {
 	opts := lifecycle.Options{
-		ProjectRoot: m.opts.ProjectRoot,
-		StatePath:   state.Path(m.opts.ProjectRoot),
-		Hooks:       m.opts.Hooks,
+		ProjectRoot:         m.opts.ProjectRoot,
+		StatePath:           state.Path(m.opts.ProjectRoot),
+		Hooks:               m.opts.Hooks,
+		WatcherRunningLabel: m.opts.WatcherRunningLabel,
+		RemoveIssueLabel:    ghissue.Runner{Cwd: m.opts.ProjectRoot}.RemoveIssueLabel,
 	}
 	runner := m.opts.lifecycle
 	return func() tea.Msg {

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -1397,7 +1397,7 @@ func paneByIssue(t *testing.T, panes []paneView, issueNum int) paneView {
 
 func TestLifecycleCloseKeyConfirmsRunsAndRefreshes(t *testing.T) {
 	runner := &fakeLifecycleRunner{code: exitcode.OK}
-	m := newModel(Options{ProjectRoot: "/repo", lifecycle: runner})
+	m := newModel(Options{ProjectRoot: "/repo", WatcherRunningLabel: "fanout:test-running", lifecycle: runner})
 	m.allPanes = []paneView{{Parent: "84", IssueNum: 101, Name: "child"}}
 	m.refreshRows()
 
@@ -1432,6 +1432,9 @@ func TestLifecycleCloseKeyConfirmsRunsAndRefreshes(t *testing.T) {
 	}
 	if runner.projectRoot != "/repo" || runner.statePath != state.Path("/repo") {
 		t.Fatalf("Close opts = %q/%q, want project root and state path", runner.projectRoot, runner.statePath)
+	}
+	if runner.watcherRunningLabel != "fanout:test-running" {
+		t.Fatalf("Close watcherRunningLabel = %q, want fanout:test-running", runner.watcherRunningLabel)
 	}
 
 	updated, cmd = m.Update(msg)
@@ -1637,17 +1640,18 @@ func TestLifecycleRunningDefersQuitKeysUntilDone(t *testing.T) {
 }
 
 type fakeLifecycleRunner struct {
-	code              exitcode.Code
-	projectRoot       string
-	statePath         string
-	closeParent       string
-	closeIssue        int
-	closeTaskParent   string
-	closeTaskID       string
-	mergeTaskParent   string
-	mergeTaskID       string
-	cleanupParent     string
-	cleanupPlanParent string
+	code                exitcode.Code
+	projectRoot         string
+	statePath           string
+	closeParent         string
+	closeIssue          int
+	closeTaskParent     string
+	closeTaskID         string
+	mergeTaskParent     string
+	mergeTaskID         string
+	cleanupParent       string
+	cleanupPlanParent   string
+	watcherRunningLabel string
 }
 
 type fakeTransitionNotifier struct {
@@ -1663,6 +1667,7 @@ func (f *fakeTransitionNotifier) Notify(events []fanoutnotify.Event) error {
 func (f *fakeLifecycleRunner) Close(opts lifecycle.Options, parent string, issueNum int, lg lifecycle.Logger) exitcode.Code {
 	f.projectRoot = opts.ProjectRoot
 	f.statePath = opts.StatePath
+	f.watcherRunningLabel = opts.WatcherRunningLabel
 	f.closeParent = parent
 	f.closeIssue = issueNum
 	fmt.Fprintf(lg.Stderr(), "[ ok ] fake close\n")


### PR DESCRIPTION
## TL;DR
Remove the watcher running label after lifecycle close/merge/cleanup succeeds, while keeping GitHub label-removal failures best-effort.

Review effort: 2

## Why
Watcher launch moves candidate issues to `watcherRunningLabel`. Closing, merging, or cleanup could leave `fanout:running` behind. Parent fan-out stores child rows under the parent, so label cleanup targets the parent only after all child issue panes are gone; standalone `@watch` rows still target the child issue.

```mermaid
flowchart LR
  A[CLI or TUI lifecycle] --> B[internal/lifecycle success path]
  B --> C{state parent}
  C -->|watch task| D[remove running label from child issue]
  C -->|parent issue with no remaining child panes| E[remove running label from parent issue]
  D -.-> F[warn only on GitHub label removal failure]
  E -.-> F
```

## Changes by file
| File | Change |
|---|---|
| `cmd/fanout/lifecycle.go` | Resolves `watcherRunningLabel` for close/merge/cleanup and injects the GitHub label remover. |
| `cmd/fanout/lifecycle_test.go` | Adds regressions for best-effort warning behavior, parent vs `@watch` targets, sibling panes, and prune-failure cleanup. |
| `cmd/fanout/tui.go` | Passes the resolved watcher running label into the TUI. |
| `internal/ghissue/ghissue.go` | Adds `RemoveIssueLabel`. |
| `internal/ghissue/ghissue_test.go` | Covers the remove-label command and error propagation. |
| `internal/lifecycle/lifecycle.go` | Removes watcher running labels after successful lifecycle state transitions, preserving exit-code behavior. |
| `internal/tui/tui.go` | Threads label cleanup settings/remover into TUI lifecycle actions. |
| `internal/tui/tui_test.go` | Verifies TUI lifecycle actions receive the watcher running label. |

## Risk
Best-effort cleanup can add a warning when `gh issue edit --remove-label` fails; the lifecycle exit code is unchanged by label-removal failures.

## Test plan
- `go test ./cmd/fanout ./internal/lifecycle ./internal/tui ./internal/ghissue`
- `make test`
- `make lint`
- `git diff --check`
- `codex review --uncommitted`

## Footer
Closes #226
