### PR TITLE
[codex] suppress post-work-review review polling

### DIFF
--- a/codex/skills/post-work-review/SKILL.md
+++ b/codex/skills/post-work-review/SKILL.md
@@ -48,8 +48,11 @@ PR 全体相当の branch diff をレビューする。`--commit HEAD` だけで
 ## Review Loop
 
 1. レビュー対象とコマンドを 1 文でユーザーに伝える。
-2. `codex review ...` を実行する。
-3. 出力を findings として読む。重大度、ファイル、行、指摘内容を保持する。
+2. `codex review ...` を 1 つの blocking shell command として実行する。完了まで
+   一切何もしない。途中 stdout、Review Session、`/codex:status`、tmux pane、
+   `exec_command` の `session_id` などを見に行かない。command が終了してから
+   final output を 1 回だけ読む。
+3. final output を findings として読む。重大度、ファイル、行、指摘内容を保持する。
 4. actionable な指摘だけ修正する。明らかな bug、規約違反、セキュリティ問題、
    テスト不整合を優先する。単なる好みの提案は理由を添えて見送ってよい。
 5. 修正したら、必要な focused test や formatting check を実行する。

--- a/codex/skills/post-work-review/SKILL.md
+++ b/codex/skills/post-work-review/SKILL.md
@@ -48,10 +48,11 @@ PR 全体相当の branch diff をレビューする。`--commit HEAD` だけで
 ## Review Loop
 
 1. レビュー対象とコマンドを 1 文でユーザーに伝える。
-2. `codex review ...` を 1 つの blocking shell command として実行する。完了まで
-   一切何もしない。途中 stdout、Review Session、`/codex:status`、tmux pane、
-   `exec_command` の `session_id` などを見に行かない。command が終了してから
-   final output を 1 回だけ読む。
+2. `codex review ...` を 1 つの blocking shell command として実行する。長時間実行で
+   `exec_command` の `session_id` が返る可能性がある場合は、stdout/stderr を一時
+   ファイルへ退避するなどして polling 中に部分出力を流さない。Review Session、
+   `/codex:status`、tmux pane は見に行かず、`session_id` はプロセス終了確認だけに
+   使う。command が終了してから final output を 1 回だけ読む。
 3. final output を findings として読む。重大度、ファイル、行、指摘内容を保持する。
 4. actionable な指摘だけ修正する。明らかな bug、規約違反、セキュリティ問題、
    テスト不整合を優先する。単なる好みの提案は理由を添えて見送ってよい。


### PR DESCRIPTION
## Summary

- Update the Codex `post-work-review` skill so `codex review ...` is treated as one blocking shell command.
- Explicitly prevent reading partial stdout, Review Session state, `/codex:status`, tmux panes, or `exec_command` session output while review is still running.
- Keep the existing review loop, clean verdict, oscillation, and marker behavior unchanged.

## Validation

- `diff -u codex/skills/post-work-review/SKILL.md ~/.codex/skills/post-work-review/SKILL.md`
- `git diff --check`

## Notes

`quick_validate.py` was attempted, but the local environment is missing `PyYAML` (`ModuleNotFoundError: No module named 'yaml'`). The change does not touch frontmatter.