### PR TITLE
docs: v0.8.0 changelog とインストール例の更新

### DIFF
--- a/site/content/docs/changelog.ja.md
+++ b/site/content/docs/changelog.ja.md
@@ -9,6 +9,14 @@ yomi: changelog
 
 リリースのハイライトを新しい順に並べています。各タグには完全なコミット一覧とビルド済みバイナリ（darwin / linux × amd64 / arm64）を含む [GitHub release](https://github.com/butaosuinu/fanout/releases) があります。バージョンは git タグから ldflags 経由で埋め込まれます — `fanout --check-update` で自分の版を確認できます。
 
+## v0.8.0 — 2026-06-24
+
+- **ラベル watcher。** opt-in すると、TUI 常駐の watcher が信頼できる `fanout:auto` issue を one-shot の fanout session に変えます。起動前に trigger ラベルを `fanout:running` に付け替え、OPEN な子を持つ issue を親 fan-out として分類し、live-pane の上限を尊重します。有効化できるのは user config か `FANOUT_WATCHER*` 環境変数だけで、repo config はラベル・間隔・子 agent・session 上限を設定できますが checkout を起動側に切り替えることはできません。[Workflow]({{< relref "/docs/workflow" >}}) と [Settings]({{< relref "/docs/settings" >}}) を参照。
+- **全 worktree を横断するダッシュボード。** Web ダッシュボードが、現在の worktree だけでなくリポジトリ内の全 worktree の Session を横断集約するようになりました。ブラウザのタブ 1 つで並列作業すべてを見渡せます。[Monitoring]({{< relref "/docs/monitoring" >}}) を参照。
+- **複数 agent の TUI 起動。** 常駐コンソールの `n` modal が、枠付きテキスト入力で agent ごとの `claude` / `codex` 起動数を指定できるようになり、`codex` pane は Plan Mode で起動します。[Monitoring]({{< relref "/docs/monitoring" >}}) を参照。
+
+[リリースノート →](https://github.com/butaosuinu/fanout/releases/tag/v0.8.0)
+
 ## v0.7.0 — 2026-06-21
 
 - **ライフサイクルフック。** worktree・pane・merge イベントの前後でユーザーの shell hook を実行するようになりました。`$XDG_CONFIG_HOME/fanout/hooks.json`(Codex 形式の `hooks` オブジェクト)で設定します。常時有効で、ファイルが無い場合やコマンドの無いイベントは no-op です。[CLI Reference]({{< relref "/docs/cli" >}}) を参照。

--- a/site/content/docs/changelog.md
+++ b/site/content/docs/changelog.md
@@ -9,6 +9,14 @@ yomi: changelog
 
 Release highlights, newest first. Every tag also has a [GitHub release](https://github.com/butaosuinu/fanout/releases) with the full commit list and prebuilt binaries (darwin / linux × amd64 / arm64). Versions come from git tags via ldflags — check yours with `fanout --check-update`.
 
+## v0.8.0 — 2026-06-24
+
+- **Label watcher.** Opt in to a TUI-resident watcher that turns trusted `fanout:auto` issues into one-shot fanout sessions. It swaps the trigger label to `fanout:running` before launch, classifies issues with OPEN children as parent fan-outs, and honors a live-pane budget. Enable it only through user config or `FANOUT_WATCHER*` environment variables; repo config can set the labels, interval, child agent, and session cap but never opt a checkout into launching. See [Workflow]({{< relref "/docs/workflow" >}}) and [Settings]({{< relref "/docs/settings" >}}).
+- **Dashboard spans every worktree.** The web dashboard now aggregates Sessions across every worktree in the repo, not just the current one, so a single browser tab covers all parallel work. See [Monitoring]({{< relref "/docs/monitoring" >}}).
+- **Multi-agent TUI launches.** The persistent console's `n` modal now takes per-agent `claude` / `codex` launch counts behind framed text inputs, and `codex` panes start in Plan Mode. See [Monitoring]({{< relref "/docs/monitoring" >}}).
+
+[Release notes →](https://github.com/butaosuinu/fanout/releases/tag/v0.8.0)
+
 ## v0.7.0 — 2026-06-21
 
 - **Lifecycle hooks.** fanout now runs user shell hooks around worktree, pane, and merge events. Configure them in `$XDG_CONFIG_HOME/fanout/hooks.json` (a Codex-style `hooks` object); they are always enabled, and a missing file or an event with no commands is a no-op. See [CLI Reference]({{< relref "/docs/cli" >}}).

--- a/site/content/docs/installation.ja.md
+++ b/site/content/docs/installation.ja.md
@@ -35,7 +35,7 @@ curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh |
 
 # 配置先や Release tag を指定
 curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh | BIN_DIR=/usr/local/bin sh
-curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh | FANOUT_VERSION=v0.2.0 sh
+curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh | FANOUT_VERSION=v0.8.0 sh
 ```
 
 `install.sh` は macOS/Linux と amd64/arm64 を自動判定し、最新 GitHub Release(または `FANOUT_VERSION` で指定した tag)から `fanout_<os>_<arch>.tar.gz` を取得します。`sha256sum` または `shasum` があれば `SHA256SUMS` で検証し、再実行時は同じパスへ上書きします。シェル rc は自動編集しません。

--- a/site/content/docs/installation.md
+++ b/site/content/docs/installation.md
@@ -35,7 +35,7 @@ curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh |
 
 # Custom destination or pinned release tag
 curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh | BIN_DIR=/usr/local/bin sh
-curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh | FANOUT_VERSION=v0.2.0 sh
+curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh | FANOUT_VERSION=v0.8.0 sh
 ```
 
 `install.sh` detects macOS/Linux and amd64/arm64, downloads `fanout_<os>_<arch>.tar.gz` from the latest GitHub Release (or `FANOUT_VERSION`), verifies `SHA256SUMS` when `sha256sum` or `shasum` exists, and overwrites the same paths on rerun. It never edits shell rc files.


### PR DESCRIPTION
## 概要

v0.8.0 リリースに向けて、未更新だったドキュメントを更新します。

- `site/content/docs/changelog.{md,ja.md}` に **v0.8.0 — 2026-06-24** エントリを追加(v0.7.0 以降の主な変更):
  - **Label watcher** — opt-in の TUI 常駐 watcher(`fanout:auto` → `fanout:running`、#299–#303)
  - **Dashboard spans every worktree** — 全 worktree 横断で Session 集約(#324)
  - **Multi-agent TUI launches** — `n` モーダルの agent ごと起動数指定・枠付き入力・codex Plan Mode(#327, #328, #330)
- `site/content/docs/installation.{md,ja.md}` のピン止め例を `FANOUT_VERSION=v0.2.0` → `v0.8.0` に更新

site docs の機能記述(watcher / dashboard / TUI / codex plan mode)は既に各ドキュメントに反映済みのため、changelog とインストール例のみの差分です。マージ後に v0.8.0 タグを打ってリリースします。

## テスト

- ドキュメントのみ。`{{< relref >}}` リンク先(`/docs/workflow`, `/docs/settings`, `/docs/monitoring`)は既存。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RtJyGvah2EtH5dnknYyKpG