### PR TITLE
[codex] add TUI close options

### DIFF
--- a/cmd/fanout/lifecycle_test.go
+++ b/cmd/fanout/lifecycle_test.go
@@ -103,6 +103,148 @@ printf '\n' >> "$TMUX_LOG"
 	}
 }
 
+func TestLifecycleClosePaneOnlyKeepsWorktreeAndBranch(t *testing.T) {
+	repo := initLifecycleRepo(t)
+	worktreePath := filepath.Join(repo, ".fanout", "worktrees", "close-child-101")
+	branch := "fanout/close-child-101"
+	gitCmdTest(t, repo, "worktree", "add", "-b", branch, worktreePath, "HEAD")
+	tmuxLog := installLifecycleScript(t, "tmux", `#!/bin/sh
+printf '%s ' "$@" >> "$TMUX_LOG"
+printf '\n' >> "$TMUX_LOG"
+`)
+	t.Setenv("TMUX_LOG", tmuxLog)
+	writeLifecycleState(t, repo, state.Pane{
+		Parent:       "84",
+		IssueNum:     101,
+		Slug:         "close-child-101",
+		BranchName:   branch,
+		PaneID:       "%42",
+		WorktreePath: worktreePath,
+	})
+
+	code := lifecycle.CloseWithMode(
+		lifecycle.Options{ProjectRoot: repo, StatePath: state.Path(repo)},
+		"84",
+		101,
+		lifecycle.ClosePaneOnly,
+		discardLogger(),
+	)
+
+	if code != exitcode.OK {
+		t.Fatalf("CloseWithMode pane-only code = %d, want %d", code, exitcode.OK)
+	}
+	if _, err := os.Stat(worktreePath); err != nil {
+		t.Fatalf("worktree path should remain: %v", err)
+	}
+	if out, err := exec.Command("git", "-C", repo, "show-ref", "--verify", "--quiet", "refs/heads/"+branch).CombinedOutput(); err != nil {
+		t.Fatalf("branch should remain: %v\n%s", err, out)
+	}
+	loaded, err := state.LoadProject(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded.Panes) != 0 {
+		t.Fatalf("state panes = %+v, want empty", loaded.Panes)
+	}
+	body, err := os.ReadFile(tmuxLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), "kill-pane -t %42") {
+		t.Fatalf("tmux log = %q, want kill-pane for %%42", body)
+	}
+}
+
+func TestLifecycleCloseEverythingDeletesLocalBranch(t *testing.T) {
+	repo := initLifecycleRepo(t)
+	worktreePath := filepath.Join(repo, ".fanout", "worktrees", "close-child-101")
+	branch := "fanout/close-child-101"
+	gitCmdTest(t, repo, "worktree", "add", "-b", branch, worktreePath, "HEAD")
+	tmuxLog := installLifecycleScript(t, "tmux", `#!/bin/sh
+printf '%s ' "$@" >> "$TMUX_LOG"
+printf '\n' >> "$TMUX_LOG"
+`)
+	t.Setenv("TMUX_LOG", tmuxLog)
+	writeLifecycleState(t, repo, state.Pane{
+		Parent:       "84",
+		IssueNum:     101,
+		Slug:         "close-child-101",
+		BranchName:   branch,
+		PaneID:       "%42",
+		WorktreePath: worktreePath,
+	})
+
+	code := lifecycle.CloseWithMode(
+		lifecycle.Options{ProjectRoot: repo, StatePath: state.Path(repo)},
+		"84",
+		101,
+		lifecycle.CloseEverything,
+		discardLogger(),
+	)
+
+	if code != exitcode.OK {
+		t.Fatalf("CloseWithMode delete-everything code = %d, want %d", code, exitcode.OK)
+	}
+	if _, err := os.Stat(worktreePath); !os.IsNotExist(err) {
+		t.Fatalf("worktree still exists or stat failed unexpectedly: %v", err)
+	}
+	if out, err := exec.Command("git", "-C", repo, "show-ref", "--verify", "--quiet", "refs/heads/"+branch).CombinedOutput(); err == nil {
+		t.Fatalf("branch should be deleted; git output:\n%s", out)
+	}
+	loaded, err := state.LoadProject(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded.Panes) != 0 {
+		t.Fatalf("state panes = %+v, want empty", loaded.Panes)
+	}
+}
+
+func TestLifecycleCloseEverythingPrunesStaleWorktreeBeforeDeletingBranch(t *testing.T) {
+	repo := initLifecycleRepo(t)
+	worktreePath := filepath.Join(repo, ".fanout", "worktrees", "stale-child-101")
+	branch := "fanout/stale-child-101"
+	gitCmdTest(t, repo, "worktree", "add", "-b", branch, worktreePath, "HEAD")
+	if err := os.RemoveAll(worktreePath); err != nil {
+		t.Fatal(err)
+	}
+	tmuxLog := installLifecycleScript(t, "tmux", `#!/bin/sh
+printf '%s ' "$@" >> "$TMUX_LOG"
+printf '\n' >> "$TMUX_LOG"
+`)
+	t.Setenv("TMUX_LOG", tmuxLog)
+	writeLifecycleState(t, repo, state.Pane{
+		Parent:       "84",
+		IssueNum:     101,
+		Slug:         "stale-child-101",
+		BranchName:   branch,
+		PaneID:       "%42",
+		WorktreePath: worktreePath,
+	})
+
+	code := lifecycle.CloseWithMode(
+		lifecycle.Options{ProjectRoot: repo, StatePath: state.Path(repo)},
+		"84",
+		101,
+		lifecycle.CloseEverything,
+		discardLogger(),
+	)
+
+	if code != exitcode.OK {
+		t.Fatalf("CloseWithMode stale worktree code = %d, want %d", code, exitcode.OK)
+	}
+	if out, err := exec.Command("git", "-C", repo, "show-ref", "--verify", "--quiet", "refs/heads/"+branch).CombinedOutput(); err == nil {
+		t.Fatalf("branch should be deleted; git output:\n%s", out)
+	}
+	loaded, err := state.LoadProject(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded.Panes) != 0 {
+		t.Fatalf("state panes = %+v, want empty", loaded.Panes)
+	}
+}
+
 func TestCmdCloseWarnsButKeepsOKWhenRunningLabelRemovalFails(t *testing.T) {
 	repo := initLifecycleRepo(t)
 	worktreePath := filepath.Join(repo, ".fanout", "worktrees", "close-child-101")

--- a/cmd/fanout/lifecycle_test.go
+++ b/cmd/fanout/lifecycle_test.go
@@ -245,6 +245,59 @@ printf '\n' >> "$TMUX_LOG"
 	}
 }
 
+func TestLifecycleCloseEverythingStillClosesWhenBranchDeleteFails(t *testing.T) {
+	repo := initLifecycleRepo(t)
+	branch := "fanout/checked-out-child-101"
+	gitCmdTest(t, repo, "switch", "-c", branch)
+	tmuxLog := installLifecycleScript(t, "tmux", `#!/bin/sh
+printf '%s ' "$@" >> "$TMUX_LOG"
+printf '\n' >> "$TMUX_LOG"
+`)
+	t.Setenv("TMUX_LOG", tmuxLog)
+	writeLifecycleState(t, repo, state.Pane{
+		Parent:       "84",
+		IssueNum:     101,
+		Slug:         "checked-out-child-101",
+		BranchName:   branch,
+		PaneID:       "%42",
+		WorktreePath: filepath.Join(repo, ".fanout", "worktrees", "missing-child-101"),
+	})
+
+	var stderr bytes.Buffer
+	lg := log.NewWith(io.Discard, &stderr, false)
+	code := lifecycle.CloseWithMode(
+		lifecycle.Options{ProjectRoot: repo, StatePath: state.Path(repo)},
+		"84",
+		101,
+		lifecycle.CloseEverything,
+		lg,
+	)
+
+	if code != exitcode.OK {
+		t.Fatalf("CloseWithMode branch delete failure code = %d, want %d; stderr=%s", code, exitcode.OK, stderr.String())
+	}
+	if out, err := exec.Command("git", "-C", repo, "show-ref", "--verify", "--quiet", "refs/heads/"+branch).CombinedOutput(); err != nil {
+		t.Fatalf("checked-out branch should remain: %v\n%s", err, out)
+	}
+	loaded, err := state.LoadProject(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(loaded.Panes) != 0 {
+		t.Fatalf("state panes = %+v, want empty", loaded.Panes)
+	}
+	body, err := os.ReadFile(tmuxLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(body), "kill-pane -t %42") {
+		t.Fatalf("tmux log = %q, want kill-pane for %%42", body)
+	}
+	if !strings.Contains(stderr.String(), "leaving branch in place") {
+		t.Fatalf("stderr = %q, want branch delete warning", stderr.String())
+	}
+}
+
 func TestCmdCloseWarnsButKeepsOKWhenRunningLabelRemovalFails(t *testing.T) {
 	repo := initLifecycleRepo(t)
 	worktreePath := filepath.Join(repo, ".fanout", "worktrees", "close-child-101")

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -461,14 +461,8 @@ func closePaneRecords(opts Options, panes []state.Pane, mode CloseMode, lg Logge
 			runBackgroundHook(hooks.WorktreeRemoved, opts, pane, "", lg)
 		}
 		if mode == CloseEverything {
-			if !pruneWorktrees(opts.ProjectRoot, lg) {
-				ok = false
-				continue
-			}
-			if !deleteBranch(opts.ProjectRoot, pane, lg) {
-				ok = false
-				continue
-			}
+			_ = pruneWorktrees(opts.ProjectRoot, lg)
+			deleteBranchBestEffort(opts.ProjectRoot, pane, lg)
 		}
 		runBackgroundHook(hooks.BeforePaneClose, opts, pane, "", lg)
 		killPaneBestEffort(pane, lg)
@@ -521,25 +515,24 @@ func removeWorktree(projectRoot string, pane state.Pane, lg Logger) bool {
 	return true
 }
 
-func deleteBranch(projectRoot string, pane state.Pane, lg Logger) bool {
+func deleteBranchBestEffort(projectRoot string, pane state.Pane, lg Logger) {
 	branch := strings.TrimSpace(pane.BranchName)
 	if branch == "" {
-		lg.Err("%s: no branchName recorded; cannot delete local branch", paneLabel(pane))
-		return false
+		lg.Warn("%s: no branchName recorded; skipping local branch delete", paneLabel(pane))
+		return
 	}
 	if !localBranchExists(projectRoot, branch) {
 		lg.Warn("%s: local branch already absent: %s", paneLabel(pane), branch)
-		return true
+		return
 	}
 	out, err := gitLifecycle(projectRoot, "branch", "-D", branch)
 	if err != nil {
-		lg.Err("%s: git branch -D %s failed", paneLabel(pane), branch)
+		lg.Warn("%s: git branch -D %s failed; leaving branch in place", paneLabel(pane), branch)
 		if s := strings.TrimSpace(string(out)); s != "" {
 			fmt.Fprintln(lg.Stderr(), s)
 		}
-		return false
+		return
 	}
-	return true
 }
 
 func localBranchExists(projectRoot, branch string) bool {

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -43,11 +43,32 @@ type statusChild struct {
 	HasMergedPR bool
 }
 
+// CloseMode selects how much repository state a close operation removes.
+type CloseMode int
+
+const (
+	// ClosePaneOnly kills the tmux pane and removes fanout state, leaving the
+	// worktree and branch available outside fanout.
+	ClosePaneOnly CloseMode = iota
+	// CloseWorktree kills the tmux pane, removes the worktree, and leaves the
+	// local branch intact. This is the historical --close behavior.
+	CloseWorktree
+	// CloseEverything also deletes the recorded local branch after removing the
+	// worktree.
+	CloseEverything
+)
+
 const watcherStandaloneParent = "@watch"
 
 // Close removes the recorded worktree(s), best-effort kills tmux pane(s), and
 // removes all state rows matching parent and issueNum.
 func Close(opts Options, parent string, issueNum int, lg Logger) exitcode.Code {
+	return CloseWithMode(opts, parent, issueNum, CloseWorktree, lg)
+}
+
+// CloseWithMode closes all recorded panes matching parent and issueNum using
+// mode to decide whether worktree and branch state should also be removed.
+func CloseWithMode(opts Options, parent string, issueNum int, mode CloseMode, lg Logger) exitcode.Code {
 	locked, code := lockStateOnly("--close", opts, lg)
 	if code != exitcode.OK {
 		return code
@@ -59,13 +80,13 @@ func Close(opts Options, parent string, issueNum int, lg Logger) exitcode.Code {
 		lg.Err("--close: #%d is not recorded for parent %s in %s", issueNum, parent, opts.StatePath)
 		return exitcode.Invocation
 	}
-	if hasManagedWorktree(panes) {
+	if mode.removesWorktree() && hasManagedWorktree(panes) {
 		if err := worktree.EnsureLocalExclude(opts.ProjectRoot); err != nil {
 			lg.Err("--close: prepare local git exclude: %v", err)
 			return exitcode.Env
 		}
 	}
-	if !cleanupPaneRecords(opts, panes, lg) {
+	if !closePaneRecords(opts, panes, mode, lg) {
 		return exitcode.Env
 	}
 	if err := locked.RemovePane(parent, issueNum); err != nil {
@@ -73,12 +94,15 @@ func Close(opts Options, parent string, issueNum int, lg Logger) exitcode.Code {
 		return exitcode.Env
 	}
 	removeWatcherRunningLabelBestEffort(opts, parent, issueNum, locked.PanesForParent(parent), lg)
-	if hasManagedWorktree(panes) && !pruneWorktrees(opts.ProjectRoot, lg) {
+	if mode.removesWorktree() && hasManagedWorktree(panes) && !pruneWorktrees(opts.ProjectRoot, lg) {
 		return exitcode.Env
 	}
-	if hasManagedWorktree(panes) {
+	switch {
+	case mode == ClosePaneOnly:
+		lg.Ok("#%d: closed pane and removed state", issueNum)
+	case hasManagedWorktree(panes):
 		lg.Ok("#%d: closed fanout worktree and removed state", issueNum)
-	} else {
+	default:
 		lg.Ok("#%d: closed shell terminal and removed state", issueNum)
 	}
 	return exitcode.OK
@@ -87,6 +111,12 @@ func Close(opts Options, parent string, issueNum int, lg Logger) exitcode.Code {
 // CloseTask removes the recorded worktree(s), best-effort kills tmux pane(s),
 // and removes all task state rows matching parent and taskID.
 func CloseTask(opts Options, parent, taskID string, lg Logger) exitcode.Code {
+	return CloseTaskWithMode(opts, parent, taskID, CloseWorktree, lg)
+}
+
+// CloseTaskWithMode closes all recorded task panes matching parent and taskID
+// using mode to decide whether worktree and branch state should also be removed.
+func CloseTaskWithMode(opts Options, parent, taskID string, mode CloseMode, lg Logger) exitcode.Code {
 	locked, code := lockStateOnly("--close", opts, lg)
 	if code != exitcode.OK {
 		return code
@@ -98,25 +128,28 @@ func CloseTask(opts Options, parent, taskID string, lg Logger) exitcode.Code {
 		lg.Err("--close: task %s is not recorded for parent %s in %s", taskID, parent, opts.StatePath)
 		return exitcode.Invocation
 	}
-	if hasManagedWorktree(panes) {
+	if mode.removesWorktree() && hasManagedWorktree(panes) {
 		if err := worktree.EnsureLocalExclude(opts.ProjectRoot); err != nil {
 			lg.Err("--close: prepare local git exclude: %v", err)
 			return exitcode.Env
 		}
 	}
-	if !cleanupPaneRecords(opts, panes, lg) {
+	if !closePaneRecords(opts, panes, mode, lg) {
 		return exitcode.Env
 	}
 	if err := locked.RemoveTaskPane(parent, taskID); err != nil {
 		lg.Err("%s: remove fanout state: %v", taskID, err)
 		return exitcode.Env
 	}
-	if hasManagedWorktree(panes) && !pruneWorktrees(opts.ProjectRoot, lg) {
+	if mode.removesWorktree() && hasManagedWorktree(panes) && !pruneWorktrees(opts.ProjectRoot, lg) {
 		return exitcode.Env
 	}
-	if hasManagedWorktree(panes) {
+	switch {
+	case mode == ClosePaneOnly:
+		lg.Ok("%s: closed pane and removed state", taskID)
+	case hasManagedWorktree(panes):
 		lg.Ok("%s: closed fanout worktree and removed state", taskID)
-	} else {
+	default:
 		lg.Ok("%s: closed shell terminal and removed state", taskID)
 	}
 	return exitcode.OK
@@ -397,11 +430,21 @@ func statusChildren(projectRoot string, nums []int, mode string, lg Logger) ([]s
 }
 
 func cleanupPaneRecords(opts Options, panes []state.Pane, lg Logger) bool {
+	return closePaneRecords(opts, panes, CloseWorktree, lg)
+}
+
+func closePaneRecords(opts Options, panes []state.Pane, mode CloseMode, lg Logger) bool {
 	ok := true
 	for _, pane := range panes {
 		if pane.IsShell() {
 			runBackgroundHook(hooks.BeforePaneClose, opts, pane, "", lg)
 			killShellPaneBestEffort(pane, lg)
+			runBackgroundHook(hooks.PaneClosed, opts, pane, "", lg)
+			continue
+		}
+		if mode == ClosePaneOnly {
+			runBackgroundHook(hooks.BeforePaneClose, opts, pane, "", lg)
+			killPaneBestEffort(pane, lg)
 			runBackgroundHook(hooks.PaneClosed, opts, pane, "", lg)
 			continue
 		}
@@ -417,11 +460,25 @@ func cleanupPaneRecords(opts Options, panes []state.Pane, lg Logger) bool {
 		if hadWorktree {
 			runBackgroundHook(hooks.WorktreeRemoved, opts, pane, "", lg)
 		}
+		if mode == CloseEverything {
+			if !pruneWorktrees(opts.ProjectRoot, lg) {
+				ok = false
+				continue
+			}
+			if !deleteBranch(opts.ProjectRoot, pane, lg) {
+				ok = false
+				continue
+			}
+		}
 		runBackgroundHook(hooks.BeforePaneClose, opts, pane, "", lg)
 		killPaneBestEffort(pane, lg)
 		runBackgroundHook(hooks.PaneClosed, opts, pane, "", lg)
 	}
 	return ok
+}
+
+func (m CloseMode) removesWorktree() bool {
+	return m == CloseWorktree || m == CloseEverything
 }
 
 func hasManagedWorktree(panes []state.Pane) bool {
@@ -462,6 +519,32 @@ func removeWorktree(projectRoot string, pane state.Pane, lg Logger) bool {
 		return false
 	}
 	return true
+}
+
+func deleteBranch(projectRoot string, pane state.Pane, lg Logger) bool {
+	branch := strings.TrimSpace(pane.BranchName)
+	if branch == "" {
+		lg.Err("%s: no branchName recorded; cannot delete local branch", paneLabel(pane))
+		return false
+	}
+	if !localBranchExists(projectRoot, branch) {
+		lg.Warn("%s: local branch already absent: %s", paneLabel(pane), branch)
+		return true
+	}
+	out, err := gitLifecycle(projectRoot, "branch", "-D", branch)
+	if err != nil {
+		lg.Err("%s: git branch -D %s failed", paneLabel(pane), branch)
+		if s := strings.TrimSpace(string(out)); s != "" {
+			fmt.Fprintln(lg.Stderr(), s)
+		}
+		return false
+	}
+	return true
+}
+
+func localBranchExists(projectRoot, branch string) bool {
+	err := exec.Command("git", "-C", projectRoot, "show-ref", "--verify", "--quiet", "refs/heads/"+branch).Run()
+	return err == nil
 }
 
 func killPaneBestEffort(pane state.Pane, lg Logger) {

--- a/internal/tui/actions.go
+++ b/internal/tui/actions.go
@@ -24,8 +24,10 @@ const (
 )
 
 type pendingLifecycleAction struct {
-	action lifecycleAction
-	pane   paneView
+	action           lifecycleAction
+	pane             paneView
+	closeMode        lifecycle.CloseMode
+	closeOptionIndex int
 }
 
 type lifecycleDoneMsg struct {
@@ -37,7 +39,9 @@ type lifecycleDoneMsg struct {
 
 type lifecycleRunner interface {
 	Close(lifecycle.Options, string, int, lifecycle.Logger) exitcode.Code
+	CloseWithMode(lifecycle.Options, string, int, lifecycle.CloseMode, lifecycle.Logger) exitcode.Code
 	CloseTask(lifecycle.Options, string, string, lifecycle.Logger) exitcode.Code
+	CloseTaskWithMode(lifecycle.Options, string, string, lifecycle.CloseMode, lifecycle.Logger) exitcode.Code
 	Merge(lifecycle.Options, string, int, lifecycle.Logger) exitcode.Code
 	MergeTask(lifecycle.Options, string, string, lifecycle.Logger) exitcode.Code
 	Cleanup(lifecycle.Options, string, lifecycle.Logger) exitcode.Code
@@ -50,8 +54,16 @@ func (defaultLifecycleRunner) Close(opts lifecycle.Options, parent string, issue
 	return lifecycle.Close(opts, parent, issueNum, lg)
 }
 
+func (defaultLifecycleRunner) CloseWithMode(opts lifecycle.Options, parent string, issueNum int, mode lifecycle.CloseMode, lg lifecycle.Logger) exitcode.Code {
+	return lifecycle.CloseWithMode(opts, parent, issueNum, mode, lg)
+}
+
 func (defaultLifecycleRunner) CloseTask(opts lifecycle.Options, parent, taskID string, lg lifecycle.Logger) exitcode.Code {
 	return lifecycle.CloseTask(opts, parent, taskID, lg)
+}
+
+func (defaultLifecycleRunner) CloseTaskWithMode(opts lifecycle.Options, parent, taskID string, mode lifecycle.CloseMode, lg lifecycle.Logger) exitcode.Code {
+	return lifecycle.CloseTaskWithMode(opts, parent, taskID, mode, lg)
 }
 
 func (defaultLifecycleRunner) Merge(opts lifecycle.Options, parent string, issueNum int, lg lifecycle.Logger) exitcode.Code {
@@ -95,6 +107,9 @@ func (l actionLogger) Stderr() io.Writer {
 }
 
 func (m model) updatePendingAction(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.pendingAction.action == actionClose && !m.pendingAction.pane.isShell() {
+		return m.updatePendingCloseChoice(msg)
+	}
 	switch msg.String() {
 	case "y", "enter":
 		pending := *m.pendingAction
@@ -104,6 +119,38 @@ func (m model) updatePendingAction(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, m.lifecycleCmd(pending)
 	case "n", "esc", "q", "ctrl+c":
 		m.actionMessage = fmt.Sprintf("%s canceled", m.pendingAction.action)
+		m.pendingAction = nil
+		return m, nil
+	}
+	return m, nil
+}
+
+func (m model) updatePendingCloseChoice(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "up", "k":
+		m.pendingAction.closeOptionIndex = clampCloseOptionIndex(m.pendingAction.closeOptionIndex - 1)
+		m.pendingAction.closeMode = closeOptions()[m.pendingAction.closeOptionIndex].mode
+		m.actionMessage = closeChoiceMessage(*m.pendingAction)
+		return m, nil
+	case "down", "j":
+		m.pendingAction.closeOptionIndex = clampCloseOptionIndex(m.pendingAction.closeOptionIndex + 1)
+		m.pendingAction.closeMode = closeOptions()[m.pendingAction.closeOptionIndex].mode
+		m.actionMessage = closeChoiceMessage(*m.pendingAction)
+		return m, nil
+	case "1", "2", "3":
+		idx := int(msg.String()[0] - '1')
+		m.pendingAction.closeOptionIndex = clampCloseOptionIndex(idx)
+		m.pendingAction.closeMode = closeOptions()[m.pendingAction.closeOptionIndex].mode
+		m.actionMessage = closeChoiceMessage(*m.pendingAction)
+		return m, nil
+	case "y", "enter":
+		pending := *m.pendingAction
+		m.pendingAction = nil
+		m.actionRunning = true
+		m.actionMessage = lifecycleRunningMessage(pending)
+		return m, m.lifecycleCmd(pending)
+	case "n", "esc", "q", "ctrl+c":
+		m.actionMessage = "close canceled"
 		m.pendingAction = nil
 		return m, nil
 	}
@@ -121,6 +168,15 @@ func (m model) startPendingAction(action lifecycleAction) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	m.pendingAction = &pendingLifecycleAction{action: action, pane: pane}
+	if action == actionClose {
+		m.pendingAction.closeMode = lifecycle.ClosePaneOnly
+		if !pane.isShell() {
+			m.pendingAction.closeOptionIndex = 0
+			m.pendingAction.closeMode = closeOptions()[0].mode
+			m.actionMessage = closeChoiceMessage(*m.pendingAction)
+			return m, nil
+		}
+	}
 	m.actionMessage = confirmMessage(action, pane)
 	return m, nil
 }
@@ -184,9 +240,9 @@ func (m model) lifecycleCmd(pending pendingLifecycleAction) tea.Cmd {
 				opts := lifecycleOpts(r)
 				var c exitcode.Code
 				if pending.pane.isTask() {
-					c = runner.CloseTask(opts, pending.pane.Parent, pending.pane.TaskID, lg)
+					c = runner.CloseTaskWithMode(opts, pending.pane.Parent, pending.pane.TaskID, pending.closeMode, lg)
 				} else {
-					c = runner.Close(opts, pending.pane.Parent, pending.pane.IssueNum, lg)
+					c = runner.CloseWithMode(opts, pending.pane.Parent, pending.pane.IssueNum, pending.closeMode, lg)
 				}
 				if c != exitcode.OK {
 					code = c
@@ -275,6 +331,8 @@ func (m model) sourceRootsForParent(parent string) []string {
 
 func confirmMessage(action lifecycleAction, pane paneView) string {
 	switch action {
+	case actionClose:
+		return fmt.Sprintf("confirm close %s? y/n", pane.identityLabel())
 	case actionCleanup:
 		return fmt.Sprintf("confirm cleanup for parent %s? y/n", dash(pane.Parent))
 	default:
@@ -301,6 +359,9 @@ func lifecycleRunningMessage(pending pendingLifecycleAction) string {
 	if pending.action == actionCleanup {
 		return fmt.Sprintf("%s parent %s...", pending.action, dash(pending.pane.Parent))
 	}
+	if pending.action == actionClose {
+		return fmt.Sprintf("%s %s...", closeModeVerb(pending.closeMode), pending.pane.identityLabel())
+	}
 	return fmt.Sprintf("%s %s...", pending.action, pending.pane.identityLabel())
 }
 
@@ -309,4 +370,54 @@ func (m model) renderActionMessage() string {
 		return warnStyle.Render(m.actionMessage)
 	}
 	return dimStyle.Render(m.actionMessage)
+}
+
+type closeOption struct {
+	mode        lifecycle.CloseMode
+	label       string
+	description string
+}
+
+func closeOptions() []closeOption {
+	return []closeOption{
+		{mode: lifecycle.ClosePaneOnly, label: "Just close pane", description: "keep worktree and branch"},
+		{mode: lifecycle.CloseWorktree, label: "Close and remove worktree", description: "keep branch"},
+		{mode: lifecycle.CloseEverything, label: "Close and delete everything", description: "remove worktree and local branch"},
+	}
+}
+
+func clampCloseOptionIndex(idx int) int {
+	opts := closeOptions()
+	if idx < 0 {
+		return 0
+	}
+	if idx >= len(opts) {
+		return len(opts) - 1
+	}
+	return idx
+}
+
+func closeChoiceMessage(pending pendingLifecycleAction) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "close %s?\n", pending.pane.identityLabel())
+	for i, opt := range closeOptions() {
+		prefix := "  "
+		if i == pending.closeOptionIndex {
+			prefix = "> "
+		}
+		fmt.Fprintf(&b, "%s%d. %s - %s\n", prefix, i+1, opt.label, opt.description)
+	}
+	b.WriteString("up/down or 1-3 select, enter confirm, esc cancel")
+	return b.String()
+}
+
+func closeModeVerb(mode lifecycle.CloseMode) string {
+	switch mode {
+	case lifecycle.ClosePaneOnly:
+		return "close pane"
+	case lifecycle.CloseEverything:
+		return "delete"
+	default:
+		return "close"
+	}
 }

--- a/internal/tui/paneview.go
+++ b/internal/tui/paneview.go
@@ -133,7 +133,7 @@ func columnsForWidth(width int) []table.Column {
 }
 
 func (m model) footerText() string {
-	parts := []string{"q quit", "n new", "A terminal", "t root", "j/k move", "[/] session", "/ filter", "enter/o focus", "p peek", "c close", "m merge", "x cleanup"}
+	parts := []string{"q quit", "n new", "A terminal", "t root", "j/k move", "[/] session", "/ filter", "enter/o focus", "p peek", "c/x close", "m merge", "X cleanup"}
 	if m.filterEditing {
 		parts = append(parts, "typing")
 	}

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -1574,8 +1574,8 @@ func TestLifecycleCloseKeyConfirmsRunsAndRefreshes(t *testing.T) {
 	if m.pendingAction == nil || m.pendingAction.action != actionClose {
 		t.Fatalf("pendingAction = %#v, want close", m.pendingAction)
 	}
-	if !strings.Contains(m.actionMessage, "confirm close #101") {
-		t.Fatalf("actionMessage = %q, want close confirmation", m.actionMessage)
+	if !strings.Contains(m.actionMessage, "Just close pane") || !strings.Contains(m.actionMessage, "Close and delete everything") {
+		t.Fatalf("actionMessage = %q, want close option menu", m.actionMessage)
 	}
 
 	updated, cmd = m.Update(keyRunes("y"))
@@ -1595,6 +1595,9 @@ func TestLifecycleCloseKeyConfirmsRunsAndRefreshes(t *testing.T) {
 	if runner.closeParent != "84" || runner.closeIssue != 101 {
 		t.Fatalf("Close called with parent=%q issue=%d, want 84/101", runner.closeParent, runner.closeIssue)
 	}
+	if runner.closeMode != lifecycle.ClosePaneOnly {
+		t.Fatalf("Close mode = %v, want pane-only", runner.closeMode)
+	}
 	if runner.projectRoot != "/repo" || runner.statePath != state.Path("/repo") {
 		t.Fatalf("Close opts = %q/%q, want project root and state path", runner.projectRoot, runner.statePath)
 	}
@@ -1612,6 +1615,54 @@ func TestLifecycleCloseKeyConfirmsRunsAndRefreshes(t *testing.T) {
 	}
 	if cmd == nil {
 		t.Fatal("done returned nil command, want state/GH reload")
+	}
+}
+
+func TestLifecycleCloseChoiceSelectsWorktreeAndBranchModes(t *testing.T) {
+	tests := []struct {
+		key  string
+		want lifecycle.CloseMode
+	}{
+		{key: "2", want: lifecycle.CloseWorktree},
+		{key: "3", want: lifecycle.CloseEverything},
+	}
+	for _, tc := range tests {
+		t.Run(tc.key, func(t *testing.T) {
+			runner := &fakeLifecycleRunner{code: exitcode.OK}
+			m := newModel(Options{ProjectRoot: "/repo", lifecycle: runner})
+			m.allPanes = []paneView{{Parent: "84", IssueNum: 101, Name: "child"}}
+			m.refreshRows()
+
+			updated, cmd := m.Update(keyRunes("c"))
+			if cmd != nil {
+				t.Fatal("close menu returned command, want nil")
+			}
+			m = updated.(model)
+
+			updated, cmd = m.Update(keyRunes(tc.key))
+			if cmd != nil {
+				t.Fatal("close choice returned command before enter, want nil")
+			}
+			m = updated.(model)
+			if m.pendingAction == nil || m.pendingAction.closeMode != tc.want {
+				t.Fatalf("pendingAction = %#v, want selected mode %v", m.pendingAction, tc.want)
+			}
+
+			updated, cmd = m.Update(keyRunes("enter"))
+			if cmd == nil {
+				t.Fatal("enter returned nil command, want lifecycle command")
+			}
+			m = updated.(model)
+			if !m.actionRunning {
+				t.Fatal("actionRunning = false, want true while command runs")
+			}
+			if _, ok := cmd().(lifecycleDoneMsg); !ok {
+				t.Fatalf("lifecycle command did not return lifecycleDoneMsg")
+			}
+			if runner.closeMode != tc.want {
+				t.Fatalf("Close mode = %v, want %v", runner.closeMode, tc.want)
+			}
+		})
 	}
 }
 
@@ -1799,7 +1850,7 @@ func TestLifecycleKeysRoutePlanTaskRows(t *testing.T) {
 			},
 		},
 		{
-			key:    "x",
+			key:    "X",
 			action: actionCleanup,
 			check: func(t *testing.T, runner *fakeLifecycleRunner) {
 				t.Helper()
@@ -1848,8 +1899,43 @@ func TestLifecycleKeysRoutePlanTaskRows(t *testing.T) {
 	}
 }
 
+func TestLifecycleCloseKeyRoutesPlanTaskRows(t *testing.T) {
+	runner := &fakeLifecycleRunner{code: exitcode.OK}
+	m := newModel(Options{ProjectRoot: "/repo", lifecycle: runner})
+	m.allPanes = []paneView{{Parent: "plan:launch-plan", IssueNum: 0, TaskID: "api-client", Name: "task"}}
+	m.refreshRows()
+
+	updated, cmd := m.Update(keyRunes("c"))
+	if cmd != nil {
+		t.Fatal("close menu returned command, want nil")
+	}
+	m = updated.(model)
+	updated, cmd = m.Update(keyRunes("3"))
+	if cmd != nil {
+		t.Fatal("close choice returned command before enter, want nil")
+	}
+	m = updated.(model)
+	updated, cmd = m.Update(keyRunes("enter"))
+	if cmd == nil {
+		t.Fatal("enter returned nil command, want lifecycle command")
+	}
+	m = updated.(model)
+	if !m.actionRunning {
+		t.Fatal("actionRunning = false, want true while command runs")
+	}
+	if _, ok := cmd().(lifecycleDoneMsg); !ok {
+		t.Fatalf("lifecycle command did not return lifecycleDoneMsg")
+	}
+	if runner.closeTaskParent != "plan:launch-plan" || runner.closeTaskID != "api-client" {
+		t.Fatalf("CloseTask called with parent=%q task=%q, want plan/api-client", runner.closeTaskParent, runner.closeTaskID)
+	}
+	if runner.closeMode != lifecycle.CloseEverything {
+		t.Fatalf("CloseTask mode = %v, want delete everything", runner.closeMode)
+	}
+}
+
 func TestLifecycleMergeAndCleanupSkipShellRows(t *testing.T) {
-	for _, key := range []string{"m", "x"} {
+	for _, key := range []string{"m", "X"} {
 		t.Run(key, func(t *testing.T) {
 			runner := &fakeLifecycleRunner{code: exitcode.OK}
 			m := newModel(Options{ProjectRoot: "/repo", lifecycle: runner})
@@ -1874,7 +1960,48 @@ func TestLifecycleMergeAndCleanupSkipShellRows(t *testing.T) {
 	}
 }
 
-func TestLifecycleCleanupUsesSelectedParent(t *testing.T) {
+func TestLifecycleCloseAliasesCloseShellRows(t *testing.T) {
+	for _, key := range []string{"c", "x"} {
+		t.Run(key, func(t *testing.T) {
+			runner := &fakeLifecycleRunner{code: exitcode.OK}
+			m := newModel(Options{ProjectRoot: "/repo", lifecycle: runner})
+			m.allPanes = []paneView{{Parent: "@manual", IssueNum: -1, Kind: state.PaneKindShell, Name: "root terminal"}}
+			m.refreshRows()
+
+			updated, cmd := m.Update(keyRunes(key))
+			if cmd != nil {
+				t.Fatalf("Update(%q) returned command before confirmation", key)
+			}
+			m = updated.(model)
+			if m.pendingAction == nil || m.pendingAction.action != actionClose {
+				t.Fatalf("pendingAction = %#v, want close", m.pendingAction)
+			}
+			if strings.Contains(m.actionMessage, "Just close pane") {
+				t.Fatalf("shell close actionMessage = %q, want simple confirmation", m.actionMessage)
+			}
+
+			updated, cmd = m.Update(keyRunes("y"))
+			if cmd == nil {
+				t.Fatal("confirm returned nil command, want lifecycle command")
+			}
+			m = updated.(model)
+			if !m.actionRunning {
+				t.Fatal("actionRunning = false, want true while command runs")
+			}
+			if _, ok := cmd().(lifecycleDoneMsg); !ok {
+				t.Fatalf("lifecycle command did not return lifecycleDoneMsg")
+			}
+			if runner.closeParent != "@manual" || runner.closeIssue != -1 {
+				t.Fatalf("Close called with parent=%q issue=%d, want @manual/-1", runner.closeParent, runner.closeIssue)
+			}
+			if runner.closeMode != lifecycle.ClosePaneOnly {
+				t.Fatalf("shell Close mode = %v, want pane-only close", runner.closeMode)
+			}
+		})
+	}
+}
+
+func TestLifecycleCloseAliasUsesSelectedPane(t *testing.T) {
 	runner := &fakeLifecycleRunner{code: exitcode.OK}
 	m := newModel(Options{ProjectRoot: "/repo", lifecycle: runner})
 	m.allPanes = []paneView{
@@ -1885,6 +2012,44 @@ func TestLifecycleCleanupUsesSelectedParent(t *testing.T) {
 	m.table.SetCursor(1)
 
 	updated, _ := m.Update(keyRunes("x"))
+	m = updated.(model)
+	if m.pendingAction == nil || m.pendingAction.action != actionClose {
+		t.Fatalf("pendingAction = %#v, want close", m.pendingAction)
+	}
+
+	updated, cmd := m.Update(keyRunes("1"))
+	if cmd != nil {
+		t.Fatal("close choice returned command before enter, want nil")
+	}
+	m = updated.(model)
+	updated, cmd = m.Update(keyRunes("enter"))
+	if cmd == nil {
+		t.Fatal("enter returned nil command, want lifecycle command")
+	}
+	m = updated.(model)
+	rawMsg := cmd()
+	if _, ok := rawMsg.(lifecycleDoneMsg); !ok {
+		t.Fatalf("lifecycle command returned %T, want lifecycleDoneMsg", rawMsg)
+	}
+	if runner.closeParent != "200" || runner.closeIssue != 2 {
+		t.Fatalf("Close target = %s/%d, want selected pane 200/2", runner.closeParent, runner.closeIssue)
+	}
+	if runner.closeMode != lifecycle.ClosePaneOnly {
+		t.Fatalf("Close mode = %v, want pane-only", runner.closeMode)
+	}
+}
+
+func TestLifecycleCleanupKeyUsesSelectedParent(t *testing.T) {
+	runner := &fakeLifecycleRunner{code: exitcode.OK}
+	m := newModel(Options{ProjectRoot: "/repo", lifecycle: runner})
+	m.allPanes = []paneView{
+		{Parent: "100", IssueNum: 1, Name: "one"},
+		{Parent: "200", IssueNum: 2, Name: "two"},
+	}
+	m.refreshRows()
+	m.table.SetCursor(1)
+
+	updated, _ := m.Update(keyRunes("X"))
 	m = updated.(model)
 	if m.pendingAction == nil || m.pendingAction.action != actionCleanup {
 		t.Fatalf("pendingAction = %#v, want cleanup", m.pendingAction)
@@ -1969,6 +2134,7 @@ type fakeLifecycleRunner struct {
 	closeIssue          int
 	closeTaskParent     string
 	closeTaskID         string
+	closeMode           lifecycle.CloseMode
 	mergeTaskParent     string
 	mergeTaskID         string
 	cleanupParent       string
@@ -1989,21 +2155,31 @@ func (f *fakeTransitionNotifier) Notify(events []fanoutnotify.Event) error {
 }
 
 func (f *fakeLifecycleRunner) Close(opts lifecycle.Options, parent string, issueNum int, lg lifecycle.Logger) exitcode.Code {
+	return f.CloseWithMode(opts, parent, issueNum, lifecycle.CloseWorktree, lg)
+}
+
+func (f *fakeLifecycleRunner) CloseWithMode(opts lifecycle.Options, parent string, issueNum int, mode lifecycle.CloseMode, lg lifecycle.Logger) exitcode.Code {
 	f.projectRoot = opts.ProjectRoot
 	f.statePath = opts.StatePath
 	f.watcherRunningLabel = opts.WatcherRunningLabel
 	f.closeParent = parent
 	f.closeIssue = issueNum
+	f.closeMode = mode
 	f.closeRoots = append(f.closeRoots, opts.ProjectRoot)
 	fmt.Fprintf(lg.Stderr(), "[ ok ] fake close\n")
 	return f.code
 }
 
 func (f *fakeLifecycleRunner) CloseTask(opts lifecycle.Options, parent, taskID string, lg lifecycle.Logger) exitcode.Code {
+	return f.CloseTaskWithMode(opts, parent, taskID, lifecycle.CloseWorktree, lg)
+}
+
+func (f *fakeLifecycleRunner) CloseTaskWithMode(opts lifecycle.Options, parent, taskID string, mode lifecycle.CloseMode, lg lifecycle.Logger) exitcode.Code {
 	f.projectRoot = opts.ProjectRoot
 	f.statePath = opts.StatePath
 	f.closeTaskParent = parent
 	f.closeTaskID = taskID
+	f.closeMode = mode
 	f.closeRoots = append(f.closeRoots, opts.ProjectRoot)
 	fmt.Fprintf(lg.Stderr(), "[ ok ] fake close task\n")
 	return f.code

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -73,6 +73,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "m":
 			return m.startPendingAction(actionMerge)
 		case "x":
+			return m.startPendingAction(actionClose)
+		case "X":
 			return m.startPendingAction(actionCleanup)
 		}
 		oldCursor := m.table.Cursor()

--- a/site/content/docs/monitoring.ja.md
+++ b/site/content/docs/monitoring.ja.md
@@ -34,9 +34,9 @@ fanout   # start the persistent tmux console
 | `t` | project root で shell terminal を開く。close は tmux ペインと state 行だけを消し、git worktree は削除しない。 |
 | `Enter` / `o` | 選択中の live 行のペインにフォーカスする。 |
 | `p` | detail panel の read-only 出力スナップショットを更新する。 |
-| `c` | 選択中のペインを close する（確認を挟み、`--close` と同じコア処理を使う）。 |
+| `c` / `x` | 選択中のペインの close option を開く。ペインだけを閉じる、ペインと worktree を閉じる、local branch も削除する、から選ぶ。 |
 | `m` | 選択中のペインの branch を fast-forward merge する（確認を挟み、`--merge` と同じコア処理を使う）。 |
-| `x` | 同じ親の merged/closed な子をまとめて cleanup する（確認を挟み、`--cleanup` と同じコア処理を使う）。 |
+| `X` | 同じ親の merged/closed な子をまとめて cleanup する（確認を挟み、`--cleanup` と同じコア処理を使う）。 |
 | `q` | コンソールを離脱する。tmux session と子ペインはそのまま残る。 |
 
 > 記録はあるものの tmux 上に存在しないペインの行は `stale!` と表示され、フォーカス操作とピーク操作の対象から外れます。

--- a/site/content/docs/monitoring.md
+++ b/site/content/docs/monitoring.md
@@ -34,9 +34,9 @@ For recorded issue parents the console also reloads the parent's child set and s
 | `t` | Open a shell terminal at the project root. Closing it kills the tmux pane and removes the state row; it never removes a git worktree. |
 | `Enter` / `o` | Focus the selected live row's pane. |
 | `p` | Refresh the read-only output snapshot shown in the detail panel. |
-| `c` | Close the selected pane — confirmation prompt, then the same core path as `--close`. |
+| `c` / `x` | Open close options for the selected pane: close only the pane, close the pane and remove the worktree, or also delete the local branch. |
 | `m` | Fast-forward merge the selected pane's branch — confirmation prompt, then the same core path as `--merge`. |
-| `x` | Clean up merged/closed children of the same parent — confirmation prompt, then the same core path as `--cleanup`. |
+| `X` | Clean up merged/closed children of the same parent — confirmation prompt, then the same core path as `--cleanup`. |
 | `q` | Leave the console. The tmux session and child panes are left running. |
 
 > Rows whose recorded pane no longer exists in tmux are marked `stale!` and are skipped by the focus and peek actions.


### PR DESCRIPTION
## 概要

TUI で pane を close するときに、dmux と同じように close option を選べるようにしました。

- `c` / `x` で close option を開く
- pane だけ閉じる、worktree まで消す、local branch も消す、の三択を選べる
- 従来の parent-scoped cleanup は `X` に移し、`--cleanup` と同じ経路を残す
- monitoring docs の keybinding 表を英日で同期

## 詳細

`internal/lifecycle` に close mode を追加し、既存の `--close` は branch を残す互換挙動のままにしています。
delete-everything では stale worktree metadata を prune してから local branch を削除するため、手動削除済み worktree の state row も片づけられます。

TUI 側では close menu の数字キーは選択だけを行い、`Enter` で実行します。
誤って destructive option を即実行しないようにしました。

## 検証

- `go test ./internal/lifecycle ./internal/tui ./cmd/fanout`
- `go test ./...`
- `make build-go`
- `make test`
- `make lint`
- `git diff --check`
- `codex review --uncommitted`（3 回目で指摘なし）