### PR TITLE
feat(tui): frame new-session modal text inputs

### DIFF
--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -446,6 +446,10 @@ var (
 	errStyle   = lipgloss.NewStyle().Foreground(colorBeni)
 	panelStyle = lipgloss.NewStyle().Border(lipgloss.NormalBorder(), true, false, false, false).BorderForeground(colorSuna)
 	modalStyle = lipgloss.NewStyle().Border(lipgloss.NormalBorder()).Padding(1, 2).BorderForeground(colorAsagi)
+	// inputBoxStyle / inputBoxFocusStyle frame the modal's text inputs so the
+	// field bounds are visible; the border color also doubles as a focus cue.
+	inputBoxStyle      = lipgloss.NewStyle().Border(lipgloss.NormalBorder()).BorderForeground(colorSuna)
+	inputBoxFocusStyle = lipgloss.NewStyle().Border(lipgloss.NormalBorder()).BorderForeground(colorAsagi)
 )
 
 // Run starts the Bubble Tea TUI.
@@ -890,9 +894,9 @@ func (m *model) resize() {
 		return
 	}
 	if m.mode == modeNewPane {
-		inputWidth := m.formInputWidth()
+		inputWidth := m.inputContentWidth()
 		m.newPane.prompt.SetWidth(inputWidth)
-		m.newPane.slug.Width = inputWidth
+		m.newPane.slug.Width = textinputWidth(inputWidth, m.newPane.slug.Prompt)
 	}
 	layout := m.monitorLayout()
 	m.table.SetWidth(layout.MainWidth)
@@ -1360,7 +1364,7 @@ func (m model) renderActionMessage() string {
 func (m *model) openNewPaneForm() {
 	m.mode = modeNewPane
 	m.notice = ""
-	m.newPane = newNewPaneForm(m.opts.DefaultAgent, m.formInputWidth())
+	m.newPane = newNewPaneForm(m.opts.DefaultAgent, m.inputContentWidth())
 }
 
 func newNewPaneForm(defaultAgent string, width int) newPaneForm {
@@ -1381,7 +1385,7 @@ func newNewPaneForm(defaultAgent string, width int) newPaneForm {
 	slug.Placeholder = "optional-slug"
 	slug.Prompt = "> "
 	slug.CharLimit = 80
-	slug.Width = width
+	slug.Width = textinputWidth(width, slug.Prompt)
 	slug.Blur()
 
 	if defaultAgent != "codex" {
@@ -1492,9 +1496,9 @@ func (m *model) submitNewPane() tea.Cmd {
 func (m model) newPaneView() string {
 	lines := []string{
 		titleStyle.Render("New agent pane"),
-		m.newPaneFieldView(newPaneFieldPrompt, "Prompt", m.newPane.prompt.View()),
-		m.newPaneFieldView(newPaneFieldAgent, "Agent", m.agentSelectorView()),
-		m.newPaneFieldView(newPaneFieldSlug, "Slug", m.newPane.slug.View()),
+		m.newPaneFieldView(newPaneFieldPrompt, "Prompt", m.newPane.prompt.View(), true),
+		m.newPaneFieldView(newPaneFieldAgent, "Agent", m.agentSelectorView(), false),
+		m.newPaneFieldView(newPaneFieldSlug, "Slug", m.newPane.slug.View(), true),
 	}
 	if m.newPane.launching {
 		lines = append(lines, dimStyle.Render("creating pane..."))
@@ -1506,10 +1510,18 @@ func (m model) newPaneView() string {
 	return modalStyle.Width(m.modalWidth()).Render(strings.Join(lines, "\n"))
 }
 
-func (m model) newPaneFieldView(field newPaneField, label, value string) string {
+func (m model) newPaneFieldView(field newPaneField, label, value string, boxed bool) string {
+	focused := m.newPane.focus == field
 	marker := "  "
-	if m.newPane.focus == field {
+	if focused {
 		marker = "> "
+	}
+	if boxed {
+		style := inputBoxStyle
+		if focused {
+			style = inputBoxFocusStyle
+		}
+		value = style.Render(value)
 	}
 	return marker + label + "\n" + value
 }
@@ -1531,6 +1543,22 @@ func (m model) formInputWidth() int {
 		return 72
 	}
 	return clampInt(m.modalWidth()-8, 24, 92)
+}
+
+// inputContentWidth is the rendered width each framed text input should occupy.
+// It leaves room for the input box's left/right border so the framed field
+// keeps the same footprint as formInputWidth.
+func (m model) inputContentWidth() int {
+	return m.formInputWidth() - 2
+}
+
+// textinputWidth converts a desired total rendered width into the bubbles
+// textinput Width setting. Unlike textarea (whose SetWidth is the full rendered
+// width, prompt included), a textinput renders its prompt plus one trailing
+// cursor cell outside of Width, so the two must be offset to frame to the same
+// width.
+func textinputWidth(rendered int, prompt string) int {
+	return rendered - lipgloss.Width(prompt) - 1
 }
 
 func (m model) modalWidth() int {

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -2251,7 +2251,9 @@ func TestNewPaneFormSubmitsMultilinePrompt(t *testing.T) {
 func TestNewPaneViewRendersModalOverMonitor(t *testing.T) {
 	m := newModel(Options{})
 	m.width = 100
-	m.height = 30
+	// Tall enough that the centered modal does not cover the monitor's header
+	// and pane rows behind it (the framed inputs make the modal ~22 lines).
+	m.height = 48
 	m.allPanes = []paneView{{Parent: "100", IssueNum: 1, Name: "existing", TmuxState: "live"}}
 	m.refreshRows()
 	m.openNewPaneForm()
@@ -2261,6 +2263,40 @@ func TestNewPaneViewRendersModalOverMonitor(t *testing.T) {
 		if !strings.Contains(view, want) {
 			t.Fatalf("modal view missing %q:\n%s", want, view)
 		}
+	}
+}
+
+func TestNewPaneViewFramesTextInputs(t *testing.T) {
+	m := newModel(Options{})
+	m.width = 100
+	m.height = 30
+	m.openNewPaneForm()
+
+	view := m.newPaneView()
+	// One border for the modal itself plus one around each text input
+	// (Prompt and Slug); the Agent toggle stays unframed, so exactly three
+	// top-left corners must appear.
+	if got := strings.Count(view, "┌"); got != 3 {
+		t.Fatalf("framed input boxes: got %d top-left corners, want 3:\n%s", got, view)
+	}
+
+	// Collect each "┌...┐" top border. Order: modal outer frame, then the
+	// Prompt box, then the Slug box. The two input boxes must frame to the same
+	// width — textarea and textinput need different Width settings to line up.
+	var boxTops []string
+	for ln := range strings.SplitSeq(view, "\n") {
+		i := strings.Index(ln, "┌")
+		j := strings.Index(ln, "┐")
+		if i < 0 || j < 0 || j < i {
+			continue
+		}
+		boxTops = append(boxTops, ln[i:j+len("┐")])
+	}
+	if len(boxTops) != 3 {
+		t.Fatalf("box top borders: got %d, want 3:\n%s", len(boxTops), view)
+	}
+	if prompt, slug := len([]rune(boxTops[1])), len([]rune(boxTops[2])); prompt != slug {
+		t.Fatalf("Prompt box width %d != Slug box width %d:\n%s", prompt, slug, view)
 	}
 }
 


### PR DESCRIPTION
## 背景

TUI 常駐コンソールで新規 Session(「New agent pane」)を立ち上げるモーダルは、モーダル全体は枠線で囲われているものの、中の Prompt 欄(`textarea`)と Slug 欄(`textinput`)には個別の枠線がなく、どこからどこまでが入力欄なのか分かりにくかった。

## 変更内容

各テキスト入力欄を `NormalBorder` のボックスで囲い、視認性を向上させた。

- **`inputBoxStyle`(砂色)/ `inputBoxFocusStyle`(浅葱色)を追加**し、フォーカス中/非フォーカスで枠線色を切り替え。枠線色がそのままフォーカス位置の手がかりになる。対象はテキスト入力欄のみ(Prompt / Slug)で、トグル選択の Agent 欄は従来どおり枠なし。
- **`inputContentWidth()`**(枠線分 -2)と **`textinputWidth()`** ヘルパーを追加。`textarea.SetWidth` は prompt 込みの総描画幅だが、`textinput` は prompt と末尾カーソル1桁を `Width` の外側に描画するため、両者をオフセットして等幅で揃えた(この補正がないと Slug ボックスが Prompt ボックスより約3桁 wide になる)。

レンダリング結果:

```
  > Prompt
  ┌────────────────────────────────────...────────┐
  │> （プロンプト入力 6 行）                          │
  └────────────────────────────────────...────────┘
    Agent
  [claude]   codex
    Slug
  ┌────────────────────────────────────...────────┐
  │> optional-slug                                 │
  └────────────────────────────────────...────────┘
```

## テスト

- `TestNewPaneViewFramesTextInputs` を追加(枠の左上角=3個 + Prompt/Slug ボックスが等幅であることを検証)。
- 枠線追加でモーダルが約4行高くなった分、既存 `TestNewPaneViewRendersModalOverMonitor` のオーバーレイ検証高さを 30→48 に引き上げ。
- `go test ./internal/tui/...` 緑、`make lint` 0 issues。

## 既知のトレードオフ

入力欄2つに枠線を付けたことでモーダルが約22行に高くなった。30行程度の端末では中央寄せモーダルが背後の監視ビューをほぼ覆い、22行未満の端末では下端がクリップされる(`overlayCentered` の既存制約)。枠線機能に伴う本質的なトレードオフのため、プロンプト高さ等の UX を削ってまでの対処は見送った。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbcMyMoRcT8YXo9QfSX8vs