### PR TITLE
feat(tui): wire watcher runner

### DIFF
--- a/cmd/fanout/tui.go
+++ b/cmd/fanout/tui.go
@@ -99,6 +99,7 @@ func newTUIWatcher(projectRoot, session, commandName string, resolvedSettings se
 	if err := gh.EnsureLabel(resolvedSettings.WatcherRunningLabel); err != nil {
 		return nil, 0, "", fmt.Errorf("ensure running label %q: %w", resolvedSettings.WatcherRunningLabel, err)
 	}
+	livePanes := &watchLivePaneCache{}
 	io := watch.IO{
 		ListLabeled: gh.ListOpenIssuesWithLabel,
 		CountOpenChildren: func(issue ghissue.Issue) (int, error) {
@@ -110,7 +111,7 @@ func newTUIWatcher(projectRoot, session, commandName string, resolvedSettings se
 		LoadState: func() (state.Store, error) {
 			return state.LoadProject(projectRoot)
 		},
-		PaneAlive: watchPaneAlive,
+		PaneAlive: livePanes.Alive,
 		LaunchStandalone: func(issue ghissue.Issue) error {
 			return launchWatchStandalone(projectRoot, session, commandName, resolvedSettings, hookConfig, issue)
 		},
@@ -124,7 +125,20 @@ func newTUIWatcher(projectRoot, session, commandName string, resolvedSettings se
 		MaxSessions:  resolvedSettings.WatcherMaxSessions,
 	}
 	interval := time.Duration(resolvedSettings.WatcherIntervalSeconds) * time.Second
-	return watch.NewEngine(cfg, io), interval, resolvedSettings.WatcherTriggerLabel, nil
+	return &tuiWatcher{engine: watch.NewEngine(cfg, io), livePanes: livePanes}, interval, resolvedSettings.WatcherTriggerLabel, nil
+}
+
+type tuiWatcher struct {
+	engine    *watch.Engine
+	livePanes *watchLivePaneCache
+}
+
+func (w *tuiWatcher) RunCycle() (watch.Report, error) {
+	if w == nil || w.engine == nil {
+		return watch.Report{}, fmt.Errorf("watcher is nil")
+	}
+	w.livePanes.Reset()
+	return w.engine.RunCycle()
 }
 
 func launchWatchStandalone(projectRoot, session, commandName string, resolvedSettings settings.Settings, hookConfig hooks.Config, issue ghissue.Issue) error {
@@ -168,11 +182,7 @@ func launchWatchParent(projectRoot, session, commandName string, resolvedSetting
 	if code := runWithRuntime(cfg, launchLogger, rt, commandName); code != exitcode.OK {
 		return watch.ParentLaunchResult{}, bufferedLaunchError(stdout, stderr, "launch parent")
 	}
-	deferred, err := watchParentHasRemainingTargets(projectRoot, cfg, gh)
-	if err != nil {
-		return watch.ParentLaunchResult{}, err
-	}
-	return watch.ParentLaunchResult{Deferred: deferred}, nil
+	return watchParentResultAfterLaunch(projectRoot, cfg, gh), nil
 }
 
 func newWatchLaunchConfig(resolvedSettings settings.Settings, parent, limit int) *cliflags.Config {
@@ -205,11 +215,27 @@ func countOpenChildTargets(gh ghissue.Runner, parent int) (int, error) {
 	return len(openIssues(loaded.Children)), nil
 }
 
-func watchPaneAlive(pane state.Pane) (bool, error) {
+type watchLivePaneCache struct {
+	list   func() ([]tmuxrun.LivePane, error)
+	loaded bool
+	panes  []tmuxrun.LivePane
+	err    error
+}
+
+func (c *watchLivePaneCache) Reset() {
+	if c == nil {
+		return
+	}
+	c.loaded = false
+	c.panes = nil
+	c.err = nil
+}
+
+func (c *watchLivePaneCache) Alive(pane state.Pane) (bool, error) {
 	if strings.TrimSpace(pane.PaneID) == "" {
 		return false, nil
 	}
-	panes, err := tmuxrun.ListLivePanes()
+	panes, err := c.load()
 	if err != nil {
 		return false, err
 	}
@@ -219,6 +245,21 @@ func watchPaneAlive(pane state.Pane) (bool, error) {
 		}
 	}
 	return false, nil
+}
+
+func (c *watchLivePaneCache) load() ([]tmuxrun.LivePane, error) {
+	if c == nil {
+		return tmuxrun.ListLivePanes()
+	}
+	if !c.loaded {
+		list := c.list
+		if list == nil {
+			list = tmuxrun.ListLivePanes
+		}
+		c.panes, c.err = list()
+		c.loaded = true
+	}
+	return c.panes, c.err
 }
 
 func watchPaneMatchesLive(pane state.Pane, live tmuxrun.LivePane) bool {
@@ -235,6 +276,16 @@ func watchPaneMatchesLive(pane state.Pane, live tmuxrun.LivePane) bool {
 	wt := filepath.Clean(worktree)
 	cp := filepath.Clean(live.CurrentPath)
 	return cp == wt || strings.HasPrefix(cp, wt+string(filepath.Separator))
+}
+
+func watchParentResultAfterLaunch(projectRoot string, cfg *cliflags.Config, gh ghissue.Runner) watch.ParentLaunchResult {
+	deferred, err := watchParentHasRemainingTargets(projectRoot, cfg, gh)
+	if err != nil {
+		// The parent fan-out already completed. Keep the parent retriable instead
+		// of reporting the completed launch as failed.
+		return watch.ParentLaunchResult{Deferred: true}
+	}
+	return watch.ParentLaunchResult{Deferred: deferred}
 }
 
 func watchParentHasRemainingTargets(projectRoot string, cfg *cliflags.Config, gh ghissue.Runner) (bool, error) {
@@ -267,7 +318,7 @@ func watchParentHasRemainingTargets(projectRoot string, cfg *cliflags.Config, gh
 			return stateName
 		},
 	)
-	return len(plan.Targets) > 0 || len(plan.LimitDeferred) > 0, nil
+	return len(plan.Targets) > 0 || len(plan.BlockedRows) > 0 || len(plan.LimitDeferred) > 0, nil
 }
 
 func loadWatchParentChildren(gh ghissue.Runner, parent int) (childLoadResult, error) {

--- a/cmd/fanout/tui.go
+++ b/cmd/fanout/tui.go
@@ -102,8 +102,8 @@ func newTUIWatcher(projectRoot, session, commandName string, resolvedSettings se
 	livePanes := &watchLivePaneCache{}
 	io := watch.IO{
 		ListLabeled: gh.ListOpenIssuesWithLabel,
-		CountOpenChildren: func(issue ghissue.Issue) (int, error) {
-			return countOpenChildTargets(gh, issue.Number)
+		CountChildren: func(issue ghissue.Issue) (watch.ChildCounts, error) {
+			return countWatchChildTargets(projectRoot, gh, issue.Number)
 		},
 		SwapLabels: func(issue ghissue.Issue, removeLabel, addLabel string) error {
 			return gh.SwapIssueLabels(issue.Number, removeLabel, addLabel)
@@ -145,7 +145,7 @@ func launchWatchStandalone(projectRoot, session, commandName string, resolvedSet
 	var stdout, stderr bytes.Buffer
 	launchLogger := log.NewWith(&stdout, &stderr, false)
 	cfg := newWatchLaunchConfig(resolvedSettings, issue.Number, 0)
-	_, recorder, code := loadRunState(cfg, projectRoot, launchLogger)
+	store, recorder, code := loadRunState(cfg, projectRoot, launchLogger)
 	if code != exitcode.OK {
 		return bufferedLaunchError(stdout, stderr, "load fanout state")
 	}
@@ -153,6 +153,9 @@ func launchWatchStandalone(projectRoot, session, commandName string, resolvedSet
 		defer func() {
 			_ = recorder.Unlock()
 		}()
+	}
+	if hasRecordedIssuePane(store, issue.Number) {
+		return nil
 	}
 	info := &fanoutruntime.Info{
 		Session:     session,
@@ -213,6 +216,19 @@ func countOpenChildTargets(gh ghissue.Runner, parent int) (int, error) {
 		return 0, err
 	}
 	return len(openIssues(loaded.Children)), nil
+}
+
+func countWatchChildTargets(projectRoot string, gh ghissue.Runner, parent int) (watch.ChildCounts, error) {
+	cfg := newWatchPlanConfig(parent, 0)
+	plan, err := buildWatchParentPlan(projectRoot, cfg, gh)
+	if err != nil {
+		return watch.ChildCounts{}, err
+	}
+	return watch.ChildCounts{
+		Open:       plan.OpenCount,
+		Launchable: len(plan.Targets),
+		Unfanned:   plan.UnfannedCount,
+	}, nil
 }
 
 type watchLivePaneCache struct {
@@ -292,18 +308,26 @@ func watchParentHasRemainingTargets(projectRoot string, cfg *cliflags.Config, gh
 	if cfg.Limit <= 0 {
 		return false, nil
 	}
-	loaded, err := loadWatchParentChildren(gh, cfg.Parent)
+	plan, err := buildWatchParentPlan(projectRoot, cfg, gh)
 	if err != nil {
 		return false, err
 	}
+	return len(plan.Targets) > 0 || len(plan.BlockedRows) > 0 || len(plan.LimitDeferred) > 0, nil
+}
+
+func buildWatchParentPlan(projectRoot string, cfg *cliflags.Config, gh ghissue.Runner) (Plan, error) {
+	loaded, err := loadWatchParentChildren(gh, cfg.Parent)
+	if err != nil {
+		return Plan{}, err
+	}
 	store, err := state.LoadProject(projectRoot)
 	if err != nil {
-		return false, fmt.Errorf("load fanout state: %w", err)
+		return Plan{}, fmt.Errorf("load fanout state: %w", err)
 	}
 	sameParentFanned := store.FannedNumbersForParent(cfg.ParentRef)
 	otherParentFanned := store.FannedNumbersForOtherParents(cfg.ParentRef)
 	worktreeFallbackFanned := existingWorktreeFanned(cfg, projectRoot, loaded.Children, otherParentFanned)
-	plan := buildPlan(
+	return buildPlan(
 		cfg,
 		loaded.Children,
 		mergeFanned(sameParentFanned, worktreeFallbackFanned),
@@ -317,23 +341,77 @@ func watchParentHasRemainingTargets(projectRoot string, cfg *cliflags.Config, gh
 			stateName, _ := gh.IssueState(num)
 			return stateName
 		},
-	)
-	return len(plan.Targets) > 0 || len(plan.BlockedRows) > 0 || len(plan.LimitDeferred) > 0, nil
+	), nil
 }
 
 func loadWatchParentChildren(gh ghissue.Runner, parent int) (childLoadResult, error) {
 	var stdout, stderr bytes.Buffer
 	lg := log.NewWith(&stdout, &stderr, false)
-	cfg := &cliflags.Config{
-		Parent:     parent,
-		ParentRef:  strconv.Itoa(parent),
-		ParentMode: cliflags.ModeIssue,
-	}
-	loaded, code := loadIssueChildren(cfg, gh, lg)
-	if code != exitcode.OK {
+	cfg := newWatchPlanConfig(parent, 0)
+	lg.Info("fetching sub-issues of #%d", cfg.Parent)
+	subIssues, err := gh.SubIssueList(cfg.Parent)
+	if err != nil {
+		lg.Err("sub-issues fetch failed: %v", err)
 		return childLoadResult{}, bufferedLaunchError(stdout, stderr, "load child issues")
 	}
-	return loaded, nil
+	parentBody, err := gh.ParentBody(cfg.Parent)
+	if err != nil {
+		lg.Err("parent body fetch failed: %v", err)
+		return childLoadResult{}, bufferedLaunchError(stdout, stderr, "load child issues")
+	}
+	bodyNums := ghissue.TaskListNumbers(parentBody)
+	loaded, added := mergeWatchExtraChildren(cfg, gh, subIssues, bodyNums, lg)
+	assignTaskListWaves(loaded, ghissue.TaskListWaves(parentBody))
+	if added > 0 {
+		lg.Info("parent body added %d extra child reference(s) not in sub-issue API", added)
+	}
+	return childLoadResult{
+		Children:       loaded,
+		ParentBody:     parentBody,
+		StrongChildren: issueSet(subIssues),
+		ChildNoun:      "sub-issues",
+	}, nil
+}
+
+func newWatchPlanConfig(parent, limit int) *cliflags.Config {
+	return &cliflags.Config{
+		Parent:        parent,
+		ParentRef:     strconv.Itoa(parent),
+		ParentMode:    cliflags.ModeIssue,
+		Limit:         limit,
+		UnblockedOnly: true,
+	}
+}
+
+func mergeWatchExtraChildren(cfg *cliflags.Config, gh ghissue.Runner, base []ghissue.Issue, bodyNums []int, lg *log.Logger) ([]ghissue.Issue, int) {
+	existing := map[int]bool{cfg.Parent: true}
+	for _, s := range base {
+		existing[s.Number] = true
+	}
+
+	var extra []ghissue.Issue
+	for _, num := range bodyNums {
+		if existing[num] {
+			continue
+		}
+		detail, err := gh.IssueDetail(num)
+		if err != nil {
+			lg.Warn("parent body references #%d but issue lookup failed; skipping", num)
+			continue
+		}
+		extra = append(extra, detail)
+		existing[num] = true
+	}
+	return ghissue.MergeExtra(base, extra), len(extra)
+}
+
+func hasRecordedIssuePane(store state.Store, issueNum int) bool {
+	for _, pane := range store.Panes {
+		if pane.IssueNum == issueNum {
+			return true
+		}
+	}
+	return false
 }
 
 func newTUILaunchPaneFunc(projectRoot, session, commandName string, hookConfig hooks.Config) fanouttui.LaunchFunc {

--- a/cmd/fanout/tui.go
+++ b/cmd/fanout/tui.go
@@ -8,12 +8,14 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/butaosuinu/fanout/internal/agent"
 	"github.com/butaosuinu/fanout/internal/cliflags"
 	"github.com/butaosuinu/fanout/internal/exitcode"
+	"github.com/butaosuinu/fanout/internal/ghissue"
 	"github.com/butaosuinu/fanout/internal/hooks"
 	"github.com/butaosuinu/fanout/internal/log"
 	fanoutnotify "github.com/butaosuinu/fanout/internal/notify"
@@ -22,6 +24,7 @@ import (
 	"github.com/butaosuinu/fanout/internal/state"
 	"github.com/butaosuinu/fanout/internal/tmuxrun"
 	fanouttui "github.com/butaosuinu/fanout/internal/tui"
+	"github.com/butaosuinu/fanout/internal/watch"
 	"github.com/butaosuinu/fanout/internal/worktree"
 )
 
@@ -49,6 +52,11 @@ func cmdTUI(commandName string, lg *log.Logger) exitcode.Code {
 	}
 	resolvedSettings := settings.Resolve(projectRoot, settings.CLIOverrides{}, lg.Warn)
 	hookConfig := hooks.LoadUserConfig(lg)
+	watcher, watchInterval, watchLabel, err := newTUIWatcher(projectRoot, session, commandName, resolvedSettings, hookConfig)
+	if err != nil {
+		lg.Err("watcher: %v", err)
+		return exitcode.Env
+	}
 	notifier, err := fanoutnotify.New(fanoutnotify.Config{
 		Channels:        resolvedSettings.Notifications,
 		TmuxTarget:      session,
@@ -67,6 +75,9 @@ func cmdTUI(commandName string, lg *log.Logger) exitcode.Code {
 		Session:             session,
 		StateInterval:       2 * time.Second,
 		GHInterval:          20 * time.Second,
+		Watcher:             watcher,
+		WatchInterval:       watchInterval,
+		WatchLabel:          watchLabel,
 		DefaultAgent:        defaultTUIAgent(),
 		WatcherRunningLabel: resolvedSettings.WatcherRunningLabel,
 		Hooks:               hookConfig,
@@ -78,6 +89,200 @@ func cmdTUI(commandName string, lg *log.Logger) exitcode.Code {
 		return exitcode.Env
 	}
 	return exitcode.OK
+}
+
+func newTUIWatcher(projectRoot, session, commandName string, resolvedSettings settings.Settings, hookConfig hooks.Config) (fanouttui.WatcherRunner, time.Duration, string, error) {
+	if !resolvedSettings.Watcher {
+		return nil, 0, "", nil
+	}
+	gh := ghissue.Runner{Cwd: projectRoot}
+	if err := gh.EnsureLabel(resolvedSettings.WatcherRunningLabel); err != nil {
+		return nil, 0, "", fmt.Errorf("ensure running label %q: %w", resolvedSettings.WatcherRunningLabel, err)
+	}
+	io := watch.IO{
+		ListLabeled: gh.ListOpenIssuesWithLabel,
+		CountOpenChildren: func(issue ghissue.Issue) (int, error) {
+			return countOpenChildTargets(gh, issue.Number)
+		},
+		SwapLabels: func(issue ghissue.Issue, removeLabel, addLabel string) error {
+			return gh.SwapIssueLabels(issue.Number, removeLabel, addLabel)
+		},
+		LoadState: func() (state.Store, error) {
+			return state.LoadProject(projectRoot)
+		},
+		PaneAlive: watchPaneAlive,
+		LaunchStandalone: func(issue ghissue.Issue) error {
+			return launchWatchStandalone(projectRoot, session, commandName, resolvedSettings, hookConfig, issue)
+		},
+		LaunchParent: func(issue ghissue.Issue, limit int) (watch.ParentLaunchResult, error) {
+			return launchWatchParent(projectRoot, session, commandName, resolvedSettings, issue, limit)
+		},
+	}
+	cfg := watch.Config{
+		TriggerLabel: resolvedSettings.WatcherTriggerLabel,
+		RunningLabel: resolvedSettings.WatcherRunningLabel,
+		MaxSessions:  resolvedSettings.WatcherMaxSessions,
+	}
+	interval := time.Duration(resolvedSettings.WatcherIntervalSeconds) * time.Second
+	return watch.NewEngine(cfg, io), interval, resolvedSettings.WatcherTriggerLabel, nil
+}
+
+func launchWatchStandalone(projectRoot, session, commandName string, resolvedSettings settings.Settings, hookConfig hooks.Config, issue ghissue.Issue) error {
+	var stdout, stderr bytes.Buffer
+	launchLogger := log.NewWith(&stdout, &stderr, false)
+	cfg := newWatchLaunchConfig(resolvedSettings, issue.Number, 0)
+	_, recorder, code := loadRunState(cfg, projectRoot, launchLogger)
+	if code != exitcode.OK {
+		return bufferedLaunchError(stdout, stderr, "load fanout state")
+	}
+	if recorder != nil {
+		defer func() {
+			_ = recorder.Unlock()
+		}()
+	}
+	info := &fanoutruntime.Info{
+		Session:     session,
+		Target:      tuiLaunchTarget(session),
+		ProjectRoot: projectRoot,
+	}
+	req := newWatchPaneRequest(cfg, projectRoot, issue, resolvedSettings, hookConfig)
+	if !createPane(cfg, launchLogger, info, req, recorder, log.Palette{}, commandName) {
+		return bufferedLaunchError(stdout, stderr, "create watch pane")
+	}
+	return nil
+}
+
+func launchWatchParent(projectRoot, session, commandName string, resolvedSettings settings.Settings, issue ghissue.Issue, limit int) (watch.ParentLaunchResult, error) {
+	gh := ghissue.Runner{Cwd: projectRoot}
+	var stdout, stderr bytes.Buffer
+	launchLogger := log.NewWith(&stdout, &stderr, false)
+	cfg := newWatchLaunchConfig(resolvedSettings, issue.Number, limit)
+	rt := &runtimeInfo{
+		info: &fanoutruntime.Info{
+			Session:     session,
+			Target:      tuiLaunchTarget(session),
+			ProjectRoot: projectRoot,
+		},
+		gh: gh,
+	}
+	if code := runWithRuntime(cfg, launchLogger, rt, commandName); code != exitcode.OK {
+		return watch.ParentLaunchResult{}, bufferedLaunchError(stdout, stderr, "launch parent")
+	}
+	deferred, err := watchParentHasRemainingTargets(projectRoot, cfg, gh)
+	if err != nil {
+		return watch.ParentLaunchResult{}, err
+	}
+	return watch.ParentLaunchResult{Deferred: deferred}, nil
+}
+
+func newWatchLaunchConfig(resolvedSettings settings.Settings, parent, limit int) *cliflags.Config {
+	return &cliflags.Config{
+		Parent:          parent,
+		ParentRef:       strconv.Itoa(parent),
+		ParentMode:      cliflags.ModeIssue,
+		Agent:           watcherAgent(resolvedSettings),
+		Limit:           limit,
+		SleepBetween:    cliflags.DefaultSleepBetween,
+		PopupTimeoutSec: cliflags.DefaultPopupTimeout,
+		ProjectStatus:   cliflags.DefaultProjectStatus,
+		Format:          cliflags.DefaultFormat,
+		UnblockedOnly:   true,
+	}
+}
+
+func watcherAgent(resolvedSettings settings.Settings) string {
+	if agentName := strings.TrimSpace(resolvedSettings.WatcherAgent); agentName != "" {
+		return agentName
+	}
+	return defaultTUIAgent()
+}
+
+func countOpenChildTargets(gh ghissue.Runner, parent int) (int, error) {
+	loaded, err := loadWatchParentChildren(gh, parent)
+	if err != nil {
+		return 0, err
+	}
+	return len(openIssues(loaded.Children)), nil
+}
+
+func watchPaneAlive(pane state.Pane) (bool, error) {
+	if strings.TrimSpace(pane.PaneID) == "" {
+		return false, nil
+	}
+	panes, err := tmuxrun.ListLivePanes()
+	if err != nil {
+		return false, err
+	}
+	for _, live := range panes {
+		if watchPaneMatchesLive(pane, live) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func watchPaneMatchesLive(pane state.Pane, live tmuxrun.LivePane) bool {
+	if pane.PaneID != live.ID {
+		return false
+	}
+	if pane.IsShell() {
+		return pane.ShellKey != "" && pane.ShellKey == live.ShellKey
+	}
+	worktree := strings.TrimSpace(pane.WorktreePath)
+	if worktree == "" {
+		return true
+	}
+	wt := filepath.Clean(worktree)
+	cp := filepath.Clean(live.CurrentPath)
+	return cp == wt || strings.HasPrefix(cp, wt+string(filepath.Separator))
+}
+
+func watchParentHasRemainingTargets(projectRoot string, cfg *cliflags.Config, gh ghissue.Runner) (bool, error) {
+	if cfg.Limit <= 0 {
+		return false, nil
+	}
+	loaded, err := loadWatchParentChildren(gh, cfg.Parent)
+	if err != nil {
+		return false, err
+	}
+	store, err := state.LoadProject(projectRoot)
+	if err != nil {
+		return false, fmt.Errorf("load fanout state: %w", err)
+	}
+	sameParentFanned := store.FannedNumbersForParent(cfg.ParentRef)
+	otherParentFanned := store.FannedNumbersForOtherParents(cfg.ParentRef)
+	worktreeFallbackFanned := existingWorktreeFanned(cfg, projectRoot, loaded.Children, otherParentFanned)
+	plan := buildPlan(
+		cfg,
+		loaded.Children,
+		mergeFanned(sameParentFanned, worktreeFallbackFanned),
+		loaded.ParentBody,
+		func(issue *ghissue.Issue) {
+			// Match runWithRuntime: a hydration failure degrades blocker checks
+			// for this recomputation but should not make a completed launch fail.
+			_ = gh.HydrateBodyLabels(issue)
+		},
+		func(num int) string {
+			stateName, _ := gh.IssueState(num)
+			return stateName
+		},
+	)
+	return len(plan.Targets) > 0 || len(plan.LimitDeferred) > 0, nil
+}
+
+func loadWatchParentChildren(gh ghissue.Runner, parent int) (childLoadResult, error) {
+	var stdout, stderr bytes.Buffer
+	lg := log.NewWith(&stdout, &stderr, false)
+	cfg := &cliflags.Config{
+		Parent:     parent,
+		ParentRef:  strconv.Itoa(parent),
+		ParentMode: cliflags.ModeIssue,
+	}
+	loaded, code := loadIssueChildren(cfg, gh, lg)
+	if code != exitcode.OK {
+		return childLoadResult{}, bufferedLaunchError(stdout, stderr, "load child issues")
+	}
+	return loaded, nil
 }
 
 func newTUILaunchPaneFunc(projectRoot, session, commandName string, hookConfig hooks.Config) fanouttui.LaunchFunc {

--- a/cmd/fanout/tui.go
+++ b/cmd/fanout/tui.go
@@ -155,7 +155,7 @@ func launchWatchStandalone(projectRoot, session, commandName string, resolvedSet
 		}()
 	}
 	if hasRecordedIssuePane(store, issue.Number) {
-		return nil
+		return watch.ErrAlreadyFanned
 	}
 	info := &fanoutruntime.Info{
 		Session:     session,
@@ -305,9 +305,6 @@ func watchParentResultAfterLaunch(projectRoot string, cfg *cliflags.Config, gh g
 }
 
 func watchParentHasRemainingTargets(projectRoot string, cfg *cliflags.Config, gh ghissue.Runner) (bool, error) {
-	if cfg.Limit <= 0 {
-		return false, nil
-	}
 	plan, err := buildWatchParentPlan(projectRoot, cfg, gh)
 	if err != nil {
 		return false, err

--- a/cmd/fanout/tui_test.go
+++ b/cmd/fanout/tui_test.go
@@ -7,8 +7,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/butaosuinu/fanout/internal/cliflags"
+	"github.com/butaosuinu/fanout/internal/ghissue"
 	"github.com/butaosuinu/fanout/internal/hooks"
 	"github.com/butaosuinu/fanout/internal/state"
+	"github.com/butaosuinu/fanout/internal/tmuxrun"
 	fanouttui "github.com/butaosuinu/fanout/internal/tui"
 )
 
@@ -151,6 +154,160 @@ func TestLaunchShellPaneFromTUIRecordsShellState(t *testing.T) {
 	}
 }
 
+func TestCountOpenChildTargetsIncludesTaskListRefs(t *testing.T) {
+	installTUIWatcherGHScript(t, `
+case "$args" in
+"api --paginate --slurp repos/{owner}/{repo}/issues/500/sub_issues?per_page=100")
+  printf '[[]]'
+  ;;
+"issue view 500 --json body -q .body")
+  printf '%s\n' '- [ ] #501 task child' '- [ ] #502 closed child'
+  ;;
+"issue view 501 --json number,title,state,body,labels")
+  printf '{"number":501,"title":"task child","state":"OPEN","body":"","labels":[]}'
+  ;;
+"issue view 502 --json number,title,state,body,labels")
+  printf '{"number":502,"title":"closed child","state":"CLOSED","body":"","labels":[]}'
+  ;;
+*)
+  printf 'unexpected gh args: %s\n' "$args" >&2
+  exit 64
+  ;;
+esac
+`)
+
+	got, err := countOpenChildTargets(ghissue.Runner{}, 500)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != 1 {
+		t.Fatalf("countOpenChildTargets() = %d, want one OPEN task-list child", got)
+	}
+}
+
+func TestWatchPaneMatchesLiveRequiresWorktreeMatch(t *testing.T) {
+	pane := state.Pane{
+		PaneID:       "%1",
+		WorktreePath: "/repo/.fanout/worktrees/child-101",
+	}
+
+	if watchPaneMatchesLive(pane, tmuxrun.LivePane{ID: "%1", CurrentPath: "/repo/other"}) {
+		t.Fatal("watchPaneMatchesLive() = true for reused pane id in another worktree")
+	}
+	if !watchPaneMatchesLive(pane, tmuxrun.LivePane{ID: "%1", CurrentPath: "/repo/.fanout/worktrees/child-101/subdir"}) {
+		t.Fatal("watchPaneMatchesLive() = false for live pane under recorded worktree")
+	}
+	if watchPaneMatchesLive(pane, tmuxrun.LivePane{ID: "%2", CurrentPath: "/repo/.fanout/worktrees/child-101"}) {
+		t.Fatal("watchPaneMatchesLive() = true for different pane id")
+	}
+}
+
+func TestWatchPaneMatchesLiveRequiresShellKeyForShellRows(t *testing.T) {
+	pane := state.Pane{
+		Kind:         state.PaneKindShell,
+		PaneID:       "%1",
+		ShellKey:     "shell-root",
+		WorktreePath: "/repo",
+	}
+
+	if watchPaneMatchesLive(pane, tmuxrun.LivePane{ID: "%1", CurrentPath: "/repo", ShellKey: "other-shell"}) {
+		t.Fatal("watchPaneMatchesLive() = true for shell row with reused pane id")
+	}
+	if !watchPaneMatchesLive(pane, tmuxrun.LivePane{ID: "%1", CurrentPath: "/repo/elsewhere", ShellKey: "shell-root"}) {
+		t.Fatal("watchPaneMatchesLive() = false for shell row with matching shell key")
+	}
+}
+
+func TestWatchParentHasRemainingTargetsUsesPostLaunchPlan(t *testing.T) {
+	installTUIWatcherGHScript(t, `
+case "$args" in
+"api --paginate --slurp repos/{owner}/{repo}/issues/500/sub_issues?per_page=100")
+  printf '[[{"number":501,"title":"one","state":"open"},{"number":502,"title":"two","state":"open"}]]'
+  ;;
+"issue view 500 --json body -q .body")
+  ;;
+*)
+  printf 'unexpected gh args: %s\n' "$args" >&2
+  exit 64
+  ;;
+esac
+`)
+	repo := t.TempDir()
+	locked, err := state.LockProject(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = locked.RecordPane(state.Pane{Parent: "500", IssueNum: 501, Slug: "one-501", PaneID: "%1"}); err != nil {
+		t.Fatal(err)
+	}
+	if err = locked.RecordPane(state.Pane{Parent: "500", IssueNum: 502, Slug: "two-502", PaneID: "%2"}); err != nil {
+		t.Fatal(err)
+	}
+	if err = locked.Unlock(); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &cliflags.Config{
+		Parent:        500,
+		ParentRef:     "500",
+		ParentMode:    cliflags.ModeIssue,
+		Limit:         1,
+		UnblockedOnly: true,
+	}
+
+	deferred, err := watchParentHasRemainingTargets(repo, cfg, ghissue.Runner{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if deferred {
+		t.Fatal("watchParentHasRemainingTargets() = true, want false after all children are already fanned")
+	}
+}
+
+func TestWatchParentHasRemainingTargetsRequeuesAfterPartialLaunch(t *testing.T) {
+	installTUIWatcherGHScript(t, `
+case "$args" in
+"api --paginate --slurp repos/{owner}/{repo}/issues/500/sub_issues?per_page=100")
+  printf '[[{"number":501,"title":"one","state":"open"},{"number":502,"title":"two","state":"open"},{"number":503,"title":"three","state":"open"}]]'
+  ;;
+"issue view 500 --json body -q .body")
+  ;;
+*)
+  printf 'unexpected gh args: %s\n' "$args" >&2
+  exit 64
+  ;;
+esac
+`)
+	repo := t.TempDir()
+	locked, err := state.LockProject(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = locked.RecordPane(state.Pane{Parent: "500", IssueNum: 501, Slug: "one-501", PaneID: "%1"}); err != nil {
+		t.Fatal(err)
+	}
+	if err = locked.RecordPane(state.Pane{Parent: "500", IssueNum: 502, Slug: "two-502", PaneID: "%2"}); err != nil {
+		t.Fatal(err)
+	}
+	if err = locked.Unlock(); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &cliflags.Config{
+		Parent:        500,
+		ParentRef:     "500",
+		ParentMode:    cliflags.ModeIssue,
+		Limit:         1,
+		UnblockedOnly: true,
+	}
+
+	deferred, err := watchParentHasRemainingTargets(repo, cfg, ghissue.Runner{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !deferred {
+		t.Fatal("watchParentHasRemainingTargets() = false, want true while an unfanned child remains")
+	}
+}
+
 func initTUITestGitRepo(t *testing.T, dir string) {
 	t.Helper()
 	cmd := exec.Command("git", "init")
@@ -181,4 +338,22 @@ esac
 	}
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	t.Setenv("TMUX_SHIM_PANE_ID", paneID)
+}
+
+func installTUIWatcherGHScript(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	argsPath := filepath.Join(dir, "args")
+	script := filepath.Join(dir, "gh")
+	content := `#!/usr/bin/env bash
+set -euo pipefail
+args="$*"
+printf '%s\n' "$args" >> "$GH_FAKE_ARGS"
+` + body
+	if err := os.WriteFile(script, []byte(content), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GH_FAKE_ARGS", argsPath)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return argsPath
 }

--- a/cmd/fanout/tui_test.go
+++ b/cmd/fanout/tui_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -14,6 +15,7 @@ import (
 	"github.com/butaosuinu/fanout/internal/state"
 	"github.com/butaosuinu/fanout/internal/tmuxrun"
 	fanouttui "github.com/butaosuinu/fanout/internal/tui"
+	"github.com/butaosuinu/fanout/internal/watch"
 )
 
 func TestTUIAgentOrDefault(t *testing.T) {
@@ -292,8 +294,8 @@ func TestLaunchWatchStandaloneSkipsIssueRecordedUnderLock(t *testing.T) {
 		Title:  "existing",
 		State:  "OPEN",
 	})
-	if err != nil {
-		t.Fatal(err)
+	if !errors.Is(err, watch.ErrAlreadyFanned) {
+		t.Fatalf("launchWatchStandalone() error = %v, want ErrAlreadyFanned", err)
 	}
 
 	store, err := state.LoadProject(repo)
@@ -503,7 +505,7 @@ esac
 	}
 }
 
-func TestWatchParentHasRemainingTargetsRequeuesBlockedRows(t *testing.T) {
+func TestWatchParentHasRemainingTargetsRequeuesBlockedRowsWithoutLimit(t *testing.T) {
 	installTUIWatcherGHScript(t, `
 case "$args" in
 "api --paginate --slurp repos/{owner}/{repo}/issues/500/sub_issues?per_page=100")
@@ -542,7 +544,6 @@ esac
 		Parent:        500,
 		ParentRef:     "500",
 		ParentMode:    cliflags.ModeIssue,
-		Limit:         1,
 		UnblockedOnly: true,
 	}
 

--- a/cmd/fanout/tui_test.go
+++ b/cmd/fanout/tui_test.go
@@ -218,6 +218,81 @@ func TestWatchPaneMatchesLiveRequiresShellKeyForShellRows(t *testing.T) {
 	}
 }
 
+func TestWatchLivePaneCacheReusesListingUntilReset(t *testing.T) {
+	calls := 0
+	cache := &watchLivePaneCache{
+		list: func() ([]tmuxrun.LivePane, error) {
+			calls++
+			return []tmuxrun.LivePane{
+				{ID: "%1", CurrentPath: "/repo/.fanout/worktrees/one-501"},
+				{ID: "%2", CurrentPath: "/repo/.fanout/worktrees/two-502"},
+			}, nil
+		},
+	}
+
+	ok, err := cache.Alive(state.Pane{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ok || calls != 0 {
+		t.Fatalf("empty pane alive/calls = %v/%d, want false/0", ok, calls)
+	}
+
+	ok, err = cache.Alive(state.Pane{PaneID: "%1", WorktreePath: "/repo/.fanout/worktrees/one-501"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("Alive() = false, want true for first live pane")
+	}
+	ok, err = cache.Alive(state.Pane{PaneID: "%2", WorktreePath: "/repo/.fanout/worktrees/two-502"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("Alive() = false, want true for second live pane")
+	}
+	if calls != 1 {
+		t.Fatalf("list calls = %d, want one cached call", calls)
+	}
+
+	cache.Reset()
+	ok, err = cache.Alive(state.Pane{PaneID: "%1", WorktreePath: "/repo/.fanout/worktrees/one-501"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok || calls != 2 {
+		t.Fatalf("after reset alive/calls = %v/%d, want true/2", ok, calls)
+	}
+}
+
+func TestWatchParentResultAfterLaunchRequeuesOnFollowupError(t *testing.T) {
+	installTUIWatcherGHScript(t, `
+case "$args" in
+"api --paginate --slurp repos/{owner}/{repo}/issues/500/sub_issues?per_page=100")
+  printf 'temporary gh failure\n' >&2
+  exit 1
+  ;;
+*)
+  printf 'unexpected gh args: %s\n' "$args" >&2
+  exit 64
+  ;;
+esac
+`)
+	cfg := &cliflags.Config{
+		Parent:        500,
+		ParentRef:     "500",
+		ParentMode:    cliflags.ModeIssue,
+		Limit:         1,
+		UnblockedOnly: true,
+	}
+
+	got := watchParentResultAfterLaunch(t.TempDir(), cfg, ghissue.Runner{})
+	if !got.Deferred {
+		t.Fatal("watchParentResultAfterLaunch() Deferred = false, want true when post-launch check fails")
+	}
+}
+
 func TestWatchParentHasRemainingTargetsUsesPostLaunchPlan(t *testing.T) {
 	installTUIWatcherGHScript(t, `
 case "$args" in
@@ -305,6 +380,58 @@ esac
 	}
 	if !deferred {
 		t.Fatal("watchParentHasRemainingTargets() = false, want true while an unfanned child remains")
+	}
+}
+
+func TestWatchParentHasRemainingTargetsRequeuesBlockedRows(t *testing.T) {
+	installTUIWatcherGHScript(t, `
+case "$args" in
+"api --paginate --slurp repos/{owner}/{repo}/issues/500/sub_issues?per_page=100")
+  printf '[[{"number":501,"title":"one","state":"open"},{"number":502,"title":"blocked","state":"open"}]]'
+  ;;
+"issue view 500 --json body -q .body")
+  printf '%s\n' '- [ ] #501 one' '- [ ] #502 blocked (blocked by #600)'
+  ;;
+"issue view 501 --json body,labels")
+  printf '{"body":"","labels":[]}'
+  ;;
+"issue view 502 --json body,labels")
+  printf '{"body":"","labels":[]}'
+  ;;
+"issue view 600 --json state -q .state")
+  printf 'OPEN\n'
+  ;;
+*)
+  printf 'unexpected gh args: %s\n' "$args" >&2
+  exit 64
+  ;;
+esac
+`)
+	repo := t.TempDir()
+	locked, err := state.LockProject(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = locked.RecordPane(state.Pane{Parent: "500", IssueNum: 501, Slug: "one-501", PaneID: "%1"}); err != nil {
+		t.Fatal(err)
+	}
+	if err = locked.Unlock(); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &cliflags.Config{
+		Parent:        500,
+		ParentRef:     "500",
+		ParentMode:    cliflags.ModeIssue,
+		Limit:         1,
+		UnblockedOnly: true,
+	}
+
+	deferred, err := watchParentHasRemainingTargets(repo, cfg, ghissue.Runner{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !deferred {
+		t.Fatal("watchParentHasRemainingTargets() = false, want true while blocked children remain")
 	}
 }
 

--- a/cmd/fanout/tui_test.go
+++ b/cmd/fanout/tui_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/butaosuinu/fanout/internal/cliflags"
 	"github.com/butaosuinu/fanout/internal/ghissue"
 	"github.com/butaosuinu/fanout/internal/hooks"
+	"github.com/butaosuinu/fanout/internal/settings"
 	"github.com/butaosuinu/fanout/internal/state"
 	"github.com/butaosuinu/fanout/internal/tmuxrun"
 	fanouttui "github.com/butaosuinu/fanout/internal/tui"
@@ -182,6 +183,125 @@ esac
 	}
 	if got != 1 {
 		t.Fatalf("countOpenChildTargets() = %d, want one OPEN task-list child", got)
+	}
+}
+
+func TestCountOpenChildTargetsFailsWhenParentBodyReadFails(t *testing.T) {
+	installTUIWatcherGHScript(t, `
+case "$args" in
+"api --paginate --slurp repos/{owner}/{repo}/issues/500/sub_issues?per_page=100")
+  printf '[[]]'
+  ;;
+"issue view 500 --json body -q .body")
+  printf 'temporary gh failure\n' >&2
+  exit 1
+  ;;
+*)
+  printf 'unexpected gh args: %s\n' "$args" >&2
+  exit 64
+  ;;
+esac
+`)
+
+	if _, err := countOpenChildTargets(ghissue.Runner{}, 500); err == nil {
+		t.Fatal("countOpenChildTargets() error = nil, want parent body failure")
+	}
+}
+
+func TestCountWatchChildTargetsCountsOnlyLaunchableChildren(t *testing.T) {
+	installTUIWatcherGHScript(t, `
+case "$args" in
+"api --paginate --slurp repos/{owner}/{repo}/issues/500/sub_issues?per_page=100")
+  printf '[[{"number":501,"title":"ready","state":"open"},{"number":502,"title":"blocked","state":"open"}]]'
+  ;;
+"issue view 500 --json body -q .body")
+  printf '%s\n' '- [ ] #501 ready' '- [ ] #502 blocked (blocked by #600)'
+  ;;
+"issue view 501 --json body,labels")
+  printf '{"body":"","labels":[]}'
+  ;;
+"issue view 502 --json body,labels")
+  printf '{"body":"","labels":[]}'
+  ;;
+"issue view 600 --json state -q .state")
+  printf 'OPEN\n'
+  ;;
+*)
+  printf 'unexpected gh args: %s\n' "$args" >&2
+  exit 64
+  ;;
+esac
+`)
+
+	counts, err := countWatchChildTargets(t.TempDir(), ghissue.Runner{}, 500)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if counts.Open != 2 || counts.Launchable != 1 || counts.Unfanned != 2 {
+		t.Fatalf("countWatchChildTargets() = %+v, want open=2 launchable=1 unfanned=2", counts)
+	}
+}
+
+func TestCountWatchChildTargetsSkipsUnresolvableTaskListRefs(t *testing.T) {
+	installTUIWatcherGHScript(t, `
+case "$args" in
+"api --paginate --slurp repos/{owner}/{repo}/issues/500/sub_issues?per_page=100")
+  printf '[[{"number":501,"title":"ready","state":"open"}]]'
+  ;;
+"issue view 500 --json body -q .body")
+  printf '%s\n' '- [ ] #501 ready' '- [ ] #599 stale'
+  ;;
+"issue view 501 --json body,labels")
+  printf '{"body":"","labels":[]}'
+  ;;
+"issue view 599 --json number,title,state,body,labels")
+  printf 'not found\n' >&2
+  exit 1
+  ;;
+*)
+  printf 'unexpected gh args: %s\n' "$args" >&2
+  exit 64
+  ;;
+esac
+`)
+
+	counts, err := countWatchChildTargets(t.TempDir(), ghissue.Runner{}, 500)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if counts.Open != 1 || counts.Launchable != 1 || counts.Unfanned != 1 {
+		t.Fatalf("countWatchChildTargets() = %+v, want open=1 launchable=1 unfanned=1", counts)
+	}
+}
+
+func TestLaunchWatchStandaloneSkipsIssueRecordedUnderLock(t *testing.T) {
+	repo := t.TempDir()
+	initTUITestGitRepo(t, repo)
+	locked, err := state.LockProject(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = locked.RecordPane(state.Pane{Parent: "700", IssueNum: 501, Slug: "existing-501", PaneID: "%1"}); err != nil {
+		t.Fatal(err)
+	}
+	if err = locked.Unlock(); err != nil {
+		t.Fatal(err)
+	}
+	err = launchWatchStandalone(repo, "fanout-test", "fanout", settings.Defaults(), hooks.EmptyConfig(), ghissue.Issue{
+		Number: 501,
+		Title:  "existing",
+		State:  "OPEN",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := state.LoadProject(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(store.Panes) != 1 || store.Panes[0].PaneID != "%1" {
+		t.Fatalf("state panes = %+v, want existing pane only", store.Panes)
 	}
 }
 

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -32,11 +32,15 @@ import (
 	"github.com/butaosuinu/fanout/internal/sessionview"
 	"github.com/butaosuinu/fanout/internal/state"
 	"github.com/butaosuinu/fanout/internal/tmuxrun"
+	"github.com/butaosuinu/fanout/internal/watch"
 )
 
 const (
 	defaultStateInterval = 2 * time.Second
 	defaultGHInterval    = 20 * time.Second
+	defaultWatchInterval = 60 * time.Second
+	minWatchInterval     = 20 * time.Second
+	defaultWatchLabel    = "fanout:auto"
 	detailHeight         = 13
 	peekLines            = 80
 	defaultLaunchAgent   = "claude"
@@ -51,6 +55,9 @@ type Options struct {
 	Session             string
 	StateInterval       time.Duration
 	GHInterval          time.Duration
+	Watcher             WatcherRunner
+	WatchInterval       time.Duration
+	WatchLabel          string
 	DefaultAgent        string
 	WatcherRunningLabel string
 	Hooks               hooks.Config
@@ -80,6 +87,11 @@ type LaunchRequest struct {
 
 // LaunchFunc creates a manual fanout pane for a TUI request.
 type LaunchFunc func(LaunchRequest) error
+
+// WatcherRunner runs one watcher cycle.
+type WatcherRunner interface {
+	RunCycle() (watch.Report, error)
+}
 
 // ShellLaunchRequest describes one shell terminal launch requested from the TUI.
 type ShellLaunchRequest struct {
@@ -220,6 +232,11 @@ type model struct {
 	stateErr        string
 	ghErr           string
 	notifyErr       string
+	watchRunning    bool
+	lastWatch       time.Time
+	watchLaunched   int
+	watchErr        string
+	watchDisabled   bool
 	notice          string
 	newPane         newPaneForm
 	peek            panePeek
@@ -312,6 +329,7 @@ type panePeek struct {
 type (
 	stateTickMsg  time.Time
 	ghTickMsg     time.Time
+	watchTickMsg  time.Time
 	launchPaneMsg struct {
 		err error
 	}
@@ -320,6 +338,12 @@ type (
 		err error
 	}
 )
+
+type watchDoneMsg struct {
+	report watch.Report
+	at     time.Time
+	err    error
+}
 
 type transitionNotifiedMsg struct {
 	count int
@@ -441,6 +465,17 @@ func normalizeOptions(opts Options) Options {
 	if opts.GHInterval <= 0 {
 		opts.GHInterval = defaultGHInterval
 	}
+	if opts.Watcher != nil {
+		if opts.WatchInterval <= 0 {
+			opts.WatchInterval = defaultWatchInterval
+		}
+		if opts.WatchInterval < minWatchInterval {
+			opts.WatchInterval = minWatchInterval
+		}
+		if strings.TrimSpace(opts.WatchLabel) == "" {
+			opts.WatchLabel = defaultWatchLabel
+		}
+	}
 	if opts.lifecycle == nil {
 		opts.lifecycle = defaultLifecycleRunner{}
 	}
@@ -489,9 +524,13 @@ func newModel(opts Options) model {
 }
 
 func (m model) Init() tea.Cmd {
+	loads := tea.Batch(m.loadStateCmd(true), m.loadGHCmd(true))
+	if m.opts.Watcher == nil {
+		return tea.Sequence(m.enableKeyboardProtocolsCmd(), loads)
+	}
 	return tea.Sequence(
 		m.enableKeyboardProtocolsCmd(),
-		tea.Batch(m.loadStateCmd(true), m.loadGHCmd(true)),
+		tea.Batch(loads, m.watchTickCmd()),
 	)
 }
 
@@ -656,6 +695,22 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.loadStateCmd(true)
 	case ghTickMsg:
 		return m, m.loadGHCmd(true)
+	case watchTickMsg:
+		if m.opts.Watcher == nil {
+			return m, nil
+		}
+		if m.watchRunning {
+			return m, m.watchTickCmd()
+		}
+		m.watchRunning = true
+		return m, tea.Batch(m.runWatchCmd(), m.watchTickCmd())
+	case watchDoneMsg:
+		m.watchRunning = false
+		m.lastWatch = msg.at
+		m.watchLaunched = len(msg.report.Launched)
+		m.watchDisabled = watchReportDisabled(msg.report)
+		m.watchErr = summarizeWatchError(msg.report, msg.err)
+		return m, tea.Batch(m.loadStateCmd(false), m.loadGHCmd(false))
 	case launchPaneMsg:
 		m.newPane.launching = false
 		if msg.err != nil {
@@ -1625,6 +1680,25 @@ func (m model) loadGHCmd(scheduleNext bool) tea.Cmd {
 	}
 }
 
+func (m model) watchTickCmd() tea.Cmd {
+	if m.opts.Watcher == nil {
+		return nil
+	}
+	interval := m.opts.WatchInterval
+	return tea.Tick(interval, func(t time.Time) tea.Msg { return watchTickMsg(t) })
+}
+
+func (m model) runWatchCmd() tea.Cmd {
+	runner := m.opts.Watcher
+	if runner == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		report, err := runner.RunCycle()
+		return watchDoneMsg{report: report, at: time.Now(), err: err}
+	}
+}
+
 func (m model) notifyEventsCmd(events []fanoutnotify.Event) tea.Cmd {
 	if len(events) == 0 || m.opts.Notifier == nil {
 		return nil
@@ -2363,8 +2437,79 @@ func (m model) footerText() string {
 	if m.filterEditing || strings.TrimSpace(m.filterQuery) != "" {
 		parts = append(parts, fmt.Sprintf("filter=%q %d/%d", m.filterQuery, len(m.panes), len(m.allPanes)))
 	}
+	if watchText := m.watchFooterText(); watchText != "" {
+		parts = append(parts, watchText)
+	}
 	parts = append(parts, "state "+formatClock(m.lastState), "gh "+formatClock(m.lastGH))
 	return strings.Join(parts, "  ")
+}
+
+func (m model) watchFooterText() string {
+	if m.opts.Watcher == nil {
+		return ""
+	}
+	status := "on"
+	if m.watchDisabled {
+		status = "disabled"
+	}
+	parts := []string{
+		"watch: " + status,
+		"label=" + m.opts.WatchLabel,
+	}
+	if m.watchRunning {
+		parts = append(parts, "running")
+	}
+	parts = append(parts,
+		"last="+formatClock(m.lastWatch),
+		fmt.Sprintf("launched=%d", m.watchLaunched),
+		"err="+dash(truncate(m.watchErr, 120)),
+	)
+	return strings.Join(parts, " ")
+}
+
+func watchReportDisabled(report watch.Report) bool {
+	for _, failure := range report.Failures {
+		if failure.Disabled {
+			return true
+		}
+	}
+	for _, skip := range report.Skipped {
+		if skip.Reason == watch.SkipDisabled {
+			return true
+		}
+	}
+	return false
+}
+
+func summarizeWatchError(report watch.Report, err error) string {
+	if err != nil {
+		return err.Error()
+	}
+	for _, failure := range slices.Backward(report.Failures) {
+		if failure.Err == nil && failure.RevertErr == nil {
+			continue
+		}
+		stage := strings.TrimSpace(string(failure.Stage))
+		if stage == "" {
+			stage = "watch"
+		}
+		prefix := stage
+		if failure.Issue.Number > 0 {
+			prefix = fmt.Sprintf("#%d %s", failure.Issue.Number, stage)
+		}
+		parts := []string{}
+		if failure.Err != nil {
+			parts = append(parts, failure.Err.Error())
+		}
+		if failure.RevertErr != nil {
+			parts = append(parts, "revert: "+failure.RevertErr.Error())
+		}
+		if failure.Disabled {
+			parts = append(parts, "disabled")
+		}
+		return prefix + ": " + strings.Join(parts, "; ")
+	}
+	return ""
 }
 
 func filterPaneViews(panes []paneView, query string) []paneView {

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -19,9 +19,21 @@ import (
 	"github.com/butaosuinu/fanout/internal/sessionview"
 	"github.com/butaosuinu/fanout/internal/state"
 	"github.com/butaosuinu/fanout/internal/tmuxrun"
+	"github.com/butaosuinu/fanout/internal/watch"
 )
 
 var errBoom = errors.New("boom")
+
+type fakeWatcherRunner struct {
+	report watch.Report
+	err    error
+	calls  int
+}
+
+func (f *fakeWatcherRunner) RunCycle() (watch.Report, error) {
+	f.calls++
+	return f.report, f.err
+}
 
 func TestBuildPaneViewsMergesStateTmuxAndIssueStatuses(t *testing.T) {
 	panes := []state.Pane{
@@ -760,6 +772,111 @@ func TestViewRendersHUDCounts(t *testing.T) {
 	got := m.View()
 	if !strings.Contains(got, "total=3 merged=1 pending=2 blocked=1") {
 		t.Fatalf("View() = %q, want HUD counts", got)
+	}
+}
+
+func TestWatchTickRunsCycleAndRefreshesStateAndGH(t *testing.T) {
+	runner := &fakeWatcherRunner{
+		report: watch.Report{
+			Launched: []watch.Action{{Issue: ghissue.Issue{Number: 101}}},
+		},
+	}
+	m := newModel(Options{
+		ProjectRoot:    "/repo",
+		Watcher:        runner,
+		WatchInterval:  time.Minute,
+		WatchLabel:     "fanout:auto",
+		StateInterval:  time.Second,
+		GHInterval:     time.Second,
+		DefaultAgent:   "codex",
+		FocusPane:      func(string) error { return nil },
+		PaneAlive:      func(string) bool { return true },
+		LaunchPane:     func(LaunchRequest) error { return nil },
+		LaunchShell:    func(ShellLaunchRequest) error { return nil },
+		Notifier:       nil,
+		lifecycle:      &fakeLifecycleRunner{},
+		keyboard:       noopKeyboardProtocols{},
+		ShellPaneAlive: func(string, string) bool { return true },
+	})
+
+	updated, cmd := m.Update(watchTickMsg(time.Unix(1, 0)))
+	m = updated.(model)
+	if !m.watchRunning {
+		t.Fatal("watchRunning = false, want true while RunCycle command is outstanding")
+	}
+	if cmd == nil {
+		t.Fatal("watch tick returned nil command, want RunCycle + next tick batch")
+	}
+	batch, ok := cmd().(tea.BatchMsg)
+	if !ok || len(batch) != 2 {
+		t.Fatalf("watch tick command = %T len=%d, want two-command BatchMsg", batch, len(batch))
+	}
+
+	msg, ok := batch[0]().(watchDoneMsg)
+	if !ok {
+		t.Fatalf("watch RunCycle command returned %T, want watchDoneMsg", msg)
+	}
+	if runner.calls != 1 {
+		t.Fatalf("RunCycle calls = %d, want 1", runner.calls)
+	}
+
+	updated, cmd = m.Update(msg)
+	m = updated.(model)
+	if m.watchRunning {
+		t.Fatal("watchRunning = true after watchDoneMsg, want false")
+	}
+	if m.watchLaunched != 1 || m.watchErr != "" {
+		t.Fatalf("watch status launched=%d err=%q, want 1 and empty", m.watchLaunched, m.watchErr)
+	}
+	if cmd == nil {
+		t.Fatal("watchDoneMsg returned nil command, want state+GH reload batch")
+	}
+	reloadBatch, ok := cmd().(tea.BatchMsg)
+	if !ok || len(reloadBatch) != 2 {
+		t.Fatalf("watch done command = %T len=%d, want state+GH reload BatchMsg", reloadBatch, len(reloadBatch))
+	}
+}
+
+func TestWatchLaunchFailureRendersFooter(t *testing.T) {
+	m := newModel(Options{
+		ProjectRoot: "/repo",
+		Watcher:     &fakeWatcherRunner{},
+		WatchLabel:  "fanout:auto",
+	})
+	m.width = 100
+	m.height = 30
+	report := watch.Report{
+		Failures: []watch.Failure{
+			{
+				Issue:    ghissue.Issue{Number: 101},
+				Stage:    watch.FailureLaunch,
+				Err:      errBoom,
+				Attempts: 3,
+				Disabled: true,
+			},
+		},
+	}
+
+	updated, _ := m.Update(watchDoneMsg{report: report, at: time.Date(2026, 6, 20, 12, 34, 56, 0, time.UTC)})
+	m = updated.(model)
+	view := m.View()
+
+	for _, want := range []string{"watch: disabled label=fanout:auto", "last=12:34:56", "launched=0", "err=#101 launch: boom; disabled"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("watch footer missing %q:\n%s", want, view)
+		}
+	}
+}
+
+func TestWatchTickIgnoredWhenWatcherDisabled(t *testing.T) {
+	m := newModel(Options{})
+
+	updated, cmd := m.Update(watchTickMsg(time.Unix(1, 0)))
+	if cmd != nil {
+		t.Fatal("watch tick without watcher returned command, want nil")
+	}
+	if updated.(model).watchRunning {
+		t.Fatal("watchRunning = true without watcher, want false")
 	}
 }
 

--- a/internal/watch/engine.go
+++ b/internal/watch/engine.go
@@ -45,6 +45,7 @@ type DeferReason string
 const (
 	DeferBackoff     DeferReason = "backoff"
 	DeferMaxSessions DeferReason = "max_sessions"
+	DeferBlocked     DeferReason = "blocked_children"
 )
 
 // FailureStage identifies the effect that failed during a cycle.
@@ -77,11 +78,22 @@ type Config struct {
 type IO struct {
 	ListLabeled       func(label string) ([]ghissue.Issue, error)
 	CountOpenChildren func(issue ghissue.Issue) (int, error)
+	CountChildren     func(issue ghissue.Issue) (ChildCounts, error)
 	SwapLabels        func(issue ghissue.Issue, removeLabel, addLabel string) error
 	LoadState         func() (state.Store, error)
 	PaneAlive         func(pane state.Pane) (bool, error)
 	LaunchStandalone  func(issue ghissue.Issue) error
 	LaunchParent      func(issue ghissue.Issue, limit int) (ParentLaunchResult, error)
+}
+
+// ChildCounts separates parent classification from launch-capacity accounting.
+// Open is every OPEN child. Launchable is the subset that can create panes now.
+// Unfanned is every OPEN child that does not already have a pane, including
+// blocked children.
+type ChildCounts struct {
+	Open       int
+	Launchable int
+	Unfanned   int
 }
 
 // Engine keeps process-local launch failure state between cycles.
@@ -124,6 +136,8 @@ type Action struct {
 	Issue        ghissue.Issue
 	Kind         LaunchKind
 	OpenChildren int
+	// LaunchableChildren is the parent-child count that consumes session budget.
+	LaunchableChildren int
 	// RetryRunning means the issue is already on the running label after a failed
 	// requeue swap, so RunCycle should not acquire it again.
 	RetryRunning bool
@@ -245,14 +259,17 @@ func (e *Engine) PlanCycle() (Report, error) {
 			continue
 		}
 
-		openChildren, err := e.io.CountOpenChildren(issue)
+		childCounts, err := countChildren(e.io, issue)
 		if err != nil {
 			report.Failures = append(report.Failures, Failure{Issue: issue, Stage: FailureCountChildren, Err: err})
 			continue
 		}
-		if openChildren < 0 {
-			openChildren = 0
-		}
+		openChildren := childCounts.Open
+		openChildren = max(openChildren, 0)
+		launchableChildren := childCounts.Launchable
+		launchableChildren = max(launchableChildren, 0)
+		unfannedChildren := childCounts.Unfanned
+		unfannedChildren = max(unfannedChildren, 0)
 		if candidate.recoverRunning && openChildren == 0 && hasPaneForParent(store, issue.Number) {
 			report.Skipped = append(report.Skipped, Skip{Issue: issue, Reason: SkipAlreadyRunning})
 			continue
@@ -268,22 +285,31 @@ func (e *Engine) PlanCycle() (Report, error) {
 			}
 		}
 		action := Action{
-			Issue:        issue,
-			Kind:         LaunchStandalone,
-			OpenChildren: openChildren,
-			RetryRunning: candidate.retryRunning,
+			Issue:              issue,
+			Kind:               LaunchStandalone,
+			OpenChildren:       openChildren,
+			LaunchableChildren: launchableChildren,
+			RetryRunning:       candidate.retryRunning,
 		}
 		consumes := 1
 		if openChildren > 0 || candidate.retryKind == LaunchParent {
 			action.Kind = LaunchParent
-			consumes = openChildren
+			consumes = launchableChildren
 		}
 		if alreadyFanned(store, action) {
 			report.Skipped = append(report.Skipped, Skip{Issue: issue, Reason: SkipAlreadyFanned})
 			continue
 		}
+		if action.Kind == LaunchParent && launchableChildren == 0 {
+			if unfannedChildren == 0 {
+				report.Skipped = append(report.Skipped, Skip{Issue: issue, Reason: SkipAlreadyFanned})
+			} else {
+				report.Deferred = append(report.Deferred, Deferred{Issue: issue, Reason: DeferBlocked})
+			}
+			continue
+		}
 		if action.Kind == LaunchParent && remaining > 0 {
-			consumes = min(openChildren, remaining)
+			consumes = min(launchableChildren, remaining)
 			action.Limit = consumes
 		}
 		report.Actions = append(report.Actions, action)
@@ -433,8 +459,8 @@ func validatePlanIO(io IO) error {
 	switch {
 	case io.ListLabeled == nil:
 		return errors.New("watch IO ListLabeled is required")
-	case io.CountOpenChildren == nil:
-		return errors.New("watch IO CountOpenChildren is required")
+	case io.CountChildren == nil && io.CountOpenChildren == nil:
+		return errors.New("watch IO CountChildren is required")
 	case io.LoadState == nil:
 		return errors.New("watch IO LoadState is required")
 	case io.PaneAlive == nil:
@@ -458,6 +484,17 @@ func validateRunIO(io IO) error {
 	default:
 		return nil
 	}
+}
+
+func countChildren(io IO, issue ghissue.Issue) (ChildCounts, error) {
+	if io.CountChildren != nil {
+		return io.CountChildren(issue)
+	}
+	open, err := io.CountOpenChildren(issue)
+	if err != nil {
+		return ChildCounts{}, err
+	}
+	return ChildCounts{Open: open, Launchable: open, Unfanned: open}, nil
 }
 
 func countLivePanes(store state.Store, alive func(state.Pane) (bool, error)) (int, error) {

--- a/internal/watch/engine.go
+++ b/internal/watch/engine.go
@@ -20,6 +20,10 @@ const (
 	defaultDisableAfterFailures = 3
 )
 
+// ErrAlreadyFanned reports that a launch target became recorded after planning
+// but before launch.
+var ErrAlreadyFanned = errors.New("already fanned")
+
 // LaunchKind classifies the launch fanout should perform for one labeled issue.
 type LaunchKind string
 
@@ -297,10 +301,17 @@ func (e *Engine) PlanCycle() (Report, error) {
 			consumes = launchableChildren
 		}
 		if alreadyFanned(store, action) {
+			if candidate.retryKind != "" {
+				delete(e.runningRetries, issue.Number)
+			}
 			report.Skipped = append(report.Skipped, Skip{Issue: issue, Reason: SkipAlreadyFanned})
 			continue
 		}
 		if action.Kind == LaunchParent && launchableChildren == 0 {
+			if candidate.retryKind == LaunchParent {
+				report.Actions = append(report.Actions, action)
+				continue
+			}
 			if unfannedChildren == 0 {
 				report.Skipped = append(report.Skipped, Skip{Issue: issue, Reason: SkipAlreadyFanned})
 			} else {
@@ -353,6 +364,16 @@ func (e *Engine) RunCycle() (Report, error) {
 			launchErr = e.io.LaunchStandalone(action.Issue)
 		}
 		if launchErr != nil {
+			if errors.Is(launchErr, ErrAlreadyFanned) {
+				report.Skipped = append(report.Skipped, Skip{Issue: action.Issue, Reason: SkipAlreadyFanned})
+				if err := e.io.SwapLabels(action.Issue, cfg.RunningLabel, cfg.TriggerLabel); err != nil {
+					e.runningRetries[action.Issue.Number] = runningRetry{kind: action.Kind}
+					report.Failures = append(report.Failures, Failure{Issue: action.Issue, Stage: FailureSwapLabels, Err: err})
+				} else {
+					delete(e.runningRetries, action.Issue.Number)
+				}
+				continue
+			}
 			revertErr := e.io.SwapLabels(action.Issue, cfg.RunningLabel, cfg.TriggerLabel)
 			if revertErr != nil {
 				e.runningRetries[action.Issue.Number] = runningRetry{kind: action.Kind}

--- a/internal/watch/engine_test.go
+++ b/internal/watch/engine_test.go
@@ -32,6 +32,7 @@ type fakeWatchIO struct {
 	runningIssues []ghissue.Issue
 	store         state.Store
 	openChildren  map[int]int
+	childCounts   map[int]ChildCounts
 	alive         map[string]bool
 
 	swapErr        map[swapKey]error
@@ -77,6 +78,15 @@ func (f *fakeWatchIO) IO() IO {
 		CountOpenChildren: func(issue ghissue.Issue) (int, error) {
 			f.countCalls = append(f.countCalls, issue.Number)
 			return f.openChildren[issue.Number], nil
+		},
+		CountChildren: func(issue ghissue.Issue) (ChildCounts, error) {
+			if f.childCounts == nil {
+				f.countCalls = append(f.countCalls, issue.Number)
+				open := f.openChildren[issue.Number]
+				return ChildCounts{Open: open, Launchable: open, Unfanned: open}, nil
+			}
+			f.countCalls = append(f.countCalls, issue.Number)
+			return f.childCounts[issue.Number], nil
 		},
 		SwapLabels: func(issue ghissue.Issue, removeLabel, addLabel string) error {
 			f.swaps = append(f.swaps, swapCall{num: issue.Number, remove: removeLabel, add: addLabel})
@@ -247,6 +257,28 @@ func TestRunCycleTableDriven(t *testing.T) {
 				}
 				if got, want := fake.parents, []parentLaunch{{num: 201, limit: 3}}; !slices.Equal(got, want) {
 					t.Fatalf("parent launches = %#v, want %#v", got, want)
+				}
+			},
+		},
+		{
+			name: "blocked-only parent does not consume capacity",
+			cfg:  Config{MaxSessions: 1},
+			fake: &fakeWatchIO{
+				issues: []ghissue.Issue{issue(301), issue(101)},
+				childCounts: map[int]ChildCounts{
+					301: {Open: 2, Launchable: 0, Unfanned: 2},
+					101: {Open: 0, Launchable: 0, Unfanned: 0},
+				},
+			},
+			check: func(t *testing.T, report Report, fake *fakeWatchIO) {
+				t.Helper()
+				assertInts(t, "count calls", fake.countCalls, []int{301, 101})
+				if got, want := fake.parents, []parentLaunch(nil); !slices.Equal(got, want) {
+					t.Fatalf("parent launches = %#v, want none", got)
+				}
+				assertInts(t, "standalone launches", fake.standalone, []int{101})
+				if len(report.Deferred) != 1 || report.Deferred[0].Issue.Number != 301 || report.Deferred[0].Reason != DeferBlocked {
+					t.Fatalf("deferred = %#v, want #301 blocked", report.Deferred)
 				}
 			},
 		},

--- a/internal/watch/engine_test.go
+++ b/internal/watch/engine_test.go
@@ -174,6 +174,26 @@ func TestRunCycleTableDriven(t *testing.T) {
 			},
 		},
 		{
+			name: "standalone already fanned during launch requeues trigger label",
+			fake: &fakeWatchIO{
+				issues:        []ghissue.Issue{issue(101)},
+				openChildren:  map[int]int{101: 0},
+				standaloneErr: map[int]error{101: ErrAlreadyFanned},
+			},
+			check: func(t *testing.T, report Report, fake *fakeWatchIO) {
+				t.Helper()
+				assertInts(t, "standalone launches", fake.standalone, []int{101})
+				assertSwaps(t, fake.swaps, []swapCall{
+					{num: 101, remove: triggerLabel, add: runningLabel},
+					{num: 101, remove: runningLabel, add: triggerLabel},
+				})
+				assertSkipReasons(t, report, []SkipReason{SkipAlreadyFanned})
+				if len(report.Launched) != 0 || len(report.Failures) != 0 {
+					t.Fatalf("report = %#v, want requeued skip without launched/failure", report)
+				}
+			},
+		},
+		{
 			name: "parent fanout ignores child issue false positive",
 			fake: &fakeWatchIO{
 				issues:       []ghissue.Issue{issue(201), issue(202)},
@@ -523,6 +543,55 @@ func TestRunCycleRetriesStandaloneWhenRequeueSwapFails(t *testing.T) {
 	}
 	assertInts(t, "count calls after state record", fake.countCalls, []int{101})
 	assertSkipReasons(t, third, []SkipReason{SkipAlreadyFanned})
+}
+
+func TestRunCycleRetriesBlockedOnlyParentWhenRequeueSwapFails(t *testing.T) {
+	baseNow := time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)
+	fake := &fakeWatchIO{
+		issues:         []ghissue.Issue{issue(301)},
+		openChildren:   map[int]int{301: 3},
+		parentDeferred: map[int]bool{301: true},
+		swapErr: map[swapKey]error{
+			{num: 301, remove: runningLabel, add: triggerLabel}: errors.New("requeue failed"),
+		},
+	}
+	engine := NewEngine(Config{
+		TriggerLabel: triggerLabel,
+		RunningLabel: runningLabel,
+		Now:          (&fakeClock{now: baseNow}).Now,
+	}, fake.IO())
+
+	first, err := engine.RunCycle()
+	if err != nil {
+		t.Fatalf("first RunCycle error = %v", err)
+	}
+	assertFailure(t, first, 301, FailureSwapLabels, 0, false)
+
+	fake.issues = nil
+	fake.runningIssues = []ghissue.Issue{issue(301, runningLabel)}
+	fake.childCounts = map[int]ChildCounts{
+		301: {Open: 2, Launchable: 0, Unfanned: 2},
+	}
+	fake.swapErr = nil
+	fake.countCalls = nil
+	fake.swaps = nil
+	fake.parents = nil
+
+	second, err := engine.RunCycle()
+	if err != nil {
+		t.Fatalf("second RunCycle error = %v", err)
+	}
+	assertInts(t, "count calls on retry", fake.countCalls, []int{301})
+	assertSwaps(t, fake.swaps, []swapCall{{num: 301, remove: runningLabel, add: triggerLabel}})
+	if got, want := fake.parents, []parentLaunch{{num: 301, limit: 0}}; !slices.Equal(got, want) {
+		t.Fatalf("parent retry launches = %#v, want %#v", got, want)
+	}
+	if len(second.Deferred) != 1 || second.Deferred[0].Reason != DeferMaxSessions {
+		t.Fatalf("second deferred = %#v, want requeued parent", second.Deferred)
+	}
+	if len(second.Failures) != 0 || len(second.Launched) != 1 {
+		t.Fatalf("second report = %#v, want clean requeue after retry", second)
+	}
 }
 
 func TestRunCycleRetriesDeferredParentWhenRequeueSwapFails(t *testing.T) {


### PR DESCRIPTION
**TL;DR**
Wires the opt-in watcher into the persistent TUI with its own ticker, launch callbacks, status footer, and post-cycle refresh. Review effort: 3

**Why**
The watcher settings, label APIs, runtime helper, and watch engine are now available, but the TUI still needed the production wiring that turns those pieces into an active background cycle.

```mermaid
flowchart LR
  TUI[cmd/fanout newTUIWatcher] --> Runner[internal/tui WatcherRunner]
  Runner -->|watchTickMsg| Cycle[watch.Engine RunCycle]
  Cycle --> Standalone[launchWatchStandalone]
  Cycle --> Parent[launchWatchParent]
  Standalone --> Refresh[loadStateCmd false + loadGHCmd false]
  Parent --> Refresh
```

**Changes by file**
<details>
<summary>Files</summary>

| File | Changes |
|---|---|
| `cmd/fanout/tui.go` | Builds the watcher engine from resolved settings, ensures the running label, wires GitHub/state/tmux IO, and launches standalone or parent fan-outs with buffered errors. |
| `cmd/fanout/tui_test.go` | Covers task-list child counting, post-launch parent requeue decisions, partial parent launch requeue, and worktree-aware pane liveness. |
| `internal/tui/tui.go` | Adds watcher options, runner interface, dedicated ticker, running guard, done refresh, and footer status. |
| `internal/tui/tui_test.go` | Covers watcher tick execution, state/GitHub refresh after completion, launch failure footer text, and disabled watcher behavior. |

</details>

**Risk**
> [!WARNING]
> Enabling `watcher` lets the TUI launch panes automatically for labeled issues. Misconfigured labels or agent settings can start unintended work; the watcher remains opt-in and uses a separate running label.

**Test plan**
- `go test ./cmd/fanout ./internal/tui ./internal/watch`
- `make lint`
- `make test`
- `codex review --uncommitted`

Closes #225
