### PR TITLE
feat(pane): label each pane's top border with "#parent · name"

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -22,6 +22,9 @@ briefing から起動します。再実行しても同じ対象に 2 つ目の�
 
 - **冪等なファンアウト** — `.fanout/state.json` が `(parent, issue)` ごとに
   ペインを管理するので、再実行しても作業が重複しません。
+- **ペイン枠線ラベル** — 各ペインの上端枠線に親と名前を表示するので
+  (例 `#123 · fix-login-bug-123`、`plan:my-feature · task-slug`)、tiled で
+  並んでも見分けが付きます。
 - **Wave 進行** — `--unblocked-only` がブロッカーを読み取り、unblock 済みの子
   だけをファンアウト。PR が merge されたら再実行すれば次の wave が開きます。
 - **常駐 TUI コンソール** — 引数なしの `fanout` で、ペイン / issue / PR を

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ English and 日本語.
 
 - **Idempotent fan-out** — `.fanout/state.json` keys every `(parent, issue)`
   pane, so reruns never duplicate work.
+- **Pane border labels** — each pane shows its parent and name on its top
+  border (e.g. `#123 · fix-login-bug-123`, `plan:my-feature · task-slug`), so
+  tiled panes are easy to tell apart.
 - **Wave progression** — `--unblocked-only` reads blockers and fans out only
   unblocked children; rerun as PRs merge and the next wave opens.
 - **Persistent TUI console** — run `fanout` with no arguments for a live

--- a/cmd/fanout/pane.go
+++ b/cmd/fanout/pane.go
@@ -159,6 +159,12 @@ func createPaneDetailed(cfg *cliflags.Config, lg *log.Logger, info *fanoutruntim
 	if err := tmuxrun.SetPaneTitle(paneID, paneTitle(req)); err != nil {
 		lg.Warn("%s: %v", paneLogLabel(req), err)
 	}
+	if err := tmuxrun.SetPaneLabel(paneID, paneBorderLabel(req)); err != nil {
+		lg.Warn("%s: pane border label: %v", paneLogLabel(req), err)
+	}
+	if err := tmuxrun.EnablePaneBorderTitles(paneID); err != nil {
+		lg.Warn("%s: pane border titles: %v", paneLogLabel(req), err)
+	}
 	if err := tmuxrun.SetPaneProjectRoot(paneID, info.ProjectRoot); err != nil {
 		lg.Warn("%s: dashboard project root hint: %v", paneLogLabel(req), err)
 	}
@@ -633,6 +639,9 @@ func printPaneDryRun(req paneRequest, target string, lg *log.Logger, c log.Palet
 	if title := paneTitle(req); title != "" {
 		fmt.Fprintf(lg.Stdout(), "    %s$ tmux select-pane -t <pane_id> -T %s%s\n", c.Dim, shellQuote(title), c.Reset)
 	}
+	fmt.Fprintf(lg.Stdout(), "    %s$ tmux set-option -p -t <pane_id> @fanout_pane_label %s%s\n", c.Dim, shellQuote(tmuxrun.NeutralizePaneLabel(paneBorderLabel(req))), c.Reset)
+	fmt.Fprintf(lg.Stdout(), "    %s$ tmux set-option -w -t <pane_id> pane-border-status top%s\n", c.Dim, c.Reset)
+	fmt.Fprintf(lg.Stdout(), "    %s$ tmux set-option -w -t <pane_id> pane-border-format %s%s\n", c.Dim, shellQuote(tmuxrun.PaneBorderFormat()), c.Reset)
 	if target != "" {
 		fmt.Fprintf(lg.Stdout(), "    %s$ tmux select-layout -t %s tiled%s\n", c.Dim, shellQuote(target), c.Reset)
 	} else {
@@ -687,6 +696,29 @@ func paneTitle(req paneRequest) string {
 		return req.DisplayNameOverride
 	}
 	return req.Slug
+}
+
+// paneBorderLabel is the text fanout shows on a pane's top border:
+// "<parent> · <pane name>" (e.g. "#123 · fix-login-bug-123").
+func paneBorderLabel(req paneRequest) string {
+	return borderLabel(req.ParentRef, paneTitle(req))
+}
+
+// borderLabel composes the "<parent> · <name>" border label shared by agent
+// panes (paneBorderLabel) and TUI shell panes (launchShellPaneFromTUI).
+func borderLabel(parent, name string) string {
+	return parentDisplay(parent) + " · " + name
+}
+
+// parentDisplay renders a parent ref for display, mirroring the dashboard's
+// parentLabel (web/src/lib/github.ts): numeric issue parents get a "#" prefix,
+// GitHub Projects URLs drop the host prefix, and plan:<slug> / @manual pass
+// through unchanged.
+func parentDisplay(parent string) string {
+	if naming.AllDigits(parent) {
+		return "#" + parent
+	}
+	return strings.TrimPrefix(parent, "https://github.com/")
 }
 
 func paneLogLabel(req paneRequest) string {

--- a/cmd/fanout/pane_test.go
+++ b/cmd/fanout/pane_test.go
@@ -692,3 +692,59 @@ func TestWaitForCodexPlanTUIReadyTimesOutWithoutStatus(t *testing.T) {
 		t.Fatalf("waitForCodexPlanTUIReady() error = %v, want timeout", err)
 	}
 }
+
+func TestParentDisplay(t *testing.T) {
+	cases := []struct {
+		parent string
+		want   string
+	}{
+		{"123", "#123"},
+		{"81", "#81"},
+		{"plan:launch-plan", "plan:launch-plan"},
+		{manualPaneParentRef, "@manual"},
+		{watchPaneParentRef, "@watch"},
+		{"https://github.com/orgs/octo/projects/3", "orgs/octo/projects/3"},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		if got := parentDisplay(tc.parent); got != tc.want {
+			t.Errorf("parentDisplay(%q) = %q, want %q", tc.parent, got, tc.want)
+		}
+	}
+}
+
+func TestPaneBorderLabel(t *testing.T) {
+	cases := []struct {
+		name string
+		req  paneRequest
+		want string
+	}{
+		{
+			name: "issue child uses slug",
+			req:  paneRequest{ParentRef: "123", Slug: "fix-login-bug-123"},
+			want: "#123 · fix-login-bug-123",
+		},
+		{
+			name: "display name override wins over slug",
+			req:  paneRequest{ParentRef: "123", Slug: "fix-login-bug-123", DisplayNameOverride: "Login fix"},
+			want: "#123 · Login fix",
+		},
+		{
+			name: "plan parent passes through",
+			req:  paneRequest{ParentRef: "plan:my-feature", Slug: "task-slug"},
+			want: "plan:my-feature · task-slug",
+		},
+		{
+			name: "manual parent passes through",
+			req:  paneRequest{ParentRef: manualPaneParentRef, Slug: "scratch"},
+			want: "@manual · scratch",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := paneBorderLabel(tc.req); got != tc.want {
+				t.Errorf("paneBorderLabel() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/fanout/tui_launch.go
+++ b/cmd/fanout/tui_launch.go
@@ -171,6 +171,8 @@ func launchShellPaneFromTUI(projectRoot, session string, req fanouttui.ShellLaun
 	// Shell pane ergonomics are best-effort; the recorded pane id is enough to
 	// keep the terminal usable when tmux metadata/layout updates fail.
 	_ = tmuxrun.SetPaneTitle(paneID, title)
+	_ = tmuxrun.SetPaneLabel(paneID, borderLabel(manualPaneParentRef, title))
+	_ = tmuxrun.EnablePaneBorderTitles(paneID)
 	_ = tmuxrun.SetPaneProjectRoot(paneID, projectRoot)
 	_ = tmuxrun.SelectTiled(tuiLaunchTarget(session))
 	if err := recorder.RecordPane(state.Pane{

--- a/internal/naming/naming.go
+++ b/internal/naming/naming.go
@@ -95,7 +95,7 @@ func QualifySlugForParent(slug, parentRef string, issueNum int) string {
 }
 
 func parentToken(parentRef string) string {
-	if allDigits(parentRef) {
+	if AllDigits(parentRef) {
 		return "parent-" + parentRef
 	}
 	token := Slugify(parentRef)
@@ -112,7 +112,10 @@ func parentToken(parentRef string) string {
 	return token + "-" + shortHash(parentRef)
 }
 
-func allDigits(s string) bool {
+// AllDigits reports whether s is non-empty and every rune is an ASCII digit.
+// It preserves leading zeros (it never parses the number), matching the
+// dashboard's `^\d+$` parent classification in web/src/lib/github.ts.
+func AllDigits(s string) bool {
 	if s == "" {
 		return false
 	}

--- a/internal/tmuxrun/tmuxrun.go
+++ b/internal/tmuxrun/tmuxrun.go
@@ -29,6 +29,18 @@ const (
 	livePaneAgentStateFormat = "#{pane_id}\t#{" + agentStateOption + "}"
 	livePaneShellKeyFormat   = "#{pane_id}\t#{" + shellKeyOption + "}"
 	paneAlternateFormat      = "#{alternate_on}"
+	// paneLabelOption is a tmux pane user option holding the border label fanout
+	// shows on the pane's top border (e.g. "#123 · fix-login-bug-123"). It is set
+	// per pane and referenced from paneBorderFormat. A dedicated user option keeps
+	// the label stable: agents such as claude/codex rewrite the terminal title
+	// (OSC), which clobbers #{pane_title}, but never touch pane user options.
+	paneLabelOption = "@fanout_pane_label"
+	// paneBorderFormat draws @fanout_pane_label (with padding) on each pane's top
+	// border, falling back to #{pane_title} for panes fanout did not label. A
+	// substituted option value is not re-expanded (verified on tmux 3.6a: #{ /
+	// #( / ## stay literal), so the "#<digit>" parent prefix is safe; only "#["
+	// is still interpreted at draw time as a style, which SetPaneLabel neutralizes.
+	paneBorderFormat = " #{?" + paneLabelOption + ",#{" + paneLabelOption + "},#{pane_title}} "
 )
 
 // paneIDPattern matches a well-formed tmux pane id (%N). The live-pane parsers
@@ -323,6 +335,60 @@ func SetPaneShellKey(paneID, shellKey string) error {
 	}
 	if err := exec.Command("tmux", "set-option", "-p", "-t", paneID, shellKeyOption, shellKey).Run(); err != nil {
 		return fmt.Errorf("tmux set-option %s: %w", shellKeyOption, err)
+	}
+	return nil
+}
+
+// PaneBorderFormat returns the pane-border-format string EnablePaneBorderTitles
+// applies, single-sourced here so the --dry-run preview matches the live command.
+func PaneBorderFormat() string { return paneBorderFormat }
+
+// SetPaneLabel records the border label fanout displays on a pane's top border.
+// An empty label is allowed (the pane then falls back to #{pane_title}). The
+// label is neutralized first so a "#[...]" sequence in a --name / display
+// override cannot inject a tmux style into the border.
+func SetPaneLabel(paneID, label string) error {
+	if strings.TrimSpace(paneID) == "" {
+		return fmt.Errorf("pane id is required")
+	}
+	if err := exec.Command("tmux", "set-option", "-p", "-t", paneID, paneLabelOption, NeutralizePaneLabel(label)).Run(); err != nil {
+		return fmt.Errorf("tmux set-option %s: %w", paneLabelOption, err)
+	}
+	return nil
+}
+
+// paneLabelStyleRE matches a run of one or more "#" immediately before a "[".
+// Stripping the whole run (not a single "#[") is what makes NeutralizePaneLabel
+// overlap-safe: a lone ReplaceAll("#[","[") turns "##[" into "#[" and re-arms
+// the style, but "#+\[" consumes the maximal run greedily so no "#[" survives.
+var paneLabelStyleRE = regexp.MustCompile(`#+\[`)
+
+// NeutralizePaneLabel defuses the only metacharacter the pane-border renderer
+// interprets at draw time: "#[" introduces a tmux style sequence. fanout's own
+// label parts (the "#<digit>" parent prefix, slugs, "·") never contain it, but a
+// --name / display override could, which would recolor or drop part of the
+// border text. Dropping the "#"(s) makes "#[fg=red]" render as the literal
+// "[fg=red]". Other "#" forms ("#{", "#(", "##") are not re-interpreted in a
+// substituted option value (verified on tmux 3.6a), so they need no handling.
+// SetPaneLabel applies it for live panes; the --dry-run preview calls it so the
+// printed command matches what would actually run.
+func NeutralizePaneLabel(label string) string {
+	return paneLabelStyleRE.ReplaceAllString(label, "[")
+}
+
+// EnablePaneBorderTitles turns on top pane-border titles for the window holding
+// paneID and points pane-border-format at @fanout_pane_label. pane-border-status
+// is a window option (its finest granularity), so this affects every pane in the
+// window; non-fanout panes fall back to #{pane_title}. Re-applying is idempotent.
+func EnablePaneBorderTitles(paneID string) error {
+	if strings.TrimSpace(paneID) == "" {
+		return fmt.Errorf("pane id is required")
+	}
+	if err := exec.Command("tmux", "set-option", "-w", "-t", paneID, "pane-border-status", "top").Run(); err != nil {
+		return fmt.Errorf("tmux set-option pane-border-status: %w", err)
+	}
+	if err := exec.Command("tmux", "set-option", "-w", "-t", paneID, "pane-border-format", paneBorderFormat).Run(); err != nil {
+		return fmt.Errorf("tmux set-option pane-border-format: %w", err)
 	}
 	return nil
 }

--- a/internal/tmuxrun/tmuxrun_test.go
+++ b/internal/tmuxrun/tmuxrun_test.go
@@ -450,6 +450,91 @@ func TestSetPaneShellKey(t *testing.T) {
 	})
 }
 
+func TestSetPaneLabel(t *testing.T) {
+	argsPath := installTmuxShim(t, `printf '%s\n' "$@" > "$TMUXRUN_ARGS"
+`)
+
+	if err := SetPaneLabel("%42", "#123 · fix-login-bug-123"); err != nil {
+		t.Fatalf("SetPaneLabel() failed: %v", err)
+	}
+
+	assertTmuxArgs(t, argsPath, []string{
+		"set-option", "-p", "-t", "%42", "@fanout_pane_label", "#123 · fix-login-bug-123",
+	})
+}
+
+func TestSetPaneLabelRequiresPaneID(t *testing.T) {
+	if err := SetPaneLabel("", "label"); err == nil {
+		t.Fatal("SetPaneLabel(empty pane id) should error")
+	}
+}
+
+func TestNeutralizePaneLabel(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain label is untouched", "#123 · fix-login-bug-123", "#123 · fix-login-bug-123"},
+		{"single style sequence is defused", "#123 · v2 #[fg=red]ship", "#123 · v2 [fg=red]ship"},
+		// A leading extra "#" must not let the style survive: ReplaceAll("#[","[")
+		// would leave "#[fg=red]" here, so the run-stripping form is required.
+		{"overlapping hashes are fully defused", "#123 · ##[fg=red]x", "#123 · [fg=red]x"},
+		{"a run of hashes before a bracket collapses", "###[bold]", "[bold]"},
+		{"a bracket without a leading hash is kept", "name[0]", "name[0]"},
+		{"empty stays empty", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := NeutralizePaneLabel(tc.in); got != tc.want {
+				t.Errorf("NeutralizePaneLabel(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSetPaneLabelNeutralizesStyleSequence(t *testing.T) {
+	argsPath := installTmuxShim(t, `printf '%s\n' "$@" > "$TMUXRUN_ARGS"
+`)
+
+	// A "#[" from a --name override must not reach the border as a tmux style.
+	if err := SetPaneLabel("%42", "#123 · v2 #[fg=red]ship"); err != nil {
+		t.Fatalf("SetPaneLabel() failed: %v", err)
+	}
+
+	assertTmuxArgs(t, argsPath, []string{
+		"set-option", "-p", "-t", "%42", "@fanout_pane_label", "#123 · v2 [fg=red]ship",
+	})
+}
+
+func TestEnablePaneBorderTitles(t *testing.T) {
+	argsPath := installTmuxShim(t, `printf '%s\n' "$@" >> "$TMUXRUN_ARGS"
+printf '%s\n' '---' >> "$TMUXRUN_ARGS"
+`)
+
+	if err := EnablePaneBorderTitles("%42"); err != nil {
+		t.Fatalf("EnablePaneBorderTitles() failed: %v", err)
+	}
+
+	body, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := strings.Join([]string{
+		"set-option", "-w", "-t", "%42", "pane-border-status", "top", "---",
+		"set-option", "-w", "-t", "%42", "pane-border-format", paneBorderFormat, "---",
+	}, "\n") + "\n"
+	if string(body) != want {
+		t.Fatalf("tmux args body = %q, want %q", string(body), want)
+	}
+}
+
+func TestEnablePaneBorderTitlesRequiresPaneID(t *testing.T) {
+	if err := EnablePaneBorderTitles(""); err == nil {
+		t.Fatal("EnablePaneBorderTitles(empty pane id) should error")
+	}
+}
+
 func TestBuildPaneLaunchCommandUsesUserShellAndKeepsPaneOpen(t *testing.T) {
 	got := BuildPaneLaunchCommand("PATH='/very/long/path:/usr/bin' /tmp/bin/codex '[fanout #1] prompt'")
 	for _, want := range []string{

--- a/tests/golden/scenario-body-task-list.dry-run.txt
+++ b/tests/golden/scenario-body-task-list.dry-run.txt
@@ -19,6 +19,9 @@
     $ git -C <REPO>/tests/fixtures/scenario-body-task-list/project_root worktree add -b fanout/first-task-201 <REPO>/tests/fixtures/scenario-body-task-list/project_root/.fanout/worktrees/first-task-201 main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-body-task-list/project_root/.fanout/worktrees/first-task-201 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout #201 of #200] first-task-201: First task. read /tmp/fanout-project_root-201.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T first-task-201
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label '#200 · first-task-201'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
@@ -37,6 +40,9 @@
     $ git -C <REPO>/tests/fixtures/scenario-body-task-list/project_root worktree add -b fanout/second-task-202 <REPO>/tests/fixtures/scenario-body-task-list/project_root/.fanout/worktrees/second-task-202 main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-body-task-list/project_root/.fanout/worktrees/second-task-202 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout #202 of #200] second-task-202: Second task. read /tmp/fanout-project_root-202.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T second-task-202
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label '#200 · second-task-202'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree

--- a/tests/golden/scenario-cross-parent-shared.dry-run.txt
+++ b/tests/golden/scenario-cross-parent-shared.dry-run.txt
@@ -18,6 +18,9 @@
     $ git -C <REPO>/tests/fixtures/scenario-cross-parent-shared/project_root worktree add -b fanout/shared-child-parent-200-501 <REPO>/tests/fixtures/scenario-cross-parent-shared/project_root/.fanout/worktrees/shared-child-parent-200-501 main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-cross-parent-shared/project_root/.fanout/worktrees/shared-child-parent-200-501 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout #501 of #200] shared-child-parent-200-501: Shared child. read /tmp/fanout-project_root-501.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T shared-child-parent-200-501
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label '#200 · shared-child-parent-200-501'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
@@ -36,6 +39,9 @@
     $ git -C <REPO>/tests/fixtures/scenario-cross-parent-shared/project_root worktree add -b fanout/b-only-child-502 <REPO>/tests/fixtures/scenario-cross-parent-shared/project_root/.fanout/worktrees/b-only-child-502 main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-cross-parent-shared/project_root/.fanout/worktrees/b-only-child-502 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout #502 of #200] b-only-child-502: B-only child. read /tmp/fanout-project_root-502.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T b-only-child-502
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label '#200 · b-only-child-502'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree

--- a/tests/golden/scenario-idempotency.dry-run.txt
+++ b/tests/golden/scenario-idempotency.dry-run.txt
@@ -19,6 +19,9 @@
     $ git -C <REPO>/tests/fixtures/scenario-idempotency/project_root worktree add -b fanout/new-target-802 <REPO>/tests/fixtures/scenario-idempotency/project_root/.fanout/worktrees/new-target-802 main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-idempotency/project_root/.fanout/worktrees/new-target-802 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout #802 of #800] new-target-802: New target. read /tmp/fanout-project_root-802.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T new-target-802
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label '#800 · new-target-802'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree

--- a/tests/golden/scenario-include.dry-run.txt
+++ b/tests/golden/scenario-include.dry-run.txt
@@ -19,6 +19,9 @@
     $ git -C <REPO>/tests/fixtures/scenario-include/project_root worktree add -b fanout/included-child-a-401 <REPO>/tests/fixtures/scenario-include/project_root/.fanout/worktrees/included-child-a-401 main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-include/project_root/.fanout/worktrees/included-child-a-401 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout #401 of #400] included-child-a-401: Included child A. read /tmp/fanout-project_root-401.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T included-child-a-401
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label '#400 · included-child-a-401'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
@@ -37,6 +40,9 @@
     $ git -C <REPO>/tests/fixtures/scenario-include/project_root worktree add -b fanout/included-child-b-402 <REPO>/tests/fixtures/scenario-include/project_root/.fanout/worktrees/included-child-b-402 main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-include/project_root/.fanout/worktrees/included-child-b-402 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout #402 of #400] included-child-b-402: Included child B. read /tmp/fanout-project_root-402.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T included-child-b-402
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label '#400 · included-child-b-402'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree

--- a/tests/golden/scenario-legacy-weak-signal.dry-run.txt
+++ b/tests/golden/scenario-legacy-weak-signal.dry-run.txt
@@ -19,6 +19,9 @@
     $ git -C <REPO>/tests/fixtures/scenario-legacy-weak-signal/project_root worktree add -b fanout/first-task-601 <REPO>/tests/fixtures/scenario-legacy-weak-signal/project_root/.fanout/worktrees/first-task-601 main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-legacy-weak-signal/project_root/.fanout/worktrees/first-task-601 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout #601 of #600] first-task-601: First task. read /tmp/fanout-project_root-601.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T first-task-601
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label '#600 · first-task-601'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
@@ -37,6 +40,9 @@
     $ git -C <REPO>/tests/fixtures/scenario-legacy-weak-signal/project_root worktree add -b fanout/second-task-602 <REPO>/tests/fixtures/scenario-legacy-weak-signal/project_root/.fanout/worktrees/second-task-602 main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-legacy-weak-signal/project_root/.fanout/worktrees/second-task-602 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout #602 of #600] second-task-602: Second task. read /tmp/fanout-project_root-602.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T second-task-602
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label '#600 · second-task-602'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree

--- a/tests/golden/scenario-limit.dry-run.txt
+++ b/tests/golden/scenario-limit.dry-run.txt
@@ -18,6 +18,9 @@
     $ git -C <REPO>/tests/fixtures/scenario-limit/project_root worktree add -b fanout/alpha-701 <REPO>/tests/fixtures/scenario-limit/project_root/.fanout/worktrees/alpha-701 main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-limit/project_root/.fanout/worktrees/alpha-701 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout #701 of #700] alpha-701: Alpha. read /tmp/fanout-project_root-701.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T alpha-701
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label '#700 · alpha-701'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
@@ -36,6 +39,9 @@
     $ git -C <REPO>/tests/fixtures/scenario-limit/project_root worktree add -b fanout/bravo-702 <REPO>/tests/fixtures/scenario-limit/project_root/.fanout/worktrees/bravo-702 main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-limit/project_root/.fanout/worktrees/bravo-702 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout #702 of #700] bravo-702: Bravo. read /tmp/fanout-project_root-702.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T bravo-702
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label '#700 · bravo-702'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree

--- a/tests/golden/scenario-only.dry-run.txt
+++ b/tests/golden/scenario-only.dry-run.txt
@@ -22,6 +22,9 @@ filtered out:
     $ git -C <REPO>/tests/fixtures/scenario-only/project_root worktree add -b fanout/alpha-501 <REPO>/tests/fixtures/scenario-only/project_root/.fanout/worktrees/alpha-501 main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-only/project_root/.fanout/worktrees/alpha-501 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout #501 of #500] alpha-501: Alpha. read /tmp/fanout-project_root-501.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T alpha-501
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label '#500 · alpha-501'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
@@ -40,6 +43,9 @@ filtered out:
     $ git -C <REPO>/tests/fixtures/scenario-only/project_root worktree add -b fanout/charlie-503 <REPO>/tests/fixtures/scenario-only/project_root/.fanout/worktrees/charlie-503 main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-only/project_root/.fanout/worktrees/charlie-503 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout #503 of #500] charlie-503: Charlie. read /tmp/fanout-project_root-503.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T charlie-503
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label '#500 · charlie-503'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree

--- a/tests/golden/scenario-plan-basic-agent-override.dry-run.txt
+++ b/tests/golden/scenario-plan-basic-agent-override.dry-run.txt
@@ -17,6 +17,9 @@
     $ git -C <REPO>/tests/fixtures/scenario-plan-basic/project_root worktree add -b fanout/launch-plan-define-base-types-base-types <REPO>/tests/fixtures/scenario-plan-basic/project_root/.fanout/worktrees/launch-plan-define-base-types-base-types main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-plan-basic/project_root/.fanout/worktrees/launch-plan-define-base-types-base-types 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout base-types of plan:launch-plan] launch-plan-define-base-types-base-types: Define base types. read /tmp/fanout-project_root-launch%2Dplan-base%2Dtypes.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T launch-plan-define-base-types-base-types
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label 'plan:launch-plan · launch-plan-define-base-types-base-types'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
@@ -35,6 +38,9 @@
     $ git -C <REPO>/tests/fixtures/scenario-plan-basic/project_root worktree add -b fanout/launch-plan-extract-api-client-api-client <REPO>/tests/fixtures/scenario-plan-basic/project_root/.fanout/worktrees/launch-plan-extract-api-client-api-client main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-plan-basic/project_root/.fanout/worktrees/launch-plan-extract-api-client-api-client 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; codex '\''\'\'''\''[fanout api-client of plan:launch-plan] launch-plan-extract-api-client-api-client: Extract API client. read /tmp/fanout-project_root-launch%2Dplan-api%2Dclient.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T launch-plan-extract-api-client-api-client
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label 'plan:launch-plan · launch-plan-extract-api-client-api-client'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree

--- a/tests/golden/scenario-plan-basic-team.dry-run.txt
+++ b/tests/golden/scenario-plan-basic-team.dry-run.txt
@@ -17,6 +17,9 @@
     $ git -C <REPO>/tests/fixtures/scenario-plan-basic/project_root worktree add -b fanout/launch-plan-define-base-types-base-types <REPO>/tests/fixtures/scenario-plan-basic/project_root/.fanout/worktrees/launch-plan-define-base-types-base-types main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-plan-basic/project_root/.fanout/worktrees/launch-plan-define-base-types-base-types 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout base-types of plan:launch-plan] launch-plan-define-base-types-base-types: Define base types. read /tmp/fanout-project_root-launch%2Dplan-base%2Dtypes.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T launch-plan-define-base-types-base-types
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label 'plan:launch-plan · launch-plan-define-base-types-base-types'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
@@ -35,6 +38,9 @@
     $ git -C <REPO>/tests/fixtures/scenario-plan-basic/project_root worktree add -b fanout/launch-plan-extract-api-client-api-client <REPO>/tests/fixtures/scenario-plan-basic/project_root/.fanout/worktrees/launch-plan-extract-api-client-api-client main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-plan-basic/project_root/.fanout/worktrees/launch-plan-extract-api-client-api-client 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout api-client of plan:launch-plan] launch-plan-extract-api-client-api-client: Extract API client. read /tmp/fanout-project_root-launch%2Dplan-api%2Dclient.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T launch-plan-extract-api-client-api-client
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label 'plan:launch-plan · launch-plan-extract-api-client-api-client'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree

--- a/tests/golden/scenario-plan-basic.dry-run.txt
+++ b/tests/golden/scenario-plan-basic.dry-run.txt
@@ -17,6 +17,9 @@
     $ git -C <REPO>/tests/fixtures/scenario-plan-basic/project_root worktree add -b fanout/launch-plan-define-base-types-base-types <REPO>/tests/fixtures/scenario-plan-basic/project_root/.fanout/worktrees/launch-plan-define-base-types-base-types main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-plan-basic/project_root/.fanout/worktrees/launch-plan-define-base-types-base-types 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout base-types of plan:launch-plan] launch-plan-define-base-types-base-types: Define base types. read /tmp/fanout-project_root-launch%2Dplan-base%2Dtypes.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T launch-plan-define-base-types-base-types
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label 'plan:launch-plan · launch-plan-define-base-types-base-types'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
@@ -35,6 +38,9 @@
     $ git -C <REPO>/tests/fixtures/scenario-plan-basic/project_root worktree add -b fanout/launch-plan-extract-api-client-api-client <REPO>/tests/fixtures/scenario-plan-basic/project_root/.fanout/worktrees/launch-plan-extract-api-client-api-client main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-plan-basic/project_root/.fanout/worktrees/launch-plan-extract-api-client-api-client 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout api-client of plan:launch-plan] launch-plan-extract-api-client-api-client: Extract API client. read /tmp/fanout-project_root-launch%2Dplan-api%2Dclient.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T launch-plan-extract-api-client-api-client
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label 'plan:launch-plan · launch-plan-extract-api-client-api-client'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree

--- a/tests/golden/scenario-plan-blocked.dry-run.txt
+++ b/tests/golden/scenario-plan-blocked.dry-run.txt
@@ -21,6 +21,9 @@ filtered out:
     $ git -C <REPO>/tests/fixtures/scenario-plan-blocked/project_root worktree add -b fanout/launch-plan-extract-api-client-api-client <REPO>/tests/fixtures/scenario-plan-blocked/project_root/.fanout/worktrees/launch-plan-extract-api-client-api-client main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-plan-blocked/project_root/.fanout/worktrees/launch-plan-extract-api-client-api-client 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout api-client of plan:launch-plan] launch-plan-extract-api-client-api-client: Extract API client. read /tmp/fanout-project_root-launch%2Dplan-api%2Dclient.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T launch-plan-extract-api-client-api-client
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label 'plan:launch-plan · launch-plan-extract-api-client-api-client'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree

--- a/tests/golden/scenario-plan-complete-blocker.dry-run.txt
+++ b/tests/golden/scenario-plan-complete-blocker.dry-run.txt
@@ -18,6 +18,9 @@
     $ git -C <REPO>/tests/fixtures/scenario-plan-complete-blocker/project_root worktree add -b fanout/launch-plan-extract-api-client-api-client <REPO>/tests/fixtures/scenario-plan-complete-blocker/project_root/.fanout/worktrees/launch-plan-extract-api-client-api-client main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-plan-complete-blocker/project_root/.fanout/worktrees/launch-plan-extract-api-client-api-client 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout api-client of plan:launch-plan] launch-plan-extract-api-client-api-client: Extract API client. read /tmp/fanout-project_root-launch%2Dplan-api%2Dclient.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T launch-plan-extract-api-client-api-client
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label 'plan:launch-plan · launch-plan-extract-api-client-api-client'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree

--- a/tests/golden/scenario-plan-fresh-blocker.dry-run.txt
+++ b/tests/golden/scenario-plan-fresh-blocker.dry-run.txt
@@ -22,6 +22,9 @@ deferred (blocked):
     $ git -C <REPO>/tests/fixtures/scenario-plan-fresh-blocker/project_root worktree add -b fanout/launch-plan-define-base-types-base-types <REPO>/tests/fixtures/scenario-plan-fresh-blocker/project_root/.fanout/worktrees/launch-plan-define-base-types-base-types main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-plan-fresh-blocker/project_root/.fanout/worktrees/launch-plan-define-base-types-base-types 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout base-types of plan:launch-plan] launch-plan-define-base-types-base-types: Define base types. read /tmp/fanout-project_root-launch%2Dplan-base%2Dtypes.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T launch-plan-define-base-types-base-types
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label 'plan:launch-plan · launch-plan-define-base-types-base-types'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree

--- a/tests/golden/scenario-plan-limit.dry-run.txt
+++ b/tests/golden/scenario-plan-limit.dry-run.txt
@@ -17,6 +17,9 @@
     $ git -C <REPO>/tests/fixtures/scenario-plan-limit/project_root worktree add -b fanout/launch-plan-define-base-types-base-types <REPO>/tests/fixtures/scenario-plan-limit/project_root/.fanout/worktrees/launch-plan-define-base-types-base-types main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-plan-limit/project_root/.fanout/worktrees/launch-plan-define-base-types-base-types 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout base-types of plan:launch-plan] launch-plan-define-base-types-base-types: Define base types. read /tmp/fanout-project_root-launch%2Dplan-base%2Dtypes.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T launch-plan-define-base-types-base-types
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label 'plan:launch-plan · launch-plan-define-base-types-base-types'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
@@ -35,6 +38,9 @@
     $ git -C <REPO>/tests/fixtures/scenario-plan-limit/project_root worktree add -b fanout/launch-plan-extract-api-client-api-client <REPO>/tests/fixtures/scenario-plan-limit/project_root/.fanout/worktrees/launch-plan-extract-api-client-api-client main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-plan-limit/project_root/.fanout/worktrees/launch-plan-extract-api-client-api-client 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout api-client of plan:launch-plan] launch-plan-extract-api-client-api-client: Extract API client. read /tmp/fanout-project_root-launch%2Dplan-api%2Dclient.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T launch-plan-extract-api-client-api-client
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label 'plan:launch-plan · launch-plan-extract-api-client-api-client'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree

--- a/tests/golden/scenario-project-basic.dry-run.txt
+++ b/tests/golden/scenario-project-basic.dry-run.txt
@@ -19,6 +19,9 @@
     $ git -C <REPO>/tests/fixtures/scenario-project-basic/project_root worktree add -b fanout/first-todo-item-901 <REPO>/tests/fixtures/scenario-project-basic/project_root/.fanout/worktrees/first-todo-item-901 main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-project-basic/project_root/.fanout/worktrees/first-todo-item-901 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout #901 of #https://github.com/users/butaosuinu/projects/3] first-todo-item-901: First todo item. read /tmp/fanout-project_root-901.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T first-todo-item-901
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label 'users/butaosuinu/projects/3 · first-todo-item-901'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
@@ -37,6 +40,9 @@
     $ git -C <REPO>/tests/fixtures/scenario-project-basic/project_root worktree add -b fanout/second-todo-item-902 <REPO>/tests/fixtures/scenario-project-basic/project_root/.fanout/worktrees/second-todo-item-902 main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-project-basic/project_root/.fanout/worktrees/second-todo-item-902 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout #902 of #https://github.com/users/butaosuinu/projects/3] second-todo-item-902: Second todo item. read /tmp/fanout-project_root-902.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T second-todo-item-902
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label 'users/butaosuinu/projects/3 · second-todo-item-902'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree

--- a/tests/golden/scenario-project-cross-repo.dry-run.txt
+++ b/tests/golden/scenario-project-cross-repo.dry-run.txt
@@ -20,6 +20,9 @@
     $ git -C <REPO>/tests/fixtures/scenario-project-cross-repo/project_root worktree add -b fanout/self-repo-todo-921 <REPO>/tests/fixtures/scenario-project-cross-repo/project_root/.fanout/worktrees/self-repo-todo-921 main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-project-cross-repo/project_root/.fanout/worktrees/self-repo-todo-921 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout #921 of #https://github.com/users/butaosuinu/projects/3] self-repo-todo-921: Self-repo todo. read /tmp/fanout-project_root-921.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T self-repo-todo-921
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label 'users/butaosuinu/projects/3 · self-repo-todo-921'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree

--- a/tests/golden/scenario-project-status-all.dry-run.txt
+++ b/tests/golden/scenario-project-status-all.dry-run.txt
@@ -19,6 +19,9 @@
     $ git -C <REPO>/tests/fixtures/scenario-project-status-all/project_root worktree add -b fanout/todo-one-911 <REPO>/tests/fixtures/scenario-project-status-all/project_root/.fanout/worktrees/todo-one-911 main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-project-status-all/project_root/.fanout/worktrees/todo-one-911 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout #911 of #https://github.com/users/butaosuinu/projects/3] todo-one-911: Todo one. read /tmp/fanout-project_root-911.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T todo-one-911
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label 'users/butaosuinu/projects/3 · todo-one-911'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
@@ -37,6 +40,9 @@
     $ git -C <REPO>/tests/fixtures/scenario-project-status-all/project_root worktree add -b fanout/todo-two-912 <REPO>/tests/fixtures/scenario-project-status-all/project_root/.fanout/worktrees/todo-two-912 main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-project-status-all/project_root/.fanout/worktrees/todo-two-912 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout #912 of #https://github.com/users/butaosuinu/projects/3] todo-two-912: Todo two. read /tmp/fanout-project_root-912.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T todo-two-912
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label 'users/butaosuinu/projects/3 · todo-two-912'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
@@ -55,6 +61,9 @@
     $ git -C <REPO>/tests/fixtures/scenario-project-status-all/project_root worktree add -b fanout/done-item-913 <REPO>/tests/fixtures/scenario-project-status-all/project_root/.fanout/worktrees/done-item-913 main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-project-status-all/project_root/.fanout/worktrees/done-item-913 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout #913 of #https://github.com/users/butaosuinu/projects/3] done-item-913: Done item. read /tmp/fanout-project_root-913.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T done-item-913
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label 'users/butaosuinu/projects/3 · done-item-913'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree

--- a/tests/golden/scenario-prviz-disabled.dry-run.txt
+++ b/tests/golden/scenario-prviz-disabled.dry-run.txt
@@ -18,6 +18,9 @@
     $ git -C <REPO>/tests/fixtures/scenario-prviz-disabled/project_root worktree add -b fanout/first-child-101 <REPO>/tests/fixtures/scenario-prviz-disabled/project_root/.fanout/worktrees/first-child-101 main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-prviz-disabled/project_root/.fanout/worktrees/first-child-101 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout #101 of #100] first-child-101: First child. read /tmp/fanout-project_root-101.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T first-child-101
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · first-child-101'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
@@ -36,6 +39,9 @@
     $ git -C <REPO>/tests/fixtures/scenario-prviz-disabled/project_root worktree add -b fanout/second-child-102 <REPO>/tests/fixtures/scenario-prviz-disabled/project_root/.fanout/worktrees/second-child-102 main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-prviz-disabled/project_root/.fanout/worktrees/second-child-102 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout #102 of #100] second-child-102: Second child. read /tmp/fanout-project_root-102.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T second-child-102
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · second-child-102'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree

--- a/tests/golden/scenario-settings-disabled.dry-run.txt
+++ b/tests/golden/scenario-settings-disabled.dry-run.txt
@@ -18,6 +18,9 @@
     $ git -C <REPO>/tests/fixtures/scenario-sub-issue-only/project_root worktree add -b fanout/first-child-101 <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/first-child-101 main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/first-child-101 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout #101 of #100] first-child-101: First child. read /tmp/fanout-project_root-101.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T first-child-101
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · first-child-101'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
@@ -36,6 +39,9 @@
     $ git -C <REPO>/tests/fixtures/scenario-sub-issue-only/project_root worktree add -b fanout/second-child-102 <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/second-child-102 main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/second-child-102 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout #102 of #100] second-child-102: Second child. read /tmp/fanout-project_root-102.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T second-child-102
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · second-child-102'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree

--- a/tests/golden/scenario-skip.dry-run.txt
+++ b/tests/golden/scenario-skip.dry-run.txt
@@ -22,6 +22,9 @@ filtered out:
     $ git -C <REPO>/tests/fixtures/scenario-skip/project_root worktree add -b fanout/alpha-601 <REPO>/tests/fixtures/scenario-skip/project_root/.fanout/worktrees/alpha-601 main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-skip/project_root/.fanout/worktrees/alpha-601 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout #601 of #600] alpha-601: Alpha. read /tmp/fanout-project_root-601.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T alpha-601
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label '#600 · alpha-601'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
@@ -40,6 +43,9 @@ filtered out:
     $ git -C <REPO>/tests/fixtures/scenario-skip/project_root worktree add -b fanout/charlie-603 <REPO>/tests/fixtures/scenario-skip/project_root/.fanout/worktrees/charlie-603 main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-skip/project_root/.fanout/worktrees/charlie-603 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout #603 of #600] charlie-603: Charlie. read /tmp/fanout-project_root-603.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T charlie-603
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label '#600 · charlie-603'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree

--- a/tests/golden/scenario-sub-issue-only-agent-override.dry-run.txt
+++ b/tests/golden/scenario-sub-issue-only-agent-override.dry-run.txt
@@ -18,6 +18,9 @@
     $ git -C <REPO>/tests/fixtures/scenario-sub-issue-only/project_root worktree add -b fanout/first-child-101 <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/first-child-101 main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/first-child-101 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout #101 of #100] first-child-101: First child. read /tmp/fanout-project_root-101.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T first-child-101
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · first-child-101'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
@@ -36,6 +39,9 @@
     $ git -C <REPO>/tests/fixtures/scenario-sub-issue-only/project_root worktree add -b fanout/second-child-102 <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/second-child-102 main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/second-child-102 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; codex '\''\'\'''\''[fanout #102 of #100] second-child-102: Second child. read /tmp/fanout-project_root-102.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T second-child-102
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · second-child-102'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree

--- a/tests/golden/scenario-sub-issue-only-branch-override.dry-run.txt
+++ b/tests/golden/scenario-sub-issue-only-branch-override.dry-run.txt
@@ -19,6 +19,9 @@
     $ git -C <REPO>/tests/fixtures/scenario-sub-issue-only/project_root worktree add -b feat/sub-issue-101-x <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/feat-x-101 main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/feat-x-101 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout #101 of #100] feat-x-101: First child. read /tmp/fanout-project_root-101.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T 'Feature X'
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · Feature X'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
@@ -37,6 +40,9 @@
     $ git -C <REPO>/tests/fixtures/scenario-sub-issue-only/project_root worktree add -b release/v2.0 <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/second-child-102 main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/second-child-102 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout #102 of #100] second-child-102: Second child. read /tmp/fanout-project_root-102.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T second-child-102
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · second-child-102'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree

--- a/tests/golden/scenario-sub-issue-only-codex-plan.dry-run.txt
+++ b/tests/golden/scenario-sub-issue-only-codex-plan.dry-run.txt
@@ -20,6 +20,9 @@
     $ git -C <REPO>/tests/fixtures/scenario-sub-issue-only/project_root worktree add -b fanout/first-child-101 <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/first-child-101 main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/first-child-101 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; fanout-go __codex-plan-tui --codex codex --prompt '\''\'\'''\''[fanout #101 of #100] first-child-101: First child. read /tmp/fanout-project_root-101.md and propose a plan.'\''\'\'''\'' --status-file /tmp/fanout-codex-plan-project_root-101.json; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T first-child-101
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · first-child-101'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # fanout waits for Plan Mode thread setup and Codex TUI attach before recording state
     # status file: /tmp/fanout-codex-plan-project_root-101.json
@@ -42,6 +45,9 @@
     $ git -C <REPO>/tests/fixtures/scenario-sub-issue-only/project_root worktree add -b fanout/second-child-102 <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/second-child-102 main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/second-child-102 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; fanout-go __codex-plan-tui --codex codex --prompt '\''\'\'''\''[fanout #102 of #100] second-child-102: Second child. read /tmp/fanout-project_root-102.md and propose a plan.'\''\'\'''\'' --status-file /tmp/fanout-codex-plan-project_root-102.json; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T second-child-102
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · second-child-102'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # fanout waits for Plan Mode thread setup and Codex TUI attach before recording state
     # status file: /tmp/fanout-codex-plan-project_root-102.json

--- a/tests/golden/scenario-sub-issue-only-codex.dry-run.txt
+++ b/tests/golden/scenario-sub-issue-only-codex.dry-run.txt
@@ -18,6 +18,9 @@
     $ git -C <REPO>/tests/fixtures/scenario-sub-issue-only/project_root worktree add -b fanout/first-child-101 <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/first-child-101 main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/first-child-101 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; codex '\''\'\'''\''[fanout #101 of #100] first-child-101: First child. read /tmp/fanout-project_root-101.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T first-child-101
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · first-child-101'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
@@ -36,6 +39,9 @@
     $ git -C <REPO>/tests/fixtures/scenario-sub-issue-only/project_root worktree add -b fanout/second-child-102 <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/second-child-102 main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/second-child-102 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; codex '\''\'\'''\''[fanout #102 of #100] second-child-102: Second child. read /tmp/fanout-project_root-102.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T second-child-102
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · second-child-102'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree

--- a/tests/golden/scenario-sub-issue-only-team.dry-run.txt
+++ b/tests/golden/scenario-sub-issue-only-team.dry-run.txt
@@ -18,6 +18,9 @@
     $ git -C <REPO>/tests/fixtures/scenario-sub-issue-only/project_root worktree add -b fanout/first-child-101 <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/first-child-101 main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/first-child-101 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout #101 of #100] first-child-101: First child. read /tmp/fanout-project_root-101.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T first-child-101
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · first-child-101'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
@@ -36,6 +39,9 @@
     $ git -C <REPO>/tests/fixtures/scenario-sub-issue-only/project_root worktree add -b fanout/second-child-102 <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/second-child-102 main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/second-child-102 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout #102 of #100] second-child-102: Second child. read /tmp/fanout-project_root-102.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T second-child-102
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · second-child-102'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree

--- a/tests/golden/scenario-sub-issue-only.dry-run.txt
+++ b/tests/golden/scenario-sub-issue-only.dry-run.txt
@@ -18,6 +18,9 @@
     $ git -C <REPO>/tests/fixtures/scenario-sub-issue-only/project_root worktree add -b fanout/first-child-101 <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/first-child-101 main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/first-child-101 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout #101 of #100] first-child-101: First child. read /tmp/fanout-project_root-101.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T first-child-101
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · first-child-101'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
@@ -36,6 +39,9 @@
     $ git -C <REPO>/tests/fixtures/scenario-sub-issue-only/project_root worktree add -b fanout/second-child-102 <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/second-child-102 main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-sub-issue-only/project_root/.fanout/worktrees/second-child-102 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout #102 of #100] second-child-102: Second child. read /tmp/fanout-project_root-102.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T second-child-102
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · second-child-102'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree

--- a/tests/golden/scenario-union.dry-run.txt
+++ b/tests/golden/scenario-union.dry-run.txt
@@ -19,6 +19,9 @@
     $ git -C <REPO>/tests/fixtures/scenario-union/project_root worktree add -b fanout/api-child-301 <REPO>/tests/fixtures/scenario-union/project_root/.fanout/worktrees/api-child-301 main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-union/project_root/.fanout/worktrees/api-child-301 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout #301 of #300] api-child-301: API child. read /tmp/fanout-project_root-301.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T api-child-301
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label '#300 · api-child-301'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
@@ -37,6 +40,9 @@
     $ git -C <REPO>/tests/fixtures/scenario-union/project_root worktree add -b fanout/body-only-302 <REPO>/tests/fixtures/scenario-union/project_root/.fanout/worktrees/body-only-302 main
     $ tmux split-window -t '%1' -d -h -P -F '#{pane_id}' -c <REPO>/tests/fixtures/scenario-union/project_root/.fanout/worktrees/body-only-302 'exec /bin/sh -lc '\''tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state running 2>/dev/null; claude '\''\'\'''\''[fanout #302 of #300] body-only-302: Body-only. read /tmp/fanout-project_root-302.md and begin.'\''\'\'''\''; __fanout_status=$?; tmux set-option -p -t "$TMUX_PANE" @fanout_agent_state done 2>/dev/null; printf '\''\'\'''\''\n[fanout] agent exited with status %d; returning to shell.\n'\''\'\'''\'' "$__fanout_status"; exec "${SHELL:-/bin/sh}" -l'\'''
     $ tmux select-pane -t <pane_id> -T body-only-302
+    $ tmux set-option -p -t <pane_id> @fanout_pane_label '#300 · body-only-302'
+    $ tmux set-option -w -t <pane_id> pane-border-status top
+    $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
     $ tmux select-layout -t '%1' tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree


### PR DESCRIPTION
## 概要

dmux と同様に、fanout が作る各ペインの**上端枠線左上**へ `#親 · ペイン名`(例 `#123 · fix-login-bug-123`)を表示し、tiled で並んだ子ペインを一目で見分けられるようにする。

## 仕組み

dmux(`github.com/formkit/dmux`)の方式を踏襲:
- window スコープで `pane-border-status top` + `pane-border-format` を設定(枠線上端=左寄せ=左上)。
- ラベルは pane user-option `@fanout_pane_label` に格納し書式から参照。`#{pane_title}` を直接使わない理由は、claude/codex が OSC でターミナルタイトルを書き換えても枠線表示を安定させるため。

## 変更点

- **`internal/tmuxrun`**: `SetPaneLabel`(`@fanout_pane_label` を設定)、`EnablePaneBorderTitles`(window スコープで border 有効化)、`PaneBorderFormat`、`NeutralizePaneLabel`。`NeutralizePaneLabel` は `#+\[` を `[` に潰し、`--name`/表示名に含まれる `#[...]` が tmux style として枠線へ注入されるのを防ぐ(overlap `##[` も安全)。
- **`cmd/fanout/pane.go`**: `parentDisplay`(ダッシュボードの `parentLabel` と同規則・`naming.AllDigits` 再利用)、`paneBorderLabel`/`borderLabel` を追加し agent ペイン作成に配線。`--dry-run` は live と同じ無害化済みコマンドをプレビュー。
- **`cmd/fanout/tui_launch.go`**: TUI shell ペインにもラベル+枠線を付与。
- **`internal/naming`**: `allDigits` を `AllDigits` として export(leading-zero 維持)。
- **`README.md` / `README.ja.md`**: 機能を追記。
- **`tests/golden/*.dry-run.txt`**: dry-run 出力変更に追従して再生成。

## 既知のトレードオフ

`pane-border-status` は window 単位が最小粒度のため、batch モードでは同 window のユーザー既存ペインにも枠線が付き、独自 `pane-border-format` を上書きする(cleanup 後も戻らない)。これは dmux と同一の挙動。

## テスト

- `make test`(Go 全パッケージ + web vitest 102 + bats Tier1/Tier2 goldens)green。
- `make lint`(golangci-lint v2 + shellcheck)0 issues。
- `/post-work-review`(code-review xhigh + codex review 4 反復)で全確定指摘を修正、codex 承認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01958dycTBzwHHC5gdyiMHyT
