### PR TITLE
[codex] TUI の Codex Plan Session 起動を修正

### DIFF
--- a/cmd/fanout/codex_plan_tui.go
+++ b/cmd/fanout/codex_plan_tui.go
@@ -87,6 +87,15 @@ type codexAppClient struct {
 	conn *websocketJSONConn
 }
 
+type codexAppRequester interface {
+	Request(id, method string, params any) (json.RawMessage, error)
+}
+
+type codexAppSessionClient interface {
+	codexAppRequester
+	Notify(method string) error
+}
+
 type codexRemoteAppServer struct {
 	Addr string
 
@@ -208,6 +217,7 @@ func runCodexPlanTUI(cfg codexPlanTUIConfig, stdout, stderr io.Writer) (err erro
 		return err
 	}
 	drainDone := make(chan error)
+	tuiPrompt := cfg.Prompt
 	if thread.UseTurnCollaborationMode {
 		if err = startCodexPlanTurn(client, thread, cwd, cfg.Prompt); err != nil {
 			client.Close()
@@ -215,15 +225,12 @@ func runCodexPlanTUI(cfg codexPlanTUIConfig, stdout, stderr io.Writer) (err erro
 		}
 		drainDone = make(chan error, 1)
 		go func() { drainDone <- drainCodexAppServer(client) }()
+		tuiPrompt = ""
 	} else {
 		client.Close()
 	}
 
-	tuiPrompt := cfg.Prompt
-	if thread.UseTurnCollaborationMode {
-		tuiPrompt = ""
-	}
-	tui, tuiDone, err := startCodexRemoteTUI(cfg.CodexPath, server.Addr, thread.SessionID, tuiPrompt, stdout, stderr)
+	tui, tuiDone, err := startCodexRemoteTUI(cfg.CodexPath, server.Addr, thread.ID, tuiPrompt, stdout, stderr)
 	if err != nil {
 		if thread.UseTurnCollaborationMode {
 			client.Close()
@@ -270,7 +277,7 @@ func runCodexPlanTUI(cfg codexPlanTUIConfig, stdout, stderr io.Writer) (err erro
 	return <-tuiDone
 }
 
-func setupCodexPlanThread(client *codexAppClient, cwd string) (codexThreadInfo, error) {
+func setupCodexPlanThread(client codexAppSessionClient, cwd string) (codexThreadInfo, error) {
 	if _, err := client.Request("fanout-init", "initialize", map[string]any{
 		"clientInfo": map[string]any{
 			"name":    "fanout-codex-plan-tui",
@@ -332,7 +339,7 @@ func codexThreadStartParams(cwd, model string) map[string]any {
 	}
 }
 
-func startCodexPlanTurn(client *codexAppClient, thread codexThreadInfo, cwd, prompt string) error {
+func startCodexPlanTurn(client codexAppRequester, thread codexThreadInfo, cwd, prompt string) error {
 	params := codexTurnStartParams(thread.ID, cwd, thread.Model, prompt, nil)
 	if thread.UseTurnCollaborationMode {
 		params["collaborationMode"] = codexPlanCollaborationMode(thread.Model, thread.PlanEffort)
@@ -379,8 +386,8 @@ func codexPlanCollaborationMode(model, effort string) map[string]any {
 	}
 }
 
-func startCodexRemoteTUI(codexPath, remoteAddr, sessionID, prompt string, stdout, stderr io.Writer) (*exec.Cmd, chan error, error) {
-	cmd := exec.Command(codexPath, codexRemoteTUIArgs(remoteAddr, sessionID, prompt)...)
+func startCodexRemoteTUI(codexPath, remoteAddr, threadID, prompt string, stdout, stderr io.Writer) (*exec.Cmd, chan error, error) {
+	cmd := exec.Command(codexPath, codexRemoteTUIArgs(remoteAddr, threadID, prompt)...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
@@ -392,8 +399,8 @@ func startCodexRemoteTUI(codexPath, remoteAddr, sessionID, prompt string, stdout
 	return cmd, done, nil
 }
 
-func codexRemoteTUIArgs(remoteAddr, sessionID, prompt string) []string {
-	args := []string{"--remote", remoteAddr, "resume", sessionID}
+func codexRemoteTUIArgs(remoteAddr, threadID, prompt string) []string {
+	args := []string{"--remote", remoteAddr, "resume", threadID}
 	if strings.TrimSpace(prompt) != "" {
 		args = append(args, "--", prompt)
 	}
@@ -1027,7 +1034,7 @@ func appServerErrorSummary(raw json.RawMessage) string {
 	return string(raw)
 }
 
-func resolveCodexSettings(client *codexAppClient, cwd string) (codexResolvedSettings, error) {
+func resolveCodexSettings(client codexAppRequester, cwd string) (codexResolvedSettings, error) {
 	configResult, configErr := client.Request("fanout-config", "config/read", map[string]any{
 		"includeLayers": false,
 		"cwd":           cwd,

--- a/cmd/fanout/codex_plan_tui_test.go
+++ b/cmd/fanout/codex_plan_tui_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"encoding/json"
 	"errors"
+	"slices"
 	"strings"
 	"syscall"
 	"testing"
@@ -402,9 +403,9 @@ func (f *fakeCodexAppClient) requestMethods() []string {
 }
 
 func (f *fakeCodexAppClient) lastRequest(method string) fakeCodexRequest {
-	for i := len(f.calls) - 1; i >= 0; i-- {
-		if f.calls[i].method == method {
-			return f.calls[i]
+	for _, call := range slices.Backward(f.calls) {
+		if call.method == method {
+			return call
 		}
 	}
 	return fakeCodexRequest{}

--- a/cmd/fanout/codex_plan_tui_test.go
+++ b/cmd/fanout/codex_plan_tui_test.go
@@ -67,8 +67,8 @@ func TestCodexThreadStartParamsCreatesPersistentStartupThread(t *testing.T) {
 }
 
 func TestCodexRemoteTUIArgsPassPromptToResume(t *testing.T) {
-	got := codexRemoteTUIArgs("ws://127.0.0.1:1234", "session-1", "hello plan")
-	want := []string{"--remote", "ws://127.0.0.1:1234", "resume", "session-1", "--", "hello plan"}
+	got := codexRemoteTUIArgs("ws://127.0.0.1:1234", "thread-1", "hello plan")
+	want := []string{"--remote", "ws://127.0.0.1:1234", "resume", "thread-1", "--", "hello plan"}
 
 	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
 		t.Fatalf("codexRemoteTUIArgs() = %#v, want %#v", got, want)
@@ -76,8 +76,8 @@ func TestCodexRemoteTUIArgsPassPromptToResume(t *testing.T) {
 }
 
 func TestCodexRemoteTUIArgsSeparatesDashLeadingPrompt(t *testing.T) {
-	got := codexRemoteTUIArgs("ws://127.0.0.1:1234", "session-1", "-- investigate")
-	want := []string{"--remote", "ws://127.0.0.1:1234", "resume", "session-1", "--", "-- investigate"}
+	got := codexRemoteTUIArgs("ws://127.0.0.1:1234", "thread-1", "-- investigate")
+	want := []string{"--remote", "ws://127.0.0.1:1234", "resume", "thread-1", "--", "-- investigate"}
 
 	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
 		t.Fatalf("codexRemoteTUIArgs() = %#v, want %#v", got, want)
@@ -85,8 +85,8 @@ func TestCodexRemoteTUIArgsSeparatesDashLeadingPrompt(t *testing.T) {
 }
 
 func TestCodexRemoteTUIArgsCanResumeWithoutPromptForFallbackTurn(t *testing.T) {
-	got := codexRemoteTUIArgs("ws://127.0.0.1:1234", "session-1", "")
-	want := []string{"--remote", "ws://127.0.0.1:1234", "resume", "session-1"}
+	got := codexRemoteTUIArgs("ws://127.0.0.1:1234", "thread-1", "")
+	want := []string{"--remote", "ws://127.0.0.1:1234", "resume", "thread-1"}
 
 	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
 		t.Fatalf("codexRemoteTUIArgs() = %#v, want %#v", got, want)
@@ -132,6 +132,62 @@ func TestCodexTurnStartParamsCanCarryPlanCollaborationMode(t *testing.T) {
 	if len(shaped.Input) != 1 || shaped.Input[0].Type != "text" || shaped.Input[0].Text != "hello plan" {
 		t.Fatalf("input = %#v, want one text prompt", shaped.Input)
 	}
+}
+
+func TestCodexPlanThreadLeavesInitialTurnForTUIAfterSettingsUpdate(t *testing.T) {
+	client := &fakeCodexAppClient{}
+
+	thread, err := setupCodexPlanThread(client, "/repo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if thread.UseTurnCollaborationMode {
+		t.Fatal("UseTurnCollaborationMode = true, want false when thread/settings/update succeeds")
+	}
+
+	want := "initialize,collaborationMode/list,config/read,model/list,thread/start,thread/settings/update"
+	if got := strings.Join(client.requestMethods(), ","); got != want {
+		t.Fatalf("request order = %s, want %s", got, want)
+	}
+	if client.hasRequest("turn/start") {
+		t.Fatal("setupCodexPlanThread started a turn; want initial prompt left for the interactive TUI")
+	}
+}
+
+func TestCodexPlanThreadStartsInitialTurnWithFallbackCollaborationMode(t *testing.T) {
+	client := &fakeCodexAppClient{
+		methodErrors: map[string]error{
+			"thread/settings/update": errors.New(`unknown method "thread/settings/update"`),
+		},
+	}
+
+	thread, err := setupCodexPlanThread(client, "/repo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !thread.UseTurnCollaborationMode {
+		t.Fatal("UseTurnCollaborationMode = false, want true when thread/settings/update is unsupported")
+	}
+	if err = startCodexPlanTurn(client, thread, "/repo", "hello fallback"); err != nil {
+		t.Fatal(err)
+	}
+
+	turn := client.lastRequest("turn/start").paramsMap(t)
+	mode, ok := turn["collaborationMode"].(map[string]any)
+	if !ok {
+		t.Fatalf("turn/start missing fallback collaborationMode: %#v", turn)
+	}
+	if mode["mode"] != "plan" {
+		t.Fatalf("collaborationMode.mode = %q, want plan", mode["mode"])
+	}
+	settings, ok := mode["settings"].(map[string]any)
+	if !ok {
+		t.Fatalf("collaborationMode.settings = %#v, want map", mode["settings"])
+	}
+	if settings["model"] != "gpt-test" || settings["reasoning_effort"] != "xhigh" {
+		t.Fatalf("fallback settings = %#v, want model gpt-test and effort xhigh", settings)
+	}
+	assertTurnStartText(t, turn, "hello fallback")
 }
 
 func TestConfigSettingsReadsModelAndReasoningEffort(t *testing.T) {
@@ -298,5 +354,87 @@ func TestUnsupportedCodexAppServerMethodDetection(t *testing.T) {
 	err := errors.New(`app-server request fanout-plan-mode failed: unknown variant "thread/settings/update"`)
 	if !isUnsupportedCodexAppServerMethod(err) {
 		t.Fatalf("isUnsupportedCodexAppServerMethod() = false, want true")
+	}
+}
+
+type fakeCodexAppClient struct {
+	calls         []fakeCodexRequest
+	notifications []string
+	methodErrors  map[string]error
+}
+
+type fakeCodexRequest struct {
+	id     string
+	method string
+	params any
+}
+
+func (f *fakeCodexAppClient) Request(id, method string, params any) (json.RawMessage, error) {
+	f.calls = append(f.calls, fakeCodexRequest{id: id, method: method, params: params})
+	if err := f.methodErrors[method]; err != nil {
+		return nil, err
+	}
+	switch method {
+	case "collaborationMode/list":
+		return json.RawMessage(`{"data":[{"mode":"plan"}]}`), nil
+	case "config/read":
+		return json.RawMessage(`{"config":{"model":"gpt-test","plan_mode_reasoning_effort":"xhigh"}}`), nil
+	case "model/list":
+		return json.RawMessage(`{"data":[{"id":"gpt-test","model":"gpt-test","isDefault":true,"supportedReasoningEfforts":[{"reasoningEffort":"low"},{"reasoningEffort":"medium"},{"reasoningEffort":"high"},{"reasoningEffort":"xhigh"}]}]}`), nil
+	case "thread/start":
+		return json.RawMessage(`{"thread":{"id":"thread-1","sessionId":"session-1"}}`), nil
+	default:
+		return json.RawMessage(`{}`), nil
+	}
+}
+
+func (f *fakeCodexAppClient) Notify(method string) error {
+	f.notifications = append(f.notifications, method)
+	return nil
+}
+
+func (f *fakeCodexAppClient) requestMethods() []string {
+	out := make([]string, 0, len(f.calls))
+	for _, call := range f.calls {
+		out = append(out, call.method)
+	}
+	return out
+}
+
+func (f *fakeCodexAppClient) lastRequest(method string) fakeCodexRequest {
+	for i := len(f.calls) - 1; i >= 0; i-- {
+		if f.calls[i].method == method {
+			return f.calls[i]
+		}
+	}
+	return fakeCodexRequest{}
+}
+
+func (f *fakeCodexAppClient) hasRequest(method string) bool {
+	for _, call := range f.calls {
+		if call.method == method {
+			return true
+		}
+	}
+	return false
+}
+
+func (r fakeCodexRequest) paramsMap(t *testing.T) map[string]any {
+	t.Helper()
+	params, ok := r.params.(map[string]any)
+	if !ok {
+		t.Fatalf("%s params = %#v, want map[string]any", r.method, r.params)
+	}
+	return params
+}
+
+func assertTurnStartText(t *testing.T, params map[string]any, want string) {
+	t.Helper()
+	input, ok := params["input"].([]map[string]any)
+	if !ok || len(input) != 1 {
+		t.Fatalf("turn/start input = %#v, want one text item", params["input"])
+	}
+	if input[0]["type"] != "text" || input[0]["text"] != want {
+		t.Fatalf("turn/start input = %#v, want text %q", input[0], want)
 	}
 }


### PR DESCRIPTION
## 概要

TUI から Codex の新規 Session を開始したときに、Codex Plan Mode の remote resume が失敗する問題を修正しました。

## 変更内容

- Codex app-server の `thread/start` で得た `thread.id` を TUI の `resume` に渡すように変更しました。
- `thread/settings/update` が使える通常 path では、初回 prompt を interactive TUI 側に渡す挙動を維持しました。
- `thread/settings/update` が未対応の fallback path だけ、fanout controller 側で `turn/start` してから TUI を attach するようにしました。
- 通常 path と fallback path の差をテストで固定しました。

## 原因

fanout は `thread/start` 後に `sessionId` を `codex --remote ... resume` へ渡していました。現行 Codex app-server の resume API は `threadId` を前提にしており、空の thread を `sessionId` で resume すると rollout を見つけられず失敗します。

一方で、単純に fanout 側で初回 `turn/start` すると、approval や user input を interactive TUI ではなく headless controller が処理してしまうため、通常 path では初回 prompt の所有者を TUI に戻しています。

## 検証

- `codex review --uncommitted` を 2 回実行し、2 回目は指摘なし
- `go test ./cmd/fanout`
- `go test ./...`
- `git diff --check`
- `make test`