### PR TITLE
fix(tui): keep new-session worktree off local base when refresh skippable

### DIFF
--- a/cmd/fanout/pane.go
+++ b/cmd/fanout/pane.go
@@ -32,6 +32,11 @@ const (
 	codexPlanTUIStartupPoll    = 200 * time.Millisecond
 )
 
+// baseRefreshSkippedNotice prefixes the warning logged when a best-effort base
+// refresh is tolerated. launchManualPaneFromTUI scrapes it from buffered launch
+// output so the TUI can surface the skip in its success notice.
+const baseRefreshSkippedNotice = "base branch refresh skipped"
+
 var errCodexPlanStartupTimeout = errors.New("timed out waiting for Codex Plan TUI startup")
 
 type paneRequest struct {
@@ -83,7 +88,10 @@ func createPane(cfg *cliflags.Config, lg *log.Logger, info *fanoutruntime.Info, 
 		return false
 	}
 	req.AgentCommand = agentCmd
-	if req.Worktree.Refresh && req.Worktree.RefreshError != nil {
+	// Strict children (issue/plan) fail fast on a known refresh error. Best-effort
+	// manual panes fall through; the skip is surfaced once via Prepare's
+	// RefreshWarning below so it is not logged twice.
+	if req.Worktree.Refresh && req.Worktree.RefreshError != nil && !req.Worktree.RefreshBestEffort {
 		lg.Err("%s: prepare worktree: %v", paneLogLabel(req), req.Worktree.RefreshError)
 		return false
 	}
@@ -109,7 +117,13 @@ func createPane(cfg *cliflags.Config, lg *log.Logger, info *fanoutruntime.Info, 
 		BaseBranch:         req.Worktree.BaseBranch,
 		NoRefresh:          cfg.NoRefresh,
 		AllowMissingOrigin: req.Worktree.AllowMissingOrigin,
+		RefreshBestEffort:  req.Worktree.RefreshBestEffort,
 	})
+	// Surface a tolerated refresh skip before the error check so the diagnostic
+	// is not lost when a later worktree step fails.
+	if prepared.RefreshWarning != nil {
+		lg.Warn("%s: %s: %v", paneLogLabel(req), baseRefreshSkippedNotice, prepared.RefreshWarning)
+	}
 	if err != nil {
 		lg.Err("%s: prepare worktree: %v", paneLogLabel(req), err)
 		return false
@@ -362,7 +376,7 @@ func newManualPaneRequest(cfg *cliflags.Config, projectRoot string, store state.
 		Hooks:        hookConfig,
 		BriefingPath: briefingPath,
 		BriefingBody: briefingBody,
-		Worktree:     worktree.BuildPlan(worktree.Options{ProjectRoot: projectRoot, Slug: slug, BranchName: branchName, BaseBranch: cfg.BaseBranch, NoRefresh: cfg.NoRefresh, AllowMissingOrigin: true}),
+		Worktree:     worktree.BuildPlan(worktree.Options{ProjectRoot: projectRoot, Slug: slug, BranchName: branchName, BaseBranch: cfg.BaseBranch, NoRefresh: cfg.NoRefresh, AllowMissingOrigin: true, RefreshBestEffort: true}),
 	}
 }
 

--- a/cmd/fanout/pane_test.go
+++ b/cmd/fanout/pane_test.go
@@ -161,10 +161,16 @@ func TestPlanAndManualPaneRequestsAllowMissingOrigin(t *testing.T) {
 	if !taskReq.Worktree.AllowMissingOrigin {
 		t.Fatal("task pane AllowMissingOrigin = false, want true")
 	}
+	if taskReq.Worktree.RefreshBestEffort {
+		t.Fatal("task pane RefreshBestEffort = true, want false (plan tasks keep strict refresh)")
+	}
 
 	manualReq := newManualPaneRequest(cfg, "/repo", state.Store{}, hooks.EmptyConfig(), manualPaneOptions{Title: "Manual diagnostics"})
 	if !manualReq.Worktree.AllowMissingOrigin {
 		t.Fatal("manual pane AllowMissingOrigin = false, want true")
+	}
+	if !manualReq.Worktree.RefreshBestEffort {
+		t.Fatal("manual pane RefreshBestEffort = false, want true (TUI new sessions tolerate a dirty local base)")
 	}
 }
 

--- a/cmd/fanout/tui.go
+++ b/cmd/fanout/tui.go
@@ -412,29 +412,29 @@ func hasRecordedIssuePane(store state.Store, issueNum int) bool {
 }
 
 func newTUILaunchPaneFunc(projectRoot, session, commandName string, hookConfig hooks.Config) fanouttui.LaunchFunc {
-	return func(req fanouttui.LaunchRequest) error {
+	return func(req fanouttui.LaunchRequest) (string, error) {
 		return launchManualPaneFromTUI(projectRoot, session, commandName, hookConfig, req)
 	}
 }
 
-func launchManualPaneFromTUI(projectRoot, session, commandName string, hookConfig hooks.Config, req fanouttui.LaunchRequest) error {
+func launchManualPaneFromTUI(projectRoot, session, commandName string, hookConfig hooks.Config, req fanouttui.LaunchRequest) (string, error) {
 	prompt := normalizeTUIPrompt(req.Prompt)
 	if prompt == "" {
-		return fmt.Errorf("prompt is required")
+		return "", fmt.Errorf("prompt is required")
 	}
 	agentName := strings.TrimSpace(req.Agent)
 	if agentName == "" {
 		agentName = defaultTUIAgent()
 	}
 	if err := agent.ValidateKnown(agentName); err != nil {
-		return err
+		return "", err
 	}
 	if err := agent.ValidateInstalled(agentName); err != nil {
-		return err
+		return "", err
 	}
 	slug, err := normalizeTUISlug(req.Slug)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	var stdout, stderr bytes.Buffer
@@ -442,7 +442,7 @@ func launchManualPaneFromTUI(projectRoot, session, commandName string, hookConfi
 	cfg := &cliflags.Config{Agent: agentName}
 	store, recorder, code := loadRunState(cfg, projectRoot, launchLogger)
 	if code != exitcode.OK {
-		return bufferedLaunchError(stdout, stderr, "load fanout state")
+		return "", bufferedLaunchError(stdout, stderr, "load fanout state")
 	}
 	if recorder != nil {
 		defer func() {
@@ -457,9 +457,20 @@ func launchManualPaneFromTUI(projectRoot, session, commandName string, hookConfi
 	}
 	paneReq := newManualPaneRequest(cfg, projectRoot, store, hookConfig, manualPaneOptionsForTUI(prompt, slug, agentName))
 	if !createPane(cfg, launchLogger, info, paneReq, recorder, log.Palette{}, commandName) {
-		return bufferedLaunchError(stdout, stderr, "create pane")
+		return "", bufferedLaunchError(stdout, stderr, "create pane")
 	}
-	return nil
+	return bufferedLaunchNotice(stderr), nil
+}
+
+// bufferedLaunchNotice extracts the tolerated base-refresh skip line, if any,
+// from a successful launch's buffered log so the TUI can show it on success.
+func bufferedLaunchNotice(stderr bytes.Buffer) string {
+	for line := range strings.SplitSeq(stderr.String(), "\n") {
+		if i := strings.Index(line, baseRefreshSkippedNotice); i >= 0 {
+			return strings.TrimSpace(line[i:])
+		}
+	}
+	return ""
 }
 
 func newTUILaunchShellFunc(projectRoot, session string) fanouttui.ShellLaunchFunc {

--- a/cmd/fanout/tui_test.go
+++ b/cmd/fanout/tui_test.go
@@ -99,7 +99,7 @@ func TestLaunchManualPaneFromTUIChecksAgentBeforeState(t *testing.T) {
 	repo := t.TempDir()
 	t.Setenv("PATH", t.TempDir())
 
-	err := launchManualPaneFromTUI(repo, "fanout-test", "fanout", hooks.EmptyConfig(), fanouttui.LaunchRequest{
+	_, err := launchManualPaneFromTUI(repo, "fanout-test", "fanout", hooks.EmptyConfig(), fanouttui.LaunchRequest{
 		Prompt: "inspect workspace",
 		Agent:  "claude",
 	})

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -85,8 +85,9 @@ type LaunchRequest struct {
 	Slug   string
 }
 
-// LaunchFunc creates a manual fanout pane for a TUI request.
-type LaunchFunc func(LaunchRequest) error
+// LaunchFunc creates a manual fanout pane for a TUI request. It returns an
+// optional notice (e.g. a tolerated base-refresh skip) to surface on success.
+type LaunchFunc func(LaunchRequest) (notice string, err error)
 
 // WatcherRunner runs one watcher cycle.
 type WatcherRunner interface {
@@ -331,7 +332,8 @@ type (
 	ghTickMsg     time.Time
 	watchTickMsg  time.Time
 	launchPaneMsg struct {
-		err error
+		notice string
+		err    error
 	}
 	launchShellMsg struct {
 		req ShellLaunchRequest
@@ -718,7 +720,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.mode = modeMonitor
-		m.notice = "created new agent pane"
+		if msg.notice != "" {
+			m.notice = msg.notice
+		} else {
+			m.notice = "created new agent pane"
+		}
 		return m, m.loadStateCmd(false)
 	case launchShellMsg:
 		if msg.err != nil {
@@ -1361,7 +1367,8 @@ func (m *model) submitNewPane() tea.Cmd {
 	}
 	launch := m.opts.LaunchPane
 	return func() tea.Msg {
-		return launchPaneMsg{err: launch(req)}
+		notice, err := launch(req)
+		return launchPaneMsg{notice: notice, err: err}
 	}
 }
 

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -791,7 +791,7 @@ func TestWatchTickRunsCycleAndRefreshesStateAndGH(t *testing.T) {
 		DefaultAgent:   "codex",
 		FocusPane:      func(string) error { return nil },
 		PaneAlive:      func(string) bool { return true },
-		LaunchPane:     func(LaunchRequest) error { return nil },
+		LaunchPane:     func(LaunchRequest) (string, error) { return "", nil },
 		LaunchShell:    func(ShellLaunchRequest) error { return nil },
 		Notifier:       nil,
 		lifecycle:      &fakeLifecycleRunner{},
@@ -1953,9 +1953,9 @@ func TestShellTerminalKeyRequiresSelectedWorktree(t *testing.T) {
 }
 
 func TestNewPaneFormRequiresPrompt(t *testing.T) {
-	m := newModel(Options{LaunchPane: func(LaunchRequest) error {
+	m := newModel(Options{LaunchPane: func(LaunchRequest) (string, error) {
 		t.Fatal("LaunchPane should not be called without a prompt")
-		return nil
+		return "", nil
 	}})
 	m.openNewPaneForm()
 
@@ -1972,10 +1972,10 @@ func TestNewPaneFormSubmitsLaunchRequest(t *testing.T) {
 	called := false
 	m := newModel(Options{
 		DefaultAgent: "codex",
-		LaunchPane: func(req LaunchRequest) error {
+		LaunchPane: func(req LaunchRequest) (string, error) {
 			called = true
 			got = req
-			return nil
+			return "", nil
 		},
 	})
 	m.openNewPaneForm()
@@ -2005,9 +2005,9 @@ func TestNewPaneFormSubmitsLaunchRequest(t *testing.T) {
 func TestNewPaneFormPromptNewlineKeysDoNotSubmit(t *testing.T) {
 	called := false
 	m := newModel(Options{
-		LaunchPane: func(LaunchRequest) error {
+		LaunchPane: func(LaunchRequest) (string, error) {
 			called = true
-			return nil
+			return "", nil
 		},
 	})
 	m.openNewPaneForm()
@@ -2028,9 +2028,9 @@ func TestNewPaneFormSubmitsMultilinePrompt(t *testing.T) {
 	var got LaunchRequest
 	m := newModel(Options{
 		DefaultAgent: "codex",
-		LaunchPane: func(req LaunchRequest) error {
+		LaunchPane: func(req LaunchRequest) (string, error) {
 			got = req
-			return nil
+			return "", nil
 		},
 	})
 	m.openNewPaneForm()
@@ -2080,6 +2080,22 @@ func TestNewPaneLaunchSuccessReturnsToMonitorAndReloadsState(t *testing.T) {
 	}
 	if cmd == nil {
 		t.Fatal("launch success did not request a state reload")
+	}
+}
+
+func TestNewPaneLaunchSuccessSurfacesNotice(t *testing.T) {
+	m := newModel(Options{})
+	m.openNewPaneForm()
+
+	skip := "base branch refresh skipped: local branch main is checked out"
+	updated, _ := m.Update(launchPaneMsg{notice: skip})
+	got := updated.(model)
+
+	if got.mode != modeMonitor {
+		t.Fatalf("mode = %v, want monitor", got.mode)
+	}
+	if got.notice != skip {
+		t.Fatalf("notice = %q, want the launch notice %q", got.notice, skip)
 	}
 }
 

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -31,6 +31,11 @@ type Options struct {
 	BaseBranch         string
 	NoRefresh          bool
 	AllowMissingOrigin bool
+	// RefreshBestEffort downgrades a failed base-branch refresh from a fatal
+	// error to a skipped step, so the worktree is still created from the
+	// un-refreshed local base. Manual TUI panes set this; issue/plan children
+	// keep the strict fail-on-dirty-base behavior.
+	RefreshBestEffort bool
 }
 
 type Plan struct {
@@ -40,6 +45,7 @@ type Plan struct {
 	BaseBranch           string
 	AllowMissingOrigin   bool
 	Refresh              bool
+	RefreshBestEffort    bool
 	RefreshDetails       RefreshDetails
 	RefreshError         error
 	RefreshSkippedReason string
@@ -49,6 +55,9 @@ type Result struct {
 	Plan
 	AlreadyExists bool
 	BranchCreated bool
+	// RefreshWarning holds the refresh error that was tolerated because
+	// RefreshBestEffort was set; nil when refresh succeeded or was not run.
+	RefreshWarning error
 }
 
 // BuildPlan resolves deterministic worktree paths and the base branch.
@@ -76,6 +85,7 @@ func BuildPlan(opts Options) Plan {
 		BaseBranch:           base,
 		AllowMissingOrigin:   opts.AllowMissingOrigin,
 		Refresh:              refresh,
+		RefreshBestEffort:    opts.RefreshBestEffort,
 		RefreshDetails:       refreshDetails,
 		RefreshError:         refreshErr,
 		RefreshSkippedReason: refreshSkippedReason,
@@ -95,16 +105,27 @@ func Prepare(opts Options) (Result, error) {
 	if exists {
 		return Result{Plan: plan, AlreadyExists: true}, nil
 	}
+	var refreshWarning error
 	if plan.Refresh {
-		if plan.RefreshError != nil {
-			return Result{Plan: plan}, plan.RefreshError
+		refreshErr := plan.RefreshError
+		if refreshErr == nil {
+			refreshErr = RefreshBase(plan.ProjectRoot, plan.BaseBranch)
 		}
-		if err := RefreshBase(plan.ProjectRoot, plan.BaseBranch); err != nil {
-			return Result{Plan: plan}, err
+		if refreshErr != nil {
+			// Best-effort downgrades a failed refresh to a warning so a manual
+			// pane is still created off the un-refreshed local base. Only tolerate
+			// it when the base is still usable for branching: a failure that left
+			// the base unresolvable (e.g. a fetch failure before the local base
+			// branch existed) must surface the clearer refresh error instead of a
+			// confusing 'git worktree add' failure later.
+			if !plan.RefreshBestEffort || !baseResolvable(plan.ProjectRoot, plan.BaseBranch) {
+				return Result{Plan: plan}, refreshErr
+			}
+			refreshWarning = refreshErr
 		}
 	}
 	if err := os.MkdirAll(filepath.Dir(plan.WorktreePath), 0o755); err != nil {
-		return Result{Plan: plan}, fmt.Errorf("create worktree parent: %w", err)
+		return Result{Plan: plan, RefreshWarning: refreshWarning}, fmt.Errorf("create worktree parent: %w", err)
 	}
 	_, _ = git(plan.ProjectRoot, "worktree", "prune")
 	branchWasPresent := branchExists(plan.ProjectRoot, plan.BranchName)
@@ -119,9 +140,9 @@ func Prepare(opts Options) (Result, error) {
 		if !branchWasPresent {
 			_, _ = git(plan.ProjectRoot, "branch", "-D", plan.BranchName)
 		}
-		return Result{Plan: plan}, fmt.Errorf("git worktree add: %w", err)
+		return Result{Plan: plan, RefreshWarning: refreshWarning}, fmt.Errorf("git worktree add: %w", err)
 	}
-	return Result{Plan: plan, BranchCreated: !branchWasPresent}, nil
+	return Result{Plan: plan, BranchCreated: !branchWasPresent, RefreshWarning: refreshWarning}, nil
 }
 
 // EnsureLocalExclude keeps generated fanout runtime files out of the user's git status.
@@ -419,5 +440,16 @@ func branchExists(root, branch string) bool {
 		return false
 	}
 	_, err := gitTrim(root, "rev-parse", "--verify", "refs/heads/"+branch)
+	return err == nil
+}
+
+// baseResolvable reports whether base names a commit git can branch from, so a
+// best-effort refresh failure is only tolerated when the resulting worktree add
+// can still succeed.
+func baseResolvable(root, base string) bool {
+	if base == "" {
+		return false
+	}
+	_, err := gitTrim(root, "rev-parse", "--verify", "--quiet", base+"^{commit}")
 	return err == nil
 }

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -101,6 +101,118 @@ func TestPrepareSupportsOriginQualifiedBase(t *testing.T) {
 	}
 }
 
+func TestPrepareBestEffortToleratesDirtyCheckedOutBase(t *testing.T) {
+	dir := t.TempDir()
+	origin := filepath.Join(dir, "origin.git")
+	seed := filepath.Join(dir, "seed")
+	repo := filepath.Join(dir, "repo")
+
+	gitTest(t, "", "init", "--bare", origin)
+	gitTest(t, "", "init", seed)
+	gitTest(t, seed, "checkout", "-b", "main")
+	writeFile(t, filepath.Join(seed, "file.txt"), "one\n")
+	gitTest(t, seed, "add", "file.txt")
+	gitTest(t, seed, "-c", "user.name=Fanout Test", "-c", "user.email=fanout@example.test", "commit", "-m", "one")
+	gitTest(t, seed, "remote", "add", "origin", origin)
+	gitTest(t, seed, "push", "-u", "origin", "main")
+
+	gitTest(t, "", "clone", origin, repo)
+	gitTest(t, repo, "checkout", "main")
+	localHead := gitOutput(t, repo, "rev-parse", "main")
+
+	// Advance origin so a refresh would try to fast-forward the local main.
+	writeFile(t, filepath.Join(seed, "file.txt"), "two\n")
+	gitTest(t, seed, "add", "file.txt")
+	gitTest(t, seed, "-c", "user.name=Fanout Test", "-c", "user.email=fanout@example.test", "commit", "-m", "two")
+	gitTest(t, seed, "push", "origin", "main")
+
+	// Make the checked-out main dirty so the fast-forward refuses (the TUI `n` repro).
+	writeFile(t, filepath.Join(repo, "file.txt"), "local edit\n")
+
+	// Strict refresh still refuses on a dirty checked-out base.
+	if _, err := Prepare(Options{
+		ProjectRoot: repo,
+		Slug:        "strict",
+		BranchName:  "fanout/strict",
+		BaseBranch:  "main",
+	}); err == nil {
+		t.Fatal("Prepare() strict = nil error, want refusal on dirty checked-out base")
+	}
+
+	// Best-effort tolerates the failed refresh and branches off local main as-is.
+	res, err := Prepare(Options{
+		ProjectRoot:       repo,
+		Slug:              "best-effort",
+		BranchName:        "fanout/best-effort",
+		BaseBranch:        "main",
+		RefreshBestEffort: true,
+	})
+	if err != nil {
+		t.Fatalf("Prepare() best-effort failed: %v", err)
+	}
+	if res.RefreshWarning == nil {
+		t.Fatal("Prepare() best-effort RefreshWarning = nil, want the skipped refresh error")
+	}
+	if got := gitOutput(t, res.WorktreePath, "rev-parse", "HEAD"); got != localHead {
+		t.Fatalf("worktree HEAD = %s, want local main %s", got, localHead)
+	}
+	if got := gitOutput(t, repo, "rev-parse", "main"); got != localHead {
+		t.Fatalf("local main = %s, want unchanged %s", got, localHead)
+	}
+	if got := gitOutput(t, repo, "status", "--short"); got == "" {
+		t.Fatal("local edit was lost; repo status is clean")
+	}
+}
+
+func TestPrepareBestEffortBranchesOffLocalCommitsWhenDiverged(t *testing.T) {
+	dir := t.TempDir()
+	origin := filepath.Join(dir, "origin.git")
+	seed := filepath.Join(dir, "seed")
+	repo := filepath.Join(dir, "repo")
+
+	gitTest(t, "", "init", "--bare", origin)
+	gitTest(t, "", "init", seed)
+	gitTest(t, seed, "checkout", "-b", "main")
+	writeFile(t, filepath.Join(seed, "file.txt"), "one\n")
+	gitTest(t, seed, "add", "file.txt")
+	gitTest(t, seed, "-c", "user.name=Fanout Test", "-c", "user.email=fanout@example.test", "commit", "-m", "one")
+	gitTest(t, seed, "remote", "add", "origin", origin)
+	gitTest(t, seed, "push", "-u", "origin", "main")
+
+	gitTest(t, "", "clone", origin, repo)
+	gitTest(t, repo, "checkout", "main")
+
+	// A committed local-only change leaves main ahead of origin; a strict refresh
+	// would refuse to fast-forward, but the user opted to keep these commits.
+	writeFile(t, filepath.Join(repo, "local.txt"), "local only\n")
+	gitTest(t, repo, "add", "local.txt")
+	gitTest(t, repo, "-c", "user.name=Fanout Test", "-c", "user.email=fanout@example.test", "commit", "-m", "local only")
+	localHead := gitOutput(t, repo, "rev-parse", "main")
+
+	res, err := Prepare(Options{
+		ProjectRoot:       repo,
+		Slug:              "ahead",
+		BranchName:        "fanout/ahead",
+		BaseBranch:        "main",
+		RefreshBestEffort: true,
+	})
+	if err != nil {
+		t.Fatalf("Prepare() best-effort failed: %v", err)
+	}
+	if res.RefreshWarning == nil {
+		t.Fatal("Prepare() best-effort RefreshWarning = nil, want the tolerated divergence error")
+	}
+	if got := gitOutput(t, res.WorktreePath, "rev-parse", "HEAD"); got != localHead {
+		t.Fatalf("worktree HEAD = %s, want local main %s (local commits must be included)", got, localHead)
+	}
+	if _, err := os.Stat(filepath.Join(res.WorktreePath, "local.txt")); err != nil {
+		t.Fatalf("worktree missing local-only commit content: %v", err)
+	}
+	if got := gitOutput(t, repo, "rev-parse", "main"); got != localHead {
+		t.Fatalf("local main = %s, want unchanged %s", got, localHead)
+	}
+}
+
 func TestPrepareAllowsMissingOriginFromCurrentBranch(t *testing.T) {
 	repo := newCommittedRepoWithoutOrigin(t)
 	baseHead := gitOutput(t, repo, "rev-parse", "HEAD")


### PR DESCRIPTION
## 背景

TUI で `n`(新規 Session = manual pane 作成)を押すと、次のエラーで Session 開始に失敗していた:

```
error: [err ] #-1: prepare worktree: local branch main is checked out at <repo> with uncommitted changes; refusing to fast-forward
```

「main で開始しようとしている」のではなく、新規ブランチ名 `fanout/manual-N-...-pane` 自体はユニーク。真の原因は **ベースブランチ `main` の refresh(ローカル main の fast-forward)** が、checkout 済み + dirty な main を更新できず致命的エラーになり、pane 作成全体を止めていたこと。`git worktree add -b <uniq> <path> main` 自体は main が dirty でも成功する。

## 変更

manual pane(TUI `n`)のベース refresh を **best-effort** 化:

- 失敗時はローカル base のままユニークな worktree を作成して続行(未 push のローカルコミットも保持)。
- skip は TUI の success notice に表示(`base branch refresh skipped: ...`)。
- best-effort で許容するのは base が commit に解決できるときだけ。fetch 失敗で base が解決不能な場合は、紛らわしい `git worktree add` エラーではなく元の明確な refresh エラーを surface する。
- issue/plan の子は CLAUDE.md 方針どおり **strict**(dirty/diverged な base は fail)を維持。

### 主なファイル

- `internal/worktree/worktree.go`: `Options`/`Plan` に `RefreshBestEffort`、`Result` に `RefreshWarning`。refresh ブロックを単一ガードに整理し、`baseResolvable` ガードを追加。warning を全リターンに伝播。
- `cmd/fanout/pane.go`: manual pane に `RefreshBestEffort: true`。preflight を strict 専用化し、skip 警告を `Prepare` 後に一本化(重複排除)。
- `cmd/fanout/tui.go` / `internal/tui/tui.go`: `LaunchFunc` を `(notice, error)` 化し、best-effort skip を TUI に可視化。

## テスト

- `worktree_test.go`: dirty な checkout 済み base / ahead(未 push コミット)の許容を検証。strict は従来どおり fail。
- `tui_test.go`: success notice に skip 警告を表示。
- `pane_test.go`: manual=best-effort / plan=strict のフラグ分岐を検証。
- `go test ./...` 全パス、Tier2 ゴールデン差分ゼロ、`make lint` 0 issues。

## レビュー

`/post-work-review` で code-review(xhigh)+ codex review を通過。codex の P2(skip 警告が TUI バッファログで握りつぶされる)を本 PR 内で修正済み(`LaunchFunc` の notice 伝播)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RTuTV1AEPioqLrce9YPkmh