### PR TITLE
[codex] post-work-review の codex review 権限処理を強化

### DIFF
--- a/codex/skills/post-work-review/SKILL.md
+++ b/codex/skills/post-work-review/SKILL.md
@@ -45,14 +45,41 @@ PR 全体相当の branch diff をレビューする。`--commit HEAD` だけで
 `--commit HEAD` だけを通して marker を書くと、古い commit が未レビューのまま PR gate を
 通す可能性がある。
 
+## Execution Permissions
+
+`codex review ...` は Codex review/app-server/network access を必要とし、managed
+sandbox で権限ブロックされやすい。権限昇格を要求できる環境では、通常 sandbox で
+試してから再実行せず、初回から `exec_command` に
+`sandbox_permissions: "require_escalated"` を付けて実行する。
+
+- justification は
+  `codex review needs Codex review/app-server/network access and is frequently blocked in the managed sandbox`
+  の趣旨にする。
+- `prefix_rule` は付けない。`require_escalated` と `justification` だけを使う。
+- `approval_policy=never` など、現在の実行環境が権限昇格要求そのものを受け付けない
+  場合だけ、同じ `codex review ...` を非昇格の直接コマンドとして 1 回実行してよい。
+  権限昇格できる環境で、通常 sandbox を先に試す fallback には使わない。
+- `codex review --uncommitted`、`codex review --base <default-branch>`、
+  `codex review --commit HEAD` は通常 1 つの直接コマンドとして実行する。pipes、
+  subshell、出力を加工する wrapper は使わない。
+- 長時間実行で `exec_command` が部分出力を返す可能性があり、全出力を最後にまとめて
+  読む必要がある場合だけ、stdout/stderr を一時ファイルへ退避してよい。その場合も
+  `codex review ...` 自体は 1 回だけ実行し、command 終了後に一時ファイルを 1 回読む。
+- 権限昇格が拒否された、または同じ権限ブロックが続く場合は clean 扱いしない。
+  marker も書かない。`--uncommitted` が実行できない場合は PR 上の
+  `@codex review` を代替確認として使わない。clean tree で、既存 PR の head が
+  レビュー対象 commit と一致する場合だけ PR 上の Codex review を代替確認として
+  使ってよい。代替確認できない場合は、実行できなかった exact command と必要な
+  権限を報告して停止する。
+
 ## Review Loop
 
 1. レビュー対象とコマンドを 1 文でユーザーに伝える。
-2. `codex review ...` を 1 つの blocking shell command として実行する。長時間実行で
-   `exec_command` の `session_id` が返る可能性がある場合は、stdout/stderr を一時
-   ファイルへ退避するなどして polling 中に部分出力を流さない。Review Session、
-   `/codex:status`、tmux pane は見に行かず、`session_id` はプロセス終了確認だけに
-   使う。command が終了してから final output を 1 回だけ読む。
+2. `codex review ...` を Execution Permissions に従って 1 つの blocking shell
+   command として実行する。長時間実行で `exec_command` の `session_id` が返る
+   可能性がある場合は、Review Session、`/codex:status`、tmux pane を見に行かず、
+   `session_id` はプロセス終了確認だけに使う。polling 中の部分出力を findings として
+   解釈せず、command が終了してから final output を 1 回だけ読む。
 3. final output を findings として読む。重大度、ファイル、行、指摘内容を保持する。
 4. actionable な指摘だけ修正する。明らかな bug、規約違反、セキュリティ問題、
    テスト不整合を優先する。単なる好みの提案は理由を添えて見送ってよい。


### PR DESCRIPTION
TL;DR
`post-work-review` の `codex review` 実行手順に権限昇格ルールを追加し、managed sandbox での権限ブロックを避けやすくしました。
`approval_policy=never` や長時間 review の出力退避も明示し、既存の review loop と marker 条件は維持しています。

Review effort: 1

## 変更内容

- `codex review ...` を権限昇格可能な環境では初回から `require_escalated` 付きで実行する手順を追加。
- `approval_policy=never` の環境では非昇格の直接実行を 1 回だけ許す fallback を追加。
- 長時間 review で findings を取りこぼさないよう、必要時の一時ファイル退避を許可。
- `--uncommitted` が実行できない場合に PR 上の `@codex review` を代替にしない条件を明記。

## 背景

Codex の `post-work-review` 実行時に `codex review` が managed sandbox の権限でブロックされ、skill が review loop に入れないケースが多発していました。
スキル本文に実行権限の扱いを明文化し、各セッションが通常 sandbox で先に失敗する流れを避けます。

## 検証

- `git diff --check`
- Ruby YAML frontmatter check
- `codex review --uncommitted`
- `codex review --base origin/main`
- `make install-integrations` 後、repo-local と installed copy の一致確認
