### PR TITLE
[codex] TUI の Codex 新規 Session 起動を修正

### DIFF
--- a/cmd/fanout/codex_plan_tui.go
+++ b/cmd/fanout/codex_plan_tui.go
@@ -36,6 +36,7 @@ const (
 	codexPlanDefaultEffort           = "xhigh"
 	codexRemoteAppConnectTimeout     = 10 * time.Second
 	codexRemoteTUIStartupGrace       = 3 * time.Second
+	codexPlanSeedAssistantText       = "Ready."
 	codexPlanUserInputFallbackAnswer = "fanout Codex Plan Mode is starting interactively; proceed with the implementation plan using stated assumptions, and call out any ambiguity instead of asking for input."
 	webSocketGUID                    = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
 )
@@ -81,6 +82,16 @@ type appServerMessage struct {
 	Params json.RawMessage `json:"params,omitempty"`
 	Result json.RawMessage `json:"result,omitempty"`
 	Error  json.RawMessage `json:"error,omitempty"`
+}
+
+type codexPlanTurnStartResult struct {
+	TurnID    string
+	Completed bool
+}
+
+type codexTurnCompletion struct {
+	Matched bool
+	Status  string
 }
 
 type codexAppClient struct {
@@ -205,36 +216,41 @@ func runCodexPlanTUI(cfg codexPlanTUIConfig, stdout, stderr io.Writer) (err erro
 	if err != nil {
 		return err
 	}
+	defer client.Close()
 
 	cwd, err := os.Getwd()
 	if err != nil {
-		client.Close()
 		return fmt.Errorf("resolve current directory: %w", err)
 	}
 	thread, err := setupCodexPlanThread(client, cwd)
 	if err != nil {
-		client.Close()
 		return err
 	}
-	drainDone := make(chan error)
-	tuiPrompt := cfg.Prompt
+	var drainDone chan error
+	tuiPrompt := ""
 	if thread.UseTurnCollaborationMode {
-		if err = startCodexPlanTurn(client, thread, cwd, cfg.Prompt); err != nil {
-			client.Close()
+		var turnStart codexPlanTurnStartResult
+		turnStart, err = startCodexPlanTurn(client, thread, cwd, cfg.Prompt)
+		if err != nil {
 			return err
 		}
-		drainDone = make(chan error, 1)
-		go func() { drainDone <- drainCodexAppServer(client) }()
-		tuiPrompt = ""
+		if turnStart.Completed {
+			client.Close()
+		} else {
+			drainDone = make(chan error, 1)
+			go func() { drainDone <- drainCodexAppServerUntilTurnComplete(client, thread.ID, turnStart.TurnID) }()
+		}
 	} else {
+		err = seedCodexPlanThreadForResume(client, thread.ID)
+		if err != nil {
+			return err
+		}
 		client.Close()
+		tuiPrompt = cfg.Prompt
 	}
 
 	tui, tuiDone, err := startCodexRemoteTUI(cfg.CodexPath, server.Addr, thread.ID, tuiPrompt, stdout, stderr)
 	if err != nil {
-		if thread.UseTurnCollaborationMode {
-			client.Close()
-		}
 		return err
 	}
 	tuiStopped := false
@@ -244,19 +260,30 @@ func runCodexPlanTUI(cfg codexPlanTUIConfig, stdout, stderr io.Writer) (err erro
 		}
 	}()
 
-	select {
-	case tuiErr := <-tuiDone:
-		tuiStopped = true
-		if tuiErr != nil {
-			return fmt.Errorf("codex TUI resume exited during startup: %w", tuiErr)
+	startupTimer := time.NewTimer(codexRemoteTUIStartupGrace)
+	defer startupTimer.Stop()
+	for waitingStartup := true; waitingStartup; {
+		select {
+		case tuiErr := <-tuiDone:
+			tuiStopped = true
+			if tuiErr != nil {
+				return fmt.Errorf("codex TUI resume exited during startup: %w", tuiErr)
+			}
+			return fmt.Errorf("codex TUI resume exited during startup")
+		case drainErr := <-drainDone:
+			client.Close()
+			drainDone = nil
+			if drainErr != nil {
+				return fmt.Errorf("codex app-server request handling failed during TUI startup: %w", drainErr)
+			}
+		case <-server.done:
+			if _, serverErr := server.Exited(); serverErr != nil {
+				return fmt.Errorf("codex app-server exited during TUI startup: %w%s", serverErr, serverLogSuffix(server))
+			}
+			return fmt.Errorf("codex app-server exited during TUI startup%s", serverLogSuffix(server))
+		case <-startupTimer.C:
+			waitingStartup = false
 		}
-		return fmt.Errorf("codex TUI resume exited during startup")
-	case drainErr := <-drainDone:
-		if drainErr != nil {
-			return fmt.Errorf("codex app-server disconnected during TUI startup: %w", drainErr)
-		}
-		return fmt.Errorf("codex app-server disconnected during TUI startup")
-	case <-time.After(codexRemoteTUIStartupGrace):
 	}
 
 	if err = writeCodexPlanTUIStatus(cfg.StatusFile, codexPlanTUIStatus{
@@ -268,13 +295,9 @@ func runCodexPlanTUI(cfg codexPlanTUIConfig, stdout, stderr io.Writer) (err erro
 		return fmt.Errorf("write Codex Plan TUI status: %w", err)
 	}
 	ready = true
-	if thread.UseTurnCollaborationMode {
-		tuiExited, err := waitForCodexTUIAfterReady(tuiDone, drainDone)
-		tuiStopped = tuiExited
-		return err
-	}
-	tuiStopped = true
-	return <-tuiDone
+	tuiExited, err := waitForCodexTUIAfterReady(tuiDone, drainDone, client)
+	tuiStopped = tuiExited
+	return err
 }
 
 func setupCodexPlanThread(client codexAppSessionClient, cwd string) (codexThreadInfo, error) {
@@ -339,15 +362,21 @@ func codexThreadStartParams(cwd, model string) map[string]any {
 	}
 }
 
-func startCodexPlanTurn(client codexAppRequester, thread codexThreadInfo, cwd, prompt string) error {
-	params := codexTurnStartParams(thread.ID, cwd, thread.Model, prompt, nil)
-	if thread.UseTurnCollaborationMode {
-		params["collaborationMode"] = codexPlanCollaborationMode(thread.Model, thread.PlanEffort)
+func startCodexPlanTurn(client codexAppRequester, thread codexThreadInfo, cwd, prompt string) (codexPlanTurnStartResult, error) {
+	params := codexTurnStartParams(thread.ID, cwd, thread.Model, prompt, codexPlanCollaborationMode(thread.Model, thread.PlanEffort))
+	result, err := client.Request("fanout-turn", "turn/start", params)
+	if err != nil {
+		return codexPlanTurnStartResult{}, err
 	}
-	if _, err := client.Request("fanout-turn", "turn/start", params); err != nil {
-		return err
+	status, turnID := codexTurnStartStatus(result)
+	switch status {
+	case "completed":
+		return codexPlanTurnStartResult{TurnID: turnID, Completed: true}, nil
+	case "failed", "interrupted":
+		return codexPlanTurnStartResult{}, fmt.Errorf("codex initial plan turn ended with status %q", status)
+	default:
+		return codexPlanTurnStartResult{TurnID: turnID}, nil
 	}
-	return nil
 }
 
 func codexTurnStartParams(threadID, cwd, model, prompt string, collaborationMode map[string]any) map[string]any {
@@ -366,6 +395,28 @@ func codexTurnStartParams(threadID, cwd, model, prompt string, collaborationMode
 		params["collaborationMode"] = collaborationMode
 	}
 	return params
+}
+
+func seedCodexPlanThreadForResume(client codexAppRequester, threadID string) error {
+	_, err := client.Request("fanout-seed", "thread/inject_items", map[string]any{
+		"threadId": threadID,
+		"items": []map[string]any{
+			{
+				"type": "message",
+				"role": "assistant",
+				"content": []map[string]any{
+					{
+						"type": "output_text",
+						"text": codexPlanSeedAssistantText,
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("seed Codex Plan TUI thread for resume: %w", err)
+	}
+	return nil
 }
 
 func codexPlanSettingsUpdateParams(threadID, model, effort string) map[string]any {
@@ -910,24 +961,31 @@ func readUntilResponse(client *codexAppClient, id string) (json.RawMessage, erro
 	}
 }
 
-func waitForCodexTUIAfterReady(tuiDone, drainDone <-chan error) (bool, error) {
-	select {
-	case tuiErr := <-tuiDone:
-		return true, tuiErr
-	case drainErr := <-drainDone:
-		if drainErr != nil {
-			return false, fmt.Errorf("codex app-server request handling failed while Codex TUI was attached: %w", drainErr)
+func waitForCodexTUIAfterReady(tuiDone <-chan error, drainDone <-chan error, client *codexAppClient) (bool, error) {
+	for drainDone != nil {
+		select {
+		case tuiErr := <-tuiDone:
+			return true, tuiErr
+		case drainErr := <-drainDone:
+			client.Close()
+			drainDone = nil
+			if drainErr != nil {
+				return false, fmt.Errorf("codex app-server request handling failed while Codex TUI was attached: %w", drainErr)
+			}
 		}
-		return false, fmt.Errorf("codex app-server disconnected while Codex TUI was attached")
 	}
+	return true, <-tuiDone
 }
 
-func drainCodexAppServer(client *codexAppClient) error {
+func drainCodexAppServerUntilTurnComplete(client *codexAppClient, threadID, turnID string) error {
 	for {
 		msg, err := client.Receive()
 		if err != nil {
-			if errors.Is(err, net.ErrClosed) || errors.Is(err, io.EOF) || errors.Is(err, io.ErrClosedPipe) {
+			if errors.Is(err, net.ErrClosed) || errors.Is(err, io.ErrClosedPipe) {
 				return nil
+			}
+			if errors.Is(err, io.EOF) {
+				return fmt.Errorf("codex app-server disconnected before initial turn completed: %w", err)
 			}
 			return err
 		}
@@ -936,6 +994,78 @@ func drainCodexAppServer(client *codexAppClient) error {
 				return err
 			}
 		}
+		completion := codexTurnCompletedNotification(msg, threadID, turnID)
+		if completion.Matched {
+			if completion.Status != "completed" {
+				return fmt.Errorf("codex initial plan turn ended with status %q", completion.Status)
+			}
+			return nil
+		}
+	}
+}
+
+func codexTurnStartStatus(raw json.RawMessage) (string, string) {
+	var res struct {
+		Turn struct {
+			ID     string `json:"id"`
+			Status string `json:"status"`
+		} `json:"turn"`
+	}
+	if err := json.Unmarshal(raw, &res); err != nil {
+		return "", ""
+	}
+	return strings.TrimSpace(res.Turn.Status), strings.TrimSpace(res.Turn.ID)
+}
+
+func codexTurnCompletedNotification(msg appServerMessage, threadID, turnID string) codexTurnCompletion {
+	if msg.Method != "turn/completed" {
+		return codexTurnCompletion{}
+	}
+	var params struct {
+		ThreadID string `json:"threadId"`
+		Turn     struct {
+			ID       string `json:"id"`
+			ThreadID string `json:"threadId"`
+			Status   string `json:"status"`
+		} `json:"turn"`
+	}
+	if err := json.Unmarshal(msg.Params, &params); err != nil {
+		return codexTurnCompletion{}
+	}
+	status := strings.TrimSpace(params.Turn.Status)
+	if !isTerminalCodexTurnStatus(status) {
+		return codexTurnCompletion{}
+	}
+	if !codexTurnCompletionMatches(params.ThreadID, params.Turn.ThreadID, params.Turn.ID, threadID, turnID) {
+		return codexTurnCompletion{}
+	}
+	return codexTurnCompletion{Matched: true, Status: status}
+}
+
+func codexTurnCompletionMatches(topLevelThreadID, turnThreadID, actualTurnID, expectedThreadID, expectedTurnID string) bool {
+	topLevelThreadID = strings.TrimSpace(topLevelThreadID)
+	turnThreadID = strings.TrimSpace(turnThreadID)
+	actualTurnID = strings.TrimSpace(actualTurnID)
+	expectedThreadID = strings.TrimSpace(expectedThreadID)
+	expectedTurnID = strings.TrimSpace(expectedTurnID)
+
+	if expectedTurnID != "" && actualTurnID != "" {
+		return actualTurnID == expectedTurnID
+	}
+	if expectedThreadID != "" && (topLevelThreadID != "" || turnThreadID != "") {
+		return topLevelThreadID == expectedThreadID || turnThreadID == expectedThreadID
+	}
+	// Older app-server payloads may only include {"turn":{"status":...}}.
+	// In fallback mode this controller starts exactly one initial turn.
+	return topLevelThreadID == "" && turnThreadID == "" && actualTurnID == ""
+}
+
+func isTerminalCodexTurnStatus(status string) bool {
+	switch strings.TrimSpace(status) {
+	case "completed", "interrupted", "failed":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/cmd/fanout/codex_plan_tui_test.go
+++ b/cmd/fanout/codex_plan_tui_test.go
@@ -135,7 +135,7 @@ func TestCodexTurnStartParamsCanCarryPlanCollaborationMode(t *testing.T) {
 	}
 }
 
-func TestCodexPlanThreadLeavesInitialTurnForTUIAfterSettingsUpdate(t *testing.T) {
+func TestCodexPlanThreadConfiguresPlanModeBeforeInitialTurn(t *testing.T) {
 	client := &fakeCodexAppClient{}
 
 	thread, err := setupCodexPlanThread(client, "/repo")
@@ -151,11 +151,44 @@ func TestCodexPlanThreadLeavesInitialTurnForTUIAfterSettingsUpdate(t *testing.T)
 		t.Fatalf("request order = %s, want %s", got, want)
 	}
 	if client.hasRequest("turn/start") {
-		t.Fatal("setupCodexPlanThread started a turn; want initial prompt left for the interactive TUI")
+		t.Fatal("setupCodexPlanThread started a turn; want runCodexPlanTUI to start the initial turn")
 	}
 }
 
-func TestCodexPlanThreadStartsInitialTurnWithFallbackCollaborationMode(t *testing.T) {
+func TestCodexPlanThreadStartsInitialTurnAfterSettingsUpdate(t *testing.T) {
+	client := &fakeCodexAppClient{}
+
+	thread, err := setupCodexPlanThread(client, "/repo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	turnStart, err := startCodexPlanTurn(client, thread, "/repo", "hello plan")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if turnStart.Completed {
+		t.Fatal("Completed = true, want false for in-progress turn response")
+	}
+
+	turn := client.lastRequest("turn/start").paramsMap(t)
+	mode, ok := turn["collaborationMode"].(map[string]any)
+	if !ok {
+		t.Fatalf("turn/start missing collaborationMode: %#v", turn)
+	}
+	if mode["mode"] != "plan" {
+		t.Fatalf("collaborationMode.mode = %q, want plan", mode["mode"])
+	}
+	settings, ok := mode["settings"].(map[string]any)
+	if !ok {
+		t.Fatalf("collaborationMode.settings = %#v, want map", mode["settings"])
+	}
+	if settings["model"] != "gpt-test" || settings["reasoning_effort"] != "xhigh" {
+		t.Fatalf("settings = %#v, want model gpt-test and effort xhigh", settings)
+	}
+	assertTurnStartText(t, turn, "hello plan")
+}
+
+func TestCodexPlanThreadStartsInitialTurnWhenSettingsUpdateIsUnsupported(t *testing.T) {
 	client := &fakeCodexAppClient{
 		methodErrors: map[string]error{
 			"thread/settings/update": errors.New(`unknown method "thread/settings/update"`),
@@ -169,8 +202,12 @@ func TestCodexPlanThreadStartsInitialTurnWithFallbackCollaborationMode(t *testin
 	if !thread.UseTurnCollaborationMode {
 		t.Fatal("UseTurnCollaborationMode = false, want true when thread/settings/update is unsupported")
 	}
-	if err = startCodexPlanTurn(client, thread, "/repo", "hello fallback"); err != nil {
+	turnStart, err := startCodexPlanTurn(client, thread, "/repo", "hello fallback")
+	if err != nil {
 		t.Fatal(err)
+	}
+	if turnStart.Completed {
+		t.Fatal("Completed = true, want false for in-progress turn response")
 	}
 
 	turn := client.lastRequest("turn/start").paramsMap(t)
@@ -189,6 +226,70 @@ func TestCodexPlanThreadStartsInitialTurnWithFallbackCollaborationMode(t *testin
 		t.Fatalf("fallback settings = %#v, want model gpt-test and effort xhigh", settings)
 	}
 	assertTurnStartText(t, turn, "hello fallback")
+}
+
+func TestCodexPlanTurnStartReportsCompletedStatus(t *testing.T) {
+	client := &fakeCodexAppClient{
+		methodResults: map[string]json.RawMessage{
+			"turn/start": json.RawMessage(`{"turn":{"id":"turn-1","status":"completed"}}`),
+		},
+	}
+	thread := codexThreadInfo{ID: "thread-1", Model: "gpt-test", PlanEffort: "xhigh"}
+
+	turnStart, err := startCodexPlanTurn(client, thread, "/repo", "hello")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !turnStart.Completed {
+		t.Fatal("Completed = false, want true for completed turn response")
+	}
+	if turnStart.TurnID != "turn-1" {
+		t.Fatalf("TurnID = %q, want turn-1", turnStart.TurnID)
+	}
+}
+
+func TestCodexPlanTurnStartErrorsOnFailedStatus(t *testing.T) {
+	client := &fakeCodexAppClient{
+		methodResults: map[string]json.RawMessage{
+			"turn/start": json.RawMessage(`{"turn":{"id":"turn-1","status":"failed"}}`),
+		},
+	}
+	thread := codexThreadInfo{ID: "thread-1", Model: "gpt-test", PlanEffort: "xhigh"}
+
+	_, err := startCodexPlanTurn(client, thread, "/repo", "hello")
+
+	if err == nil || !strings.Contains(err.Error(), `status "failed"`) {
+		t.Fatalf("error = %v, want failed status error", err)
+	}
+}
+
+func TestSeedCodexPlanThreadForResumeInjectsReadyAssistantItem(t *testing.T) {
+	client := &fakeCodexAppClient{}
+
+	if err := seedCodexPlanThreadForResume(client, "thread-1"); err != nil {
+		t.Fatal(err)
+	}
+
+	req := client.lastRequest("thread/inject_items")
+	params := req.paramsMap(t)
+	if params["threadId"] != "thread-1" {
+		t.Fatalf("threadId = %q, want thread-1", params["threadId"])
+	}
+	items, ok := params["items"].([]map[string]any)
+	if !ok || len(items) != 1 {
+		t.Fatalf("items = %#v, want one injected item", params["items"])
+	}
+	if items[0]["type"] != "message" || items[0]["role"] != "assistant" {
+		t.Fatalf("item = %#v, want assistant message", items[0])
+	}
+	content, ok := items[0]["content"].([]map[string]any)
+	if !ok || len(content) != 1 {
+		t.Fatalf("content = %#v, want one output_text item", items[0]["content"])
+	}
+	if content[0]["type"] != "output_text" || content[0]["text"] != codexPlanSeedAssistantText {
+		t.Fatalf("content = %#v, want Ready output_text", content[0])
+	}
 }
 
 func TestConfigSettingsReadsModelAndReasoningEffort(t *testing.T) {
@@ -300,7 +401,7 @@ func TestWaitForCodexTUIAfterReadyReturnsTUIExit(t *testing.T) {
 	drainDone := make(chan error, 1)
 	tuiDone <- nil
 
-	tuiExited, err := waitForCodexTUIAfterReady(tuiDone, drainDone)
+	tuiExited, err := waitForCodexTUIAfterReady(tuiDone, drainDone, &codexAppClient{})
 
 	if !tuiExited {
 		t.Fatal("tuiExited = false, want true")
@@ -315,13 +416,71 @@ func TestWaitForCodexTUIAfterReadyReturnsDrainError(t *testing.T) {
 	drainDone := make(chan error, 1)
 	drainDone <- errors.New("unsupported request")
 
-	tuiExited, err := waitForCodexTUIAfterReady(tuiDone, drainDone)
+	tuiExited, err := waitForCodexTUIAfterReady(tuiDone, drainDone, &codexAppClient{})
 
 	if tuiExited {
 		t.Fatal("tuiExited = true, want false")
 	}
 	if err == nil || !strings.Contains(err.Error(), "unsupported request") {
 		t.Fatalf("error = %v, want unsupported request", err)
+	}
+}
+
+func TestWaitForCodexTUIAfterReadyIgnoresCompletedTurnDrain(t *testing.T) {
+	tuiDone := make(chan error, 1)
+	drainDone := make(chan error, 1)
+	drainDone <- nil
+	tuiDone <- nil
+
+	tuiExited, err := waitForCodexTUIAfterReady(tuiDone, drainDone, &codexAppClient{})
+
+	if !tuiExited {
+		t.Fatal("tuiExited = false, want true")
+	}
+	if err != nil {
+		t.Fatalf("error = %v, want nil", err)
+	}
+}
+
+func TestCodexTurnCompletedNotificationMatchesThread(t *testing.T) {
+	msg := appServerMessage{
+		Method: "turn/completed",
+		Params: json.RawMessage(`{"threadId":"thread-1","turn":{"status":"completed"}}`),
+	}
+
+	completion := codexTurnCompletedNotification(msg, "thread-1", "")
+	if !completion.Matched || completion.Status != "completed" {
+		t.Fatalf("completion = %+v, want completed match", completion)
+	}
+	if codexTurnCompletedNotification(msg, "thread-2", "").Matched {
+		t.Fatal("codexTurnCompletedNotification() matched the wrong thread")
+	}
+}
+
+func TestCodexTurnCompletedNotificationMatchesNestedTurn(t *testing.T) {
+	msg := appServerMessage{
+		Method: "turn/completed",
+		Params: json.RawMessage(`{"turn":{"id":"turn-1","threadId":"thread-1","status":"completed"}}`),
+	}
+
+	completion := codexTurnCompletedNotification(msg, "thread-1", "turn-1")
+	if !completion.Matched || completion.Status != "completed" {
+		t.Fatalf("completion = %+v, want completed match", completion)
+	}
+	if codexTurnCompletedNotification(msg, "thread-1", "turn-2").Matched {
+		t.Fatal("codexTurnCompletedNotification() matched the wrong turn")
+	}
+}
+
+func TestCodexTurnCompletedNotificationReportsFailedStatus(t *testing.T) {
+	msg := appServerMessage{
+		Method: "turn/completed",
+		Params: json.RawMessage(`{"turn":{"id":"turn-1","status":"failed"}}`),
+	}
+
+	completion := codexTurnCompletedNotification(msg, "thread-1", "turn-1")
+	if !completion.Matched || completion.Status != "failed" {
+		t.Fatalf("completion = %+v, want failed match", completion)
 	}
 }
 
@@ -362,6 +521,7 @@ type fakeCodexAppClient struct {
 	calls         []fakeCodexRequest
 	notifications []string
 	methodErrors  map[string]error
+	methodResults map[string]json.RawMessage
 }
 
 type fakeCodexRequest struct {
@@ -375,6 +535,9 @@ func (f *fakeCodexAppClient) Request(id, method string, params any) (json.RawMes
 	if err := f.methodErrors[method]; err != nil {
 		return nil, err
 	}
+	if result, ok := f.methodResults[method]; ok {
+		return result, nil
+	}
 	switch method {
 	case "collaborationMode/list":
 		return json.RawMessage(`{"data":[{"mode":"plan"}]}`), nil
@@ -384,6 +547,8 @@ func (f *fakeCodexAppClient) Request(id, method string, params any) (json.RawMes
 		return json.RawMessage(`{"data":[{"id":"gpt-test","model":"gpt-test","isDefault":true,"supportedReasoningEfforts":[{"reasoningEffort":"low"},{"reasoningEffort":"medium"},{"reasoningEffort":"high"},{"reasoningEffort":"xhigh"}]}]}`), nil
 	case "thread/start":
 		return json.RawMessage(`{"thread":{"id":"thread-1","sessionId":"session-1"}}`), nil
+	case "turn/start":
+		return json.RawMessage(`{"turn":{"status":"inProgress"}}`), nil
 	default:
 		return json.RawMessage(`{}`), nil
 	}


### PR DESCRIPTION
## TL;DR

fanout TUI の `n` から Codex の新規 Session を作る経路で、空の app-server thread をそのまま `codex resume` して落ちる問題を修正しました。

## 変更内容

- `thread/settings/update` が使える通常経路では、`thread/inject_items` で最小の `Ready.` assistant item を seed してから interactive Codex TUI に実プロンプトを渡すようにしました。
- `thread/settings/update` が使えない古い app-server 向け fallback では、従来通り `turn/start` で Plan Mode を指定し、初回 turn 完了まで controller connection を drain します。
- Codex TUI 起動直後の app-server 終了や drain error を startup 時にも検出するようにしました。
- seed item、fallback turn、turn completion 判定、TUI 待機処理の regression test を追加しました。

## 原因

現行 Codex CLI では、`thread/start` 直後の空 thread を `codex --remote ... resume <thread>` すると rollout が未作成のため `no rollout found` で失敗します。
一方で bootstrap turn をモデル応答完了まで待つ方式は pane startup timeout と競合し、完了前に実プロンプトを渡す方式は active turn と race します。
そのため、モデル turn を開始せずに thread を resume 可能な状態へ seed する形にしました。

## 確認

- 実機 tmux 上で `./fanout-go` の TUI を起動し、`n` から Codex pane を作成できることを確認
- 作成された pane で Codex TUI が manual Plan Mode prompt を受け取り `Working` 状態まで進むことを確認
- `make test`
- `make lint`
- `git diff --check`
- `codex review --uncommitted`
