### PR TITLE
feat(pane): tmux ペイン枠線を fanout テーマカラーに

### DIFF
--- a/cmd/fanout/pane.go
+++ b/cmd/fanout/pane.go
@@ -647,6 +647,8 @@ func printPaneDryRun(req paneRequest, target string, lg *log.Logger, c log.Palet
 	fmt.Fprintf(lg.Stdout(), "    %s$ tmux set-option -p -t <pane_id> @fanout_pane_label %s%s\n", c.Dim, shellQuote(tmuxrun.NeutralizePaneLabel(paneBorderLabel(req))), c.Reset)
 	fmt.Fprintf(lg.Stdout(), "    %s$ tmux set-option -w -t <pane_id> pane-border-status top%s\n", c.Dim, c.Reset)
 	fmt.Fprintf(lg.Stdout(), "    %s$ tmux set-option -w -t <pane_id> pane-border-format %s%s\n", c.Dim, shellQuote(tmuxrun.PaneBorderFormat()), c.Reset)
+	fmt.Fprintf(lg.Stdout(), "    %s$ tmux set-option -w -t <pane_id> pane-active-border-style %s%s\n", c.Dim, shellQuote(tmuxrun.PaneActiveBorderStyle()), c.Reset)
+	fmt.Fprintf(lg.Stdout(), "    %s$ tmux set-option -w -t <pane_id> pane-border-style %s%s\n", c.Dim, shellQuote(tmuxrun.PaneBorderStyle()), c.Reset)
 	fmt.Fprintf(lg.Stdout(), "    %s# would re-layout the window: fanout grid (sidebar + comfortable-width grid),%s\n", c.Dim, c.Reset)
 	fmt.Fprintf(lg.Stdout(), "    %s#   falling back to main-vertical then tiled%s\n", c.Dim, c.Reset)
 	if req.CodexPlanMode {

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -55,8 +55,9 @@ func paletteFor(term, colorterm string) Palette {
 		strings.EqualFold(colorterm, "truecolor") || strings.EqualFold(colorterm, "24bit") {
 		// 256-color approximations of the PAPER BREEZE palette
 		// (site/assets/css/main.css; keep in sync with the internal/tui
-		// AdaptiveColor palette): 藍, 青緑, 土, 紅 — mid-brightness values
-		// readable on both light and dark backgrounds.
+		// AdaptiveColor palette and the internal/tmuxrun pane-border hex):
+		// 藍, 青緑, 土, 紅 — mid-brightness values readable on both light
+		// and dark backgrounds.
 		p.Info = "\x1b[38;5;31m"
 		p.Ok = "\x1b[38;5;36m"
 		p.Warn = "\x1b[38;5;136m"

--- a/internal/tmuxrun/tmuxrun.go
+++ b/internal/tmuxrun/tmuxrun.go
@@ -41,6 +41,17 @@ const (
 	// #( / ## stay literal), so the "#<digit>" parent prefix is safe; only "#["
 	// is still interpreted at draw time as a style, which SetPaneLabel neutralizes.
 	paneBorderFormat = " #{?" + paneLabelOption + ",#{" + paneLabelOption + "},#{pane_title}} "
+	// paneActiveBorderStyle / paneBorderStyle recolor the pane borders to fanout's
+	// PAPER BREEZE palette: 浅葱 (asagi) for the active border, in place of tmux's
+	// default green, and 藍 (ai) for inactive borders. These are the site/light
+	// values from the palette (site/assets/css/main.css; keep in sync with the
+	// internal/tui AdaptiveColor and internal/log 256-color copies). Like
+	// internal/log, tmux cannot query the terminal background, so it cannot pick
+	// the AdaptiveColor dark variants the TUI uses; 浅葱 reads on both backgrounds
+	// and the 藍 inactive border is intentionally subtle. Truecolor hex; tmux
+	// falls back to the nearest 256-color when the terminal lacks RGB support.
+	paneActiveBorderStyle = "fg=#00A3AF"
+	paneBorderStyle       = "fg=#165E83"
 )
 
 // paneIDPattern matches a well-formed tmux pane id (%N). The live-pane parsers
@@ -343,6 +354,12 @@ func SetPaneShellKey(paneID, shellKey string) error {
 // applies, single-sourced here so the --dry-run preview matches the live command.
 func PaneBorderFormat() string { return paneBorderFormat }
 
+// PaneActiveBorderStyle and PaneBorderStyle return the pane border styles
+// EnablePaneBorderTitles applies, single-sourced here so the --dry-run preview
+// matches the live command.
+func PaneActiveBorderStyle() string { return paneActiveBorderStyle }
+func PaneBorderStyle() string       { return paneBorderStyle }
+
 // SetPaneLabel records the border label fanout displays on a pane's top border.
 // An empty label is allowed (the pane then falls back to #{pane_title}). The
 // label is neutralized first so a "#[...]" sequence in a --name / display
@@ -377,9 +394,16 @@ func NeutralizePaneLabel(label string) string {
 }
 
 // EnablePaneBorderTitles turns on top pane-border titles for the window holding
-// paneID and points pane-border-format at @fanout_pane_label. pane-border-status
-// is a window option (its finest granularity), so this affects every pane in the
-// window; non-fanout panes fall back to #{pane_title}. Re-applying is idempotent.
+// paneID, points pane-border-format at @fanout_pane_label, and recolors the pane
+// borders to fanout's theme (浅葱 active, 藍 inactive). pane-border-status and the
+// two *-border-style options are window options (their finest granularity), so
+// this affects every pane in the window: non-fanout panes fall back to
+// #{pane_title}, and any pane-border-style / pane-active-border-style the user
+// configured is overwritten for the window with no teardown (only the active
+// border defaults to green; the inactive default is the terminal foreground). On
+// the documented "use the current pane" path this restyles the user's existing
+// window — the same window-scope trade-off pane-border-status/-format already
+// make. Re-applying is idempotent.
 func EnablePaneBorderTitles(paneID string) error {
 	if strings.TrimSpace(paneID) == "" {
 		return fmt.Errorf("pane id is required")
@@ -389,6 +413,12 @@ func EnablePaneBorderTitles(paneID string) error {
 	}
 	if err := exec.Command("tmux", "set-option", "-w", "-t", paneID, "pane-border-format", paneBorderFormat).Run(); err != nil {
 		return fmt.Errorf("tmux set-option pane-border-format: %w", err)
+	}
+	if err := exec.Command("tmux", "set-option", "-w", "-t", paneID, "pane-active-border-style", paneActiveBorderStyle).Run(); err != nil {
+		return fmt.Errorf("tmux set-option pane-active-border-style: %w", err)
+	}
+	if err := exec.Command("tmux", "set-option", "-w", "-t", paneID, "pane-border-style", paneBorderStyle).Run(); err != nil {
+		return fmt.Errorf("tmux set-option pane-border-style: %w", err)
 	}
 	return nil
 }

--- a/internal/tmuxrun/tmuxrun_test.go
+++ b/internal/tmuxrun/tmuxrun_test.go
@@ -523,6 +523,8 @@ printf '%s\n' '---' >> "$TMUXRUN_ARGS"
 	want := strings.Join([]string{
 		"set-option", "-w", "-t", "%42", "pane-border-status", "top", "---",
 		"set-option", "-w", "-t", "%42", "pane-border-format", paneBorderFormat, "---",
+		"set-option", "-w", "-t", "%42", "pane-active-border-style", paneActiveBorderStyle, "---",
+		"set-option", "-w", "-t", "%42", "pane-border-style", paneBorderStyle, "---",
 	}, "\n") + "\n"
 	if string(body) != want {
 		t.Fatalf("tmux args body = %q, want %q", string(body), want)

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -5,7 +5,8 @@ import (
 )
 
 // PAPER BREEZE palette (site/assets/css/main.css; keep the internal/log
-// 256-color approximations in sync). Light = site values (紅 is an addition;
+// 256-color approximations and the internal/tmuxrun pane-border hex in sync).
+// Light = site values (紅 is an addition;
 // the site defines no red), dark = same hue lifted for dark backgrounds.
 var (
 	colorAi     = lipgloss.AdaptiveColor{Light: "#165E83", Dark: "#6FAECE"} // 藍

--- a/tests/golden/scenario-body-task-list.dry-run.txt
+++ b/tests/golden/scenario-body-task-list.dry-run.txt
@@ -22,6 +22,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#200 · first-task-201'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
@@ -44,6 +46,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#200 · second-task-202'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>

--- a/tests/golden/scenario-cross-parent-shared.dry-run.txt
+++ b/tests/golden/scenario-cross-parent-shared.dry-run.txt
@@ -21,6 +21,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#200 · shared-child-parent-200-501'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
@@ -43,6 +45,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#200 · b-only-child-502'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>

--- a/tests/golden/scenario-idempotency.dry-run.txt
+++ b/tests/golden/scenario-idempotency.dry-run.txt
@@ -22,6 +22,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#800 · new-target-802'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>

--- a/tests/golden/scenario-include.dry-run.txt
+++ b/tests/golden/scenario-include.dry-run.txt
@@ -22,6 +22,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#400 · included-child-a-401'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
@@ -44,6 +46,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#400 · included-child-b-402'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>

--- a/tests/golden/scenario-legacy-weak-signal.dry-run.txt
+++ b/tests/golden/scenario-legacy-weak-signal.dry-run.txt
@@ -22,6 +22,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#600 · first-task-601'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
@@ -44,6 +46,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#600 · second-task-602'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>

--- a/tests/golden/scenario-limit.dry-run.txt
+++ b/tests/golden/scenario-limit.dry-run.txt
@@ -21,6 +21,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#700 · alpha-701'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
@@ -43,6 +45,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#700 · bravo-702'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>

--- a/tests/golden/scenario-only.dry-run.txt
+++ b/tests/golden/scenario-only.dry-run.txt
@@ -25,6 +25,8 @@ filtered out:
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#500 · alpha-501'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
@@ -47,6 +49,8 @@ filtered out:
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#500 · charlie-503'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>

--- a/tests/golden/scenario-plan-basic-agent-override.dry-run.txt
+++ b/tests/golden/scenario-plan-basic-agent-override.dry-run.txt
@@ -20,6 +20,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label 'plan:launch-plan · launch-plan-define-base-types-base-types'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
@@ -42,6 +44,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label 'plan:launch-plan · launch-plan-extract-api-client-api-client'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>

--- a/tests/golden/scenario-plan-basic-team.dry-run.txt
+++ b/tests/golden/scenario-plan-basic-team.dry-run.txt
@@ -20,6 +20,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label 'plan:launch-plan · launch-plan-define-base-types-base-types'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
@@ -42,6 +44,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label 'plan:launch-plan · launch-plan-extract-api-client-api-client'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>

--- a/tests/golden/scenario-plan-basic.dry-run.txt
+++ b/tests/golden/scenario-plan-basic.dry-run.txt
@@ -20,6 +20,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label 'plan:launch-plan · launch-plan-define-base-types-base-types'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
@@ -42,6 +44,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label 'plan:launch-plan · launch-plan-extract-api-client-api-client'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>

--- a/tests/golden/scenario-plan-blocked.dry-run.txt
+++ b/tests/golden/scenario-plan-blocked.dry-run.txt
@@ -24,6 +24,8 @@ filtered out:
     $ tmux set-option -p -t <pane_id> @fanout_pane_label 'plan:launch-plan · launch-plan-extract-api-client-api-client'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>

--- a/tests/golden/scenario-plan-complete-blocker.dry-run.txt
+++ b/tests/golden/scenario-plan-complete-blocker.dry-run.txt
@@ -21,6 +21,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label 'plan:launch-plan · launch-plan-extract-api-client-api-client'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>

--- a/tests/golden/scenario-plan-fresh-blocker.dry-run.txt
+++ b/tests/golden/scenario-plan-fresh-blocker.dry-run.txt
@@ -25,6 +25,8 @@ deferred (blocked):
     $ tmux set-option -p -t <pane_id> @fanout_pane_label 'plan:launch-plan · launch-plan-define-base-types-base-types'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>

--- a/tests/golden/scenario-plan-limit.dry-run.txt
+++ b/tests/golden/scenario-plan-limit.dry-run.txt
@@ -20,6 +20,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label 'plan:launch-plan · launch-plan-define-base-types-base-types'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
@@ -42,6 +44,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label 'plan:launch-plan · launch-plan-extract-api-client-api-client'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>

--- a/tests/golden/scenario-project-basic.dry-run.txt
+++ b/tests/golden/scenario-project-basic.dry-run.txt
@@ -22,6 +22,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label 'users/butaosuinu/projects/3 · first-todo-item-901'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
@@ -44,6 +46,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label 'users/butaosuinu/projects/3 · second-todo-item-902'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>

--- a/tests/golden/scenario-project-cross-repo.dry-run.txt
+++ b/tests/golden/scenario-project-cross-repo.dry-run.txt
@@ -23,6 +23,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label 'users/butaosuinu/projects/3 · self-repo-todo-921'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>

--- a/tests/golden/scenario-project-status-all.dry-run.txt
+++ b/tests/golden/scenario-project-status-all.dry-run.txt
@@ -22,6 +22,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label 'users/butaosuinu/projects/3 · todo-one-911'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
@@ -44,6 +46,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label 'users/butaosuinu/projects/3 · todo-two-912'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
@@ -66,6 +70,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label 'users/butaosuinu/projects/3 · done-item-913'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>

--- a/tests/golden/scenario-prviz-disabled.dry-run.txt
+++ b/tests/golden/scenario-prviz-disabled.dry-run.txt
@@ -21,6 +21,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · first-child-101'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
@@ -43,6 +45,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · second-child-102'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>

--- a/tests/golden/scenario-settings-disabled.dry-run.txt
+++ b/tests/golden/scenario-settings-disabled.dry-run.txt
@@ -21,6 +21,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · first-child-101'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
@@ -43,6 +45,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · second-child-102'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>

--- a/tests/golden/scenario-skip.dry-run.txt
+++ b/tests/golden/scenario-skip.dry-run.txt
@@ -25,6 +25,8 @@ filtered out:
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#600 · alpha-601'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
@@ -47,6 +49,8 @@ filtered out:
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#600 · charlie-603'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>

--- a/tests/golden/scenario-sub-issue-only-agent-override.dry-run.txt
+++ b/tests/golden/scenario-sub-issue-only-agent-override.dry-run.txt
@@ -21,6 +21,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · first-child-101'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
@@ -43,6 +45,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · second-child-102'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>

--- a/tests/golden/scenario-sub-issue-only-branch-override.dry-run.txt
+++ b/tests/golden/scenario-sub-issue-only-branch-override.dry-run.txt
@@ -22,6 +22,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · Feature X'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
@@ -44,6 +46,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · second-child-102'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>

--- a/tests/golden/scenario-sub-issue-only-codex-plan.dry-run.txt
+++ b/tests/golden/scenario-sub-issue-only-codex-plan.dry-run.txt
@@ -23,6 +23,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · first-child-101'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # fanout waits for Plan Mode thread setup and Codex TUI attach before recording state
@@ -49,6 +51,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · second-child-102'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # fanout waits for Plan Mode thread setup and Codex TUI attach before recording state

--- a/tests/golden/scenario-sub-issue-only-codex.dry-run.txt
+++ b/tests/golden/scenario-sub-issue-only-codex.dry-run.txt
@@ -21,6 +21,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · first-child-101'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
@@ -43,6 +45,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · second-child-102'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>

--- a/tests/golden/scenario-sub-issue-only-team.dry-run.txt
+++ b/tests/golden/scenario-sub-issue-only-team.dry-run.txt
@@ -21,6 +21,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · first-child-101'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
@@ -43,6 +45,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · second-child-102'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>

--- a/tests/golden/scenario-sub-issue-only.dry-run.txt
+++ b/tests/golden/scenario-sub-issue-only.dry-run.txt
@@ -21,6 +21,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · first-child-101'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
@@ -43,6 +45,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#100 · second-child-102'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>

--- a/tests/golden/scenario-union.dry-run.txt
+++ b/tests/golden/scenario-union.dry-run.txt
@@ -22,6 +22,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#300 · api-child-301'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>
@@ -44,6 +46,8 @@
     $ tmux set-option -p -t <pane_id> @fanout_pane_label '#300 · body-only-302'
     $ tmux set-option -w -t <pane_id> pane-border-status top
     $ tmux set-option -w -t <pane_id> pane-border-format ' #{?@fanout_pane_label,#{@fanout_pane_label},#{pane_title}} '
+    $ tmux set-option -w -t <pane_id> pane-active-border-style 'fg=#00A3AF'
+    $ tmux set-option -w -t <pane_id> pane-border-style 'fg=#165E83'
     # would re-layout the window: fanout grid (sidebar + comfortable-width grid),
     #   falling back to main-vertical then tiled
     # would write .fanout/state.json with paneId <pane_id>


### PR DESCRIPTION
## 概要

fanout が管理する tmux ペインの枠線色を、tmux デフォルトの緑(黄緑)から fanout の PAPER BREEZE テーマカラーに変更し、Web ダッシュボード / docs サイトと見た目を統一する。

- アクティブ枠線(これまで黄緑だった部分) → 浅葱 `fg=#00A3AF`(`--asagi`, アクセント色)
- 非アクティブ枠線 → 藍 `fg=#165E83`(`--ai`, プライマリ色)

## 実装

枠線スタイルは tmux の window オプションのため、既に `pane-border-status` / `pane-border-format` を window スコープ(`-w`)で設定している唯一の箇所 `EnablePaneBorderTitles()` に集約した。最初の split で window 全体(TUI コンソールペイン含む)に色が乗る。単独ペイン時は枠線自体が出ないため、これだけで全経路をカバーする。

- `internal/tmuxrun/tmuxrun.go`: `paneActiveBorderStyle` / `paneBorderStyle` 定数追加、`EnablePaneBorderTitles` で `pane-active-border-style` / `pane-border-style` を設定、`PaneActiveBorderStyle()` / `PaneBorderStyle()` アクセサで dry-run と単一ソース化
- `cmd/fanout/pane.go`: `printPaneDryRun` に 2 行のプレビュー出力追加
- `internal/tmuxrun/tmuxrun_test.go`: `TestEnablePaneBorderTitles` の期待値更新
- `internal/tui/styles.go` / `internal/log/log.go`: PAPER BREEZE keep-in-sync コメントに `internal/tmuxrun` を追記
- `tests/golden/*.dry-run.txt`(27 ファイル): 各 2 行追加で再生成

truecolor hex 指定。RGB 非対応端末では tmux が最寄りの 256 色へフォールバックする。

## 注意点

枠線色は window スコープ(`-w`)。既存 tmux 内から `fanout` を実行する「現在のペインを使う」経路では、その window 内の無関係ペインの枠線色やユーザー設定の `pane-border-style` も上書きし、teardown はない。これは既存の `pane-border-status` / `pane-border-format` が既に取っている window スコープのトレードオフと同じで、doc コメントに明記済み。

## 検証

- `make test`(Go 全パッケージ + web 102 tests + bats 50/50)→ EXIT=0
- `make lint`(golangci-lint v2 + shellcheck)→ 0 issues
- golden 差分は `pane-active-border-style 'fg=#00A3AF'` / `pane-border-style 'fg=#165E83'` の 2 行追加のみ・削除ゼロ
- post-work-review: code-review(xhigh)+ codex review 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013P6UDbKZ9Uti92zPS4V826