### PR TITLE
docs: document watcher workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ The package map: `cmd/fanout` is the command flow (`main.go` dispatch and
 orchestration, `plan.go` filtering, `status.go`, `lifecycle.go`, `report.go`).
 `internal/` holds `agent`,
 `cliflags`, `ghissue`, `runtime`, `worktree`, `tmuxrun`, `state`, `naming`,
-`blockers`, `displayname`, `briefing`, `team`, `msgstore`, plus
+`blockers`, `displayname`, `briefing`, `watch`, `team`, `msgstore`, plus
 `atomicfs`/`log`/`tty`/`exitcode`.
 
 - Runtime discovery (`internal/runtime`) resolves the git repo root with
@@ -102,6 +102,14 @@ orchestration, `plan.go` filtering, `status.go`, `lifecycle.go`, `report.go`).
 - `--status`, `--close`, `--merge`, and `--cleanup` operate from
   `.fanout/state.json`; set `FANOUT_STATE_PATH` to point at a specific state
   file outside the repository checkout.
+- `internal/watch` owns one repository watcher cycle behind the no-argument
+  TUI. It lists `watcherTriggerLabel` issues, swaps them to
+  `watcherRunningLabel`, launches standalone panes for issues without OPEN
+  children, and launches normal parent fan-outs for issues with OPEN children.
+  The watcher is opt-in from user config or `FANOUT_WATCHER` only; repo config
+  cannot enable it. Keep this separate from #107's skill-led loop for
+  revisiting children under a known parent, and treat trigger labels as a
+  prompt-injection boundary because issue bodies become briefings.
 - `--team` (`cmd/fanout/team.go`) and the `fanout msg` subcommand
   (`cmd/fanout/msg.go`) are sibling-pane peer messaging over a per-parent
   SQLite bus. `internal/team` owns the DB (`modernc.org/sqlite`, pure-Go — no

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,9 @@ Build the binary with `make build-go` and validate with `make test`.
   after a live `executePlan`).
 - `cmd/fanout/tui.go` implements the no-argument persistent TUI console. Plain
   shells are relaunched into a deterministic fanout-managed tmux session;
-  invocations already inside tmux use the current pane.
+  invocations already inside tmux use the current pane. It also wires the
+  opt-in label watcher into the TUI runtime; no other command path starts the
+  watcher.
 - `internal/runtime` resolves the git repository root and the tmux target.
   Batch pane-creation mode must be invoked from inside tmux. By default fanout
   targets the invoking pane; `--session` targets a named tmux session.
@@ -160,6 +162,14 @@ Build the binary with `make build-go` and validate with `make test`.
   merged code nudges a pane. The `@fanout_agent_state` (`running` / `done`,
   set by the launch wrapper in `internal/tmuxrun`) idle-nudge accelerator is a
   separate, still-unmerged issue (#72) — do not assume an idle gate exists.
+- `internal/watch` owns one repository watcher cycle. It is pure at the package
+  boundary: production wires GitHub labels, `.fanout/state.json`, tmux liveness,
+  and launch helpers through `watch.IO`, while unit tests inject fakes. The
+  engine lists `watcherTriggerLabel` issues, swaps them to
+  `watcherRunningLabel` before launch, classifies issues with OPEN children as
+  parent fan-outs and issues without OPEN children as standalone panes, applies
+  the live-pane budget/backoff, and leaves lifecycle label cleanup to
+  `internal/lifecycle`.
 - `internal/ghissue`, `internal/blockers`, `internal/briefing`,
   `internal/settings`, `internal/displayname`, `internal/atomicfs`,
   `internal/log`, `internal/tty`, and `internal/exitcode` hold the remaining
@@ -199,6 +209,14 @@ Build the binary with `make build-go` and validate with `make test`.
   decision to dashboard #117, which this implements standalone (no TUI
   dependency — the future TUI just reuses `internal/sessionview`). Keep it
   read-only: do not add mutation endpoints.
+- The label watcher is a TUI-resident, opt-in launcher, not a cron/webhook
+  service and not the #107 skill loop. Only user config or environment
+  variables may enable `watcher`; repo config may set labels, interval, agent,
+  and max sessions but cannot opt a checkout into launching. Its scope is
+  repository-wide label discovery (`fanout:auto` -> `fanout:running`) and
+  one-shot session launch. #107 remains the skill-led loop for revisiting
+  children under a known parent. Because issue bodies become child briefings,
+  trigger labels are a prompt-injection boundary.
 - `.fanout/worktrees/<slug>/` directories without a state row are treated as an
   action-mode migration fallback and skipped when their slug matches the child
   this run would create.

--- a/README.ja.md
+++ b/README.ja.md
@@ -105,12 +105,17 @@ fanout
 fanout はそのラベルを `fanout:running` に付け替え、OPEN 子が無い issue は standalone
 pane として、OPEN 子がある issue は通常の parent fan-out として起動します。parent
 fan-out は `--unblocked-only` を使います。watcher からの起動はすべて
-`watcherMaxSessions` の対象になります。
+`watcherMaxSessions` の対象になります。blocked child や session 上限により残りが
+ある場合、fanout は `fanout:running` を `fanout:auto` に戻し、後続 cycle でその
+parent を自動再試行します。
 
-起動した作業が merge または close されたら、`--merge`、`--close`、`--cleanup` が
-`fanout:running` を best-effort で外します。cleanup 後に同じ親を watcher へ戻す
-には、`fanout:auto` を付け直してください。issue 本文は agent briefing になるため、
-信頼できない issue に trigger label を付けないでください。
+parent fan-out では、`fanout <parent> --merge <child>`、`--close`、`--cleanup` が
+`fanout:running` を best-effort で外します。standalone watcher pane は TUI の
+lifecycle key（`m`、`c`、`x`）で処理してください。公開 CLI の parent 引数では
+予約 parent `@watch` の row を指定できません。standalone pane または完全 cleanup
+済み parent を新しく投入するには、`fanout:auto` を付け直してください。label 付き
+issue と、起動される OPEN child の本文は agent briefing になります。信頼できない
+issue に trigger label を付けないでください。
 
 この watcher は [#107](https://github.com/butaosuinu/fanout/issues/107) とは別レーンです。
 watcher は repo 全体から label 付き issue を探し、one-shot session を起動します。

--- a/README.ja.md
+++ b/README.ja.md
@@ -27,6 +27,8 @@ briefing から起動します。再実行しても同じ対象に 2 つ目の�
 - **常駐 TUI コンソール** — 引数なしの `fanout` で、ペイン / issue / PR を
   ライブ表示し、コンパクトな Session ナビゲータと focus・peek・terminal・lifecycle
   キーを備えたコンソールを開きます。
+- **ラベル watcher** — opt-in すると、TUI 常駐中に信頼できる `fanout:auto`
+  issue を one-shot fanout session に投入します。
 - **Web ダッシュボード** — localhost で動く read-only のダッシュボード(ライブ
   更新)。どのペインからでも `prefix + D` でポップできます。
 - **状態確認とレポート** — `--status` の JSON / table で PR review・CI 状態を
@@ -85,6 +87,34 @@ fanout 123 --status     # ファンアウトした子の PR review + CI 状態�
 与えます — 詳細は
 [ワークフローのドキュメント](https://butaosuinu.github.io/fanout/ja/docs/workflow/)
 を参照してください。
+
+## watcher モード
+
+watcher は引数なしの TUI コンソールが開いている間だけ動きます。既定は off で、
+有効化できるのは user config か環境変数だけです。repo config で checkout を
+自動起動の対象にすることはできません。
+
+```bash
+# One shell
+export FANOUT_WATCHER=1
+export FANOUT_WATCHER_AGENT=codex
+fanout
+```
+
+信頼できる issue に `fanout:auto` を付けると投入予約されます。次の cycle で
+fanout はそのラベルを `fanout:running` に付け替え、OPEN 子が無い issue は standalone
+pane として、OPEN 子がある issue は通常の parent fan-out として起動します。parent
+fan-out は `--unblocked-only` を使います。watcher からの起動はすべて
+`watcherMaxSessions` の対象になります。
+
+起動した作業が merge または close されたら、`--merge`、`--close`、`--cleanup` が
+`fanout:running` を best-effort で外します。cleanup 後に同じ親を watcher へ戻す
+には、`fanout:auto` を付け直してください。issue 本文は agent briefing になるため、
+信頼できない issue に trigger label を付けないでください。
+
+この watcher は [#107](https://github.com/butaosuinu/fanout/issues/107) とは別レーンです。
+watcher は repo 全体から label 付き issue を探し、one-shot session を起動します。
+#107 は既知の親 issue 配下の子を skill 主体で継続巡回するループです。
 
 ## 日常コマンド
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ English and 日本語.
 - **Persistent TUI console** — run `fanout` with no arguments for a live
   pane / issue / PR view with a compact Session navigator plus focus, peek,
   terminal, and lifecycle keys.
+- **Label watcher** — opt in to a TUI-resident watcher that turns trusted
+  `fanout:auto` issues into one-shot fanout sessions.
 - **Web dashboard** — a read-only localhost dashboard with live updates; pop it
   from any pane with `prefix + D`.
 - **Status & reporting** — `--status` JSON / table with PR review and CI state,
@@ -82,6 +84,34 @@ Three moves — **prepare → fan out → fold away**:
 `fanout plan <spec>` fans out a local plan spec instead of GitHub child issues,
 and `--team` + `fanout msg` give sibling panes lightweight peer messaging — both
 detailed in the [workflow docs](https://butaosuinu.github.io/fanout/docs/workflow/).
+
+## Watcher mode
+
+The watcher runs only while the no-argument TUI console is open. It is off by
+default, and only user config or environment variables can enable it; repo
+config cannot opt a checkout into background launches.
+
+```bash
+# One shell
+export FANOUT_WATCHER=1
+export FANOUT_WATCHER_AGENT=codex
+fanout
+```
+
+Add `fanout:auto` to a trusted issue to queue it. On the next cycle fanout
+swaps that label to `fanout:running`, then launches either a standalone pane
+for an issue with no OPEN children or a normal parent fan-out for an issue with
+OPEN children. Parent fan-outs use `--unblocked-only`; every watcher launch
+counts against `watcherMaxSessions`.
+
+When the launched work is merged or closed, `--merge`, `--close`, and
+`--cleanup` remove `fanout:running` best-effort. To put the same parent back
+into the watcher after cleanup, add `fanout:auto` again. Do not apply the
+trigger label to untrusted issues: the issue body becomes the agent briefing.
+
+This watcher is separate from [#107](https://github.com/butaosuinu/fanout/issues/107):
+it discovers labeled issues across the repository and starts one-shot sessions.
+#107 remains the skill-led loop for revisiting children under a known parent.
 
 ## Daily commands
 

--- a/README.md
+++ b/README.md
@@ -102,12 +102,17 @@ Add `fanout:auto` to a trusted issue to queue it. On the next cycle fanout
 swaps that label to `fanout:running`, then launches either a standalone pane
 for an issue with no OPEN children or a normal parent fan-out for an issue with
 OPEN children. Parent fan-outs use `--unblocked-only`; every watcher launch
-counts against `watcherMaxSessions`.
+counts against `watcherMaxSessions`. If blocked children or the session cap
+leaves work for later, fanout swaps `fanout:running` back to `fanout:auto` so a
+later cycle retries the parent automatically.
 
-When the launched work is merged or closed, `--merge`, `--close`, and
-`--cleanup` remove `fanout:running` best-effort. To put the same parent back
-into the watcher after cleanup, add `fanout:auto` again. Do not apply the
-trigger label to untrusted issues: the issue body becomes the agent briefing.
+For parent fan-outs, `fanout <parent> --merge <child>`, `--close`, and
+`--cleanup` remove `fanout:running` best-effort. For standalone watcher panes,
+use the TUI lifecycle keys (`m`, `c`, `x`); the public CLI parent argument does
+not target reserved `@watch` rows. To queue a fresh run after a standalone pane
+or fully cleaned parent, add `fanout:auto` again. Do not apply the trigger label
+to untrusted issues: the labeled issue and any OPEN children it launches become
+agent briefings.
 
 This watcher is separate from [#107](https://github.com/butaosuinu/fanout/issues/107):
 it discovers labeled issues across the repository and starts one-shot sessions.

--- a/claude/skills/fanout/SKILL.md
+++ b/claude/skills/fanout/SKILL.md
@@ -46,7 +46,7 @@ does not call an LLM and does not infer tasks from prose.
 
 `fanout <parent-issue-or-project-url>` enumerates either a GitHub parent issue's OPEN sub-issues *or* a GitHub Projects v2 board's OPEN items, and for each child creates a new tmux pane with its own git worktree under `.fanout/worktrees/` and an agent CLI started with a briefing that points at `/tmp/fanout-<repo>-<N>.md`. The caller's pane is not modified.
 
-`fanout` with no arguments starts the persistent fanout TUI console. From a plain shell it creates or attaches a deterministic fanout-managed tmux session for the current repository, then runs the console there. From inside tmux it turns the current pane into the console. The console shows `.fanout/state.json` panes with live tmux plus issue/PR status, a `total` / `merged` / `pending` / `blocked` header rollup, and a compact Session navigator that stays fixed on the side or top depending on terminal width; `[` / `]` jump the pane table to the previous / next Session. It lets the user press `n` to open a modal and launch a manual prompt-based `claude` / `codex` pane (multi-line prompt input uses `Shift+Enter` for newline, with `Ctrl+J` as a terminal fallback; `Enter` creates the pane), and exits on `q` without killing the session or child panes. On a selected recorded pane, `c` closes it, `m` fast-forward merges its recorded branch, and `x` cleans up merged/closed siblings for the same parent after confirmation. It also compares consecutive GitHub snapshots and notifies once per transition when a child becomes merged, CI turns failing, or a child becomes waiting on an open blocker; channels are configured through fanout settings.
+`fanout` with no arguments starts the persistent fanout TUI console. From a plain shell it creates or attaches a deterministic fanout-managed tmux session for the current repository, then runs the console there. From inside tmux it turns the current pane into the console. The console shows `.fanout/state.json` panes with live tmux plus issue/PR status, a `total` / `merged` / `pending` / `blocked` header rollup, and a compact Session navigator that stays fixed on the side or top depending on terminal width; `[` / `]` jump the pane table to the previous / next Session. It lets the user press `n` to open a modal and launch a manual prompt-based `claude` / `codex` pane (multi-line prompt input uses `Shift+Enter` for newline, with `Ctrl+J` as a terminal fallback; `Enter` creates the pane), and exits on `q` without killing the session or child panes. On a selected recorded pane, `c` closes it, `m` fast-forward merges its recorded branch, and `x` cleans up merged/closed siblings for the same parent after confirmation. It also compares consecutive GitHub snapshots and notifies once per transition when a child becomes merged, CI turns failing, or a child becomes waiting on an open blocker; channels are configured through fanout settings. When `watcher` is enabled from user config or the environment, this same TUI runs the label watcher: it looks for trusted `fanout:auto` issues, swaps them to `fanout:running`, and starts one-shot standalone or parent fan-out sessions. Repo config cannot enable the watcher.
 
 The positional argument selects the mode: a bare integer means **issue mode**; a URL of the form `https://github.com/(users|orgs)/<owner>/projects/<num>` means **project mode**. User-facing issue refs like `#N` are accepted by this skill, but strip the leading `#` before invoking the CLI. The two modes share everything downstream of child enumeration — briefing generation, filters, deterministic naming, direct git worktree creation, and tmux pane launch — only the children come from a different source.
 
@@ -62,6 +62,7 @@ Good fits:
 - The user asks whether the installed `fanout` binary is up to date; in that case use `fanout --check-update`, not the pane-creation workflow.
 - The user asks to update fanout itself; in that case run `fanout update` immediately.
 - The user asks to start the fanout console / TUI; in that case run `fanout` with no arguments directly from the target repository worktree, skipping parent resolution, dry-run, pane naming, and agent selection.
+- The user asks for the label watcher; in that case use the TUI-only watcher recipe below.
 - The user asks to fan out an implementation plan or invokes `/fanout plan`; use the `fanout-plan` skill instead of the issue/Project workflow below.
 - The user types `/fanout` or mentions "fan out" / "並列展開".
 
@@ -115,6 +116,33 @@ Before running the real command:
 8. **Dry-run** — run `fanout <N-or-URL> --dry-run <forwarded-flags>` (including any `--include` from step 5 and `--name` from step 7) and show the user: the mode banner (issue / project) the CLI prints, how many children, their titles, the briefing paths, generated names, worktree paths, and warnings. Treat briefing paths in dry-run output as preview paths; fanout writes the files only during the live run. In project mode also surface any "cross-repo item skipped" warnings — those items are intentionally excluded from fan-out. This is the confirmation step for the targets themselves (not the names).
 
 Run fanout from the target repository worktree so `git rev-parse --show-toplevel` resolves the intended project root. For batch pane creation, run it from inside tmux; for the no-argument TUI, a plain shell is fine.
+
+## Label watcher recipe
+
+Use this only when the user asks for watcher behavior: repository-wide label
+discovery and one-shot session launch while the TUI is running. The watcher is
+not a scheduler, webhook, or the #107 known-parent skill loop.
+
+1. Enable it from user config (`~/.config/fanout/config.json` or
+   `$XDG_CONFIG_HOME/fanout/config.json`) or from the current shell with
+   `FANOUT_WATCHER=1`. Use `FANOUT_WATCHER_AGENT` or `watcherAgent` when the
+   default TUI agent is not the desired child agent.
+2. Run `fanout` with no arguments and keep the TUI open. The watcher stops
+   when the TUI exits.
+3. Apply `fanout:auto` only to issues the user trusts. The issue body is copied
+   into the child briefing, so the label is a prompt-injection boundary.
+4. On each cycle fanout swaps `fanout:auto` to `fanout:running`. Issues with no
+   OPEN children launch as standalone panes under parent `@watch`; issues with
+   OPEN children launch as normal parent fan-outs with `--unblocked-only` and
+   the `watcherMaxSessions` budget.
+5. After launched work is merged or closed, `--merge`, `--close`, and
+   `--cleanup` remove `fanout:running` best-effort. To run the same parent
+   again after cleanup, add `fanout:auto` again.
+
+#107 remains the known-parent loop: a skill or `/loop` keeps revisiting one
+parent's children, ready labels, and blocker wave progress. Do not describe the
+label watcher as that flow; it discovers labeled issues across the repository
+and starts sessions once.
 
 ## Running
 

--- a/claude/skills/fanout/SKILL.md
+++ b/claude/skills/fanout/SKILL.md
@@ -129,15 +129,19 @@ not a scheduler, webhook, or the #107 known-parent skill loop.
    default TUI agent is not the desired child agent.
 2. Run `fanout` with no arguments and keep the TUI open. The watcher stops
    when the TUI exits.
-3. Apply `fanout:auto` only to issues the user trusts. The issue body is copied
-   into the child briefing, so the label is a prompt-injection boundary.
+3. Apply `fanout:auto` only when the user trusts the labeled issue and any OPEN
+   children it can launch. Those issue bodies become agent briefings, so the
+   label is a prompt-injection boundary.
 4. On each cycle fanout swaps `fanout:auto` to `fanout:running`. Issues with no
    OPEN children launch as standalone panes under parent `@watch`; issues with
    OPEN children launch as normal parent fan-outs with `--unblocked-only` and
-   the `watcherMaxSessions` budget.
-5. After launched work is merged or closed, `--merge`, `--close`, and
-   `--cleanup` remove `fanout:running` best-effort. To run the same parent
-   again after cleanup, add `fanout:auto` again.
+   the `watcherMaxSessions` budget. Deferred parent fan-outs are requeued by
+   swapping `fanout:running` back to `fanout:auto`.
+5. For parent fan-outs, `--merge`, `--close`, and `--cleanup` remove
+   `fanout:running` best-effort. For standalone `@watch` panes, use the TUI
+   lifecycle keys; the public CLI parent argument cannot target `@watch` rows.
+   To run a completed standalone pane or fully cleaned parent again, add
+   `fanout:auto` again.
 
 #107 remains the known-parent loop: a skill or `/loop` keeps revisiting one
 parent's children, ready labels, and blocker wave progress. Do not describe the

--- a/codex/skills/fanout/SKILL.md
+++ b/codex/skills/fanout/SKILL.md
@@ -163,6 +163,9 @@ export FANOUT_WATCHER_AGENT=codex
 fanout
 ```
 
+Keep the TUI open and skip the rest of this workflow. Watcher mode does not need
+parent resolution, batch tmux pre-flight, dry-run, pane naming, or confirmation.
+
 1. Resolve the parent target from the user's request or recent context. Two
    shapes are accepted; identify which one matches and pass the normalized
    form to the CLI as the positional argument:
@@ -318,15 +321,19 @@ not a scheduler, webhook, or the #107 known-parent skill loop.
    default TUI agent is not the desired child agent.
 2. Run `fanout` with no arguments and keep the TUI open. The watcher stops
    when the TUI exits.
-3. Apply `fanout:auto` only to issues the user trusts. The issue body is copied
-   into the child briefing, so the label is a prompt-injection boundary.
+3. Apply `fanout:auto` only when the user trusts the labeled issue and any OPEN
+   children it can launch. Those issue bodies become agent briefings, so the
+   label is a prompt-injection boundary.
 4. On each cycle fanout swaps `fanout:auto` to `fanout:running`. Issues with no
    OPEN children launch as standalone panes under parent `@watch`; issues with
    OPEN children launch as normal parent fan-outs with `--unblocked-only` and
-   the `watcherMaxSessions` budget.
-5. After launched work is merged or closed, `--merge`, `--close`, and
-   `--cleanup` remove `fanout:running` best-effort. To run the same parent
-   again after cleanup, add `fanout:auto` again.
+   the `watcherMaxSessions` budget. Deferred parent fan-outs are requeued by
+   swapping `fanout:running` back to `fanout:auto`.
+5. For parent fan-outs, `--merge`, `--close`, and `--cleanup` remove
+   `fanout:running` best-effort. For standalone `@watch` panes, use the TUI
+   lifecycle keys; the public CLI parent argument cannot target `@watch` rows.
+   To run a completed standalone pane or fully cleaned parent again, add
+   `fanout:auto` again.
 
 #107 remains the known-parent loop: a skill or `/loop` keeps revisiting one
 parent's children, ready labels, and blocker wave progress. Do not describe the

--- a/codex/skills/fanout/SKILL.md
+++ b/codex/skills/fanout/SKILL.md
@@ -73,6 +73,10 @@ confirmation.
 The TUI also compares consecutive GitHub snapshots and notifies once per
 transition when a child becomes merged, CI turns failing, or a child becomes
 waiting on an open blocker; channels are configured through fanout settings.
+When `watcher` is enabled from user config or the environment, this same TUI
+runs the label watcher: it looks for trusted `fanout:auto` issues, swaps them
+to `fanout:running`, and starts one-shot standalone or parent fan-out sessions.
+Repo config cannot enable the watcher.
 
 The positional argument selects the mode: a bare integer means **issue mode**;
 a URL of the form
@@ -99,6 +103,7 @@ user asks to update fanout itself, run `fanout update` immediately.
 If the user asks to start the fanout console / TUI, run `fanout` with no
 arguments directly from the target repository worktree; skip parent resolution,
 dry-run, pane naming, and agent selection.
+If the user asks for the label watcher, use the TUI-only watcher recipe below.
 If the user asks to fan out an implementation plan, run `$fanout-plan` instead
 of the issue/Project workflow below.
 Do not invoke fanout just because an issue has sub-issues; pane creation is
@@ -147,6 +152,16 @@ If the user's intent is to start the persistent TUI console, run `fanout` with
 no arguments from the target repository worktree and skip the rest of this
 workflow. TUI mode does not need a parent issue, Project URL, `--agent`,
 dry-run, generated pane names, or confirmation.
+
+If the user's intent is repo-wide automatic launch from labels, enable the
+watcher only through user config or environment variables, then run the
+no-argument TUI. Do not use `.fanout/config.json` to opt in. A one-shell setup:
+
+```bash
+export FANOUT_WATCHER=1
+export FANOUT_WATCHER_AGENT=codex
+fanout
+```
 
 1. Resolve the parent target from the user's request or recent context. Two
    shapes are accepted; identify which one matches and pass the normalized
@@ -290,6 +305,33 @@ exclusive with all action-bearing flags
 `--no-codex-plan-mode`, `--pr-visualization`, `--no-pr-visualization`). Set
 `FANOUT_STATE_PATH` to
 read a specific state file outside the repository checkout.
+
+## Label watcher recipe
+
+Use this only when the user asks for watcher behavior: repository-wide label
+discovery and one-shot session launch while the TUI is running. The watcher is
+not a scheduler, webhook, or the #107 known-parent skill loop.
+
+1. Enable it from user config (`~/.config/fanout/config.json` or
+   `$XDG_CONFIG_HOME/fanout/config.json`) or from the current shell with
+   `FANOUT_WATCHER=1`. Use `FANOUT_WATCHER_AGENT` or `watcherAgent` when the
+   default TUI agent is not the desired child agent.
+2. Run `fanout` with no arguments and keep the TUI open. The watcher stops
+   when the TUI exits.
+3. Apply `fanout:auto` only to issues the user trusts. The issue body is copied
+   into the child briefing, so the label is a prompt-injection boundary.
+4. On each cycle fanout swaps `fanout:auto` to `fanout:running`. Issues with no
+   OPEN children launch as standalone panes under parent `@watch`; issues with
+   OPEN children launch as normal parent fan-outs with `--unblocked-only` and
+   the `watcherMaxSessions` budget.
+5. After launched work is merged or closed, `--merge`, `--close`, and
+   `--cleanup` remove `fanout:running` best-effort. To run the same parent
+   again after cleanup, add `fanout:auto` again.
+
+#107 remains the known-parent loop: a skill or `/loop` keeps revisiting one
+parent's children, ready labels, and blocker wave progress. Do not describe the
+label watcher as that flow; it discovers labeled issues across the repository
+and starts sessions once.
 
 ## Implicit Child Scan
 

--- a/site/content/docs/settings.ja.md
+++ b/site/content/docs/settings.ja.md
@@ -73,8 +73,9 @@ integer の環境変数は 10 進整数を受け付けます。`watcherIntervalS
 
 repo config では watcher を opt-in できません。`<project_root>/.fanout/config.json` が `watcher` を設定している場合、fanout は警告してそのキーを無視します。user config または `FANOUT_WATCHER` を使ってください。repo config では `watcherTriggerLabel`、`watcherRunningLabel`、`watcherIntervalSeconds`、`watcherAgent`、`watcherMaxSessions` は設定できます。
 
-trigger label は issue 本文から agent 作業を始める合図です。信頼できる issue にだけ
-付けてください。
+trigger label は label 付き issue と、parent fan-out で起動される OPEN child から
+agent 作業を始める合図です。それらの本文は agent briefing になります。label は
+実行依頼として扱い、その issue と起動対象 child を信頼できる場合だけ付けてください。
 
 ## 前方互換
 

--- a/site/content/docs/settings.ja.md
+++ b/site/content/docs/settings.ja.md
@@ -73,6 +73,9 @@ integer の環境変数は 10 進整数を受け付けます。`watcherIntervalS
 
 repo config では watcher を opt-in できません。`<project_root>/.fanout/config.json` が `watcher` を設定している場合、fanout は警告してそのキーを無視します。user config または `FANOUT_WATCHER` を使ってください。repo config では `watcherTriggerLabel`、`watcherRunningLabel`、`watcherIntervalSeconds`、`watcherAgent`、`watcherMaxSessions` は設定できます。
 
+trigger label は issue 本文から agent 作業を始める合図です。信頼できる issue にだけ
+付けてください。
+
 ## 前方互換
 
 不正な bool / integer env 値、設定ファイル内の未知キー、JSON type が合わない値は warn して無視します。将来の設定追加で古い fanout バイナリが壊れないようにするためです。

--- a/site/content/docs/settings.md
+++ b/site/content/docs/settings.md
@@ -73,6 +73,9 @@ Integer environment values accept base-10 integers. `watcherIntervalSeconds` res
 
 Repo config cannot opt into the watcher. If `<project_root>/.fanout/config.json` sets `watcher`, fanout warns and ignores that key; use user config or `FANOUT_WATCHER` instead. Repo config may still set `watcherTriggerLabel`, `watcherRunningLabel`, `watcherIntervalSeconds`, `watcherAgent`, and `watcherMaxSessions`.
 
+The trigger label starts agent work from issue text, so treat it as an execution
+request. Apply it only to issues you trust.
+
 ## Forward compatibility
 
 Invalid boolean or integer env values, unknown file keys, and file values with the wrong JSON type are warned and ignored, so future settings additions do not break older fanout binaries.

--- a/site/content/docs/settings.md
+++ b/site/content/docs/settings.md
@@ -73,8 +73,10 @@ Integer environment values accept base-10 integers. `watcherIntervalSeconds` res
 
 Repo config cannot opt into the watcher. If `<project_root>/.fanout/config.json` sets `watcher`, fanout warns and ignores that key; use user config or `FANOUT_WATCHER` instead. Repo config may still set `watcherTriggerLabel`, `watcherRunningLabel`, `watcherIntervalSeconds`, `watcherAgent`, and `watcherMaxSessions`.
 
-The trigger label starts agent work from issue text, so treat it as an execution
-request. Apply it only to issues you trust.
+The trigger label starts agent work from the labeled issue and, for parent
+fan-outs, any OPEN children it launches. Their bodies become agent briefings, so
+treat the label as an execution request and apply it only when you trust that
+issue and its launchable children.
 
 ## Forward compatibility
 

--- a/site/content/docs/workflow.ja.md
+++ b/site/content/docs/workflow.ja.md
@@ -76,6 +76,34 @@ fanout 123 --unblocked-only --limit 3
 
 2 つ目の形は、fanout に次の unblocked バッチを選ばせつつ、各 wave の件数を制限します。
 
+## ラベル watcher
+
+watcher は引数なしの TUI コンソールが開いている間だけ動きます。既定は off で、
+有効化できるのは user config か環境変数だけです。repo config で checkout を
+自動起動の対象にすることはできません。
+
+```bash
+# One shell
+export FANOUT_WATCHER=1
+export FANOUT_WATCHER_AGENT=codex
+fanout
+```
+
+信頼できる issue に `fanout:auto` を付けると投入予約されます。次の cycle で
+fanout はそのラベルを `fanout:running` に付け替え、OPEN 子が無い issue は standalone
+pane として、OPEN 子がある issue は通常の parent fan-out として起動します。parent
+fan-out は `--unblocked-only` を使います。watcher からの起動はすべて
+`watcherMaxSessions` の対象になります。
+
+起動した作業が merge または close されたら、`--merge`、`--close`、`--cleanup` が
+`fanout:running` を best-effort で外します。cleanup 後に同じ親を watcher へ戻す
+には、`fanout:auto` を付け直してください。issue 本文は agent briefing になるため、
+信頼できない issue に trigger label を付けないでください。
+
+この watcher は [#107](https://github.com/butaosuinu/fanout/issues/107) とは別レーンです。
+watcher は repo 全体から label 付き issue を探し、one-shot session を起動します。
+#107 は既知の親 issue 配下の子を skill 主体で継続巡回するループです。
+
 ## issue-less plan fan-out
 
 作業がローカルで既に分解されていて、GitHub child issue を作りたくない場合は

--- a/site/content/docs/workflow.ja.md
+++ b/site/content/docs/workflow.ja.md
@@ -93,12 +93,17 @@ fanout
 fanout はそのラベルを `fanout:running` に付け替え、OPEN 子が無い issue は standalone
 pane として、OPEN 子がある issue は通常の parent fan-out として起動します。parent
 fan-out は `--unblocked-only` を使います。watcher からの起動はすべて
-`watcherMaxSessions` の対象になります。
+`watcherMaxSessions` の対象になります。blocked child や session 上限により残りが
+ある場合、fanout は `fanout:running` を `fanout:auto` に戻し、後続 cycle でその
+parent を自動再試行します。
 
-起動した作業が merge または close されたら、`--merge`、`--close`、`--cleanup` が
-`fanout:running` を best-effort で外します。cleanup 後に同じ親を watcher へ戻す
-には、`fanout:auto` を付け直してください。issue 本文は agent briefing になるため、
-信頼できない issue に trigger label を付けないでください。
+parent fan-out では、`fanout <parent> --merge <child>`、`--close`、`--cleanup` が
+`fanout:running` を best-effort で外します。standalone watcher pane は TUI の
+lifecycle key（`m`、`c`、`x`）で処理してください。公開 CLI の parent 引数では
+予約 parent `@watch` の row を指定できません。standalone pane または完全 cleanup
+済み parent を新しく投入するには、`fanout:auto` を付け直してください。label 付き
+issue と、起動される OPEN child の本文は agent briefing になります。信頼できない
+issue に trigger label を付けないでください。
 
 この watcher は [#107](https://github.com/butaosuinu/fanout/issues/107) とは別レーンです。
 watcher は repo 全体から label 付き issue を探し、one-shot session を起動します。

--- a/site/content/docs/workflow.md
+++ b/site/content/docs/workflow.md
@@ -93,12 +93,17 @@ Add `fanout:auto` to a trusted issue to queue it. On the next cycle fanout
 swaps that label to `fanout:running`, then launches either a standalone pane
 for an issue with no OPEN children or a normal parent fan-out for an issue with
 OPEN children. Parent fan-outs use `--unblocked-only`; every watcher launch
-counts against `watcherMaxSessions`.
+counts against `watcherMaxSessions`. If blocked children or the session cap
+leaves work for later, fanout swaps `fanout:running` back to `fanout:auto` so a
+later cycle retries the parent automatically.
 
-When the launched work is merged or closed, `--merge`, `--close`, and
-`--cleanup` remove `fanout:running` best-effort. To put the same parent back
-into the watcher after cleanup, add `fanout:auto` again. Do not apply the
-trigger label to untrusted issues: the issue body becomes the agent briefing.
+For parent fan-outs, `fanout <parent> --merge <child>`, `--close`, and
+`--cleanup` remove `fanout:running` best-effort. For standalone watcher panes,
+use the TUI lifecycle keys (`m`, `c`, `x`); the public CLI parent argument does
+not target reserved `@watch` rows. To queue a fresh run after a standalone pane
+or fully cleaned parent, add `fanout:auto` again. Do not apply the trigger label
+to untrusted issues: the labeled issue and any OPEN children it launches become
+agent briefings.
 
 This watcher is separate from [#107](https://github.com/butaosuinu/fanout/issues/107):
 it discovers labeled issues across the repository and starts one-shot sessions.

--- a/site/content/docs/workflow.md
+++ b/site/content/docs/workflow.md
@@ -76,6 +76,34 @@ fanout 123 --unblocked-only --limit 3
 
 The second form caps each wave while letting fanout pick the next unblocked batch.
 
+## Label watcher
+
+The watcher runs only while the no-argument TUI console is open. It is off by
+default, and only user config or environment variables can enable it; repo
+config cannot opt a checkout into background launches.
+
+```bash
+# One shell
+export FANOUT_WATCHER=1
+export FANOUT_WATCHER_AGENT=codex
+fanout
+```
+
+Add `fanout:auto` to a trusted issue to queue it. On the next cycle fanout
+swaps that label to `fanout:running`, then launches either a standalone pane
+for an issue with no OPEN children or a normal parent fan-out for an issue with
+OPEN children. Parent fan-outs use `--unblocked-only`; every watcher launch
+counts against `watcherMaxSessions`.
+
+When the launched work is merged or closed, `--merge`, `--close`, and
+`--cleanup` remove `fanout:running` best-effort. To put the same parent back
+into the watcher after cleanup, add `fanout:auto` again. Do not apply the
+trigger label to untrusted issues: the issue body becomes the agent briefing.
+
+This watcher is separate from [#107](https://github.com/butaosuinu/fanout/issues/107):
+it discovers labeled issues across the repository and starts one-shot sessions.
+#107 remains the skill-led loop for revisiting children under a known parent.
+
 ## Issue-less plan fan-out
 
 Use `fanout plan` when the work is already decomposed locally and you do not


### PR DESCRIPTION
## TL;DR

Documented the watcher workflow and constraints across the README, site docs, repo guidance, and bundled fanout skills. Review effort: 2

## Why

Issue #227 asks for watcher usage docs, the TUI-only and opt-in constraints, label flow, cleanup requeue UX, prompt-injection warning, and a clear boundary with #107. The issue is specific and docs-focused.

## Changes by file

<details><summary>Changed files</summary>

| File | What changed | Why |
|---|---|---|
| `README.md` | Added a watcher feature bullet and watcher mode section. | Put the user-facing watcher contract in the top-level English README. |
| `README.ja.md` | Added the matching Japanese watcher feature bullet and watcher mode section. | Keep README languages in sync. |
| `site/content/docs/workflow.md` | Added the watcher workflow section matching README behavior. | Mirror README guidance in the docs site workflow page. |
| `site/content/docs/workflow.ja.md` | Added the matching Japanese watcher workflow section. | Keep docs site language pairs in sync. |
| `site/content/docs/settings.md` | Added a trigger-label safety note under watcher safety. | Make the prompt-injection boundary discoverable near watcher settings. |
| `site/content/docs/settings.ja.md` | Added the matching Japanese trigger-label safety note. | Keep settings docs language pairs in sync. |
| `CLAUDE.md` | Documented `cmd/fanout/tui.go`, `internal/watch`, and watcher behavior boundaries. | Keep repo architecture notes aligned with the merged watcher packages. |
| `AGENTS.md` | Added `internal/watch` to the package map and watcher boundary notes. | Give Codex the same repository guidance. |
| `claude/skills/fanout/SKILL.md` | Added the label watcher recipe and invocation guidance. | Teach Claude-side fanout usage how to operate watcher mode safely. |
| `codex/skills/fanout/SKILL.md` | Added the label watcher recipe, workflow branch, and invocation guidance. | Teach Codex-side fanout usage how to operate watcher mode safely. |

</details>

## Risk

> [!WARNING]
> This is docs and integration guidance only, but inaccurate watcher wording could cause users to label untrusted issues. The updated README, workflow docs, settings docs, and skills all state that issue bodies become briefings and trigger labels should only be applied to trusted issues.

## Test plan

- `make lint` — passed.
- `make test` — passed, including Go unit tests, web vitest, Tier1 bats, and Tier2 golden tests.
- `codex review --uncommitted` — passed with no findings.
- `git diff --name-only main...HEAD` and `git status --short` — matched the 10 changed files above; worktree clean.

Closes #227
