### PR TITLE
[codex] Codex Plan Mode の effort 設定を反映

### DIFF
--- a/cmd/fanout/codex_plan_tui.go
+++ b/cmd/fanout/codex_plan_tui.go
@@ -67,6 +67,11 @@ type codexResolvedSettings struct {
 	ReasoningEffort string
 }
 
+type codexModelSelection struct {
+	Model                     string
+	SupportedReasoningEfforts []string
+}
+
 type appServerMessage struct {
 	ID     json.RawMessage `json:"id,omitempty"`
 	Method string          `json:"method,omitempty"`
@@ -1008,35 +1013,37 @@ func resolveCodexSettings(client *codexAppClient, cwd string) (codexResolvedSett
 			effort = config.ReasoningEffort
 		}
 	}
-	if model != "" {
-		return codexResolvedSettings{Model: model, ReasoningEffort: effort}, nil
-	}
 
-	model, err := resolveCodexModelFallback(client, configErr)
-	if err != nil {
-		return codexResolvedSettings{}, err
-	}
-	return codexResolvedSettings{Model: model, ReasoningEffort: effort}, nil
-}
-
-func resolveCodexModelFallback(client *codexAppClient, configErr error) (string, error) {
 	modelResult, modelErr := client.Request("fanout-models", "model/list", map[string]any{
 		"includeHidden": false,
 	})
 	if modelErr != nil {
-		if configErr != nil {
-			return "", fmt.Errorf("resolve codex model: config/read failed: %w; model/list failed: %w", configErr, modelErr)
+		if model != "" {
+			return codexResolvedSettings{Model: model, ReasoningEffort: effort}, nil
 		}
-		return "", fmt.Errorf("resolve codex model from model/list: %w", modelErr)
+		if configErr != nil {
+			return codexResolvedSettings{}, fmt.Errorf("resolve codex model: config/read failed: %w; model/list failed: %w", configErr, modelErr)
+		}
+		return codexResolvedSettings{}, fmt.Errorf("resolve codex model from model/list: %w", modelErr)
 	}
-	model, err := modelListDefault(modelResult)
+
+	selection, err := modelListSelection(modelResult, model)
 	if err != nil {
-		if configErr != nil {
-			return "", fmt.Errorf("resolve codex model: config/read failed: %w; model/list failed: %w", configErr, err)
+		if model != "" {
+			return codexResolvedSettings{Model: model, ReasoningEffort: effort}, nil
 		}
-		return "", err
+		if configErr != nil {
+			return codexResolvedSettings{}, fmt.Errorf("resolve codex model: config/read failed: %w; model/list failed: %w", configErr, err)
+		}
+		return codexResolvedSettings{}, err
 	}
-	return model, nil
+	if model == "" {
+		model = selection.Model
+	}
+	if len(selection.SupportedReasoningEfforts) > 0 {
+		effort = supportedReasoningEffort(effort, selection.SupportedReasoningEfforts)
+	}
+	return codexResolvedSettings{Model: model, ReasoningEffort: effort}, nil
 }
 
 func configSettings(raw json.RawMessage) codexResolvedSettings {
@@ -1044,7 +1051,6 @@ func configSettings(raw json.RawMessage) codexResolvedSettings {
 		Config struct {
 			Model                   string `json:"model"`
 			ReasoningEffort         string `json:"reasoning_effort"`
-			ModelReasoningEffort    string `json:"model_reasoning_effort"`
 			PlanModeReasoningEffort string `json:"plan_mode_reasoning_effort"`
 		} `json:"config"`
 	}
@@ -1055,33 +1061,46 @@ func configSettings(raw json.RawMessage) codexResolvedSettings {
 	if effort == "" {
 		effort = strings.TrimSpace(res.Config.ReasoningEffort)
 	}
-	if effort == "" {
-		effort = strings.TrimSpace(res.Config.ModelReasoningEffort)
-	}
 	return codexResolvedSettings{
 		Model:           strings.TrimSpace(res.Config.Model),
 		ReasoningEffort: effort,
 	}
 }
 
-func modelListDefault(raw json.RawMessage) (string, error) {
+func modelListSelection(raw json.RawMessage, preferred string) (codexModelSelection, error) {
 	var res struct {
 		Data []struct {
-			ID        string `json:"id"`
-			Model     string `json:"model"`
-			Hidden    bool   `json:"hidden"`
-			IsDefault bool   `json:"isDefault"`
+			ID                                string   `json:"id"`
+			Model                             string   `json:"model"`
+			Hidden                            bool     `json:"hidden"`
+			IsDefault                         bool     `json:"isDefault"`
+			SupportedReasoningEfforts         []string `json:"supportedReasoningEfforts"`
+			SupportedReasoningEffortsFallback []string `json:"supported_reasoning_efforts"`
 		} `json:"data"`
 	}
 	if err := json.Unmarshal(raw, &res); err != nil {
-		return "", fmt.Errorf("parse model/list response: %w", err)
+		return codexModelSelection{}, fmt.Errorf("parse model/list response: %w", err)
+	}
+	preferred = strings.TrimSpace(preferred)
+	if preferred != "" {
+		for _, model := range res.Data {
+			if model.Hidden {
+				continue
+			}
+			if modelName(model.Model, model.ID) != preferred && strings.TrimSpace(model.ID) != preferred {
+				continue
+			}
+			if name := modelName(model.Model, model.ID); name != "" {
+				return codexModelSelection{Model: name, SupportedReasoningEfforts: modelSupportedReasoningEfforts(model.SupportedReasoningEfforts, model.SupportedReasoningEffortsFallback)}, nil
+			}
+		}
 	}
 	for _, model := range res.Data {
 		if model.Hidden || !model.IsDefault {
 			continue
 		}
 		if name := modelName(model.Model, model.ID); name != "" {
-			return name, nil
+			return codexModelSelection{Model: name, SupportedReasoningEfforts: modelSupportedReasoningEfforts(model.SupportedReasoningEfforts, model.SupportedReasoningEffortsFallback)}, nil
 		}
 	}
 	for _, model := range res.Data {
@@ -1089,10 +1108,42 @@ func modelListDefault(raw json.RawMessage) (string, error) {
 			continue
 		}
 		if name := modelName(model.Model, model.ID); name != "" {
-			return name, nil
+			return codexModelSelection{Model: name, SupportedReasoningEfforts: modelSupportedReasoningEfforts(model.SupportedReasoningEfforts, model.SupportedReasoningEffortsFallback)}, nil
 		}
 	}
-	return "", fmt.Errorf("model/list response did not include an available model")
+	return codexModelSelection{}, fmt.Errorf("model/list response did not include an available model")
+}
+
+func modelSupportedReasoningEfforts(primary, fallback []string) []string {
+	if len(primary) > 0 {
+		return primary
+	}
+	return fallback
+}
+
+func supportedReasoningEffort(requested string, supported []string) string {
+	requested = strings.TrimSpace(requested)
+	available := map[string]bool{}
+	for _, effort := range supported {
+		effort = strings.TrimSpace(effort)
+		if effort != "" {
+			available[effort] = true
+		}
+	}
+	if len(available) == 0 || available[requested] {
+		return requested
+	}
+	for _, effort := range []string{"xhigh", "high", "medium", "low", "minimal"} {
+		if available[effort] {
+			return effort
+		}
+	}
+	for _, effort := range supported {
+		if effort = strings.TrimSpace(effort); effort != "" {
+			return effort
+		}
+	}
+	return requested
 }
 
 func modelName(model, id string) string {

--- a/cmd/fanout/codex_plan_tui.go
+++ b/cmd/fanout/codex_plan_tui.go
@@ -18,6 +18,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -71,6 +72,8 @@ type codexModelSelection struct {
 	Model                     string
 	SupportedReasoningEfforts []string
 }
+
+type supportedReasoningEfforts []string
 
 type appServerMessage struct {
 	ID     json.RawMessage `json:"id,omitempty"`
@@ -1015,7 +1018,7 @@ func resolveCodexSettings(client *codexAppClient, cwd string) (codexResolvedSett
 	}
 
 	modelResult, modelErr := client.Request("fanout-models", "model/list", map[string]any{
-		"includeHidden": false,
+		"includeHidden": true,
 	})
 	if modelErr != nil {
 		if model != "" {
@@ -1051,6 +1054,7 @@ func configSettings(raw json.RawMessage) codexResolvedSettings {
 		Config struct {
 			Model                   string `json:"model"`
 			ReasoningEffort         string `json:"reasoning_effort"`
+			ModelReasoningEffort    string `json:"model_reasoning_effort"`
 			PlanModeReasoningEffort string `json:"plan_mode_reasoning_effort"`
 		} `json:"config"`
 	}
@@ -1061,6 +1065,9 @@ func configSettings(raw json.RawMessage) codexResolvedSettings {
 	if effort == "" {
 		effort = strings.TrimSpace(res.Config.ReasoningEffort)
 	}
+	if effort == "" {
+		effort = strings.TrimSpace(res.Config.ModelReasoningEffort)
+	}
 	return codexResolvedSettings{
 		Model:           strings.TrimSpace(res.Config.Model),
 		ReasoningEffort: effort,
@@ -1070,12 +1077,12 @@ func configSettings(raw json.RawMessage) codexResolvedSettings {
 func modelListSelection(raw json.RawMessage, preferred string) (codexModelSelection, error) {
 	var res struct {
 		Data []struct {
-			ID                                string   `json:"id"`
-			Model                             string   `json:"model"`
-			Hidden                            bool     `json:"hidden"`
-			IsDefault                         bool     `json:"isDefault"`
-			SupportedReasoningEfforts         []string `json:"supportedReasoningEfforts"`
-			SupportedReasoningEffortsFallback []string `json:"supported_reasoning_efforts"`
+			ID                                string                    `json:"id"`
+			Model                             string                    `json:"model"`
+			Hidden                            bool                      `json:"hidden"`
+			IsDefault                         bool                      `json:"isDefault"`
+			SupportedReasoningEfforts         supportedReasoningEfforts `json:"supportedReasoningEfforts"`
+			SupportedReasoningEffortsFallback supportedReasoningEfforts `json:"supported_reasoning_efforts"`
 		} `json:"data"`
 	}
 	if err := json.Unmarshal(raw, &res); err != nil {
@@ -1084,9 +1091,6 @@ func modelListSelection(raw json.RawMessage, preferred string) (codexModelSelect
 	preferred = strings.TrimSpace(preferred)
 	if preferred != "" {
 		for _, model := range res.Data {
-			if model.Hidden {
-				continue
-			}
 			if modelName(model.Model, model.ID) != preferred && strings.TrimSpace(model.ID) != preferred {
 				continue
 			}
@@ -1121,6 +1125,41 @@ func modelSupportedReasoningEfforts(primary, fallback []string) []string {
 	return fallback
 }
 
+func (e *supportedReasoningEfforts) UnmarshalJSON(raw []byte) error {
+	var items []json.RawMessage
+	if err := json.Unmarshal(raw, &items); err != nil {
+		return err
+	}
+	out := make([]string, 0, len(items))
+	for _, item := range items {
+		var effort string
+		if err := json.Unmarshal(item, &effort); err == nil {
+			effort = strings.TrimSpace(effort)
+			if effort != "" {
+				out = append(out, effort)
+			}
+			continue
+		}
+		var shaped struct {
+			ReasoningEffort string `json:"reasoningEffort"`
+			Value           string `json:"value"`
+			ID              string `json:"id"`
+			Name            string `json:"name"`
+		}
+		if err := json.Unmarshal(item, &shaped); err != nil {
+			return err
+		}
+		for _, candidate := range []string{shaped.ReasoningEffort, shaped.Value, shaped.ID, shaped.Name} {
+			if effort = strings.TrimSpace(candidate); effort != "" {
+				out = append(out, effort)
+				break
+			}
+		}
+	}
+	*e = out
+	return nil
+}
+
 func supportedReasoningEffort(requested string, supported []string) string {
 	requested = strings.TrimSpace(requested)
 	available := map[string]bool{}
@@ -1133,12 +1172,7 @@ func supportedReasoningEffort(requested string, supported []string) string {
 	if len(available) == 0 || available[requested] {
 		return requested
 	}
-	for _, effort := range []string{"xhigh", "high", "medium", "low", "minimal"} {
-		if available[effort] {
-			return effort
-		}
-	}
-	for _, effort := range supported {
+	for _, effort := range slices.Backward(supported) {
 		if effort = strings.TrimSpace(effort); effort != "" {
 			return effort
 		}

--- a/cmd/fanout/codex_plan_tui.go
+++ b/cmd/fanout/codex_plan_tui.go
@@ -32,6 +32,7 @@ const (
 	codexPlanTUICommand              = "__codex-plan-tui"
 	codexPlanTUIStatusReady          = "ready"
 	codexPlanTUIStatusFailed         = "failed"
+	codexPlanDefaultEffort           = "xhigh"
 	codexRemoteAppConnectTimeout     = 10 * time.Second
 	codexRemoteTUIStartupGrace       = 3 * time.Second
 	codexPlanUserInputFallbackAnswer = "fanout Codex Plan Mode is starting interactively; proceed with the implementation plan using stated assumptions, and call out any ambiguity instead of asking for input."
@@ -59,6 +60,11 @@ type codexThreadInfo struct {
 	Model                    string
 	PlanEffort               string
 	UseTurnCollaborationMode bool
+}
+
+type codexResolvedSettings struct {
+	Model           string
+	ReasoningEffort string
 }
 
 type appServerMessage struct {
@@ -262,17 +268,16 @@ func setupCodexPlanThread(client *codexAppClient, cwd string) (codexThreadInfo, 
 	if err != nil {
 		return codexThreadInfo{}, err
 	}
-	planEffort, err := codexPlanEffort(modeResult)
+	if planModeErr := ensureCodexPlanMode(modeResult); planModeErr != nil {
+		return codexThreadInfo{}, planModeErr
+	}
+
+	settings, err := resolveCodexSettings(client, cwd)
 	if err != nil {
 		return codexThreadInfo{}, err
 	}
 
-	model, err := resolveCodexModel(client, cwd)
-	if err != nil {
-		return codexThreadInfo{}, err
-	}
-
-	threadResult, err := client.Request("fanout-thread", "thread/start", codexThreadStartParams(cwd, model))
+	threadResult, err := client.Request("fanout-thread", "thread/start", codexThreadStartParams(cwd, settings.Model))
 	if err != nil {
 		return codexThreadInfo{}, err
 	}
@@ -280,10 +285,10 @@ func setupCodexPlanThread(client *codexAppClient, cwd string) (codexThreadInfo, 
 	if err != nil {
 		return codexThreadInfo{}, err
 	}
-	thread.Model = model
-	thread.PlanEffort = planEffort
+	thread.Model = settings.Model
+	thread.PlanEffort = settings.ReasoningEffort
 
-	if _, err := client.Request("fanout-plan-mode", "thread/settings/update", codexPlanSettingsUpdateParams(thread.ID, model, planEffort)); err != nil {
+	if _, err := client.Request("fanout-plan-mode", "thread/settings/update", codexPlanSettingsUpdateParams(thread.ID, settings.Model, settings.ReasoningEffort)); err != nil {
 		if !isUnsupportedCodexAppServerMethod(err) {
 			return codexThreadInfo{}, err
 		}
@@ -989,17 +994,32 @@ func appServerErrorSummary(raw json.RawMessage) string {
 	return string(raw)
 }
 
-func resolveCodexModel(client *codexAppClient, cwd string) (string, error) {
+func resolveCodexSettings(client *codexAppClient, cwd string) (codexResolvedSettings, error) {
 	configResult, configErr := client.Request("fanout-config", "config/read", map[string]any{
 		"includeLayers": false,
 		"cwd":           cwd,
 	})
+	model := ""
+	effort := codexPlanDefaultEffort
 	if configErr == nil {
-		if model := configModel(configResult); model != "" {
-			return model, nil
+		config := configSettings(configResult)
+		model = config.Model
+		if config.ReasoningEffort != "" {
+			effort = config.ReasoningEffort
 		}
 	}
+	if model != "" {
+		return codexResolvedSettings{Model: model, ReasoningEffort: effort}, nil
+	}
 
+	model, err := resolveCodexModelFallback(client, configErr)
+	if err != nil {
+		return codexResolvedSettings{}, err
+	}
+	return codexResolvedSettings{Model: model, ReasoningEffort: effort}, nil
+}
+
+func resolveCodexModelFallback(client *codexAppClient, configErr error) (string, error) {
 	modelResult, modelErr := client.Request("fanout-models", "model/list", map[string]any{
 		"includeHidden": false,
 	})
@@ -1019,16 +1039,29 @@ func resolveCodexModel(client *codexAppClient, cwd string) (string, error) {
 	return model, nil
 }
 
-func configModel(raw json.RawMessage) string {
+func configSettings(raw json.RawMessage) codexResolvedSettings {
 	var res struct {
 		Config struct {
-			Model string `json:"model"`
+			Model                   string `json:"model"`
+			ReasoningEffort         string `json:"reasoning_effort"`
+			ModelReasoningEffort    string `json:"model_reasoning_effort"`
+			PlanModeReasoningEffort string `json:"plan_mode_reasoning_effort"`
 		} `json:"config"`
 	}
 	if err := json.Unmarshal(raw, &res); err != nil {
-		return ""
+		return codexResolvedSettings{}
 	}
-	return strings.TrimSpace(res.Config.Model)
+	effort := strings.TrimSpace(res.Config.PlanModeReasoningEffort)
+	if effort == "" {
+		effort = strings.TrimSpace(res.Config.ReasoningEffort)
+	}
+	if effort == "" {
+		effort = strings.TrimSpace(res.Config.ModelReasoningEffort)
+	}
+	return codexResolvedSettings{
+		Model:           strings.TrimSpace(res.Config.Model),
+		ReasoningEffort: effort,
+	}
 }
 
 func modelListDefault(raw json.RawMessage) (string, error) {
@@ -1069,33 +1102,23 @@ func modelName(model, id string) string {
 	return strings.TrimSpace(id)
 }
 
-func codexPlanEffort(raw json.RawMessage) (string, error) {
+func ensureCodexPlanMode(raw json.RawMessage) error {
 	var res struct {
 		Data []struct {
-			Name            string  `json:"name"`
-			Mode            string  `json:"mode"`
-			ReasoningEffort *string `json:"reasoning_effort"`
-			Settings        *struct {
-				ReasoningEffort *string `json:"reasoning_effort"`
-			} `json:"settings"`
+			Name string `json:"name"`
+			Mode string `json:"mode"`
 		} `json:"data"`
 	}
 	if err := json.Unmarshal(raw, &res); err != nil {
-		return "", fmt.Errorf("parse collaborationMode/list response: %w", err)
+		return fmt.Errorf("parse collaborationMode/list response: %w", err)
 	}
 	for _, mode := range res.Data {
 		if mode.Mode != "plan" {
 			continue
 		}
-		if mode.ReasoningEffort != nil && *mode.ReasoningEffort != "" {
-			return *mode.ReasoningEffort, nil
-		}
-		if mode.Settings != nil && mode.Settings.ReasoningEffort != nil && *mode.Settings.ReasoningEffort != "" {
-			return *mode.Settings.ReasoningEffort, nil
-		}
-		return "medium", nil
+		return nil
 	}
-	return "", fmt.Errorf("codex app-server does not advertise collaborationMode.mode=plan")
+	return fmt.Errorf("codex app-server does not advertise collaborationMode.mode=plan")
 }
 
 func parseThreadStart(raw json.RawMessage) (codexThreadInfo, error) {

--- a/cmd/fanout/codex_plan_tui_test.go
+++ b/cmd/fanout/codex_plan_tui_test.go
@@ -131,11 +131,11 @@ func TestConfigSettingsReadsModelAndReasoningEffort(t *testing.T) {
 	}
 }
 
-func TestConfigSettingsFallsBackToModelReasoningEffort(t *testing.T) {
+func TestConfigSettingsDoesNotUseModelReasoningEffort(t *testing.T) {
 	got := configSettings([]byte(`{"config":{"model":"gpt-test","model_reasoning_effort":"high"}}`))
 
-	if got.ReasoningEffort != "high" {
-		t.Fatalf("reasoning_effort = %q, want high", got.ReasoningEffort)
+	if got.ReasoningEffort != "" {
+		t.Fatalf("reasoning_effort = %q, want empty", got.ReasoningEffort)
 	}
 }
 
@@ -171,6 +171,35 @@ func TestEnsureCodexPlanModeIgnoresAdvertisedEffort(t *testing.T) {
 	err := ensureCodexPlanMode([]byte(`{"data":[{"mode":"plan","reasoning_effort":"medium","settings":{"reasoning_effort":"medium"}}]}`))
 	if err != nil {
 		t.Fatalf("ensureCodexPlanMode() failed: %v", err)
+	}
+}
+
+func TestModelListSelectionReturnsSupportedReasoningEfforts(t *testing.T) {
+	got, err := modelListSelection([]byte(`{"data":[{"id":"gpt-test","model":"gpt-test","isDefault":true,"supportedReasoningEfforts":["low","medium","high"]}]}`), "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Model != "gpt-test" {
+		t.Fatalf("model = %q, want gpt-test", got.Model)
+	}
+	if strings.Join(got.SupportedReasoningEfforts, ",") != "low,medium,high" {
+		t.Fatalf("supported efforts = %#v, want low,medium,high", got.SupportedReasoningEfforts)
+	}
+}
+
+func TestSupportedReasoningEffortKeepsSupportedRequestedEffort(t *testing.T) {
+	got := supportedReasoningEffort("xhigh", []string{"low", "medium", "xhigh"})
+
+	if got != "xhigh" {
+		t.Fatalf("supportedReasoningEffort() = %q, want xhigh", got)
+	}
+}
+
+func TestSupportedReasoningEffortFallsBackToStrongestSupportedEffort(t *testing.T) {
+	got := supportedReasoningEffort("xhigh", []string{"low", "medium", "high"})
+
+	if got != "high" {
+		t.Fatalf("supportedReasoningEffort() = %q, want high", got)
 	}
 }
 

--- a/cmd/fanout/codex_plan_tui_test.go
+++ b/cmd/fanout/codex_plan_tui_test.go
@@ -91,7 +91,7 @@ func TestCodexTurnStartParamsSubmitsPromptThroughAppServer(t *testing.T) {
 }
 
 func TestCodexTurnStartParamsCanCarryPlanCollaborationMode(t *testing.T) {
-	got := codexTurnStartParams("thread-1", "/repo", "gpt-test", "hello plan", codexPlanCollaborationMode("gpt-test", "medium"))
+	got := codexTurnStartParams("thread-1", "/repo", "gpt-test", "hello plan", codexPlanCollaborationMode("gpt-test", "xhigh"))
 
 	body, err := json.Marshal(got)
 	if err != nil {
@@ -115,8 +115,62 @@ func TestCodexTurnStartParamsCanCarryPlanCollaborationMode(t *testing.T) {
 	if shaped.CollaborationMode.Settings.Model != "gpt-test" {
 		t.Fatalf("model = %q, want gpt-test", shaped.CollaborationMode.Settings.Model)
 	}
-	if shaped.CollaborationMode.Settings.ReasoningEffort != "medium" {
-		t.Fatalf("reasoning_effort = %q, want medium", shaped.CollaborationMode.Settings.ReasoningEffort)
+	if shaped.CollaborationMode.Settings.ReasoningEffort != "xhigh" {
+		t.Fatalf("reasoning_effort = %q, want xhigh", shaped.CollaborationMode.Settings.ReasoningEffort)
+	}
+}
+
+func TestConfigSettingsReadsModelAndReasoningEffort(t *testing.T) {
+	got := configSettings([]byte(`{"config":{"model":" gpt-test ","plan_mode_reasoning_effort":" xhigh "}}`))
+
+	if got.Model != "gpt-test" {
+		t.Fatalf("model = %q, want gpt-test", got.Model)
+	}
+	if got.ReasoningEffort != "xhigh" {
+		t.Fatalf("reasoning_effort = %q, want xhigh", got.ReasoningEffort)
+	}
+}
+
+func TestConfigSettingsFallsBackToModelReasoningEffort(t *testing.T) {
+	got := configSettings([]byte(`{"config":{"model":"gpt-test","model_reasoning_effort":"high"}}`))
+
+	if got.ReasoningEffort != "high" {
+		t.Fatalf("reasoning_effort = %q, want high", got.ReasoningEffort)
+	}
+}
+
+func TestConfigSettingsPlanModeReasoningEffortWins(t *testing.T) {
+	got := configSettings([]byte(`{"config":{"model":"gpt-test","reasoning_effort":"low","model_reasoning_effort":"medium","plan_mode_reasoning_effort":"xhigh"}}`))
+
+	if got.ReasoningEffort != "xhigh" {
+		t.Fatalf("reasoning_effort = %q, want xhigh", got.ReasoningEffort)
+	}
+}
+
+func TestCodexPlanCollaborationModeUsesXHighFallback(t *testing.T) {
+	got := codexPlanCollaborationMode("gpt-test", codexPlanDefaultEffort)
+
+	body, err := json.Marshal(got)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var shaped struct {
+		Settings struct {
+			ReasoningEffort string `json:"reasoning_effort"`
+		} `json:"settings"`
+	}
+	if err := json.Unmarshal(body, &shaped); err != nil {
+		t.Fatal(err)
+	}
+	if shaped.Settings.ReasoningEffort != "xhigh" {
+		t.Fatalf("reasoning_effort = %q, want xhigh", shaped.Settings.ReasoningEffort)
+	}
+}
+
+func TestEnsureCodexPlanModeIgnoresAdvertisedEffort(t *testing.T) {
+	err := ensureCodexPlanMode([]byte(`{"data":[{"mode":"plan","reasoning_effort":"medium","settings":{"reasoning_effort":"medium"}}]}`))
+	if err != nil {
+		t.Fatalf("ensureCodexPlanMode() failed: %v", err)
 	}
 }
 

--- a/cmd/fanout/codex_plan_tui_test.go
+++ b/cmd/fanout/codex_plan_tui_test.go
@@ -131,11 +131,11 @@ func TestConfigSettingsReadsModelAndReasoningEffort(t *testing.T) {
 	}
 }
 
-func TestConfigSettingsDoesNotUseModelReasoningEffort(t *testing.T) {
+func TestConfigSettingsFallsBackToModelReasoningEffort(t *testing.T) {
 	got := configSettings([]byte(`{"config":{"model":"gpt-test","model_reasoning_effort":"high"}}`))
 
-	if got.ReasoningEffort != "" {
-		t.Fatalf("reasoning_effort = %q, want empty", got.ReasoningEffort)
+	if got.ReasoningEffort != "high" {
+		t.Fatalf("reasoning_effort = %q, want high", got.ReasoningEffort)
 	}
 }
 
@@ -175,7 +175,7 @@ func TestEnsureCodexPlanModeIgnoresAdvertisedEffort(t *testing.T) {
 }
 
 func TestModelListSelectionReturnsSupportedReasoningEfforts(t *testing.T) {
-	got, err := modelListSelection([]byte(`{"data":[{"id":"gpt-test","model":"gpt-test","isDefault":true,"supportedReasoningEfforts":["low","medium","high"]}]}`), "")
+	got, err := modelListSelection([]byte(`{"data":[{"id":"gpt-test","model":"gpt-test","isDefault":true,"supportedReasoningEfforts":[{"reasoningEffort":"low"},{"reasoningEffort":"medium"},{"reasoningEffort":"high"}]}]}`), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -184,6 +184,19 @@ func TestModelListSelectionReturnsSupportedReasoningEfforts(t *testing.T) {
 	}
 	if strings.Join(got.SupportedReasoningEfforts, ",") != "low,medium,high" {
 		t.Fatalf("supported efforts = %#v, want low,medium,high", got.SupportedReasoningEfforts)
+	}
+}
+
+func TestModelListSelectionUsesPreferredHiddenModel(t *testing.T) {
+	got, err := modelListSelection([]byte(`{"data":[{"id":"gpt-visible","model":"gpt-visible","isDefault":true,"supportedReasoningEfforts":[{"reasoningEffort":"low"}]},{"id":"gpt-hidden","model":"gpt-hidden","hidden":true,"supportedReasoningEfforts":[{"reasoningEffort":"xhigh"}]}]}`), "gpt-hidden")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Model != "gpt-hidden" {
+		t.Fatalf("model = %q, want gpt-hidden", got.Model)
+	}
+	if strings.Join(got.SupportedReasoningEfforts, ",") != "xhigh" {
+		t.Fatalf("supported efforts = %#v, want xhigh", got.SupportedReasoningEfforts)
 	}
 }
 
@@ -196,10 +209,10 @@ func TestSupportedReasoningEffortKeepsSupportedRequestedEffort(t *testing.T) {
 }
 
 func TestSupportedReasoningEffortFallsBackToStrongestSupportedEffort(t *testing.T) {
-	got := supportedReasoningEffort("xhigh", []string{"low", "medium", "high"})
+	got := supportedReasoningEffort("xhigh", []string{"low", "medium", "high", "ultra"})
 
-	if got != "high" {
-		t.Fatalf("supportedReasoningEffort() = %q, want high", got)
+	if got != "ultra" {
+		t.Fatalf("supportedReasoningEffort() = %q, want ultra", got)
 	}
 }
 


### PR DESCRIPTION
TL;DR: Codex Plan Mode 起動時に Codex 側の reasoning effort 設定を反映します。設定がない場合は xhigh を使います。
Review effort: 2

## Summary
- Codex Plan Mode controller が config/read から model と reasoning effort をまとめて解決するように変更
- plan_mode_reasoning_effort を最優先にし、reasoning_effort、model_reasoning_effort、xhigh の順に fallback
- collaborationMode/list は Plan mode の存在確認だけに使い、advertise された medium を採用しないように変更

## Test plan
- go test ./cmd/fanout
- make lint
- make test
- codex review --uncommitted