### PR TITLE
[codex] Codex PR言語ルールを追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,17 @@ versions and rerun `make install` or `make link`.
 The user-facing surface is documented in `README.md` and `README.ja.md`. Read
 the README before changing CLI behavior.
 
+## Codex PR Language
+
+When Codex creates a PR in this repository, write the PR description/body in
+Japanese. Keep machine-readable tokens such as `TL;DR`, `Review effort: <0-5>`,
+file paths, commands, code identifiers, and required footer lines like
+`Closes #N` unchanged.
+
+When Codex runs or posts automatic review comments for a PR in this repository,
+write those review comments in Japanese. Keep file paths, line numbers, symbol
+names, command names, and quoted code unchanged.
+
 ## Working With fanout
 
 `fanout` is a standalone git worktree + tmux pane + agent launcher. Build with


### PR DESCRIPTION
## TL;DR

AGENTS.md に、Codex がこのリポジトリで作成する PR 本文と PR 自動レビューコメントを日本語にするルールを追加しました。

Review effort: 0

## 背景

fanout 本体の briefing や同梱 skill ではなく、このプロジェクトで Codex が従う作業ルールとして管理します。

## 変更内容

| File | What changed | Why |
|---|---|---|
| AGENTS.md | Codex PR Language 節を追加 | PR 本文と Codex 自動レビューコメントの言語ルールをプロジェクトスコープで明文化するため |

## テスト

- `git diff --check -- AGENTS.md`
