### PR TITLE
feat: dmux 相当の pane 自動レイアウト

### DIFF
--- a/cmd/fanout/pane.go
+++ b/cmd/fanout/pane.go
@@ -17,6 +17,7 @@ import (
 	"github.com/butaosuinu/fanout/internal/hooks"
 	"github.com/butaosuinu/fanout/internal/log"
 	"github.com/butaosuinu/fanout/internal/naming"
+	"github.com/butaosuinu/fanout/internal/panelayout"
 	"github.com/butaosuinu/fanout/internal/planspec"
 	fanoutruntime "github.com/butaosuinu/fanout/internal/runtime"
 	"github.com/butaosuinu/fanout/internal/settings"
@@ -168,9 +169,6 @@ func createPaneDetailed(cfg *cliflags.Config, lg *log.Logger, info *fanoutruntim
 	if err := tmuxrun.SetPaneProjectRoot(paneID, info.ProjectRoot); err != nil {
 		lg.Warn("%s: dashboard project root hint: %v", paneLogLabel(req), err)
 	}
-	if err := tmuxrun.SelectTiled(info.Target); err != nil {
-		lg.Warn("%s: %v", paneLogLabel(req), err)
-	}
 	if req.CodexPlanMode {
 		if err := waitForCodexPlanTUIReady(req.CodexPlanStatusPath, codexPlanTUIStartupTimeout); err != nil {
 			lg.Err("%s: start Codex Plan Mode TUI in pane %s: %v", paneLogLabel(req), paneID, err)
@@ -198,6 +196,13 @@ func createPaneDetailed(cfg *cliflags.Config, lg *log.Logger, info *fanoutruntim
 		rollbackState(recorder, req, lg)
 		cleanupFailedLaunch(paneLogLabel(req), paneID, prepared, lg)
 		return createdPane{}, false
+	}
+	// Re-layout last, after the fallible steps: an earlier failure runs
+	// cleanupFailedLaunch (which kills this pane), and laying out only on the
+	// success path means a failed launch never leaves an orphaned spacer pane
+	// behind for the grid.
+	if err := panelayout.Apply(info.Target, panelayout.Create); err != nil {
+		lg.Warn("%s: %v", paneLogLabel(req), err)
 	}
 	lg.Ok("%s: pane %s created in %s", paneLogLabel(req), paneID, prepared.WorktreePath)
 	return createdPane{req: req, paneID: paneID, prepared: prepared}, true
@@ -642,11 +647,8 @@ func printPaneDryRun(req paneRequest, target string, lg *log.Logger, c log.Palet
 	fmt.Fprintf(lg.Stdout(), "    %s$ tmux set-option -p -t <pane_id> @fanout_pane_label %s%s\n", c.Dim, shellQuote(tmuxrun.NeutralizePaneLabel(paneBorderLabel(req))), c.Reset)
 	fmt.Fprintf(lg.Stdout(), "    %s$ tmux set-option -w -t <pane_id> pane-border-status top%s\n", c.Dim, c.Reset)
 	fmt.Fprintf(lg.Stdout(), "    %s$ tmux set-option -w -t <pane_id> pane-border-format %s%s\n", c.Dim, shellQuote(tmuxrun.PaneBorderFormat()), c.Reset)
-	if target != "" {
-		fmt.Fprintf(lg.Stdout(), "    %s$ tmux select-layout -t %s tiled%s\n", c.Dim, shellQuote(target), c.Reset)
-	} else {
-		fmt.Fprintf(lg.Stdout(), "    %s$ tmux select-layout tiled%s\n", c.Dim, c.Reset)
-	}
+	fmt.Fprintf(lg.Stdout(), "    %s# would re-layout the window: fanout grid (sidebar + comfortable-width grid),%s\n", c.Dim, c.Reset)
+	fmt.Fprintf(lg.Stdout(), "    %s#   falling back to main-vertical then tiled%s\n", c.Dim, c.Reset)
 	if req.CodexPlanMode {
 		fmt.Fprintf(lg.Stdout(), "    %s# fanout waits for Plan Mode thread setup and Codex TUI attach before recording state%s\n", c.Dim, c.Reset)
 		fmt.Fprintf(lg.Stdout(), "    %s# status file: %s%s\n", c.Dim, shellQuote(req.CodexPlanStatusPath), c.Reset)

--- a/cmd/fanout/pane.go
+++ b/cmd/fanout/pane.go
@@ -146,7 +146,7 @@ func createPaneDetailed(cfg *cliflags.Config, lg *log.Logger, info *fanoutruntim
 	if result := hooks.RunBlocking(hooks.WorktreeCreated, paneHookContext(req, info.ProjectRoot, prepared.WorktreePath, ""), req.Hooks, lg); !result.OK() {
 		lg.Err("%s: %v", paneLogLabel(req), result.Err)
 		printPaneHookOutput(result, lg)
-		cleanupFailedLaunch(paneLogLabel(req), "", prepared, lg)
+		cleanupFailedLaunch(paneLogLabel(req), info.Target, "", prepared, lg)
 		return createdPane{}, false
 	}
 	hooks.RunBackground(hooks.BeforePaneCreate, paneHookContext(req, info.ProjectRoot, prepared.WorktreePath, ""), req.Hooks, lg)
@@ -154,7 +154,7 @@ func createPaneDetailed(cfg *cliflags.Config, lg *log.Logger, info *fanoutruntim
 	paneID, err := tmuxrun.SplitPaneWithAgentCommand(info.Target, prepared.WorktreePath, req.AgentCommand)
 	if err != nil {
 		lg.Err("%s: %v", paneLogLabel(req), err)
-		cleanupFailedLaunch(paneLogLabel(req), "", prepared, lg)
+		cleanupFailedLaunch(paneLogLabel(req), info.Target, "", prepared, lg)
 		return createdPane{}, false
 	}
 	if err := tmuxrun.SetPaneTitle(paneID, paneTitle(req)); err != nil {
@@ -169,10 +169,17 @@ func createPaneDetailed(cfg *cliflags.Config, lg *log.Logger, info *fanoutruntim
 	if err := tmuxrun.SetPaneProjectRoot(paneID, info.ProjectRoot); err != nil {
 		lg.Warn("%s: dashboard project root hint: %v", paneLogLabel(req), err)
 	}
+	// Re-layout right after the split so the new pane is sized into the grid
+	// immediately — a Codex Plan Mode pane otherwise sits at the ~half-width split
+	// for the whole (up to 30s) startup wait below. A failed launch reconciles any
+	// spacer this created via cleanupFailedLaunch's relayout, so no orphan remains.
+	if err := panelayout.Apply(info.Target, panelayout.Create); err != nil {
+		lg.Warn("%s: %v", paneLogLabel(req), err)
+	}
 	if req.CodexPlanMode {
 		if err := waitForCodexPlanTUIReady(req.CodexPlanStatusPath, codexPlanTUIStartupTimeout); err != nil {
 			lg.Err("%s: start Codex Plan Mode TUI in pane %s: %v", paneLogLabel(req), paneID, err)
-			cleanupFailedLaunch(paneLogLabel(req), paneID, prepared, lg)
+			cleanupFailedLaunch(paneLogLabel(req), info.Target, paneID, prepared, lg)
 			return createdPane{}, false
 		}
 		_ = os.Remove(req.CodexPlanStatusPath)
@@ -181,7 +188,7 @@ func createPaneDetailed(cfg *cliflags.Config, lg *log.Logger, info *fanoutruntim
 		entry := statePane(req, paneID, prepared.WorktreePath, time.Now().UTC())
 		if err := recorder.RecordPane(entry); err != nil {
 			lg.Err("%s: write fanout state: %v", paneLogLabel(req), err)
-			cleanupFailedLaunch(paneLogLabel(req), paneID, prepared, lg)
+			cleanupFailedLaunch(paneLogLabel(req), info.Target, paneID, prepared, lg)
 			return createdPane{}, false
 		}
 	}
@@ -194,15 +201,8 @@ func createPaneDetailed(cfg *cliflags.Config, lg *log.Logger, info *fanoutruntim
 	}); err != nil {
 		lg.Err("%s: write worktree metadata: %v", paneLogLabel(req), err)
 		rollbackState(recorder, req, lg)
-		cleanupFailedLaunch(paneLogLabel(req), paneID, prepared, lg)
+		cleanupFailedLaunch(paneLogLabel(req), info.Target, paneID, prepared, lg)
 		return createdPane{}, false
-	}
-	// Re-layout last, after the fallible steps: an earlier failure runs
-	// cleanupFailedLaunch (which kills this pane), and laying out only on the
-	// success path means a failed launch never leaves an orphaned spacer pane
-	// behind for the grid.
-	if err := panelayout.Apply(info.Target, panelayout.Create); err != nil {
-		lg.Warn("%s: %v", paneLogLabel(req), err)
 	}
 	lg.Ok("%s: pane %s created in %s", paneLogLabel(req), paneID, prepared.WorktreePath)
 	return createdPane{req: req, paneID: paneID, prepared: prepared}, true
@@ -745,10 +745,15 @@ func rollbackState(recorder paneStateRecorder, req paneRequest, lg *log.Logger) 
 	}
 }
 
-func cleanupFailedLaunch(label string, paneID string, prepared worktree.Result, lg *log.Logger) {
+func cleanupFailedLaunch(label, relayoutTarget, paneID string, prepared worktree.Result, lg *log.Logger) {
 	if paneID != "" {
 		if err := tmuxrun.KillPane(paneID); err != nil {
 			lg.Warn("%s: cleanup incomplete pane %s: %v", label, paneID, err)
+		}
+		// The failed pane is gone; re-tile so neither it nor a spacer that an
+		// early/concurrent relayout may have created is left dangling in the grid.
+		if err := panelayout.Apply(relayoutTarget, panelayout.Close); err != nil {
+			lg.Warn("%s: relayout after failed launch: %v", label, err)
 		}
 	}
 	if err := worktree.CleanupCreated(prepared); err != nil {

--- a/cmd/fanout/tui.go
+++ b/cmd/fanout/tui.go
@@ -14,6 +14,7 @@ import (
 	"github.com/butaosuinu/fanout/internal/hooks"
 	"github.com/butaosuinu/fanout/internal/log"
 	fanoutnotify "github.com/butaosuinu/fanout/internal/notify"
+	"github.com/butaosuinu/fanout/internal/panelayout"
 	"github.com/butaosuinu/fanout/internal/settings"
 	"github.com/butaosuinu/fanout/internal/tmuxrun"
 	fanouttui "github.com/butaosuinu/fanout/internal/tui"
@@ -74,6 +75,7 @@ func cmdTUI(commandName string, lg *log.Logger) exitcode.Code {
 		Hooks:               hookConfig,
 		LaunchPane:          newTUILaunchPaneFunc(projectRoot, session, commandName, hookConfig),
 		LaunchShell:         newTUILaunchShellFunc(projectRoot, session),
+		Relayout:            func() error { return panelayout.Apply(tuiLaunchTarget(session), panelayout.Resize) },
 		Notifier:            notifier,
 	}); err != nil {
 		lg.Err("tui: %v", err)
@@ -159,6 +161,8 @@ func markTUIRunning(projectRoot string) func() {
 		return func() {}
 	}
 	_ = tmuxrun.SetPaneProjectRoot(paneID, projectRoot) // Best-effort dashboard keybinding hint.
+	// Mark this pane as the console so the auto-layout reserves it as a sidebar.
+	_ = tmuxrun.SetPaneRole(paneID, tmuxrun.RoleConsole)
 	originalTitle, err := tmuxrun.PaneTitle(paneID)
 	if err != nil {
 		originalTitle = "fanout"
@@ -166,6 +170,10 @@ func markTUIRunning(projectRoot string) func() {
 	_ = tmuxrun.SetPaneTitle(paneID, tuiPaneTitle)
 	return func() {
 		_ = tmuxrun.SetPaneTitle(paneID, originalTitle)
+		_ = tmuxrun.SetPaneRole(paneID, "") // a post-TUI shell must not look like a sidebar
+		// Re-tile so the ex-console pane is not left stuck at the 40-col sidebar
+		// width beside full-size agent panes.
+		_ = panelayout.Apply(paneID, panelayout.Close)
 	}
 }
 

--- a/cmd/fanout/tui_launch.go
+++ b/cmd/fanout/tui_launch.go
@@ -16,6 +16,7 @@ import (
 	"github.com/butaosuinu/fanout/internal/exitcode"
 	"github.com/butaosuinu/fanout/internal/hooks"
 	"github.com/butaosuinu/fanout/internal/log"
+	"github.com/butaosuinu/fanout/internal/panelayout"
 	fanoutruntime "github.com/butaosuinu/fanout/internal/runtime"
 	"github.com/butaosuinu/fanout/internal/state"
 	"github.com/butaosuinu/fanout/internal/tmuxrun"
@@ -174,7 +175,6 @@ func launchShellPaneFromTUI(projectRoot, session string, req fanouttui.ShellLaun
 	_ = tmuxrun.SetPaneLabel(paneID, borderLabel(manualPaneParentRef, title))
 	_ = tmuxrun.EnablePaneBorderTitles(paneID)
 	_ = tmuxrun.SetPaneProjectRoot(paneID, projectRoot)
-	_ = tmuxrun.SelectTiled(tuiLaunchTarget(session))
 	if err := recorder.RecordPane(state.Pane{
 		Parent:       manualPaneParentRef,
 		IssueNum:     number,
@@ -190,6 +190,10 @@ func launchShellPaneFromTUI(projectRoot, session string, req fanouttui.ShellLaun
 		_ = tmuxrun.KillPane(paneID)
 		return fmt.Errorf("write fanout state: %w", err)
 	}
+	// Re-layout only after the pane is recorded, so a failed/rolled-back launch
+	// never leaves the window arranged around a pane that no longer exists or an
+	// orphaned spacer behind.
+	_ = panelayout.Apply(tuiLaunchTarget(session), panelayout.Create)
 	return nil
 }
 

--- a/cmd/fanout/tui_launch.go
+++ b/cmd/fanout/tui_launch.go
@@ -188,6 +188,9 @@ func launchShellPaneFromTUI(projectRoot, session string, req fanouttui.ShellLaun
 		CreatedAt:    time.Now().UTC().Format(time.RFC3339),
 	}); err != nil {
 		_ = tmuxrun.KillPane(paneID)
+		// Reconcile any spacer a concurrent resize relayout may have created for
+		// this now-killed pane, so no blank pane is left behind.
+		_ = panelayout.Apply(tuiLaunchTarget(session), panelayout.Close)
 		return fmt.Errorf("write fanout state: %w", err)
 	}
 	// Re-layout only after the pane is recorded, so a failed/rolled-back launch

--- a/cmd/fanout/tui_test.go
+++ b/cmd/fanout/tui_test.go
@@ -645,6 +645,18 @@ case "${1:-}" in
   split-window)
     printf '%s\n' "$TMUX_SHIM_PANE_ID"
     ;;
+  display-message)
+    # Answer the auto-layout window-geometry query; stay empty for any other.
+    if [[ "$*" == *window_width* ]]; then
+      printf '@1\t200\t50\n'
+    fi
+    ;;
+  list-panes)
+    # Answer the auto-layout per-window roster (a console sidebar + the new pane).
+    if [[ "$*" == *fanout_role* ]]; then
+      printf '%%0\t0\t1\tconsole\t\n%s\t1\t0\t\t\n' "$TMUX_SHIM_PANE_ID"
+    fi
+    ;;
   select-pane|set-option|select-layout|kill-pane)
     ;;
   *)

--- a/internal/lifecycle/lifecycle.go
+++ b/internal/lifecycle/lifecycle.go
@@ -14,6 +14,7 @@ import (
 	"github.com/butaosuinu/fanout/internal/exitcode"
 	"github.com/butaosuinu/fanout/internal/ghissue"
 	"github.com/butaosuinu/fanout/internal/hooks"
+	"github.com/butaosuinu/fanout/internal/panelayout"
 	"github.com/butaosuinu/fanout/internal/state"
 	"github.com/butaosuinu/fanout/internal/tmuxrun"
 	"github.com/butaosuinu/fanout/internal/worktree"
@@ -80,13 +81,15 @@ func CloseWithMode(opts Options, parent string, issueNum int, mode CloseMode, lg
 		lg.Err("--close: #%d is not recorded for parent %s in %s", issueNum, parent, opts.StatePath)
 		return exitcode.Invocation
 	}
+	windows := map[string]struct{}{}
+	defer relayoutClosedWindows(windows, lg)
 	if mode.removesWorktree() && hasManagedWorktree(panes) {
 		if err := worktree.EnsureLocalExclude(opts.ProjectRoot); err != nil {
 			lg.Err("--close: prepare local git exclude: %v", err)
 			return exitcode.Env
 		}
 	}
-	if !closePaneRecords(opts, panes, mode, lg) {
+	if !closePaneRecords(opts, panes, mode, lg, windows) {
 		return exitcode.Env
 	}
 	if err := locked.RemovePane(parent, issueNum); err != nil {
@@ -128,13 +131,15 @@ func CloseTaskWithMode(opts Options, parent, taskID string, mode CloseMode, lg L
 		lg.Err("--close: task %s is not recorded for parent %s in %s", taskID, parent, opts.StatePath)
 		return exitcode.Invocation
 	}
+	windows := map[string]struct{}{}
+	defer relayoutClosedWindows(windows, lg)
 	if mode.removesWorktree() && hasManagedWorktree(panes) {
 		if err := worktree.EnsureLocalExclude(opts.ProjectRoot); err != nil {
 			lg.Err("--close: prepare local git exclude: %v", err)
 			return exitcode.Env
 		}
 	}
-	if !closePaneRecords(opts, panes, mode, lg) {
+	if !closePaneRecords(opts, panes, mode, lg, windows) {
 		return exitcode.Env
 	}
 	if err := locked.RemoveTaskPane(parent, taskID); err != nil {
@@ -256,12 +261,14 @@ func Cleanup(opts Options, parent string, lg Logger) exitcode.Code {
 
 	closed := 0
 	failed := 0
+	windows := map[string]struct{}{}
+	defer relayoutClosedWindows(windows, lg)
 	for _, issueNum := range sortedUnique(nums) {
 		if !eligible[issueNum] {
 			continue
 		}
 		issuePanes := panesForIssue(panes, issueNum)
-		if !cleanupPaneRecords(opts, issuePanes, lg) {
+		if !cleanupPaneRecords(opts, issuePanes, lg, windows) {
 			failed++
 			continue
 		}
@@ -329,9 +336,11 @@ func CleanupPlan(opts Options, parent string, lg Logger) exitcode.Code {
 
 	closed := 0
 	failed := 0
+	windows := map[string]struct{}{}
+	defer relayoutClosedWindows(windows, lg)
 	for _, taskID := range sortedTaskIDs(eligible) {
 		taskPanes := panesForTask(panes, taskID)
-		if !cleanupPaneRecords(opts, taskPanes, lg) {
+		if !cleanupPaneRecords(opts, taskPanes, lg, windows) {
 			failed++
 			continue
 		}
@@ -429,21 +438,32 @@ func statusChildren(projectRoot string, nums []int, mode string, lg Logger) ([]s
 	return children, exitcode.OK
 }
 
-func cleanupPaneRecords(opts Options, panes []state.Pane, lg Logger) bool {
-	return closePaneRecords(opts, panes, CloseWorktree, lg)
+func cleanupPaneRecords(opts Options, panes []state.Pane, lg Logger, windows map[string]struct{}) bool {
+	return closePaneRecords(opts, panes, CloseWorktree, lg, windows)
 }
 
-func closePaneRecords(opts Options, panes []state.Pane, mode CloseMode, lg Logger) bool {
+// relayoutWindow re-lays out a tmux window after a pane is removed. It is a var
+// so tests can stub it without a real tmux.
+var relayoutWindow = panelayout.Apply
+
+// closePaneRecords kills/cleans the given panes and records the window of each
+// pane it actually kills into windows. It does not relayout itself; the caller
+// relayouts the accumulated set once so a multi-pane cleanup re-tiles a shared
+// window a single time instead of once per pane. The window is captured at the
+// kill site (after the shell-pane identity check) so a stale pane id that tmux
+// has reused for an unrelated pane never drags that pane's window into a relayout.
+func closePaneRecords(opts Options, panes []state.Pane, mode CloseMode, lg Logger, windows map[string]struct{}) bool {
 	ok := true
 	for _, pane := range panes {
 		if pane.IsShell() {
 			runBackgroundHook(hooks.BeforePaneClose, opts, pane, "", lg)
-			killShellPaneBestEffort(pane, lg)
+			killShellPaneBestEffort(pane, lg, windows)
 			runBackgroundHook(hooks.PaneClosed, opts, pane, "", lg)
 			continue
 		}
 		if mode == ClosePaneOnly {
 			runBackgroundHook(hooks.BeforePaneClose, opts, pane, "", lg)
+			captureWindow(pane.PaneID, windows)
 			killPaneBestEffort(pane, lg)
 			runBackgroundHook(hooks.PaneClosed, opts, pane, "", lg)
 			continue
@@ -465,10 +485,21 @@ func closePaneRecords(opts Options, panes []state.Pane, mode CloseMode, lg Logge
 			deleteBranchBestEffort(opts.ProjectRoot, pane, lg)
 		}
 		runBackgroundHook(hooks.BeforePaneClose, opts, pane, "", lg)
+		captureWindow(pane.PaneID, windows)
 		killPaneBestEffort(pane, lg)
 		runBackgroundHook(hooks.PaneClosed, opts, pane, "", lg)
 	}
 	return ok
+}
+
+// relayoutClosedWindows re-tiles each affected window into the fanout grid.
+// A window that emptied out (every pane killed) is gone, so Apply no-ops on it.
+func relayoutClosedWindows(windows map[string]struct{}, lg Logger) {
+	for id := range windows {
+		if err := relayoutWindow(id, panelayout.Close); err != nil {
+			lg.Warn("relayout window %s: %v", id, err)
+		}
+	}
 }
 
 func (m CloseMode) removesWorktree() bool {
@@ -550,7 +581,7 @@ func killPaneBestEffort(pane state.Pane, lg Logger) {
 	}
 }
 
-func killShellPaneBestEffort(pane state.Pane, lg Logger) {
+func killShellPaneBestEffort(pane state.Pane, lg Logger, windows map[string]struct{}) {
 	if strings.TrimSpace(pane.PaneID) == "" {
 		lg.Warn("%s: no paneId recorded; skipping tmux kill-pane", paneLabel(pane))
 		return
@@ -573,10 +604,20 @@ func killShellPaneBestEffort(pane state.Pane, lg Logger) {
 			lg.Warn("%s: shell pane %s identity changed; skipping tmux kill-pane to avoid pane id reuse", paneLabel(pane), pane.PaneID)
 			return
 		}
+		// Identity confirmed: capture the window only now, so a reused pane id
+		// never schedules an unrelated window for relayout.
+		captureWindow(pane.PaneID, windows)
 		killPaneBestEffort(pane, lg)
 		return
 	}
 	lg.Warn("%s: shell pane %s is gone; skipping tmux kill-pane", paneLabel(pane), pane.PaneID)
+}
+
+// captureWindow records the window holding paneID into windows, best-effort.
+func captureWindow(paneID string, windows map[string]struct{}) {
+	if id, err := tmuxrun.WindowOfPane(paneID); err == nil && id != "" {
+		windows[id] = struct{}{}
+	}
 }
 
 func pruneWorktrees(projectRoot string, lg Logger) bool {

--- a/internal/lifecycle/lifecycle_test.go
+++ b/internal/lifecycle/lifecycle_test.go
@@ -1,0 +1,112 @@
+package lifecycle
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/butaosuinu/fanout/internal/hooks"
+	"github.com/butaosuinu/fanout/internal/panelayout"
+	"github.com/butaosuinu/fanout/internal/state"
+)
+
+type nopLogger struct{}
+
+func (nopLogger) Info(string, ...any) {}
+func (nopLogger) Ok(string, ...any)   {}
+func (nopLogger) Warn(string, ...any) {}
+func (nopLogger) Err(string, ...any)  {}
+func (nopLogger) Stderr() io.Writer   { return io.Discard }
+
+// installFakeTmux puts a tmux shim on PATH. display-message prints windowID (or
+// exits 1 when fail is set); every other subcommand is a silent no-op.
+func installFakeTmux(t *testing.T, windowID string, fail bool) {
+	t.Helper()
+	dir := t.TempDir()
+	dm := "printf '%s\\n' '" + windowID + "'"
+	if fail {
+		dm = "exit 1"
+	}
+	script := "#!/bin/sh\ncase \"$1\" in\n  display-message) " + dm + " ;;\n  *) : ;;\nesac\n"
+	if err := os.WriteFile(filepath.Join(dir, "tmux"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+type relayoutCall struct {
+	id   string
+	trig panelayout.Trigger
+}
+
+func stubRelayout(t *testing.T) *[]relayoutCall {
+	t.Helper()
+	var calls []relayoutCall
+	orig := relayoutWindow
+	relayoutWindow = func(id string, trig panelayout.Trigger) error {
+		calls = append(calls, relayoutCall{id, trig})
+		return nil
+	}
+	t.Cleanup(func() { relayoutWindow = orig })
+	return &calls
+}
+
+// closeAndRelayout mirrors the public entrypoints: capture windows during the
+// close, then relayout the accumulated set once.
+func closeAndRelayout(panes []state.Pane) {
+	windows := map[string]struct{}{}
+	closePaneRecords(Options{Hooks: hooks.EmptyConfig()}, panes, ClosePaneOnly, nopLogger{}, windows)
+	relayoutClosedWindows(windows, nopLogger{})
+}
+
+func TestClosePaneRecordsRelayoutsAffectedWindowOnce(t *testing.T) {
+	installFakeTmux(t, "@1", false)
+	calls := stubRelayout(t)
+
+	closeAndRelayout([]state.Pane{{PaneID: "%1", IssueNum: 1}, {PaneID: "%2", IssueNum: 2}})
+	// Both panes share window @1, so it is re-laid-out exactly once.
+	if len(*calls) != 1 {
+		t.Fatalf("relayout calls = %+v, want one", *calls)
+	}
+	if (*calls)[0].id != "@1" || (*calls)[0].trig != panelayout.Close {
+		t.Fatalf("relayout = %+v, want Close on @1", (*calls)[0])
+	}
+}
+
+func TestClosePaneRecordsSkipsRelayoutWhenWindowUnknown(t *testing.T) {
+	installFakeTmux(t, "", true) // display-message fails: window can't be resolved
+	calls := stubRelayout(t)
+
+	closeAndRelayout([]state.Pane{{PaneID: "%1", IssueNum: 1}})
+	if len(*calls) != 0 {
+		t.Fatalf("relayout calls = %+v, want none", *calls)
+	}
+}
+
+func TestClosePaneRecordsCapturesWindowBeforeKill(t *testing.T) {
+	// A pane with no recorded id can't be resolved to a window, so no relayout.
+	installFakeTmux(t, "@1", false)
+	calls := stubRelayout(t)
+
+	closeAndRelayout([]state.Pane{{PaneID: "", IssueNum: 1}})
+	if len(*calls) != 0 {
+		t.Fatalf("relayout calls = %+v, want none for id-less pane", *calls)
+	}
+}
+
+func TestCleanupAccumulatesWindowsAcrossPanes(t *testing.T) {
+	// Two panes cleaned in separate cleanupPaneRecords calls but sharing one
+	// window must relayout that window exactly once (the Cleanup-loop pattern).
+	installFakeTmux(t, "@7", false)
+	calls := stubRelayout(t)
+
+	windows := map[string]struct{}{}
+	cleanupPaneRecords(Options{Hooks: hooks.EmptyConfig()}, []state.Pane{{PaneID: "%1", IssueNum: 1}}, nopLogger{}, windows)
+	cleanupPaneRecords(Options{Hooks: hooks.EmptyConfig()}, []state.Pane{{PaneID: "%2", IssueNum: 2}}, nopLogger{}, windows)
+	relayoutClosedWindows(windows, nopLogger{})
+
+	if len(*calls) != 1 || (*calls)[0].id != "@7" {
+		t.Fatalf("relayout calls = %+v, want one on @7", *calls)
+	}
+}

--- a/internal/panelayout/apply.go
+++ b/internal/panelayout/apply.go
@@ -1,0 +1,257 @@
+package panelayout
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/butaosuinu/fanout/internal/tmuxrun"
+)
+
+// Trigger is why a relayout was requested. It controls only the resize dedup:
+// Create and Close always reapply, Resize skips when nothing relevant changed.
+type Trigger int
+
+const (
+	Create Trigger = iota
+	Close
+	Resize
+)
+
+// ops is the tmux IO panelayout needs, injected so the orchestration is unit
+// testable without a real tmux.
+type ops interface {
+	WindowGeometry(target string) (tmuxrun.Geometry, error)
+	WindowPanes(windowID string) ([]tmuxrun.WindowPane, error)
+	SplitSpacer(windowID string) (string, error)
+	KillPane(paneID string) error
+	ApplyLayout(windowID, layout string) error
+	SelectMainVertical(windowID string, mainPaneWidth int) error
+	SelectTiled(windowID string) error
+}
+
+type tmuxOps struct{}
+
+func (tmuxOps) WindowGeometry(t string) (tmuxrun.Geometry, error)  { return tmuxrun.WindowGeometry(t) }
+func (tmuxOps) WindowPanes(w string) ([]tmuxrun.WindowPane, error) { return tmuxrun.WindowPanes(w) }
+func (tmuxOps) SplitSpacer(w string) (string, error)               { return tmuxrun.SplitSpacerPane(w) }
+func (tmuxOps) KillPane(p string) error                            { return tmuxrun.KillPane(p) }
+func (tmuxOps) ApplyLayout(w, l string) error                      { return tmuxrun.ApplyLayout(w, l) }
+func (tmuxOps) SelectMainVertical(w string, mw int) error          { return tmuxrun.SelectMainVertical(w, mw) }
+func (tmuxOps) SelectTiled(w string) error                         { return tmuxrun.SelectTiled(w) }
+
+// applier holds the tmux ops, the comfort config, and the per-window resize memo
+// that breaks the relayout-triggers-resize feedback loop.
+type applier struct {
+	ops  ops
+	cfg  Config
+	mu   sync.Mutex
+	memo map[string]string
+}
+
+var defaultApplier = &applier{ops: tmuxOps{}, cfg: DefaultConfig(), memo: map[string]string{}}
+
+// Apply re-lays out the tmux window that holds target (a pane id, window id, or
+// session name) into the fanout grid: a console sidebar (when present) plus a
+// comfortable-width grid of the remaining panes, with an optional spacer. It is
+// best-effort — a missing window or a rejected custom layout degrades quietly
+// (main-vertical, then tiled) and never returns an error that should block pane
+// creation or teardown.
+func Apply(target string, trigger Trigger) error {
+	return defaultApplier.apply(target, trigger)
+}
+
+func (a *applier) apply(target string, trigger Trigger) error {
+	// Serialize the whole apply: it is invoked concurrently from bubbletea
+	// command goroutines (resize, create, close), and its tmux ops (list, split,
+	// kill, select-layout) would otherwise interleave on the same window. The
+	// memo helpers below assume this lock is held.
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	geom, err := a.ops.WindowGeometry(target)
+	if err != nil {
+		// Window gone or tmux unavailable: best-effort no-op.
+		return nil
+	}
+	windowID := geom.WindowID
+	win := Window{Width: geom.Width, Height: geom.Height}
+
+	panes, err := a.ops.WindowPanes(windowID)
+	if err != nil {
+		return err
+	}
+	console, grid, spacers := partition(panes)
+
+	// Resize dedup: our own relayout resizes the console pane, which makes the
+	// TUI emit a fresh resize. The window geometry and pane set are unchanged by
+	// that, so a matching signature means there is nothing to do. Create/Close
+	// always changed the pane set, so they bypass the check.
+	if trigger == Resize && a.memoMatch(windowID, win, console != nil, numericIDs(grid), numericIDs(spacers)) {
+		return nil
+	}
+
+	cfg := a.cfg
+	cfg.SidebarWidth = 0
+	if console != nil {
+		cfg.SidebarWidth = SidebarWidthDefault
+	}
+
+	// No grid panes: nothing to arrange. Drop any leftover spacers and let the
+	// console (or lone pane) fill the window.
+	if len(grid) == 0 {
+		for _, s := range spacers {
+			_ = a.ops.KillPane(s.ID)
+		}
+		a.store(windowID, win, console != nil, nil, nil)
+		return nil
+	}
+
+	plan := DecidePlan(win, len(grid), cfg)
+	// Spacers only earn their keep with a resident TUI (console present) that
+	// reconciles them on later relayouts; a one-shot batch run would leave the
+	// blank pane orphaned, so skip it there. Always drop pre-existing spacers.
+	desired := 0
+	if plan.Spacer.Needed && console != nil {
+		desired = 1
+	}
+	spacerIDs := a.reconcileSpacers(windowID, spacers, desired)
+
+	gridIDs := numericIDs(grid)
+	contentIDs := gridIDs
+	lastCellSpacer := false
+	if len(spacerIDs) > 0 {
+		contentIDs = append(append([]string(nil), gridIDs...), spacerIDs...)
+		lastCellSpacer = true
+	}
+	sidebarID := ""
+	if console != nil {
+		sidebarID = console.NumericID
+	}
+
+	applied := a.applyLayout(windowID, win, cfg, plan, sidebarID, contentIDs, lastCellSpacer)
+	if !applied && len(spacerIDs) > 0 {
+		// The coarse fallbacks do not place the spacer cell, so the blank pane
+		// would dangle; remove it and record no spacer.
+		for _, id := range spacerIDs {
+			_ = a.ops.KillPane("%" + id)
+		}
+		spacerIDs = nil
+	}
+	// Only memoize when the custom grid actually applied. After a fallback we must
+	// not let an identical resize short-circuit and leave the window stuck in the
+	// coarse layout — the next relayout should retry the grid.
+	if applied {
+		a.store(windowID, win, console != nil, gridIDs, spacerIDs)
+	}
+	return nil
+}
+
+// applyLayout renders and applies the custom grid and reports whether that grid
+// was applied. A comfortable plan whose custom layout tmux rejects cascades to
+// main-vertical then tiled; an un-comfortable (too cramped) plan goes straight
+// to tiled, the layout that handles dense windows best. Both fallbacks return
+// false.
+func (a *applier) applyLayout(windowID string, win Window, cfg Config, plan Plan, sidebarID string, contentIDs []string, lastCellSpacer bool) bool {
+	if plan.Comfortable {
+		layout, err := Render(RenderInput{
+			Win:            win,
+			SidebarPaneID:  sidebarID,
+			ContentPaneIDs: contentIDs,
+			Cols:           plan.Cols,
+			LastCellSpacer: lastCellSpacer,
+			Cfg:            cfg,
+		})
+		if err == nil && a.ops.ApplyLayout(windowID, layout) == nil {
+			return true
+		}
+		if a.ops.SelectMainVertical(windowID, cfg.SidebarWidth) != nil {
+			_ = a.ops.SelectTiled(windowID)
+		}
+		return false
+	}
+	_ = a.ops.SelectTiled(windowID)
+	return false
+}
+
+// reconcileSpacers brings the window's spacer panes to the desired count
+// (0 or 1), killing surplus and splitting deficit, and returns the numeric ids
+// of the spacers that remain. It is self-healing: stale spacers from a crashed
+// run are reconciled away.
+func (a *applier) reconcileSpacers(windowID string, existing []tmuxrun.WindowPane, desired int) []string {
+	for i := desired; i < len(existing); i++ {
+		_ = a.ops.KillPane(existing[i].ID)
+	}
+	var kept []string
+	for i := 0; i < desired && i < len(existing); i++ {
+		kept = append(kept, existing[i].NumericID)
+	}
+	for i := len(existing); i < desired; i++ {
+		id, err := a.ops.SplitSpacer(windowID)
+		if err != nil {
+			break // best-effort: lay out with whatever spacers we have
+		}
+		kept = append(kept, strings.TrimPrefix(strings.TrimSpace(id), "%"))
+	}
+	return kept
+}
+
+// partition splits a window's panes into the console (if any), the grid panes in
+// stable pane-index order, and existing spacers.
+func partition(panes []tmuxrun.WindowPane) (console *tmuxrun.WindowPane, grid, spacers []tmuxrun.WindowPane) {
+	for i := range panes {
+		p := panes[i]
+		switch {
+		case p.Spacer:
+			spacers = append(spacers, p)
+		case p.Role == tmuxrun.RoleConsole && console == nil:
+			c := p
+			console = &c
+		default:
+			grid = append(grid, p)
+		}
+	}
+	sort.Slice(grid, func(i, j int) bool { return grid[i].Index < grid[j].Index })
+	return console, grid, spacers
+}
+
+// memoCap bounds the per-window resize-dedup memo. tmux window ids are
+// monotonic and never reused, so without a cap a long-lived TUI would accumulate
+// one stale entry per window forever. The memo is only a dedup hint, so dropping
+// it wholesale at the cap is harmless (the next resize just recomputes).
+const memoCap = 256
+
+// memoMatch reports whether the window's last applied signature is unchanged.
+// The caller must hold a.mu.
+func (a *applier) memoMatch(windowID string, win Window, hasConsole bool, gridIDs, spacerIDs []string) bool {
+	prev, ok := a.memo[windowID]
+	return ok && prev == layoutSignature(win, hasConsole, gridIDs, spacerIDs)
+}
+
+// store records the window's signature. The caller must hold a.mu.
+func (a *applier) store(windowID string, win Window, hasConsole bool, gridIDs, spacerIDs []string) {
+	if len(a.memo) >= memoCap {
+		a.memo = make(map[string]string)
+	}
+	a.memo[windowID] = layoutSignature(win, hasConsole, gridIDs, spacerIDs)
+}
+
+// layoutSignature is the resize-dedup key: window size, console presence, and
+// the sorted grid/spacer id sets. It deliberately ignores ordering so an
+// identical arrangement maps to one signature.
+func layoutSignature(win Window, hasConsole bool, gridIDs, spacerIDs []string) string {
+	g := append([]string(nil), gridIDs...)
+	sort.Strings(g)
+	s := append([]string(nil), spacerIDs...)
+	sort.Strings(s)
+	return fmt.Sprintf("%dx%d|c=%t|g=%s|sp=%s", win.Width, win.Height, hasConsole, strings.Join(g, ","), strings.Join(s, ","))
+}
+
+func numericIDs(panes []tmuxrun.WindowPane) []string {
+	out := make([]string, len(panes))
+	for i, p := range panes {
+		out[i] = p.NumericID
+	}
+	return out
+}

--- a/internal/panelayout/apply_test.go
+++ b/internal/panelayout/apply_test.go
@@ -1,0 +1,267 @@
+package panelayout
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/butaosuinu/fanout/internal/tmuxrun"
+)
+
+type fakeOps struct {
+	geom     tmuxrun.Geometry
+	geomErr  error
+	panes    []tmuxrun.WindowPane
+	panesErr error
+	applyErr error
+	mainvErr error
+	spacerID string
+
+	panesCalls int
+	applied    []string
+	mainvCalls int
+	tiledCalls int
+	killed     []string
+	splits     int
+}
+
+func (f *fakeOps) WindowGeometry(string) (tmuxrun.Geometry, error) { return f.geom, f.geomErr }
+func (f *fakeOps) WindowPanes(string) ([]tmuxrun.WindowPane, error) {
+	f.panesCalls++
+	return f.panes, f.panesErr
+}
+
+func (f *fakeOps) SplitSpacer(string) (string, error) {
+	f.splits++
+	id := f.spacerID
+	if id == "" {
+		id = "%900"
+	}
+	return id, nil
+}
+func (f *fakeOps) KillPane(id string) error             { f.killed = append(f.killed, id); return nil }
+func (f *fakeOps) ApplyLayout(_, l string) error        { f.applied = append(f.applied, l); return f.applyErr }
+func (f *fakeOps) SelectMainVertical(string, int) error { f.mainvCalls++; return f.mainvErr }
+func (f *fakeOps) SelectTiled(string) error             { f.tiledCalls++; return nil }
+
+func newTestApplier(f *fakeOps) *applier {
+	return &applier{ops: f, cfg: DefaultConfig(), memo: map[string]string{}}
+}
+
+func wp(num string, idx int, role string, spacer bool) tmuxrun.WindowPane {
+	return tmuxrun.WindowPane{ID: "%" + num, NumericID: num, Index: idx, Role: role, Spacer: spacer}
+}
+
+func TestApplyNoSidebarGrid(t *testing.T) {
+	f := &fakeOps{
+		geom:  tmuxrun.Geometry{WindowID: "@1", Width: 200, Height: 50},
+		panes: []tmuxrun.WindowPane{wp("1079", 0, "", false), wp("1080", 1, "", false)},
+	}
+	a := newTestApplier(f)
+	if err := a.apply("%1079", Create); err != nil {
+		t.Fatal(err)
+	}
+	if len(f.applied) != 1 {
+		t.Fatalf("applied = %v", f.applied)
+	}
+	want := "2cc9,200x50,0,0{100x50,0,0,1079,99x50,101,0,1080}"
+	if f.applied[0] != want {
+		t.Errorf("layout = %q, want %q", f.applied[0], want)
+	}
+	if f.mainvCalls != 0 || f.tiledCalls != 0 {
+		t.Errorf("unexpected fallback: mainv=%d tiled=%d", f.mainvCalls, f.tiledCalls)
+	}
+}
+
+func TestApplySidebarGrid(t *testing.T) {
+	f := &fakeOps{
+		geom: tmuxrun.Geometry{WindowID: "@1", Width: 200, Height: 50},
+		panes: []tmuxrun.WindowPane{
+			wp("1093", 0, tmuxrun.RoleConsole, false),
+			wp("1094", 1, "", false),
+			wp("1095", 2, "", false),
+		},
+	}
+	a := newTestApplier(f)
+	if err := a.apply("%1093", Create); err != nil {
+		t.Fatal(err)
+	}
+	want := "fab2,200x50,0,0{40x50,0,0,1093,159x50,41,0{79x50,41,0,1094,79x50,121,0,1095}}"
+	if len(f.applied) != 1 || f.applied[0] != want {
+		t.Fatalf("layout = %v, want %q", f.applied, want)
+	}
+}
+
+func TestApplyAddsSpacerWithConsole(t *testing.T) {
+	// A console + 5 grid panes on a wide window picks a short, wide last row that
+	// warrants a spacer; spacers are only created when a console is present.
+	f := &fakeOps{
+		geom:     tmuxrun.Geometry{WindowID: "@1", Width: 320, Height: 50},
+		panes:    append([]tmuxrun.WindowPane{wp("c", 0, tmuxrun.RoleConsole, false)}, panesN(5)...),
+		spacerID: "%9",
+	}
+	a := newTestApplier(f)
+	if err := a.apply("%c", Create); err != nil {
+		t.Fatal(err)
+	}
+	if f.splits != 1 {
+		t.Fatalf("splits = %d, want 1", f.splits)
+	}
+	// Sidebar layout closes with the spacer cell, the content's [], then the root {}.
+	if len(f.applied) != 1 || !strings.HasSuffix(f.applied[0], ",9}]}") {
+		t.Errorf("spacer cell (id 9) not the trailing cell: %q", f.applied[0])
+	}
+}
+
+func TestApplyNoSpacerWithoutConsole(t *testing.T) {
+	// Same spacer-warranting geometry but no console (batch run): no resident
+	// process would reconcile a spacer, so none is created.
+	f := &fakeOps{
+		geom:  tmuxrun.Geometry{WindowID: "@1", Width: 320, Height: 50},
+		panes: panesN(5),
+	}
+	a := newTestApplier(f)
+	if err := a.apply("%1", Create); err != nil {
+		t.Fatal(err)
+	}
+	if f.splits != 0 {
+		t.Errorf("splits = %d, want 0 (no spacer without a console)", f.splits)
+	}
+}
+
+func TestApplyRemovesStaleSpacer(t *testing.T) {
+	f := &fakeOps{
+		geom: tmuxrun.Geometry{WindowID: "@1", Width: 200, Height: 50},
+		panes: []tmuxrun.WindowPane{
+			wp("1", 0, "", false),
+			wp("2", 1, "", false),
+			wp("8", 2, "", true), // stale spacer, no longer needed at this size
+		},
+	}
+	a := newTestApplier(f)
+	if err := a.apply("%1", Create); err != nil {
+		t.Fatal(err)
+	}
+	if len(f.killed) != 1 || f.killed[0] != "%8" {
+		t.Errorf("killed = %v, want [%%8]", f.killed)
+	}
+	if len(f.applied) != 1 || strings.Contains(f.applied[0], ",8") {
+		t.Errorf("spacer still in layout: %q", f.applied[0])
+	}
+}
+
+func TestApplyFallbackCascade(t *testing.T) {
+	// Custom layout rejected → main-vertical.
+	f := &fakeOps{
+		geom:     tmuxrun.Geometry{WindowID: "@1", Width: 200, Height: 50},
+		panes:    panesN(3),
+		applyErr: fmt.Errorf("tmux rejected layout"),
+	}
+	a := newTestApplier(f)
+	_ = a.apply("%1", Create)
+	if f.mainvCalls != 1 || f.tiledCalls != 0 {
+		t.Errorf("mainv=%d tiled=%d, want 1/0", f.mainvCalls, f.tiledCalls)
+	}
+
+	// Main-vertical also fails → tiled.
+	f = &fakeOps{
+		geom:     tmuxrun.Geometry{WindowID: "@1", Width: 200, Height: 50},
+		panes:    panesN(3),
+		applyErr: fmt.Errorf("rejected"),
+		mainvErr: fmt.Errorf("rejected too"),
+	}
+	a = newTestApplier(f)
+	_ = a.apply("%1", Create)
+	if f.tiledCalls != 1 {
+		t.Errorf("tiled = %d, want 1", f.tiledCalls)
+	}
+}
+
+func TestApplyCrampedFallsBackToTiled(t *testing.T) {
+	// A window too small for a comfortable grid skips the custom layout and uses
+	// tiled (the layout that handles dense windows best), not main-vertical.
+	f := &fakeOps{
+		geom:  tmuxrun.Geometry{WindowID: "@1", Width: 50, Height: 10},
+		panes: panesN(3),
+	}
+	a := newTestApplier(f)
+	_ = a.apply("%1", Create)
+	if len(f.applied) != 0 {
+		t.Errorf("expected no custom layout for cramped window, got %v", f.applied)
+	}
+	if f.tiledCalls != 1 || f.mainvCalls != 0 {
+		t.Errorf("cramped fallback = tiled %d / mainv %d, want 1/0", f.tiledCalls, f.mainvCalls)
+	}
+}
+
+func TestApplyResizeMemoSkips(t *testing.T) {
+	f := &fakeOps{
+		geom:  tmuxrun.Geometry{WindowID: "@1", Width: 200, Height: 50},
+		panes: panesN(2),
+	}
+	a := newTestApplier(f)
+	if err := a.apply("%1", Create); err != nil {
+		t.Fatal(err)
+	}
+	// Same geometry + pane set: a resize event should be a no-op.
+	if err := a.apply("%1", Resize); err != nil {
+		t.Fatal(err)
+	}
+	if len(f.applied) != 1 {
+		t.Errorf("resize was not deduped: applied=%d", len(f.applied))
+	}
+	// A changed window size must reapply.
+	f.geom.Width = 240
+	if err := a.apply("%1", Resize); err != nil {
+		t.Fatal(err)
+	}
+	if len(f.applied) != 2 {
+		t.Errorf("resize after size change did not reapply: applied=%d", len(f.applied))
+	}
+}
+
+func TestApplyCreateBypassesMemo(t *testing.T) {
+	f := &fakeOps{
+		geom:  tmuxrun.Geometry{WindowID: "@1", Width: 200, Height: 50},
+		panes: panesN(2),
+	}
+	a := newTestApplier(f)
+	_ = a.apply("%1", Create)
+	_ = a.apply("%1", Create)
+	if len(f.applied) != 2 {
+		t.Errorf("Create should not dedup: applied=%d", len(f.applied))
+	}
+}
+
+func TestApplyWindowGone(t *testing.T) {
+	f := &fakeOps{geomErr: fmt.Errorf("can't find window")}
+	a := newTestApplier(f)
+	if err := a.apply("%1", Create); err != nil {
+		t.Fatal(err)
+	}
+	if f.panesCalls != 0 || len(f.applied) != 0 {
+		t.Errorf("expected no-op for missing window: panesCalls=%d applied=%v", f.panesCalls, f.applied)
+	}
+}
+
+func TestApplyConsoleOnly(t *testing.T) {
+	f := &fakeOps{
+		geom:  tmuxrun.Geometry{WindowID: "@1", Width: 200, Height: 50},
+		panes: []tmuxrun.WindowPane{wp("5", 0, tmuxrun.RoleConsole, false)},
+	}
+	a := newTestApplier(f)
+	if err := a.apply("%5", Create); err != nil {
+		t.Fatal(err)
+	}
+	if len(f.applied) != 0 || f.mainvCalls != 0 {
+		t.Errorf("console-only window should not lay out: applied=%v mainv=%d", f.applied, f.mainvCalls)
+	}
+}
+
+func panesN(n int) []tmuxrun.WindowPane {
+	out := make([]tmuxrun.WindowPane, n)
+	for i := range out {
+		out[i] = wp(fmt.Sprintf("%d", i+1), i, "", false)
+	}
+	return out
+}

--- a/internal/panelayout/checksum.go
+++ b/internal/panelayout/checksum.go
@@ -1,0 +1,20 @@
+package panelayout
+
+import "fmt"
+
+// Checksum computes tmux's 16-bit window-layout checksum over body, the layout
+// string without its leading "checksum," prefix. tmux rejects a custom layout
+// passed to `select-layout` whose checksum does not match, so this must mirror
+// tmux's algorithm exactly (right-rotate by one bit, add the byte, wrap to 16
+// bits) and emit four lowercase hex digits.
+//
+// Layout strings are ASCII only (digits and the set "x,{}[]"), so iterating
+// bytes is equivalent to tmux's per-character pass; never feed it non-ASCII.
+func Checksum(body string) string {
+	var c uint16
+	for _, b := range []byte(body) {
+		c = (c >> 1) + ((c & 1) << 15)
+		c += uint16(b)
+	}
+	return fmt.Sprintf("%04x", c)
+}

--- a/internal/panelayout/layout.go
+++ b/internal/panelayout/layout.go
@@ -1,0 +1,297 @@
+// Package panelayout computes and applies a dmux-style auto layout for the
+// tmux window that holds fanout's panes: a fixed-width sidebar (the TUI console
+// pane) plus a grid of the remaining panes sized for comfortable widths, with
+// an optional spacer pane absorbing excess width. The pure calculation
+// (DecidePlan/Render/Checksum) lives here and imports only the standard
+// library; the tmux IO orchestration (Apply) lives in apply.go behind an
+// injected ops interface.
+//
+// The algorithm mirrors dmux (github.com/standardagents/dmux): the column
+// count is chosen by scoring candidates on balance, vertical space, and
+// comfortable width, and the layout is emitted as a tmux custom layout string
+// with a 16-bit checksum.
+package panelayout
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Config holds the comfort thresholds. The defaults match dmux.
+type Config struct {
+	SidebarWidth         int // reserved console/sidebar width; 0 = no sidebar
+	MinComfortableWidth  int // feasibility floor and comfort lower bound
+	MaxComfortableWidth  int // panes wider than this are penalized / capped
+	MinComfortableHeight int // minimum row height for a feasible layout
+	MinSpacerWidth       int // a spacer is only worth adding above this width
+}
+
+// DefaultConfig returns dmux's constants. SidebarWidth defaults to 0 (no
+// sidebar); callers set it to the console width when a console pane exists.
+func DefaultConfig() Config {
+	return Config{
+		SidebarWidth:         0,
+		MinComfortableWidth:  60,
+		MaxComfortableWidth:  100,
+		MinComfortableHeight: 15,
+		MinSpacerWidth:       20,
+	}
+}
+
+// SidebarWidthDefault is the console sidebar width used when a console pane is
+// present, matching dmux's SIDEBAR_WIDTH.
+const SidebarWidthDefault = 40
+
+// Window is a tmux window's interior geometry (status bar already excluded).
+type Window struct {
+	Width, Height int
+}
+
+// Plan is the pure layout decision: how many columns/rows, how content panes
+// are distributed per row, whether the result is comfortable, and whether a
+// spacer pane is warranted. It carries no pane ids so it can be computed in
+// dry-run from a count alone.
+type Plan struct {
+	Cols             int
+	Rows             int
+	PaneDistribution []int // content panes per row; len == Rows
+	Comfortable      bool  // false: caller should consider a coarser fallback
+	Spacer           SpacerPlan
+}
+
+// SpacerPlan describes the single optional spacer cell at the end of the last
+// row. dmux only ever adds one spacer.
+type SpacerPlan struct {
+	Needed bool
+	Width  int
+}
+
+// DecidePlan chooses a column count for contentPaneCount grid panes (the
+// sidebar and any spacer are not counted) and decides whether a spacer is
+// warranted. It returns a zero Plan for non-positive inputs.
+func DecidePlan(win Window, contentPaneCount int, cfg Config) Plan {
+	if contentPaneCount <= 0 || win.Width <= 0 || win.Height <= 0 {
+		return Plan{}
+	}
+	reserve := sidebarReserve(cfg)
+	minFeasibleW := max(1, min(cfg.MinComfortableWidth, cfg.MaxComfortableWidth))
+
+	var best, feasibleBest *Plan
+	bestScore, feasibleScore := -1.0, -1.0
+
+	// Descend so that, on a score tie, the smaller column count (wider panes)
+	// is the one that ends up retained — matching dmux's tie-break.
+	for cols := contentPaneCount; cols >= 1; cols-- {
+		rows := ceilDiv(contentPaneCount, cols)
+		paneWidth := float64(win.Width-reserve-(cols-1)) / float64(cols) // not floored: score input
+		paneHeight := (win.Height - (rows - 1)) / rows                   // int division = floor
+
+		cand := Plan{
+			Cols:             cols,
+			Rows:             rows,
+			PaneDistribution: distribute(contentPaneCount, cols, rows),
+		}
+		score := scoreLayout(cand, paneWidth, paneHeight, win.Height, cfg)
+
+		minReqW := reserve + cols*minFeasibleW + (cols - 1)
+		minReqH := rows*cfg.MinComfortableHeight + (rows - 1)
+		feasible := minReqW <= win.Width && minReqH <= win.Height
+		cand.Comfortable = feasible
+
+		if better(score, bestScore, cols, best) {
+			bestScore = score
+			c := cand
+			best = &c
+		}
+		if feasible && better(score, feasibleScore, cols, feasibleBest) {
+			feasibleScore = score
+			c := cand
+			feasibleBest = &c
+		}
+	}
+
+	chosen := best
+	if feasibleBest != nil { // prefer a feasible layout; fall back to best-effort
+		chosen = feasibleBest
+	}
+	chosen.Spacer = decideSpacer(win, *chosen, cfg)
+	return *chosen
+}
+
+// scoreLayout reproduces dmux's balanceScore * heightScore * widthScore.
+func scoreLayout(p Plan, paneWidth float64, paneHeight, winHeight int, cfg Config) float64 {
+	balance := 1.0
+	if p.PaneDistribution[p.Rows-1] == 1 {
+		balance = 0.5 // a lone pane in the last row reads as unbalanced
+	}
+	height := float64(paneHeight) / float64(winHeight)
+	width := 1.0
+	if paneWidth > float64(cfg.MaxComfortableWidth) {
+		width = 0.8
+	}
+	return balance * height * width
+}
+
+// better reports whether score beats the incumbent, treating an equal score as
+// an improvement only when the candidate uses fewer columns.
+func better(score, bestScore float64, cols int, incumbent *Plan) bool {
+	if score > bestScore {
+		return true
+	}
+	return score == bestScore && (incumbent == nil || cols < incumbent.Cols)
+}
+
+// decideSpacer mirrors dmux's SpacerManager: add one spacer when the last row
+// is short and its panes would otherwise stretch past MaxComfortableWidth, and
+// the reclaimed width is itself worth a pane.
+func decideSpacer(win Window, p Plan, cfg Config) SpacerPlan {
+	if p.Cols <= 1 || p.Rows == 0 {
+		return SpacerPlan{}
+	}
+	panesInLastRow := p.PaneDistribution[p.Rows-1]
+	if panesInLastRow == p.Cols {
+		return SpacerPlan{}
+	}
+	contentWidth := win.Width - sidebarReserve(cfg)
+	available := contentWidth - (panesInLastRow - 1)
+	widthPerPane := float64(available) / float64(panesInLastRow)
+	if widthPerPane <= float64(cfg.MaxComfortableWidth) {
+		return SpacerPlan{}
+	}
+	// With a spacer, the last row holds panesInLastRow capped content panes plus
+	// one spacer cell, so there are panesInLastRow borders.
+	spacerWidth := contentWidth - panesInLastRow*cfg.MaxComfortableWidth - panesInLastRow
+	if spacerWidth < cfg.MinSpacerWidth {
+		return SpacerPlan{}
+	}
+	return SpacerPlan{Needed: true, Width: spacerWidth}
+}
+
+// RenderInput is the input to Render. ContentPaneIDs are the numeric pane ids
+// (the digits of "%N", without the leading '%') in row-major order; when a
+// spacer is used its id is the final element and LastCellSpacer is true.
+type RenderInput struct {
+	Win            Window
+	SidebarPaneID  string // numeric console pane id; "" for no sidebar
+	ContentPaneIDs []string
+	Cols           int
+	LastCellSpacer bool
+	Cfg            Config
+}
+
+// Render builds a tmux custom layout string of the form
+// "checksum,WxH,0,0{sidebar,content}" (or just the content node when there is
+// no sidebar). It returns an error when the geometry cannot hold the panes so
+// the caller can fall back.
+func Render(in RenderInput) (string, error) {
+	n := len(in.ContentPaneIDs)
+	switch {
+	case n == 0:
+		return "", errors.New("panelayout: no content panes")
+	case in.Cols < 1:
+		return "", errors.New("panelayout: cols must be >= 1")
+	case in.Win.Width <= 0 || in.Win.Height <= 0:
+		return "", errors.New("panelayout: window dimensions must be positive")
+	}
+	reserve := sidebarReserve(in.Cfg)
+	contentWidth := in.Win.Width - reserve
+	contentStartX := reserve
+	if contentWidth <= 0 {
+		return "", errors.New("panelayout: content width must be positive")
+	}
+	rows := ceilDiv(n, in.Cols)
+	paneHeight := (in.Win.Height - (rows - 1)) / rows
+	if paneHeight <= 0 {
+		return "", errors.New("panelayout: pane height must be positive")
+	}
+
+	gridRows := make([]string, 0, rows)
+	idx, currentY := 0, 0
+	for r := range rows {
+		panesInRow := min(in.Cols, n-idx)
+		rowHeight := paneHeight
+		if r == rows-1 {
+			rowHeight = in.Win.Height - currentY // last row absorbs the remainder
+		}
+		lastRowSpacer := in.LastCellSpacer && r == rows-1
+		widths := rowWidths(contentWidth, panesInRow, lastRowSpacer, in.Cfg)
+
+		cells := make([]string, panesInRow)
+		x := contentStartX
+		for c := range panesInRow {
+			cells[c] = fmt.Sprintf("%dx%d,%d,%d,%s", widths[c], rowHeight, x, currentY, in.ContentPaneIDs[idx+c])
+			x += widths[c] + 1 // cell width plus one border column
+		}
+		idx += panesInRow
+
+		if panesInRow == 1 {
+			gridRows = append(gridRows, cells[0]) // a single pane needs no container
+		} else {
+			gridRows = append(gridRows, fmt.Sprintf("%dx%d,%d,%d{%s}", contentWidth, rowHeight, contentStartX, currentY, strings.Join(cells, ",")))
+		}
+		if r < rows-1 {
+			currentY += paneHeight + 1
+		}
+	}
+
+	content := gridRows[0]
+	if len(gridRows) > 1 {
+		content = fmt.Sprintf("%dx%d,%d,0[%s]", contentWidth, in.Win.Height, contentStartX, strings.Join(gridRows, ","))
+	}
+
+	body := content
+	if in.SidebarPaneID != "" && in.Cfg.SidebarWidth > 0 {
+		sidebar := fmt.Sprintf("%dx%d,0,0,%s", in.Cfg.SidebarWidth, in.Win.Height, in.SidebarPaneID)
+		body = fmt.Sprintf("%dx%d,0,0{%s,%s}", in.Win.Width, in.Win.Height, sidebar, content)
+	}
+	return Checksum(body) + "," + body, nil
+}
+
+// rowWidths distributes contentWidth across panesInRow cells. Without a spacer
+// the remainder lands on the first pane; with a spacer the content panes are
+// capped at MaxComfortableWidth and the trailing spacer cell takes the rest.
+func rowWidths(contentWidth, panesInRow int, spacer bool, cfg Config) []int {
+	w := make([]int, panesInRow)
+	if spacer {
+		nContent := panesInRow - 1
+		for i := range nContent {
+			w[i] = cfg.MaxComfortableWidth
+		}
+		borders := panesInRow - 1
+		w[panesInRow-1] = contentWidth - nContent*cfg.MaxComfortableWidth - borders
+		return w
+	}
+	available := contentWidth - (panesInRow - 1)
+	even := available / panesInRow
+	for i := range w {
+		w[i] = even
+	}
+	w[0] += available - even*panesInRow // first pane absorbs the remainder
+	return w
+}
+
+// sidebarReserve is the width consumed by the sidebar and its border column.
+func sidebarReserve(cfg Config) int {
+	if cfg.SidebarWidth > 0 {
+		return cfg.SidebarWidth + 1
+	}
+	return 0
+}
+
+// distribute returns the content-pane count for each row, row-major: full rows
+// of cols, then the remainder in the last row.
+func distribute(n, cols, rows int) []int {
+	out := make([]int, rows)
+	for i := range rows - 1 {
+		out[i] = cols
+	}
+	last := n % cols
+	if last == 0 {
+		last = cols
+	}
+	out[rows-1] = last
+	return out
+}
+
+func ceilDiv(a, b int) int { return (a + b - 1) / b }

--- a/internal/panelayout/layout_test.go
+++ b/internal/panelayout/layout_test.go
@@ -1,0 +1,276 @@
+package panelayout
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"testing"
+)
+
+// gridCfg is a no-sidebar config with dmux's comfort thresholds.
+func gridCfg() Config { return DefaultConfig() }
+
+// sidebarCfg is the same with a console sidebar reserved.
+func sidebarCfg() Config {
+	c := DefaultConfig()
+	c.SidebarWidth = SidebarWidthDefault
+	return c
+}
+
+// The two checksums below were captured from real tmux 3.6a (see the
+// layout-probe runs during development); they pin both Checksum and Render to
+// tmux's actual algorithm and geometry, not just to our understanding of it.
+func TestChecksumMatchesRealTmux(t *testing.T) {
+	cases := []struct{ body, want string }{
+		{"200x50,0,0{100x50,0,0,1079,99x50,101,0,1080}", "2cc9"},
+		{"200x50,0,0{40x50,0,0,1093,159x50,41,0{79x50,41,0,1094,79x50,121,0,1095}}", "fab2"},
+	}
+	for _, tc := range cases {
+		if got := Checksum(tc.body); got != tc.want {
+			t.Errorf("Checksum(%q) = %q, want %q", tc.body, got, tc.want)
+		}
+	}
+}
+
+func TestRenderGolden(t *testing.T) {
+	cases := []struct {
+		name string
+		in   RenderInput
+		want string
+	}{
+		{
+			// Real tmux: `tmux new -x200 -y50; split-window -h` → this exact string.
+			name: "no-sidebar 2 panes single row",
+			in: RenderInput{
+				Win:            Window{200, 50},
+				ContentPaneIDs: []string{"1079", "1080"},
+				Cols:           2,
+				Cfg:            gridCfg(),
+			},
+			want: "2cc9,200x50,0,0{100x50,0,0,1079,99x50,101,0,1080}",
+		},
+		{
+			// Real tmux accepted this verbatim (select-layout rc=0, identical echo).
+			name: "sidebar + 2-pane grid row",
+			in: RenderInput{
+				Win:            Window{200, 50},
+				SidebarPaneID:  "1093",
+				ContentPaneIDs: []string{"1094", "1095"},
+				Cols:           2,
+				Cfg:            sidebarCfg(),
+			},
+			want: "fab2,200x50,0,0{40x50,0,0,1093,159x50,41,0{79x50,41,0,1094,79x50,121,0,1095}}",
+		},
+		{
+			name: "single pane no sidebar",
+			in: RenderInput{
+				Win:            Window{120, 40},
+				ContentPaneIDs: []string{"7"},
+				Cols:           1,
+				Cfg:            gridCfg(),
+			},
+			want: "ab04,120x40,0,0,7",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Render(tc.in)
+			if err != nil {
+				t.Fatalf("Render: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("Render = %q\nwant       %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRenderMultiRowNesting(t *testing.T) {
+	// 3 grid panes, 2 columns → row0 has 2 panes, row1 has 1: a [] vertical
+	// container wrapping a {} horizontal row and a bare leaf, with the height
+	// remainder on the last row. Verified accepted by real tmux 3.6a (rc=0,
+	// identical echo) with these pane ids.
+	got, err := Render(RenderInput{
+		Win:            Window{200, 50},
+		ContentPaneIDs: []string{"1108", "1109", "1110"},
+		Cols:           2,
+		Cfg:            gridCfg(),
+	})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	want := "7c6f,200x50,0,0[200x24,0,0{100x24,0,0,1108,99x24,101,0,1109},200x25,0,25,1110]"
+	if got != want {
+		t.Errorf("Render = %q\nwant       %q", got, want)
+	}
+}
+
+func TestRenderSpacerRow(t *testing.T) {
+	// n=5 grid panes at 250x50 picks 3 cols / 2 rows with a short last row that
+	// would stretch past MaxComfortableWidth, so a spacer cell is appended.
+	// Verified accepted by real tmux 3.6a (rc=0) with these six pane ids.
+	got, err := Render(RenderInput{
+		Win:            Window{250, 50},
+		ContentPaneIDs: []string{"1117", "1118", "1119", "1120", "1121", "1122"},
+		Cols:           3,
+		LastCellSpacer: true,
+		Cfg:            gridCfg(),
+	})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	// Last row: two content panes capped at 100 plus a 48-wide spacer.
+	want := "0ea2,250x50,0,0[250x24,0,0{84x24,0,0,1117,82x24,85,0,1118,82x24,168,0,1119},250x25,0,25{100x25,0,25,1120,100x25,101,25,1121,48x25,202,25,1122}]"
+	if got != want {
+		t.Errorf("Render = %q\nwant       %q", got, want)
+	}
+}
+
+func TestRenderErrors(t *testing.T) {
+	cfg := gridCfg()
+	cases := []RenderInput{
+		{Win: Window{200, 50}, ContentPaneIDs: nil, Cols: 1, Cfg: cfg},
+		{Win: Window{200, 50}, ContentPaneIDs: []string{"1"}, Cols: 0, Cfg: cfg},
+		{Win: Window{0, 50}, ContentPaneIDs: []string{"1"}, Cols: 1, Cfg: cfg},
+		// 60 grid panes in 1 column can't fit positive height in 50 rows.
+		{Win: Window{200, 50}, ContentPaneIDs: ids(60), Cols: 1, Cfg: cfg},
+	}
+	for i, in := range cases {
+		if _, err := Render(in); err == nil {
+			t.Errorf("case %d: expected error, got nil", i)
+		}
+	}
+}
+
+func TestDecidePlan(t *testing.T) {
+	cases := []struct {
+		name    string
+		win     Window
+		n       int
+		cfg     Config
+		cols    int
+		rows    int
+		dist    []int
+		comfort bool
+		spacer  bool
+		spacerW int
+	}{
+		{"1 pane", Window{200, 50}, 1, gridCfg(), 1, 1, []int{1}, true, false, 0},
+		{"2 panes one row", Window{200, 50}, 2, gridCfg(), 2, 1, []int{2}, true, false, 0},
+		{"3 panes one row", Window{200, 50}, 3, gridCfg(), 3, 1, []int{3}, true, false, 0},
+		{"4 panes 2x2", Window{200, 50}, 4, gridCfg(), 2, 2, []int{2, 2}, true, false, 0},
+		{"5 panes spacer", Window{250, 50}, 5, gridCfg(), 3, 2, []int{3, 2}, true, true, 48},
+		{"sidebar 2 panes", Window{200, 50}, 2, sidebarCfg(), 2, 1, []int{2}, true, false, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := DecidePlan(tc.win, tc.n, tc.cfg)
+			if got.Cols != tc.cols || got.Rows != tc.rows {
+				t.Errorf("cols/rows = %d/%d, want %d/%d", got.Cols, got.Rows, tc.cols, tc.rows)
+			}
+			if fmt.Sprint(got.PaneDistribution) != fmt.Sprint(tc.dist) {
+				t.Errorf("dist = %v, want %v", got.PaneDistribution, tc.dist)
+			}
+			if got.Comfortable != tc.comfort {
+				t.Errorf("comfortable = %v, want %v", got.Comfortable, tc.comfort)
+			}
+			if got.Spacer.Needed != tc.spacer {
+				t.Errorf("spacer.Needed = %v, want %v", got.Spacer.Needed, tc.spacer)
+			}
+			if tc.spacer && got.Spacer.Width != tc.spacerW {
+				t.Errorf("spacer.Width = %d, want %d", got.Spacer.Width, tc.spacerW)
+			}
+		})
+	}
+}
+
+func TestDecidePlanTieBreakPrefersFewerColumns(t *testing.T) {
+	// A square window where multiple column counts tie on score should resolve
+	// to the smaller column count (wider panes).
+	got := DecidePlan(Window{180, 50}, 2, gridCfg())
+	if got.Cols != 2 { // 2 panes: one row (cols 2) beats stacked (cols 1)
+		t.Fatalf("cols = %d, want 2", got.Cols)
+	}
+}
+
+func TestDecidePlanZero(t *testing.T) {
+	for _, in := range []struct {
+		w Window
+		n int
+	}{{Window{200, 50}, 0}, {Window{0, 50}, 3}, {Window{200, 0}, 3}} {
+		if got := DecidePlan(in.w, in.n, gridCfg()); got.Cols != 0 || got.Rows != 0 {
+			t.Errorf("DecidePlan(%v,%d) = %+v, want zero", in.w, in.n, got)
+		}
+	}
+}
+
+// leafRe matches a leaf cell "WxH,X,Y,id" but not a container "WxH,X,Y{" / "[".
+var leafRe = regexp.MustCompile(`(\d+)x(\d+),(\d+),(\d+),([^,{}\[\]]+)`)
+
+// TestRenderInvariants sweeps sizes/pane counts and asserts every leaf cell
+// stays within the window and the sidebar width math closes.
+func TestRenderInvariants(t *testing.T) {
+	for _, sidebar := range []bool{false, true} {
+		cfg := gridCfg()
+		if sidebar {
+			cfg = sidebarCfg()
+		}
+		for _, win := range []Window{{120, 40}, {200, 50}, {320, 60}, {80, 24}} {
+			for n := 1; n <= 6; n++ {
+				plan := DecidePlan(win, n, cfg)
+				if plan.Cols == 0 {
+					continue
+				}
+				in := RenderInput{
+					Win:            win,
+					ContentPaneIDs: ids(n),
+					Cols:           plan.Cols,
+					Cfg:            cfg,
+				}
+				if sidebar {
+					in.SidebarPaneID = "9"
+				}
+				out, err := Render(in)
+				if err != nil {
+					continue // infeasible geometry is allowed to error; apply falls back
+				}
+				assertLeavesWithinWindow(t, out, win, sidebar, cfg)
+			}
+		}
+	}
+}
+
+func assertLeavesWithinWindow(t *testing.T, layout string, win Window, sidebar bool, cfg Config) {
+	t.Helper()
+	startX := 0
+	if sidebar {
+		startX = sidebarReserve(cfg)
+	}
+	for _, m := range leafRe.FindAllStringSubmatch(layout, -1) {
+		w, _ := strconv.Atoi(m[1])
+		h, _ := strconv.Atoi(m[2])
+		x, _ := strconv.Atoi(m[3])
+		y, _ := strconv.Atoi(m[4])
+		id := m[5]
+		if id == "9" { // the sidebar leaf sits at x=0
+			continue
+		}
+		if x < startX {
+			t.Errorf("layout %q: leaf x=%d < contentStartX=%d", layout, x, startX)
+		}
+		if x+w > win.Width {
+			t.Errorf("layout %q: leaf x+w=%d > width=%d", layout, x+w, win.Width)
+		}
+		if y+h > win.Height {
+			t.Errorf("layout %q: leaf y+h=%d > height=%d", layout, y+h, win.Height)
+		}
+	}
+}
+
+func ids(n int) []string {
+	out := make([]string, n)
+	for i := range out {
+		out[i] = strconv.Itoa(i + 1)
+	}
+	return out
+}

--- a/internal/tmuxrun/layout.go
+++ b/internal/tmuxrun/layout.go
@@ -1,0 +1,238 @@
+package tmuxrun
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+const (
+	// roleOption marks a pane's role for the auto-layout orchestrator. The TUI
+	// console pane is stamped "console" so it can be reserved as a sidebar.
+	roleOption = "@fanout_role"
+	// spacerOption marks a filler pane the orchestrator inserts to keep grid
+	// panes from stretching past a comfortable width. Spacers are never recorded
+	// in state.json and are reconciled away on every relayout.
+	spacerOption = "@fanout_spacer"
+	// RoleConsole is the roleOption value for the resident TUI console pane.
+	RoleConsole = "console"
+
+	windowPaneFormat = "#{pane_id}\t#{pane_index}\t#{pane_active}\t#{" + roleOption + "}\t#{" + spacerOption + "}"
+	windowGeomFormat = "#{window_id}\t#{window_width}\t#{window_height}"
+)
+
+// Geometry is a tmux window's id and interior size (status bar excluded).
+type Geometry struct {
+	WindowID string
+	Width    int
+	Height   int
+}
+
+// WindowPane is one pane in a window as seen by the auto-layout orchestrator.
+// NumericID is the pane id without its leading '%', the form tmux custom layout
+// strings embed in each leaf cell.
+type WindowPane struct {
+	ID        string
+	NumericID string
+	Index     int
+	Active    bool
+	Role      string
+	Spacer    bool
+}
+
+// WindowGeometry resolves target (a pane id, window id, or session name) to the
+// window that holds it and returns that window's id and interior size. Callers
+// use the returned WindowID as the canonical handle for the rest of a relayout.
+func WindowGeometry(target string) (Geometry, error) {
+	target = strings.TrimSpace(target)
+	args := []string{"display-message", "-p"}
+	if target != "" {
+		args = append(args, "-t", target)
+	}
+	args = append(args, "-F", windowGeomFormat)
+	out, err := exec.Command("tmux", args...).Output()
+	if err != nil {
+		return Geometry{}, fmt.Errorf("tmux display-message window geometry: %w", err)
+	}
+	fields := strings.Split(strings.TrimRight(string(out), "\r\n"), "\t")
+	if len(fields) != 3 {
+		return Geometry{}, fmt.Errorf("parse tmux window geometry: expected 3 fields, got %d", len(fields))
+	}
+	width, err := strconv.Atoi(fields[1])
+	if err != nil {
+		return Geometry{}, fmt.Errorf("parse tmux window width: %w", err)
+	}
+	height, err := strconv.Atoi(fields[2])
+	if err != nil {
+		return Geometry{}, fmt.Errorf("parse tmux window height: %w", err)
+	}
+	id := strings.TrimSpace(fields[0])
+	if id == "" {
+		return Geometry{}, fmt.Errorf("tmux did not report a window id")
+	}
+	return Geometry{WindowID: id, Width: width, Height: height}, nil
+}
+
+// WindowOfPane returns the window id that contains paneID. Lifecycle captures
+// this before killing a pane so it can relayout the surviving window.
+func WindowOfPane(paneID string) (string, error) {
+	paneID = strings.TrimSpace(paneID)
+	if paneID == "" {
+		return "", fmt.Errorf("pane id is required")
+	}
+	out, err := exec.Command("tmux", "display-message", "-p", "-t", paneID, "#{window_id}").Output()
+	if err != nil {
+		return "", fmt.Errorf("tmux display-message window_id: %w", err)
+	}
+	id := strings.TrimSpace(string(out))
+	if id == "" {
+		return "", fmt.Errorf("tmux did not report a window id for pane %s", paneID)
+	}
+	return id, nil
+}
+
+// WindowPanes lists the panes of one window with their auto-layout roles. It is
+// window-scoped on purpose: the dashboard's all-sessions ListLivePanes sweep
+// and its injection-defense join stay untouched.
+func WindowPanes(windowTarget string) ([]WindowPane, error) {
+	windowTarget = strings.TrimSpace(windowTarget)
+	args := []string{"list-panes"}
+	if windowTarget != "" {
+		args = append(args, "-t", windowTarget)
+	}
+	args = append(args, "-F", windowPaneFormat)
+	out, err := exec.Command("tmux", args...).Output()
+	if err != nil {
+		return nil, fmt.Errorf("tmux list-panes window: %w", err)
+	}
+	var panes []WindowPane
+	for lineNum, line := range strings.Split(strings.TrimRight(string(out), "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		fields := strings.SplitN(line, "\t", 5)
+		if len(fields) != 5 {
+			return nil, fmt.Errorf("parse tmux window pane line %d: expected 5 fields, got %d", lineNum+1, len(fields))
+		}
+		id := strings.TrimSpace(fields[0])
+		if !paneIDPattern.MatchString(id) {
+			return nil, fmt.Errorf("parse tmux window pane line %d: malformed pane id %q", lineNum+1, id)
+		}
+		index, err := strconv.Atoi(fields[1])
+		if err != nil {
+			return nil, fmt.Errorf("parse tmux window pane line %d index: %w", lineNum+1, err)
+		}
+		active, err := parsePaneActive(fields[2])
+		if err != nil {
+			return nil, fmt.Errorf("parse tmux window pane line %d active: %w", lineNum+1, err)
+		}
+		panes = append(panes, WindowPane{
+			ID:        id,
+			NumericID: strings.TrimPrefix(id, "%"),
+			Index:     index,
+			Active:    active,
+			Role:      strings.TrimSpace(fields[3]),
+			Spacer:    strings.TrimSpace(fields[4]) == "1",
+		})
+	}
+	return panes, nil
+}
+
+// ApplyLayout applies a custom tmux layout string (checksum,WxH,...) to target.
+// The layout string is passed as a single argv element, so its commas and
+// brackets are never word-split or shell-interpreted.
+func ApplyLayout(target, layoutString string) error {
+	if strings.TrimSpace(layoutString) == "" {
+		return fmt.Errorf("layout string is required")
+	}
+	args := []string{"select-layout"}
+	if strings.TrimSpace(target) != "" {
+		args = append(args, "-t", target)
+	}
+	args = append(args, layoutString)
+	if err := exec.Command("tmux", args...).Run(); err != nil {
+		return fmt.Errorf("tmux select-layout custom: %w", err)
+	}
+	return nil
+}
+
+// SelectMainVertical is the coarse fallback when a custom layout is rejected: a
+// fixed-width main pane on the left with the rest stacked on the right. The
+// sidebar's grid fidelity is lost but the window stays usable.
+func SelectMainVertical(target string, mainPaneWidth int) error {
+	if mainPaneWidth > 0 {
+		args := []string{"set-window-option"}
+		if strings.TrimSpace(target) != "" {
+			args = append(args, "-t", target)
+		}
+		args = append(args, "main-pane-width", strconv.Itoa(mainPaneWidth))
+		if err := exec.Command("tmux", args...).Run(); err != nil {
+			return fmt.Errorf("tmux set-window-option main-pane-width: %w", err)
+		}
+	}
+	args := []string{"select-layout"}
+	if strings.TrimSpace(target) != "" {
+		args = append(args, "-t", target)
+	}
+	args = append(args, "main-vertical")
+	if err := exec.Command("tmux", args...).Run(); err != nil {
+		return fmt.Errorf("tmux select-layout main-vertical: %w", err)
+	}
+	return nil
+}
+
+// SetPaneRole stamps a pane's auto-layout role (e.g. RoleConsole). Pass an empty
+// role to clear it (so a post-TUI shell is not mistaken for a console sidebar).
+func SetPaneRole(paneID, role string) error {
+	if strings.TrimSpace(paneID) == "" {
+		return fmt.Errorf("pane id is required")
+	}
+	if strings.TrimSpace(role) == "" {
+		if err := exec.Command("tmux", "set-option", "-pu", "-t", paneID, roleOption).Run(); err != nil {
+			return fmt.Errorf("tmux set-option -u %s: %w", roleOption, err)
+		}
+		return nil
+	}
+	if err := exec.Command("tmux", "set-option", "-p", "-t", paneID, roleOption, role).Run(); err != nil {
+		return fmt.Errorf("tmux set-option %s: %w", roleOption, err)
+	}
+	return nil
+}
+
+// SplitSpacerPane creates a blank filler pane in windowTarget, marks it with
+// spacerOption, and returns its pane id. The marker is stamped from the parent
+// using the explicit pane id split-window returned, so there is no active-pane
+// race and the next relayout can immediately reconcile the spacer. The pane
+// idles on a cleared screen until KillPane removes it.
+//
+// The marker is load-bearing: an unmarked filler pane would be misclassified as
+// a real grid pane on the next relayout and never reconciled away. So if the
+// marker cannot be set, the pane is killed and an error returned rather than
+// leaving an orphaned blank pane behind.
+func SplitSpacerPane(windowTarget string) (string, error) {
+	args := []string{"split-window"}
+	if strings.TrimSpace(windowTarget) != "" {
+		args = append(args, "-t", windowTarget)
+	}
+	args = append(args, "-d", "-h", "-P", "-F", "#{pane_id}", spacerIdleCommand())
+	out, err := exec.Command("tmux", args...).Output()
+	if err != nil {
+		return "", fmt.Errorf("tmux split-window spacer: %w", err)
+	}
+	paneID := strings.TrimSpace(string(out))
+	if paneID == "" {
+		return "", fmt.Errorf("tmux split-window spacer returned an empty pane id")
+	}
+	if err := exec.Command("tmux", "set-option", "-p", "-t", paneID, spacerOption, "1").Run(); err != nil {
+		_ = KillPane(paneID) // don't leave an unmarked blank pane the grid would absorb
+		return "", fmt.Errorf("tmux set-option %s: %w", spacerOption, err)
+	}
+	return paneID, nil
+}
+
+// spacerIdleCommand keeps a spacer pane visually blank: clear the screen, then
+// block on cat so nothing renders and no shell prompt appears.
+func spacerIdleCommand() string {
+	return "exec /bin/sh -lc " + shellQuote("clear; exec cat")
+}

--- a/internal/tmuxrun/layout_test.go
+++ b/internal/tmuxrun/layout_test.go
@@ -1,0 +1,174 @@
+package tmuxrun
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// printArgsShim records argv and prints stdout via the given printf body.
+func printArgsShim(t *testing.T, stdout string) string {
+	t.Helper()
+	script := `printf '%s\n' "$@" > "$TMUXRUN_ARGS"
+` + stdout + "\n"
+	return installTmuxShim(t, script)
+}
+
+func TestWindowGeometryParsesAndTargets(t *testing.T) {
+	argsPath := printArgsShim(t, `printf '@5\t208\t60\n'`)
+	geom, err := WindowGeometry("%1")
+	if err != nil {
+		t.Fatalf("WindowGeometry: %v", err)
+	}
+	if geom != (Geometry{WindowID: "@5", Width: 208, Height: 60}) {
+		t.Fatalf("geom = %+v", geom)
+	}
+	assertTmuxArgs(t, argsPath, []string{"display-message", "-p", "-t", "%1", "-F", windowGeomFormat})
+}
+
+func TestWindowGeometryRejectsMalformedOutput(t *testing.T) {
+	printArgsShim(t, `printf 'not-three-fields\n'`)
+	if _, err := WindowGeometry("%1"); err == nil {
+		t.Fatal("expected error for malformed geometry output")
+	}
+}
+
+func TestWindowOfPane(t *testing.T) {
+	argsPath := printArgsShim(t, `printf '@9\n'`)
+	got, err := WindowOfPane("%3")
+	if err != nil {
+		t.Fatalf("WindowOfPane: %v", err)
+	}
+	if got != "@9" {
+		t.Fatalf("WindowOfPane = %q, want @9", got)
+	}
+	assertTmuxArgs(t, argsPath, []string{"display-message", "-p", "-t", "%3", "#{window_id}"})
+}
+
+func TestApplyLayoutPassesLayoutAsSingleArg(t *testing.T) {
+	argsPath := printArgsShim(t, "")
+	layout := "fab2,200x50,0,0{40x50,0,0,1,159x50,41,0{79x50,41,0,2,79x50,121,0,3}}"
+	if err := ApplyLayout("@5", layout); err != nil {
+		t.Fatalf("ApplyLayout: %v", err)
+	}
+	got := readTmuxArgs(t, argsPath)
+	want := []string{"select-layout", "-t", "@5", layout}
+	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("args = %#v, want %#v", got, want)
+	}
+	// The comma/brace-laden layout must arrive as exactly one argv element.
+	if len(got) != 4 || got[3] != layout {
+		t.Fatalf("layout string was split: %#v", got)
+	}
+}
+
+func TestApplyLayoutRequiresLayout(t *testing.T) {
+	printArgsShim(t, "")
+	if err := ApplyLayout("@5", "  "); err == nil {
+		t.Fatal("expected error for empty layout string")
+	}
+}
+
+func TestSelectMainVerticalOrdersCommands(t *testing.T) {
+	script := `printf '%s\n' "$@" >> "$TMUXRUN_ARGS"
+printf -- '---\n' >> "$TMUXRUN_ARGS"
+`
+	argsPath := installTmuxShim(t, script)
+	if err := SelectMainVertical("@5", 40); err != nil {
+		t.Fatalf("SelectMainVertical: %v", err)
+	}
+	body, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	calls := strings.Split(strings.TrimRight(string(body), "\n"), "---")
+	if len(calls) < 2 {
+		t.Fatalf("expected two tmux calls, got %q", string(body))
+	}
+	if !strings.Contains(calls[0], "set-window-option") || !strings.Contains(calls[0], "main-pane-width") || !strings.Contains(calls[0], "40") {
+		t.Errorf("first call not set-window-option main-pane-width 40: %q", calls[0])
+	}
+	if !strings.Contains(calls[1], "select-layout") || !strings.Contains(calls[1], "main-vertical") {
+		t.Errorf("second call not select-layout main-vertical: %q", calls[1])
+	}
+}
+
+func TestSetPaneRoleSetAndClear(t *testing.T) {
+	argsPath := printArgsShim(t, "")
+	if err := SetPaneRole("%2", RoleConsole); err != nil {
+		t.Fatalf("SetPaneRole set: %v", err)
+	}
+	assertTmuxArgs(t, argsPath, []string{"set-option", "-p", "-t", "%2", roleOption, "console"})
+
+	argsPath = printArgsShim(t, "")
+	if err := SetPaneRole("%2", ""); err != nil {
+		t.Fatalf("SetPaneRole clear: %v", err)
+	}
+	assertTmuxArgs(t, argsPath, []string{"set-option", "-pu", "-t", "%2", roleOption})
+}
+
+func TestSplitSpacerPane(t *testing.T) {
+	// Two tmux calls (split-window, then set-option marker); record both.
+	script := `printf '%s\n' "$@" >> "$TMUXRUN_ARGS"
+printf -- '---\n' >> "$TMUXRUN_ARGS"
+printf '%%77\n'
+`
+	argsPath := installTmuxShim(t, script)
+	id, err := SplitSpacerPane("@5")
+	if err != nil {
+		t.Fatalf("SplitSpacerPane: %v", err)
+	}
+	if id != "%77" {
+		t.Fatalf("id = %q, want %%77", id)
+	}
+	body, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	calls := strings.Split(strings.TrimRight(string(body), "\n"), "---")
+	if len(calls) < 2 {
+		t.Fatalf("expected split + set-option calls, got %q", string(body))
+	}
+	split := strings.Fields(calls[0])
+	wantSplit := []string{"split-window", "-t", "@5", "-d", "-h", "-P", "-F", "#{pane_id}", spacerIdleCommand()}
+	// spacerIdleCommand has spaces, so compare the prefix args and the trailing command separately.
+	if strings.Join(split[:len(wantSplit)-1], "\x00") != strings.Join(wantSplit[:len(wantSplit)-1], "\x00") {
+		t.Errorf("split args = %#v", calls[0])
+	}
+	if !strings.Contains(calls[0], "split-window") || !strings.Contains(calls[0], "#{pane_id}") {
+		t.Errorf("first call not a split-window: %q", calls[0])
+	}
+	// The marker is stamped from the parent against the explicit pane id.
+	if !strings.Contains(calls[1], "set-option") || !strings.Contains(calls[1], "%77") || !strings.Contains(calls[1], spacerOption) {
+		t.Errorf("second call did not stamp %s on %%77: %q", spacerOption, calls[1])
+	}
+}
+
+func TestWindowPanesParsing(t *testing.T) {
+	argsPath := printArgsShim(t, `printf '%%1\t0\t1\tconsole\t\n%%2\t1\t0\t\t\n%%3\t2\t0\t\t1\n'`)
+	panes, err := WindowPanes("@5")
+	if err != nil {
+		t.Fatalf("WindowPanes: %v", err)
+	}
+	want := []WindowPane{
+		{ID: "%1", NumericID: "1", Index: 0, Active: true, Role: "console", Spacer: false},
+		{ID: "%2", NumericID: "2", Index: 1, Active: false, Role: "", Spacer: false},
+		{ID: "%3", NumericID: "3", Index: 2, Active: false, Role: "", Spacer: true},
+	}
+	if len(panes) != len(want) {
+		t.Fatalf("got %d panes, want %d (%+v)", len(panes), len(want), panes)
+	}
+	for i := range want {
+		if panes[i] != want[i] {
+			t.Errorf("pane %d = %+v, want %+v", i, panes[i], want[i])
+		}
+	}
+	assertTmuxArgs(t, argsPath, []string{"list-panes", "-t", "@5", "-F", windowPaneFormat})
+}
+
+func TestWindowPanesRejectsMalformedPaneID(t *testing.T) {
+	printArgsShim(t, `printf 'bogus\t0\t1\t\t\n'`)
+	if _, err := WindowPanes("@5"); err == nil {
+		t.Fatal("expected error for malformed pane id")
+	}
+}

--- a/internal/tui/relayout_test.go
+++ b/internal/tui/relayout_test.go
@@ -1,0 +1,74 @@
+package tui
+
+import (
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestWindowResizeSchedulesDebouncedRelayout(t *testing.T) {
+	called := 0
+	m := newModel(Options{Relayout: func() error { called++; return nil }})
+
+	updated, cmd := m.Update(tea.WindowSizeMsg{Width: 200, Height: 50})
+	mm := updated.(model)
+	if mm.relayoutGen != 1 {
+		t.Fatalf("relayoutGen = %d, want 1", mm.relayoutGen)
+	}
+	if cmd == nil {
+		t.Fatal("resize did not schedule a debounce tick")
+	}
+
+	// The matching tick triggers the relayout command.
+	updated, tickCmd := mm.Update(relayoutTickMsg{gen: 1})
+	mm = updated.(model)
+	if tickCmd == nil {
+		t.Fatal("matching tick did not produce a relayout command")
+	}
+	if _, ok := tickCmd().(relayoutDoneMsg); !ok {
+		t.Fatal("relayout command did not return relayoutDoneMsg")
+	}
+	if called != 1 {
+		t.Fatalf("Relayout called %d times, want 1", called)
+	}
+}
+
+func TestStaleResizeTickIsSuperseded(t *testing.T) {
+	called := 0
+	m := newModel(Options{Relayout: func() error { called++; return nil }})
+
+	updated, _ := m.Update(tea.WindowSizeMsg{Width: 200, Height: 50})              // gen 1
+	updated, _ = updated.(model).Update(tea.WindowSizeMsg{Width: 240, Height: 50}) // gen 2
+	mm := updated.(model)
+	if mm.relayoutGen != 2 {
+		t.Fatalf("relayoutGen = %d, want 2", mm.relayoutGen)
+	}
+
+	// The earlier tick is stale and must not relayout.
+	_, staleCmd := mm.Update(relayoutTickMsg{gen: 1})
+	if staleCmd != nil {
+		t.Fatal("stale tick should be a no-op")
+	}
+
+	// Only the latest tick fires.
+	_, freshCmd := mm.Update(relayoutTickMsg{gen: 2})
+	if freshCmd == nil {
+		t.Fatal("latest tick should produce a relayout command")
+	}
+	freshCmd()
+	if called != 1 {
+		t.Fatalf("Relayout called %d times, want 1", called)
+	}
+}
+
+func TestResizeWithoutRelayoutIsNoop(t *testing.T) {
+	m := newModel(Options{}) // no Relayout wired
+
+	updated, cmd := m.Update(tea.WindowSizeMsg{Width: 200, Height: 50})
+	if cmd != nil {
+		t.Fatal("resize with no Relayout callback should not schedule anything")
+	}
+	if updated.(model).relayoutGen != 0 {
+		t.Fatal("relayoutGen should stay 0 when no Relayout is wired")
+	}
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -27,6 +27,9 @@ const (
 	sessionSidebarAt     = 120
 	sessionSidebarWidth  = 26
 	sessionTopHeight     = 3
+	// relayoutDebounce coalesces the burst of resize events tmux emits while a
+	// terminal window is being dragged into a single relayout.
+	relayoutDebounce = 150 * time.Millisecond
 )
 
 // Options configures the TUI monitor.
@@ -43,14 +46,18 @@ type Options struct {
 	Hooks               hooks.Config
 	LaunchPane          LaunchFunc
 	LaunchShell         ShellLaunchFunc
-	FocusPane           func(string) error
-	PaneAlive           func(string) bool
-	ShellPaneAlive      func(paneID, shellKey string) bool
-	CapturePaneOutput   func(string, int) (string, error)
-	ListRepoFiles       func(root string) ([]string, error)
-	Notifier            transitionNotifier
-	lifecycle           lifecycleRunner
-	keyboard            keyboardProtocols
+	// Relayout re-tiles the TUI's tmux window into the fanout grid. It is wired
+	// to panelayout.Apply(target, Resize) in production and left nil in tests
+	// (then resize handling is a no-op).
+	Relayout          func() error
+	FocusPane         func(string) error
+	PaneAlive         func(string) bool
+	ShellPaneAlive    func(paneID, shellKey string) bool
+	CapturePaneOutput func(string, int) (string, error)
+	ListRepoFiles     func(root string) ([]string, error)
+	Notifier          transitionNotifier
+	lifecycle         lifecycleRunner
+	keyboard          keyboardProtocols
 }
 
 type viewMode int
@@ -98,6 +105,7 @@ type model struct {
 	notifications    map[issueKey]issueTransitionSnapshot
 	notifyPrimed     bool
 	keyboardPaused   bool
+	relayoutGen      int
 }
 
 type keyboardProtocolsEnabledMsg struct{}
@@ -115,6 +123,10 @@ type (
 		req ShellLaunchRequest
 		err error
 	}
+	// relayoutTickMsg fires after the debounce window; gen lets a newer resize
+	// supersede a pending tick so only the last one in a burst relayouts.
+	relayoutTickMsg struct{ gen int }
+	relayoutDoneMsg struct{ err error }
 )
 
 // Run starts the Bubble Tea TUI.

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -16,6 +16,18 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.width = msg.Width
 		m.height = msg.Height
 		m.resize()
+		// Bump the generation here (not in the return expression) so the mutated
+		// model is the one returned.
+		cmd := m.scheduleRelayout()
+		return m, cmd
+	case relayoutTickMsg:
+		if msg.gen != m.relayoutGen {
+			return m, nil // a newer resize superseded this debounce tick
+		}
+		return m, m.relayoutCmd()
+	case relayoutDoneMsg:
+		// Layout follow is best-effort; the orchestrator already fell back if the
+		// custom layout was rejected, so there is nothing to surface here.
 		return m, nil
 	case tea.KeyMsg:
 		m.resumeKeyboardProtocols()
@@ -270,6 +282,26 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	return m, nil
+}
+
+// scheduleRelayout bumps the resize generation and returns a debounced tick. A
+// later resize bumps the generation again, so only the last tick in a burst
+// actually relayouts. It is a no-op when no Relayout callback is wired (tests).
+func (m *model) scheduleRelayout() tea.Cmd {
+	if m.opts.Relayout == nil {
+		return nil
+	}
+	m.relayoutGen++
+	gen := m.relayoutGen
+	return tea.Tick(relayoutDebounce, func(time.Time) tea.Msg { return relayoutTickMsg{gen: gen} })
+}
+
+func (m model) relayoutCmd() tea.Cmd {
+	relayout := m.opts.Relayout
+	if relayout == nil {
+		return nil
+	}
+	return func() tea.Msg { return relayoutDoneMsg{err: relayout()} }
 }
 
 func (m *model) resumeKeyboardProtocols() {

--- a/site/content/docs/quickstart.ja.md
+++ b/site/content/docs/quickstart.ja.md
@@ -62,7 +62,7 @@ live 実行は次のステップで進みます。
 3. Sub-issues と親タスクリスト行の和集合で子を列挙する（OPEN の子のみ処理）。
 4. `.fanout/state.json` を読み、`(parent, issueNum)` ペアが記録済みの子はスキップする。
 5. 対象 issue ごとに、issue 本文と短い Requirements チェックリストからなる briefing を書き出す。
-6. fresh 化した base branch から `.fanout/worktrees/<slug>/` を作り、`tmux split-window` で子ペインを選択せずに開き、ペインタイトルを設定して `tmux select-layout tiled` を適用し、次の子に進む前に `--sleep` 秒（既定 4）スリープする。
+6. fresh 化した base branch から `.fanout/worktrees/<slug>/` を作り、`tmux split-window` で子ペインを選択せずに開き、ペインタイトルを設定してウィンドウを快適幅グリッドに組み直し（失敗時は `main-vertical` → `tiled` にフォールバック）、次の子に進む前に `--sleep` 秒（既定 4）スリープする。
 7. created / skipped / deferred / failed の件数サマリを表示する。
 
 > ペイン起動プロンプトが短いのは意図的です。完全な issue 本文は briefing ファイルにあり、エージェントはそれを読むよう指示されます。`deferred` は `--unblocked-only` 指定時のみ現れ、OPEN な blocker が残る子を保留します。

--- a/site/content/docs/quickstart.md
+++ b/site/content/docs/quickstart.md
@@ -62,7 +62,7 @@ A live run walks these steps:
 3. Enumerates children as the union of Sub-issues and parent task-list rows; only OPEN children are processed.
 4. Reads `.fanout/state.json` and skips children whose `(parent, issueNum)` pair is already recorded.
 5. Writes a briefing for each target with the issue body and a short Requirements checklist.
-6. Creates `.fanout/worktrees/<slug>/` from the refreshed base branch, creates the child pane with `tmux split-window` without selecting it, sets the pane title, applies `tmux select-layout tiled`, then sleeps `--sleep` seconds (default 4) before the next child.
+6. Creates `.fanout/worktrees/<slug>/` from the refreshed base branch, creates the child pane with `tmux split-window` without selecting it, sets the pane title, re-lays out the window into a comfortable-width grid (falling back to `main-vertical` then `tiled`), then sleeps `--sleep` seconds (default 4) before the next child.
 7. Prints a summary of created / skipped / deferred / failed counts.
 
 > The pane launch prompt stays short on purpose: the full issue body lives in the briefing file, and the agent is told to read it from there. `deferred` only appears with `--unblocked-only`, which holds back children that still have an OPEN blocker.

--- a/tests/golden/scenario-body-task-list.dry-run.txt
+++ b/tests/golden/scenario-body-task-list.dry-run.txt
@@ -22,7 +22,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#200 · first-task-201'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] #201: dry-run complete
@@ -43,7 +44,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#200 · second-task-202'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] #202: dry-run complete

--- a/tests/golden/scenario-cross-parent-shared.dry-run.txt
+++ b/tests/golden/scenario-cross-parent-shared.dry-run.txt
@@ -21,7 +21,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#200 · shared-child-parent-200-501'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] #501: dry-run complete
@@ -42,7 +43,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#200 · b-only-child-502'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] #502: dry-run complete

--- a/tests/golden/scenario-idempotency.dry-run.txt
+++ b/tests/golden/scenario-idempotency.dry-run.txt
@@ -22,7 +22,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#800 · new-target-802'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] #802: dry-run complete

--- a/tests/golden/scenario-include.dry-run.txt
+++ b/tests/golden/scenario-include.dry-run.txt
@@ -22,7 +22,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#400 · included-child-a-401'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] #401: dry-run complete
@@ -43,7 +44,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#400 · included-child-b-402'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] #402: dry-run complete

--- a/tests/golden/scenario-legacy-weak-signal.dry-run.txt
+++ b/tests/golden/scenario-legacy-weak-signal.dry-run.txt
@@ -22,7 +22,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#600 · first-task-601'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] #601: dry-run complete
@@ -43,7 +44,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#600 · second-task-602'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] #602: dry-run complete

--- a/tests/golden/scenario-limit.dry-run.txt
+++ b/tests/golden/scenario-limit.dry-run.txt
@@ -21,7 +21,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#700 · alpha-701'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] #701: dry-run complete
@@ -42,7 +43,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#700 · bravo-702'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] #702: dry-run complete

--- a/tests/golden/scenario-only.dry-run.txt
+++ b/tests/golden/scenario-only.dry-run.txt
@@ -25,7 +25,8 @@ filtered out:
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#500 · alpha-501'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] #501: dry-run complete
@@ -46,7 +47,8 @@ filtered out:
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#500 · charlie-503'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] #503: dry-run complete

--- a/tests/golden/scenario-plan-basic-agent-override.dry-run.txt
+++ b/tests/golden/scenario-plan-basic-agent-override.dry-run.txt
@@ -20,7 +20,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label 'plan:launch-plan · launch-plan-define-base-types-base-types'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] base-types: dry-run complete
@@ -41,7 +42,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label 'plan:launch-plan · launch-plan-extract-api-client-api-client'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] api-client: dry-run complete

--- a/tests/golden/scenario-plan-basic-team.dry-run.txt
+++ b/tests/golden/scenario-plan-basic-team.dry-run.txt
@@ -20,7 +20,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label 'plan:launch-plan · launch-plan-define-base-types-base-types'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] base-types: dry-run complete
@@ -41,7 +42,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label 'plan:launch-plan · launch-plan-extract-api-client-api-client'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] api-client: dry-run complete

--- a/tests/golden/scenario-plan-basic.dry-run.txt
+++ b/tests/golden/scenario-plan-basic.dry-run.txt
@@ -20,7 +20,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label 'plan:launch-plan · launch-plan-define-base-types-base-types'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] base-types: dry-run complete
@@ -41,7 +42,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label 'plan:launch-plan · launch-plan-extract-api-client-api-client'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] api-client: dry-run complete

--- a/tests/golden/scenario-plan-blocked.dry-run.txt
+++ b/tests/golden/scenario-plan-blocked.dry-run.txt
@@ -24,7 +24,8 @@ filtered out:
     $ tmux set-option -p -t <pane_id> @fanout_pane_label 'plan:launch-plan · launch-plan-extract-api-client-api-client'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] api-client: dry-run complete

--- a/tests/golden/scenario-plan-complete-blocker.dry-run.txt
+++ b/tests/golden/scenario-plan-complete-blocker.dry-run.txt
@@ -21,7 +21,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label 'plan:launch-plan · launch-plan-extract-api-client-api-client'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] api-client: dry-run complete

--- a/tests/golden/scenario-plan-fresh-blocker.dry-run.txt
+++ b/tests/golden/scenario-plan-fresh-blocker.dry-run.txt
@@ -25,7 +25,8 @@ deferred (blocked):
     $ tmux set-option -p -t <pane_id> @fanout_pane_label 'plan:launch-plan · launch-plan-define-base-types-base-types'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] base-types: dry-run complete

--- a/tests/golden/scenario-plan-limit.dry-run.txt
+++ b/tests/golden/scenario-plan-limit.dry-run.txt
@@ -20,7 +20,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label 'plan:launch-plan · launch-plan-define-base-types-base-types'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] base-types: dry-run complete
@@ -41,7 +42,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label 'plan:launch-plan · launch-plan-extract-api-client-api-client'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] api-client: dry-run complete

--- a/tests/golden/scenario-project-basic.dry-run.txt
+++ b/tests/golden/scenario-project-basic.dry-run.txt
@@ -22,7 +22,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label 'users/butaosuinu/projects/3 · first-todo-item-901'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] #901: dry-run complete
@@ -43,7 +44,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label 'users/butaosuinu/projects/3 · second-todo-item-902'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] #902: dry-run complete

--- a/tests/golden/scenario-project-cross-repo.dry-run.txt
+++ b/tests/golden/scenario-project-cross-repo.dry-run.txt
@@ -23,7 +23,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label 'users/butaosuinu/projects/3 · self-repo-todo-921'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] #921: dry-run complete

--- a/tests/golden/scenario-project-status-all.dry-run.txt
+++ b/tests/golden/scenario-project-status-all.dry-run.txt
@@ -22,7 +22,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label 'users/butaosuinu/projects/3 · todo-one-911'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] #911: dry-run complete
@@ -43,7 +44,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label 'users/butaosuinu/projects/3 · todo-two-912'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] #912: dry-run complete
@@ -64,7 +66,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label 'users/butaosuinu/projects/3 · done-item-913'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] #913: dry-run complete

--- a/tests/golden/scenario-prviz-disabled.dry-run.txt
+++ b/tests/golden/scenario-prviz-disabled.dry-run.txt
@@ -21,7 +21,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · first-child-101'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] #101: dry-run complete
@@ -42,7 +43,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · second-child-102'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] #102: dry-run complete

--- a/tests/golden/scenario-settings-disabled.dry-run.txt
+++ b/tests/golden/scenario-settings-disabled.dry-run.txt
@@ -21,7 +21,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · first-child-101'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] #101: dry-run complete
@@ -42,7 +43,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · second-child-102'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] #102: dry-run complete

--- a/tests/golden/scenario-skip.dry-run.txt
+++ b/tests/golden/scenario-skip.dry-run.txt
@@ -25,7 +25,8 @@ filtered out:
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#600 · alpha-601'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] #601: dry-run complete
@@ -46,7 +47,8 @@ filtered out:
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#600 · charlie-603'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] #603: dry-run complete

--- a/tests/golden/scenario-sub-issue-only-agent-override.dry-run.txt
+++ b/tests/golden/scenario-sub-issue-only-agent-override.dry-run.txt
@@ -21,7 +21,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · first-child-101'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] #101: dry-run complete
@@ -42,7 +43,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · second-child-102'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] #102: dry-run complete

--- a/tests/golden/scenario-sub-issue-only-branch-override.dry-run.txt
+++ b/tests/golden/scenario-sub-issue-only-branch-override.dry-run.txt
@@ -22,7 +22,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · Feature X'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] #101: dry-run complete
@@ -43,7 +44,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · second-child-102'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] #102: dry-run complete

--- a/tests/golden/scenario-sub-issue-only-codex-plan.dry-run.txt
+++ b/tests/golden/scenario-sub-issue-only-codex-plan.dry-run.txt
@@ -23,7 +23,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · first-child-101'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # fanout waits for Plan Mode thread setup and Codex TUI attach before recording state
     # status file: /tmp/fanout-codex-plan-project_root-101.json
     # would write .fanout/state.json with paneId <pane_id>
@@ -48,7 +49,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · second-child-102'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # fanout waits for Plan Mode thread setup and Codex TUI attach before recording state
     # status file: /tmp/fanout-codex-plan-project_root-102.json
     # would write .fanout/state.json with paneId <pane_id>

--- a/tests/golden/scenario-sub-issue-only-codex.dry-run.txt
+++ b/tests/golden/scenario-sub-issue-only-codex.dry-run.txt
@@ -21,7 +21,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · first-child-101'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] #101: dry-run complete
@@ -42,7 +43,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · second-child-102'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] #102: dry-run complete

--- a/tests/golden/scenario-sub-issue-only-team.dry-run.txt
+++ b/tests/golden/scenario-sub-issue-only-team.dry-run.txt
@@ -21,7 +21,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · first-child-101'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] #101: dry-run complete
@@ -42,7 +43,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · second-child-102'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] #102: dry-run complete

--- a/tests/golden/scenario-sub-issue-only.dry-run.txt
+++ b/tests/golden/scenario-sub-issue-only.dry-run.txt
@@ -21,7 +21,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · first-child-101'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] #101: dry-run complete
@@ -42,7 +43,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · second-child-102'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] #102: dry-run complete

--- a/tests/golden/scenario-union.dry-run.txt
+++ b/tests/golden/scenario-union.dry-run.txt
@@ -22,7 +22,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#300 · api-child-301'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] #301: dry-run complete
@@ -43,7 +44,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#300 · body-only-302'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
-    $ tmux select-layout -t '%1' tiled
+    # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
+    #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
     # would write .fanout/worktree-metadata.json in the child worktree
 [ ok ] #302: dry-run complete


### PR DESCRIPTION
## 概要

dmux 同様に、新しい pane が作られたときに pane レイアウトを自動調整する。従来は pane 作成のたびに `tmux select-layout tiled` を呼ぶだけで、pane が増えると全 pane が等分に潰れ TUI コンソールも巻き込まれていた。これを dmux のアルゴリズムに倣った賢いレイアウトへ格上げする。

dmux(`standardagents/dmux`)の実装をソースから調査し、`tiled` ではなく次のレイアウトを移植した:

- 固定幅サイドバー(TUI コンソール、40 桁)を確保
- 残りを **快適幅(60–100 桁)を最大化する列数**でグリッド配置(列数はスコアリングで決定)
- 最終行が短く余白が広いときは **spacer pane** を挿入して快適幅を維持
- これを **カスタム tmux layout 文字列(16bit checksum 付き)**で一括適用、失敗時は `main-vertical` → `tiled` にフォールバック
- **pane 作成 / 終了 / 端末リサイズ**で再計算

## 主な変更

| 領域 | 内容 |
|---|---|
| `internal/panelayout`(新規) | 純粋計算(`DecidePlan` 列数スコアリング / `Render` layout 文字列 / `Checksum`)+ orchestration(`Apply`)。`ops` 注入でテスト可能、`apply` 全体を mutex で直列化、resize は per-window memo で重複排除しフィードバックループを遮断 |
| `internal/tmuxrun/layout.go`(新規) | tmux verb: `WindowGeometry` / `WindowOfPane` / `WindowPanes` / `ApplyLayout` / `SelectMainVertical` / `SetPaneRole` / `SplitSpacerPane`。`SelectTiled` は最終フォールバックとして存置 |
| 発火点 | `pane.go` / `tui_launch.go`(作成、いずれも state 記録成功後に layout)、`lifecycle.go`(終了、window 単位で 1 回)、`internal/tui`(リサイズを debounce) |
| サイドバー識別 | TUI コンソール pane を `@fanout_role console` でマーク(`markTUIRunning`)、終了時に解除して relayout |
| dry-run / docs | dry-run 出力をコメント化し Tier2 golden(27 件)を再生成、`quickstart.md` / `quickstart.ja.md` を新挙動へ更新 |

## 挙動の境界 / 既知の制約

- カスタム layout 文字列は window 内の**全 pane を配置する必要がある**ため、自動レイアウトはウィンドウ全体を管理する(`tiled` が常にそうだったのと同じ方針)。手動分割 pane がある既存ウィンドウ内で `fanout` TUI を起動した場合、リサイズで手動配置が再構成される。プレーンシェルから起動する専用 fanout セッションでは発生しない。
- 端末リサイズ追従は TUI 常駐時のみ(batch モードは追従しないが、次の作成/終了で再適用される)。
- spacer pane は常駐 TUI(コンソール存在時)のみ生成し、毎 relayout で目標数に reconcile する自己修復方式。batch では孤児化を避けるため生成しない。

## テスト

- `go test ./...` 全通過(`internal/panelayout` の checksum / Render golden は実 tmux 3.6a 採取値に固定、apply の分岐は fake 注入で網羅)
- `make lint`(golangci-lint v2 + shellcheck)0 issues
- bats tier1 / tier2 通過、dry-run golden 再生成済み
- 実 tmux での end-to-end 検証: コンソール + 3 pane で `40 桁サイドバー + 67/65/65 グリッド`が tmux に受理されることを確認

## レビュー

`/post-work-review` 実施済み。code-review(xhigh)で 9 件、codex review 3 反復で 3 件の correctness 指摘を修正し、最終 codex review は approve。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ChEjetqWG8cGaemxNBZDBR
