### PR TITLE
[codex] Restore fanout TUI panes on restart

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -29,7 +29,8 @@ briefing から起動します。再実行しても同じ対象に 2 つ目の�
   だけをファンアウト。PR が merge されたら再実行すれば次の wave が開きます。
 - **常駐 TUI コンソール** — 引数なしの `fanout` で、ペイン / issue / PR を
   ライブ表示し、コンパクトな Session ナビゲータと focus・peek・terminal・
-  複数 agent の手動起動・lifecycle キーを備えたコンソールを開きます。
+  複数 agent の手動起動・lifecycle キー・消えた worktree ペインの自動復元を
+  備えたコンソールを開きます。
 - **ラベル watcher** — opt-in すると、TUI 常駐中に信頼できる `fanout:auto`
   issue を one-shot fanout session に投入します。
 - **Web ダッシュボード** — localhost で動く read-only のダッシュボード(ライブ
@@ -68,8 +69,9 @@ fanout 123              # issue #123 の OPEN な子をすべて個別ペイン�
 fanout 123 --status     # ファンアウトした子の PR review + CI 状態を確認
 ```
 
-引数なしの `fanout` で、現在のリポジトリの常駐 TUI コンソールを開きます。最初の
-実行は
+引数なしの `fanout` で、現在のリポジトリの常駐 TUI コンソールを開きます。
+再起動すると既存 state を読み、tmux 上に残っているペインへ再バインドし、消えた
+worktree ペインは agent CLI を resume して作り直します。最初の実行は
 [5 分クイックスタート](https://butaosuinu.github.io/fanout/ja/docs/quickstart/)
 を参照してください。
 
@@ -132,7 +134,7 @@ watcher は repo 全体から label 付き issue を探し、one-shot session �
 | `fanout 123 --unblocked-only` | ブロッカーが closed の子だけをファンアウト — 次の wave |
 | `fanout 123 --dry-run` | git / tmux / state / briefing file を変更せず計画だけ表示 |
 | `fanout plan spec.json --agent claude` | GitHub の子 issue でなくローカル plan spec をファンアウト |
-| `fanout` | 常駐 TUI コンソールを起動(Session ジャンプ・focus・peek・terminal・複数 agent の手動起動・lifecycle キー) |
+| `fanout` | 常駐 TUI コンソールを起動(Session ジャンプ・focus・peek・terminal・複数 agent の手動起動・復元・lifecycle キー) |
 | `fanout 123 --status` | ペイン・PR review・CI 状態を JSON または table で |
 | `fanout dashboard --web` | localhost で read-only Web ダッシュボードを配信 |
 | `fanout 123 --merge 4` | 子 branch を fast-forward merge(`--close` / `--cleanup` でペインを畳む) |

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ English and 日本語.
   unblocked children; rerun as PRs merge and the next wave opens.
 - **Persistent TUI console** — run `fanout` with no arguments for a live
   pane / issue / PR view with a compact Session navigator plus focus, peek,
-  terminal, multi-agent manual launch, and lifecycle keys.
+  terminal, multi-agent manual launch, lifecycle keys, and automatic restore
+  of missing worktree panes.
 - **Label watcher** — opt in to a TUI-resident watcher that turns trusted
   `fanout:auto` issues into one-shot fanout sessions.
 - **Web dashboard** — a read-only localhost dashboard with live updates; pop it
@@ -68,7 +69,9 @@ fanout 123 --status     # PR review + CI state for the fanned children
 ```
 
 Run `fanout` with no arguments to open the persistent TUI console for the
-current repository. See the
+current repository. Restarting it reuses existing state, rebinds panes still
+alive in tmux, and recreates missing worktree panes by resuming their agent
+CLI. See the
 [five-minute quickstart](https://butaosuinu.github.io/fanout/docs/quickstart/)
 for a guided first run.
 
@@ -129,7 +132,7 @@ it discovers labeled issues across the repository and starts one-shot sessions.
 | `fanout 123 --unblocked-only` | Fan out only children whose blockers are closed — the next wave |
 | `fanout 123 --dry-run` | Print the plan without modifying git, tmux, state, or briefing files |
 | `fanout plan spec.json --agent claude` | Fan out a local plan spec instead of GitHub child issues |
-| `fanout` | Start the persistent TUI console (Session jump, focus, peek, terminal, multi-agent manual launch, lifecycle keys) |
+| `fanout` | Start the persistent TUI console (Session jump, focus, peek, terminal, multi-agent manual launch, restore, lifecycle keys) |
 | `fanout 123 --status` | Pane, PR review, and CI state as JSON or a table |
 | `fanout dashboard --web` | Serve the read-only web dashboard on localhost |
 | `fanout 123 --merge 4` | Fast-forward merge a child branch (`--close` / `--cleanup` fold panes away) |

--- a/cmd/fanout/codex_plan_tui.go
+++ b/cmd/fanout/codex_plan_tui.go
@@ -42,10 +42,12 @@ const (
 )
 
 type codexPlanTUIConfig struct {
-	CodexPath  string
-	Prompt     string
-	StatusFile string
-	Help       bool
+	CodexPath       string
+	Prompt          string
+	ResumeThreadID  string
+	ResumeSessionID string
+	StatusFile      string
+	Help            bool
 }
 
 type codexPlanTUIStatus struct {
@@ -153,7 +155,7 @@ func parseCodexPlanTUIArgs(args []string, lg *log.Logger) (codexPlanTUIConfig, e
 	for i := 0; i < len(args); {
 		switch args[i] {
 		case "--help", "-h":
-			fmt.Fprint(lg.Stdout(), "Usage: fanout __codex-plan-tui --codex <path> --prompt <prompt> --status-file <path>\n")
+			fmt.Fprint(lg.Stdout(), "Usage: fanout __codex-plan-tui --codex <path> (--prompt <prompt>|--resume-thread-id <thread>) --status-file <path>\n")
 			cfg.Help = true
 			return cfg, exitcode.OK
 		case "--codex":
@@ -177,12 +179,26 @@ func parseCodexPlanTUIArgs(args []string, lg *log.Logger) (codexPlanTUIConfig, e
 			}
 			cfg.StatusFile = args[i+1]
 			i += 2
+		case "--resume-thread-id":
+			if i+1 >= len(args) {
+				lg.Err("--resume-thread-id requires an argument")
+				return codexPlanTUIConfig{}, exitcode.Env
+			}
+			cfg.ResumeThreadID = args[i+1]
+			i += 2
+		case "--resume-session-id":
+			if i+1 >= len(args) {
+				lg.Err("--resume-session-id requires an argument")
+				return codexPlanTUIConfig{}, exitcode.Env
+			}
+			cfg.ResumeSessionID = args[i+1]
+			i += 2
 		default:
 			lg.Err("unknown codex plan TUI option: %s", args[i])
 			return codexPlanTUIConfig{}, exitcode.Invocation
 		}
 	}
-	if strings.TrimSpace(cfg.Prompt) == "" {
+	if strings.TrimSpace(cfg.Prompt) == "" && strings.TrimSpace(cfg.ResumeThreadID) == "" {
 		lg.Err("--prompt is required")
 		return codexPlanTUIConfig{}, exitcode.Env
 	}
@@ -222,34 +238,42 @@ func runCodexPlanTUI(cfg codexPlanTUIConfig, stdout, stderr io.Writer) (err erro
 	if err != nil {
 		return fmt.Errorf("resolve current directory: %w", err)
 	}
-	thread, err := setupCodexPlanThread(client, cwd)
-	if err != nil {
-		return err
+	thread := codexThreadInfo{ID: strings.TrimSpace(cfg.ResumeThreadID), SessionID: strings.TrimSpace(cfg.ResumeSessionID)}
+	if thread.ID != "" && thread.SessionID == "" {
+		thread.SessionID = thread.ID
 	}
 	var drainDone chan error
 	tuiPrompt := ""
-	if thread.UseTurnCollaborationMode {
-		var turnStart codexPlanTurnStartResult
-		turnStart, err = startCodexPlanTurn(client, thread, cwd, cfg.Prompt)
+	if thread.ID == "" {
+		thread, err = setupCodexPlanThread(client, cwd)
 		if err != nil {
 			return err
 		}
-		if turnStart.Completed {
-			client.Close()
+		if thread.UseTurnCollaborationMode {
+			var turnStart codexPlanTurnStartResult
+			turnStart, err = startCodexPlanTurn(client, thread, cwd, cfg.Prompt)
+			if err != nil {
+				return err
+			}
+			if turnStart.Completed {
+				client.Close()
+			} else {
+				drainDone = make(chan error, 1)
+				go func() { drainDone <- drainCodexAppServerUntilTurnComplete(client, thread.ID, turnStart.TurnID) }()
+			}
 		} else {
-			drainDone = make(chan error, 1)
-			go func() { drainDone <- drainCodexAppServerUntilTurnComplete(client, thread.ID, turnStart.TurnID) }()
+			err = seedCodexPlanThreadForResume(client, thread.ID)
+			if err != nil {
+				return err
+			}
+			client.Close()
+			tuiPrompt = cfg.Prompt
 		}
 	} else {
-		err = seedCodexPlanThreadForResume(client, thread.ID)
-		if err != nil {
-			return err
-		}
 		client.Close()
-		tuiPrompt = cfg.Prompt
 	}
 
-	tui, tuiDone, err := startCodexRemoteTUI(cfg.CodexPath, server.Addr, thread.ID, tuiPrompt, stdout, stderr)
+	tui, tuiDone, err := startCodexRemoteTUI(cfg.CodexPath, server.Addr, codexRemoteTUIResumeID(thread), tuiPrompt, stdout, stderr)
 	if err != nil {
 		return err
 	}
@@ -437,8 +461,8 @@ func codexPlanCollaborationMode(model, effort string) map[string]any {
 	}
 }
 
-func startCodexRemoteTUI(codexPath, remoteAddr, threadID, prompt string, stdout, stderr io.Writer) (*exec.Cmd, chan error, error) {
-	cmd := exec.Command(codexPath, codexRemoteTUIArgs(remoteAddr, threadID, prompt)...)
+func startCodexRemoteTUI(codexPath, remoteAddr, resumeID, prompt string, stdout, stderr io.Writer) (*exec.Cmd, chan error, error) {
+	cmd := exec.Command(codexPath, codexRemoteTUIArgs(remoteAddr, resumeID, prompt)...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
@@ -450,12 +474,19 @@ func startCodexRemoteTUI(codexPath, remoteAddr, threadID, prompt string, stdout,
 	return cmd, done, nil
 }
 
-func codexRemoteTUIArgs(remoteAddr, threadID, prompt string) []string {
-	args := []string{"--remote", remoteAddr, "resume", threadID}
+func codexRemoteTUIArgs(remoteAddr, resumeID, prompt string) []string {
+	args := []string{"--remote", remoteAddr, "resume", resumeID}
 	if strings.TrimSpace(prompt) != "" {
 		args = append(args, "--", prompt)
 	}
 	return args
+}
+
+func codexRemoteTUIResumeID(thread codexThreadInfo) string {
+	if strings.TrimSpace(thread.SessionID) != "" {
+		return thread.SessionID
+	}
+	return thread.ID
 }
 
 func startCodexRemoteAppServer(codexPath string) (*codexRemoteAppServer, error) {

--- a/cmd/fanout/codex_plan_tui_test.go
+++ b/cmd/fanout/codex_plan_tui_test.go
@@ -1,12 +1,16 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"slices"
 	"strings"
 	"syscall"
 	"testing"
+
+	"github.com/butaosuinu/fanout/internal/exitcode"
+	"github.com/butaosuinu/fanout/internal/log"
 )
 
 func TestCodexPlanSettingsUpdateParamsUsesPlanMode(t *testing.T) {
@@ -91,6 +95,52 @@ func TestCodexRemoteTUIArgsCanResumeWithoutPromptForFallbackTurn(t *testing.T) {
 
 	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
 		t.Fatalf("codexRemoteTUIArgs() = %#v, want %#v", got, want)
+	}
+}
+
+func TestCodexRemoteTUIResumeIDPrefersSessionID(t *testing.T) {
+	got := codexRemoteTUIResumeID(codexThreadInfo{ID: "thread-1", SessionID: "session-1"})
+	if got != "session-1" {
+		t.Fatalf("codexRemoteTUIResumeID() = %q, want session-1", got)
+	}
+}
+
+func TestCodexRemoteTUIResumeIDFallsBackToThreadID(t *testing.T) {
+	got := codexRemoteTUIResumeID(codexThreadInfo{ID: "thread-1"})
+	if got != "thread-1" {
+		t.Fatalf("codexRemoteTUIResumeID() = %q, want thread-1", got)
+	}
+}
+
+func TestParseCodexPlanTUIArgsAllowsResumeThreadWithoutPrompt(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	cfg, code := parseCodexPlanTUIArgs([]string{
+		"--codex", "/bin/codex",
+		"--resume-thread-id", "thread-1",
+		"--resume-session-id", "session-1",
+		"--status-file", "/tmp/status.json",
+	}, log.NewWith(&stdout, &stderr, false))
+
+	if code != exitcode.OK {
+		t.Fatalf("parseCodexPlanTUIArgs code = %v, stderr = %q", code, stderr.String())
+	}
+	if cfg.ResumeThreadID != "thread-1" || cfg.ResumeSessionID != "session-1" || cfg.Prompt != "" {
+		t.Fatalf("cfg = %+v, want resume thread without prompt", cfg)
+	}
+}
+
+func TestParseCodexPlanTUIArgsStillRequiresPromptOrResumeThread(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	_, code := parseCodexPlanTUIArgs([]string{
+		"--codex", "/bin/codex",
+		"--status-file", "/tmp/status.json",
+	}, log.NewWith(&stdout, &stderr, false))
+
+	if code != exitcode.Env {
+		t.Fatalf("parseCodexPlanTUIArgs code = %v, want Env", code)
+	}
+	if !strings.Contains(stderr.String(), "--prompt is required") {
+		t.Fatalf("stderr = %q, want prompt error", stderr.String())
 	}
 }
 

--- a/cmd/fanout/pane.go
+++ b/cmd/fanout/pane.go
@@ -92,9 +92,9 @@ func createPane(cfg *cliflags.Config, lg *log.Logger, info *fanoutruntime.Info, 
 }
 
 func createPaneDetailed(cfg *cliflags.Config, lg *log.Logger, info *fanoutruntime.Info, req paneRequest, recorder paneStateRecorder, c log.Palette, commandName string) (createdPane, bool) {
-	agentCmd, err := buildAgentCommand(cfg, req, commandName)
-	if err != nil {
-		lg.Err("%s: %v", paneLogLabel(req), err)
+	agentCmd, cmdErr := buildAgentCommand(cfg, req, commandName)
+	if cmdErr != nil {
+		lg.Err("%s: %v", paneLogLabel(req), cmdErr)
 		return createdPane{}, false
 	}
 	req.AgentCommand = agentCmd
@@ -107,8 +107,8 @@ func createPaneDetailed(cfg *cliflags.Config, lg *log.Logger, info *fanoutruntim
 	}
 
 	if req.BriefingPath != "" && !cfg.DryRun {
-		if err = os.WriteFile(req.BriefingPath, []byte(req.BriefingBody), 0o644); err != nil {
-			lg.Err("%s: write briefing: %v", paneLogLabel(req), err)
+		if writeErr := os.WriteFile(req.BriefingPath, []byte(req.BriefingBody), 0o644); writeErr != nil {
+			lg.Err("%s: write briefing: %v", paneLogLabel(req), writeErr)
 			return createdPane{}, false
 		}
 	}
@@ -120,7 +120,7 @@ func createPaneDetailed(cfg *cliflags.Config, lg *log.Logger, info *fanoutruntim
 		return createdPane{}, true
 	}
 
-	prepared, err := worktree.Prepare(worktree.Options{
+	prepared, prepErr := worktree.Prepare(worktree.Options{
 		ProjectRoot:        info.ProjectRoot,
 		Slug:               req.Slug,
 		BranchName:         req.BranchName,
@@ -134,8 +134,8 @@ func createPaneDetailed(cfg *cliflags.Config, lg *log.Logger, info *fanoutruntim
 	if prepared.RefreshWarning != nil {
 		lg.Warn("%s: %s: %v", paneLogLabel(req), baseRefreshSkippedNotice, prepared.RefreshWarning)
 	}
-	if err != nil {
-		lg.Err("%s: prepare worktree: %v", paneLogLabel(req), err)
+	if prepErr != nil {
+		lg.Err("%s: prepare worktree: %v", paneLogLabel(req), prepErr)
 		return createdPane{}, false
 	}
 	if prepared.AlreadyExists {
@@ -151,9 +151,9 @@ func createPaneDetailed(cfg *cliflags.Config, lg *log.Logger, info *fanoutruntim
 	}
 	hooks.RunBackground(hooks.BeforePaneCreate, paneHookContext(req, info.ProjectRoot, prepared.WorktreePath, ""), req.Hooks, lg)
 
-	paneID, err := tmuxrun.SplitPaneWithAgentCommand(info.Target, prepared.WorktreePath, req.AgentCommand)
-	if err != nil {
-		lg.Err("%s: %v", paneLogLabel(req), err)
+	paneID, splitErr := tmuxrun.SplitPaneWithAgentCommand(info.Target, prepared.WorktreePath, req.AgentCommand)
+	if splitErr != nil {
+		lg.Err("%s: %v", paneLogLabel(req), splitErr)
 		cleanupFailedLaunch(paneLogLabel(req), info.Target, "", prepared, lg)
 		return createdPane{}, false
 	}
@@ -176,16 +176,19 @@ func createPaneDetailed(cfg *cliflags.Config, lg *log.Logger, info *fanoutruntim
 	if err := panelayout.Apply(info.Target, panelayout.Create); err != nil {
 		lg.Warn("%s: %v", paneLogLabel(req), err)
 	}
+	var codexPlanStatus codexPlanTUIStatus
 	if req.CodexPlanMode {
-		if err := waitForCodexPlanTUIReady(req.CodexPlanStatusPath, codexPlanTUIStartupTimeout); err != nil {
-			lg.Err("%s: start Codex Plan Mode TUI in pane %s: %v", paneLogLabel(req), paneID, err)
+		var planErr error
+		codexPlanStatus, planErr = waitForCodexPlanTUIReadyStatus(req.CodexPlanStatusPath, codexPlanTUIStartupTimeout)
+		if planErr != nil {
+			lg.Err("%s: start Codex Plan Mode TUI in pane %s: %v", paneLogLabel(req), paneID, planErr)
 			cleanupFailedLaunch(paneLogLabel(req), info.Target, paneID, prepared, lg)
 			return createdPane{}, false
 		}
 		_ = os.Remove(req.CodexPlanStatusPath)
 	}
 	if recorder != nil {
-		entry := statePane(req, paneID, prepared.WorktreePath, time.Now().UTC())
+		entry := statePane(req, paneID, prepared.WorktreePath, time.Now().UTC(), codexPlanStatus)
 		if err := recorder.RecordPane(entry); err != nil {
 			lg.Err("%s: write fanout state: %v", paneLogLabel(req), err)
 			cleanupFailedLaunch(paneLogLabel(req), info.Target, paneID, prepared, lg)
@@ -193,11 +196,13 @@ func createPaneDetailed(cfg *cliflags.Config, lg *log.Logger, info *fanoutruntim
 		}
 	}
 	if err := displayname.WriteFanoutMetadata(prepared.WorktreePath, displayname.FanoutMetadata{
-		Agent:        req.Agent,
-		DisplayName:  paneTitle(req),
-		BranchName:   req.BranchName,
-		Slug:         req.Slug,
-		WorktreePath: prepared.WorktreePath,
+		Agent:          req.Agent,
+		DisplayName:    paneTitle(req),
+		BranchName:     req.BranchName,
+		Slug:           req.Slug,
+		WorktreePath:   prepared.WorktreePath,
+		CodexThreadID:  codexPlanStatus.ThreadID,
+		CodexSessionID: codexPlanStatus.SessionID,
 	}); err != nil {
 		lg.Err("%s: write worktree metadata: %v", paneLogLabel(req), err)
 		rollbackState(recorder, req, lg)
@@ -208,23 +213,25 @@ func createPaneDetailed(cfg *cliflags.Config, lg *log.Logger, info *fanoutruntim
 	return createdPane{req: req, paneID: paneID, prepared: prepared}, true
 }
 
-func statePane(req paneRequest, paneID, worktreePath string, now time.Time) state.Pane {
+func statePane(req paneRequest, paneID, worktreePath string, now time.Time, codexPlanStatus codexPlanTUIStatus) state.Pane {
 	return state.Pane{
-		Parent:        req.ParentRef,
-		IssueNum:      req.Number,
-		TaskID:        req.TaskID,
-		Slug:          req.Slug,
-		BranchName:    req.BranchName,
-		BaseBranch:    req.Worktree.BaseBranch,
-		PaneID:        paneID,
-		Agent:         req.Agent,
-		CodexPlanMode: req.CodexPlanMode,
-		DisplayName:   paneTitle(req),
-		WorktreePath:  worktreePath,
-		Prompt:        req.Prompt,
-		Wave:          req.Wave,
-		CreatedAt:     now.Format(time.RFC3339),
-		AgentStatus:   "running",
+		Parent:         req.ParentRef,
+		IssueNum:       req.Number,
+		TaskID:         req.TaskID,
+		Slug:           req.Slug,
+		BranchName:     req.BranchName,
+		BaseBranch:     req.Worktree.BaseBranch,
+		PaneID:         paneID,
+		Agent:          req.Agent,
+		CodexPlanMode:  req.CodexPlanMode,
+		CodexThreadID:  codexPlanStatus.ThreadID,
+		CodexSessionID: codexPlanStatus.SessionID,
+		DisplayName:    paneTitle(req),
+		WorktreePath:   worktreePath,
+		Prompt:         req.Prompt,
+		Wave:           req.Wave,
+		CreatedAt:      now.Format(time.RFC3339),
+		AgentStatus:    "running",
 	}
 }
 
@@ -263,6 +270,27 @@ func buildCodexPlanTUILaunchCommand(fanoutPath, codexPath, prompt, statusPath st
 		"--prompt", prompt,
 		"--status-file", statusPath,
 	}
+	quoted := make([]string, len(args))
+	for i, arg := range args {
+		quoted[i] = agent.ShellQuote(arg)
+	}
+	return strings.Join(quoted, " ")
+}
+
+func buildCodexPlanTUIResumeLaunchCommand(fanoutPath, codexPath, threadID, sessionID, statusPath string) string {
+	if strings.TrimSpace(fanoutPath) == "" {
+		fanoutPath = "fanout"
+	}
+	args := []string{
+		fanoutPath,
+		"__codex-plan-tui",
+		"--codex", codexPath,
+		"--resume-thread-id", threadID,
+	}
+	if strings.TrimSpace(sessionID) != "" {
+		args = append(args, "--resume-session-id", sessionID)
+	}
+	args = append(args, "--status-file", statusPath)
 	quoted := make([]string, len(args))
 	for i, arg := range args {
 		quoted[i] = agent.ShellQuote(arg)
@@ -547,8 +575,13 @@ func oneLineText(s string) string {
 }
 
 func waitForCodexPlanTUIReady(statusPath string, timeout time.Duration) error {
+	_, err := waitForCodexPlanTUIReadyStatus(statusPath, timeout)
+	return err
+}
+
+func waitForCodexPlanTUIReadyStatus(statusPath string, timeout time.Duration) (codexPlanTUIStatus, error) {
 	if strings.TrimSpace(statusPath) == "" {
-		return fmt.Errorf("missing Codex Plan TUI status path")
+		return codexPlanTUIStatus{}, fmt.Errorf("missing Codex Plan TUI status path")
 	}
 	deadline := time.Now().Add(timeout)
 	var lastErr error
@@ -557,12 +590,12 @@ func waitForCodexPlanTUIReady(statusPath string, timeout time.Duration) error {
 		if err == nil {
 			switch status.Status {
 			case codexPlanTUIStatusReady:
-				return nil
+				return status, nil
 			case codexPlanTUIStatusFailed:
 				if status.Error == "" {
-					return fmt.Errorf("Codex Plan TUI setup failed") //nolint:staticcheck // ST1005: "Codex Plan TUI" is a proper noun
+					return codexPlanTUIStatus{}, fmt.Errorf("Codex Plan TUI setup failed") //nolint:staticcheck // ST1005: "Codex Plan TUI" is a proper noun
 				}
-				return errors.New(status.Error)
+				return codexPlanTUIStatus{}, errors.New(status.Error)
 			default:
 				lastErr = fmt.Errorf("unexpected Codex Plan TUI status %q", status.Status)
 			}
@@ -571,9 +604,9 @@ func waitForCodexPlanTUIReady(statusPath string, timeout time.Duration) error {
 		}
 		if time.Now().After(deadline) {
 			if lastErr != nil {
-				return fmt.Errorf("%w after %s; last status error: %w", errCodexPlanStartupTimeout, timeout, lastErr)
+				return codexPlanTUIStatus{}, fmt.Errorf("%w after %s; last status error: %w", errCodexPlanStartupTimeout, timeout, lastErr)
 			}
-			return fmt.Errorf("%w after %s; no status file at %s", errCodexPlanStartupTimeout, timeout, statusPath)
+			return codexPlanTUIStatus{}, fmt.Errorf("%w after %s; no status file at %s", errCodexPlanStartupTimeout, timeout, statusPath)
 		}
 		time.Sleep(codexPlanTUIStartupPoll)
 	}

--- a/cmd/fanout/pane_test.go
+++ b/cmd/fanout/pane_test.go
@@ -79,7 +79,10 @@ func TestStatePaneCapturesCreatedPaneFields(t *testing.T) {
 		Worktree:            worktree.Plan{BaseBranch: "main"},
 	}
 
-	got := statePane(req, "%42", "/repo/.fanout/worktrees/state-idempotency-83", now)
+	got := statePane(req, "%42", "/repo/.fanout/worktrees/state-idempotency-83", now, codexPlanTUIStatus{
+		ThreadID:  "thread-1",
+		SessionID: "session-1",
+	})
 
 	if got.Parent != "81" || got.IssueNum != 83 || got.PaneID != "%42" {
 		t.Fatalf("state pane identity = %+v", got)
@@ -102,6 +105,9 @@ func TestStatePaneCapturesCreatedPaneFields(t *testing.T) {
 	if !got.CodexPlanMode {
 		t.Fatal("codexPlanMode = false, want passthrough of req.CodexPlanMode")
 	}
+	if got.CodexThreadID != "thread-1" || got.CodexSessionID != "session-1" {
+		t.Fatalf("codex session ids = %q/%q, want thread-1/session-1", got.CodexThreadID, got.CodexSessionID)
+	}
 }
 
 func TestStatePaneCapturesTaskID(t *testing.T) {
@@ -116,7 +122,7 @@ func TestStatePaneCapturesTaskID(t *testing.T) {
 		Worktree:   worktree.Plan{BaseBranch: "main"},
 	}
 
-	got := statePane(req, "%42", "/repo/.fanout/worktrees/extract-api-client-api-client", now)
+	got := statePane(req, "%42", "/repo/.fanout/worktrees/extract-api-client-api-client", now, codexPlanTUIStatus{})
 
 	if got.Parent != "plan:launch-plan" || got.IssueNum != 0 || got.TaskID != "api-client" {
 		t.Fatalf("task state identity = %+v, want plan parent, issueNum 0, taskID", got)
@@ -467,7 +473,7 @@ func TestNewWatchPaneRequestUsesReservedParentAndIssueBriefing(t *testing.T) {
 		t.Fatalf("watch briefing used Codex Plan Mode body:\n%s", got.BriefingBody)
 	}
 
-	pane := statePane(got, "%42", got.Worktree.WorktreePath, time.Date(2026, 6, 20, 1, 2, 3, 0, time.UTC))
+	pane := statePane(got, "%42", got.Worktree.WorktreePath, time.Date(2026, 6, 20, 1, 2, 3, 0, time.UTC), codexPlanTUIStatus{})
 	if pane.Parent != watchPaneParentRef || pane.IssueNum != 223 {
 		t.Fatalf("state key = %q/%d, want %q/223", pane.Parent, pane.IssueNum, watchPaneParentRef)
 	}

--- a/cmd/fanout/tui.go
+++ b/cmd/fanout/tui.go
@@ -75,6 +75,7 @@ func cmdTUI(commandName string, lg *log.Logger) exitcode.Code {
 		Hooks:               hookConfig,
 		LaunchPane:          newTUILaunchPaneFunc(projectRoot, session, commandName, hookConfig),
 		LaunchShell:         newTUILaunchShellFunc(projectRoot, session),
+		RestorePanes:        newTUIRestoreFunc(projectRoot, session, commandName),
 		Relayout:            func() error { return panelayout.Apply(tuiLaunchTarget(session), panelayout.Resize) },
 		Notifier:            notifier,
 	}); err != nil {

--- a/cmd/fanout/tui_restore.go
+++ b/cmd/fanout/tui_restore.go
@@ -1,0 +1,433 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+
+	"github.com/butaosuinu/fanout/internal/agent"
+	"github.com/butaosuinu/fanout/internal/panelayout"
+	"github.com/butaosuinu/fanout/internal/state"
+	"github.com/butaosuinu/fanout/internal/tmuxrun"
+	"github.com/butaosuinu/fanout/internal/worktree"
+)
+
+type tuiRestoreReport struct {
+	Rebound       int
+	Restored      int
+	RemovedShells int
+	Skipped       int
+}
+
+type tuiRestoreSnapshot struct {
+	Live         map[string]tmuxrun.LivePane
+	PanesByTitle map[string][]tmuxrun.LivePane
+}
+
+func newTUIRestoreFunc(projectRoot, session, commandName string) func() (string, error) {
+	var mu sync.Mutex
+	return func() (string, error) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		report, err := restoreRecordedPanes(projectRoot, session, commandName)
+		return report.Notice(), err
+	}
+}
+
+func restoreRecordedPanes(projectRoot, session, commandName string) (tuiRestoreReport, error) {
+	roots, _ := worktree.ListRoots(projectRoot) // Degrade to the current root, matching the TUI state loader.
+	initialSnapshot, err := loadTUIRestoreSnapshot(session)
+	if err != nil {
+		return tuiRestoreReport{}, err
+	}
+	var report tuiRestoreReport
+	var restoreErr error
+	claimed := preclaimLiveRestoreIdentities(roots, initialSnapshot)
+	for _, root := range uniqueRestoreRoots(roots) {
+		rootReport, err := restoreRecordedPanesForRoot(root, session, commandName, claimed)
+		report.Add(rootReport)
+		restoreErr = errors.Join(restoreErr, err)
+	}
+	if report.Changed() {
+		_ = panelayout.Apply(tuiLaunchTarget(session), panelayout.Create)
+	}
+	return report, restoreErr
+}
+
+func preclaimLiveRestoreIdentities(roots []string, snapshot tuiRestoreSnapshot) map[string]bool {
+	claimed := map[string]bool{}
+	if snapshot.Live == nil {
+		snapshot.Live = map[string]tmuxrun.LivePane{}
+	}
+	for _, root := range uniqueRestoreRoots(roots) {
+		store, err := state.LoadProject(root)
+		if err != nil {
+			continue
+		}
+		for _, pane := range store.Panes {
+			identity := restoreDedupeKey(pane)
+			if identity != "" && restorePaneAlive(snapshot.Live, pane) {
+				claimed[identity] = true
+			}
+		}
+	}
+	return claimed
+}
+
+func restoreRecordedPanesForRoot(root, session, commandName string, claimed map[string]bool) (tuiRestoreReport, error) {
+	return restoreRecordedPanesForRootWithSnapshot(root, session, commandName, loadTUIRestoreSnapshot, claimed)
+}
+
+func restoreRecordedPanesForRootWithSnapshot(root, session, commandName string, loadSnapshot func(string) (tuiRestoreSnapshot, error), claimed map[string]bool) (tuiRestoreReport, error) {
+	hasState, err := restoreStateFileExists(root)
+	if err != nil || !hasState {
+		return tuiRestoreReport{}, err
+	}
+	if claimed == nil {
+		claimed = map[string]bool{}
+	}
+	locked, err := state.LockProject(root)
+	if err != nil {
+		return tuiRestoreReport{}, err
+	}
+	defer func() { _ = locked.Unlock() }()
+
+	snapshot, err := loadSnapshot(session)
+	if err != nil {
+		return tuiRestoreReport{}, err
+	}
+	if snapshot.Live == nil {
+		snapshot.Live = map[string]tmuxrun.LivePane{}
+	}
+
+	var report tuiRestoreReport
+	changed := false
+	var restoreErr error
+	var createdPaneIDs []string
+	for idx := 0; idx < len(locked.Panes); idx++ {
+		pane := locked.Panes[idx]
+		identity := restoreDedupeKey(pane)
+		if identity != "" && claimed[identity] {
+			report.Skipped++
+			continue
+		}
+		if restorePaneAlive(snapshot.Live, pane) {
+			if identity != "" {
+				claimed[identity] = true
+			}
+			continue
+		}
+		if pane.IsShell() {
+			if livePane, ok := snapshot.Live[pane.PaneID]; ok && strings.TrimSpace(livePane.ShellKey) == "" {
+				report.Skipped++
+				continue
+			}
+			locked.Panes = append(locked.Panes[:idx], locked.Panes[idx+1:]...)
+			idx--
+			report.RemovedShells++
+			changed = true
+			continue
+		}
+		if livePane, ok := snapshot.Live[pane.PaneID]; ok && restorePaneIDStillBelongsToRecord(livePane, pane) {
+			if identity != "" {
+				claimed[identity] = true
+			}
+			report.Skipped++
+			continue
+		}
+		if strings.TrimSpace(pane.WorktreePath) == "" {
+			report.Skipped++
+			continue
+		}
+		if !dirExistsForRestore(pane.WorktreePath) {
+			report.Skipped++
+			continue
+		}
+		if rebound, ok := rebindRecordedPane(pane, snapshot.PanesByTitle); ok {
+			locked.Panes[idx] = rebound
+			snapshot.Live[rebound.PaneID] = tmuxrun.LivePane{
+				ID:          rebound.PaneID,
+				CurrentPath: pane.WorktreePath,
+				Title:       restorePaneTitle(rebound),
+				AgentState:  "running",
+			}
+			report.Rebound++
+			if identity != "" {
+				claimed[identity] = true
+			}
+			changed = true
+			continue
+		}
+		restored, err := recreateRecordedPane(pane, root, session, commandName)
+		if err != nil {
+			report.Skipped++
+			restoreErr = errors.Join(restoreErr, err)
+			continue
+		}
+		locked.Panes[idx] = restored
+		createdPaneIDs = append(createdPaneIDs, restored.PaneID)
+		snapshot.Live[restored.PaneID] = tmuxrun.LivePane{
+			ID:          restored.PaneID,
+			CurrentPath: restored.WorktreePath,
+			Title:       restorePaneTitle(restored),
+			AgentState:  "running",
+		}
+		report.Restored++
+		if identity != "" {
+			claimed[identity] = true
+		}
+		changed = true
+	}
+	if changed {
+		if err := locked.Save(); err != nil {
+			killRestoredPanes(createdPaneIDs)
+			return report, err
+		}
+	}
+	return report, restoreErr
+}
+
+func killRestoredPanes(paneIDs []string) {
+	for _, paneID := range paneIDs {
+		_ = tmuxrun.KillPane(paneID)
+	}
+}
+
+func loadTUIRestoreSnapshot(session string) (tuiRestoreSnapshot, error) {
+	livePanes, err := tmuxrun.ListLivePanes()
+	if err != nil {
+		return tuiRestoreSnapshot{}, err
+	}
+	live := make(map[string]tmuxrun.LivePane, len(livePanes))
+	for _, pane := range livePanes {
+		live[pane.ID] = pane
+	}
+	sessionPanes, err := tmuxrun.ListPanes(session)
+	if err != nil {
+		return tuiRestoreSnapshot{}, err
+	}
+	return tuiRestoreSnapshot{Live: live, PanesByTitle: liveSessionPanesByTitle(sessionPanes, live)}, nil
+}
+
+func liveSessionPanesByTitle(sessionPanes []tmuxrun.PaneInfo, live map[string]tmuxrun.LivePane) map[string][]tmuxrun.LivePane {
+	out := map[string][]tmuxrun.LivePane{}
+	for _, pane := range sessionPanes {
+		title := strings.TrimSpace(pane.Title)
+		if title == "" {
+			continue
+		}
+		livePane, ok := live[pane.ID]
+		if !ok {
+			continue
+		}
+		out[title] = append(out[title], livePane)
+	}
+	return out
+}
+
+func rebindRecordedPane(pane state.Pane, panesByTitle map[string][]tmuxrun.LivePane) (state.Pane, bool) {
+	for _, title := range restorePaneTitleCandidates(pane) {
+		for _, livePane := range panesByTitle[title] {
+			candidate := pane
+			candidate.PaneID = livePane.ID
+			if restorePaneAlive(map[string]tmuxrun.LivePane{livePane.ID: livePane}, candidate) {
+				candidate.AgentStatus = "running"
+				return candidate, true
+			}
+		}
+	}
+	return state.Pane{}, false
+}
+
+func recreateRecordedPane(pane state.Pane, root, session, commandName string) (state.Pane, error) {
+	command, statusPath, err := restoreAgentCommand(pane, root, commandName)
+	if err != nil {
+		return pane, err
+	}
+	paneID, err := tmuxrun.SplitPaneWithAgentCommand(tuiLaunchTarget(session), pane.WorktreePath, command)
+	if err != nil {
+		return pane, err
+	}
+	_ = tmuxrun.SetPaneTitle(paneID, restorePaneTitle(pane))                           // cosmetic; pane is still usable if tmux rejects title updates
+	_ = tmuxrun.SetPaneLabel(paneID, borderLabel(pane.Parent, restorePaneTitle(pane))) // cosmetic pane-border label
+	_ = tmuxrun.EnablePaneBorderTitles(paneID)                                         // cosmetic pane-border label
+	_ = tmuxrun.SetPaneProjectRoot(paneID, root)                                       // best-effort dashboard keybinding hint
+	if statusPath != "" {
+		status, err := waitForCodexPlanTUIReadyStatus(statusPath, codexPlanTUIStartupTimeout)
+		_ = os.Remove(statusPath)
+		if err != nil {
+			_ = tmuxrun.KillPane(paneID)
+			return pane, fmt.Errorf("resume Codex Plan Mode TUI in pane %s: %w", paneID, err)
+		}
+		pane.CodexThreadID = status.ThreadID
+		pane.CodexSessionID = status.SessionID
+	}
+	pane.PaneID = paneID
+	pane.AgentStatus = "running"
+	return pane, nil
+}
+
+func restoreAgentCommand(pane state.Pane, root, commandName string) (string, string, error) {
+	if pane.CodexPlanMode {
+		if strings.TrimSpace(pane.CodexThreadID) == "" {
+			return "", "", fmt.Errorf("cannot restore Codex Plan Mode pane %q: missing codex thread id", restorePaneTitle(pane))
+		}
+		codexPath, err := agent.ResolveExecutable("codex")
+		if err != nil {
+			return "", "", err
+		}
+		fanoutPath, err := os.Executable()
+		if err != nil || strings.TrimSpace(fanoutPath) == "" {
+			fanoutPath = commandName
+		}
+		statusPath := codexPlanStatusPath(root, pane.IssueNum, false)
+		command := "PATH=" + agent.ShellQuote(os.Getenv("PATH")) + " " +
+			buildCodexPlanTUIResumeLaunchCommand(fanoutPath, codexPath, pane.CodexThreadID, pane.CodexSessionID, statusPath)
+		return command, statusPath, nil
+	}
+	command, err := agent.BuildResolvedResumeCommand(pane.Agent)
+	return command, "", err
+}
+
+func restorePaneAlive(live map[string]tmuxrun.LivePane, pane state.Pane) bool {
+	if strings.TrimSpace(pane.PaneID) == "" {
+		return false
+	}
+	cur, ok := live[pane.PaneID]
+	if !ok {
+		return false
+	}
+	if pane.IsShell() {
+		return strings.TrimSpace(pane.ShellKey) != "" && cur.ShellKey == pane.ShellKey
+	}
+	return pathWithin(cur.CurrentPath, pane.WorktreePath)
+}
+
+func restorePaneIDStillBelongsToRecord(livePane tmuxrun.LivePane, pane state.Pane) bool {
+	return slices.Contains(restorePaneTitleCandidates(pane), livePane.Title)
+}
+
+func pathWithin(path, base string) bool {
+	if strings.TrimSpace(base) == "" {
+		return true
+	}
+	path = filepath.Clean(path)
+	base = filepath.Clean(base)
+	rel, err := filepath.Rel(base, path)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel))
+}
+
+func restoreDedupeKey(pane state.Pane) string {
+	if pane.IsShell() || pane.IssueNum <= 0 {
+		return ""
+	}
+	return "issue\x00" + normalizeRestoreParent(pane.Parent) + "\x00" + strconv.Itoa(pane.IssueNum)
+}
+
+func normalizeRestoreParent(parent string) string {
+	num, err := strconv.Atoi(parent)
+	if err != nil {
+		return parent
+	}
+	return strconv.Itoa(num)
+}
+
+func restorePaneTitleCandidates(pane state.Pane) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, title := range []string{pane.DisplayName, pane.Slug} {
+		title = strings.TrimSpace(title)
+		if title == "" || seen[title] {
+			continue
+		}
+		seen[title] = true
+		out = append(out, title)
+	}
+	return out
+}
+
+func restorePaneTitle(pane state.Pane) string {
+	if title := strings.TrimSpace(pane.DisplayName); title != "" {
+		return title
+	}
+	if title := strings.TrimSpace(pane.Slug); title != "" {
+		return title
+	}
+	if pane.TaskID != "" {
+		return pane.TaskID
+	}
+	if pane.IssueNum != 0 {
+		return strconv.Itoa(pane.IssueNum)
+	}
+	return "fanout pane"
+}
+
+func dirExistsForRestore(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
+}
+
+func restoreStateFileExists(root string) (bool, error) {
+	_, err := os.Stat(state.Path(root))
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	return false, err
+}
+
+func uniqueRestoreRoots(roots []string) []string {
+	if len(roots) == 0 {
+		return nil
+	}
+	seen := map[string]bool{}
+	out := make([]string, 0, len(roots))
+	for _, root := range roots {
+		key := filepath.Clean(root)
+		if resolved, err := filepath.EvalSymlinks(root); err == nil {
+			key = resolved
+		}
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, root)
+	}
+	return out
+}
+
+func (r *tuiRestoreReport) Add(other tuiRestoreReport) {
+	r.Rebound += other.Rebound
+	r.Restored += other.Restored
+	r.RemovedShells += other.RemovedShells
+	r.Skipped += other.Skipped
+}
+
+func (r tuiRestoreReport) Changed() bool {
+	return r.Rebound > 0 || r.Restored > 0 || r.RemovedShells > 0
+}
+
+func (r tuiRestoreReport) Notice() string {
+	var parts []string
+	if r.Restored > 0 {
+		parts = append(parts, fmt.Sprintf("restored %d pane(s)", r.Restored))
+	}
+	if r.Rebound > 0 {
+		parts = append(parts, fmt.Sprintf("rebound %d pane(s)", r.Rebound))
+	}
+	if r.RemovedShells > 0 {
+		parts = append(parts, fmt.Sprintf("removed %d stale terminal(s)", r.RemovedShells))
+	}
+	return strings.Join(parts, ", ")
+}

--- a/cmd/fanout/tui_restore_test.go
+++ b/cmd/fanout/tui_restore_test.go
@@ -1,0 +1,401 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/butaosuinu/fanout/internal/state"
+	"github.com/butaosuinu/fanout/internal/tmuxrun"
+)
+
+func TestRestoreRecordedPanesRebindsLivePaneByTitle(t *testing.T) {
+	root := t.TempDir()
+	wt := filepath.Join(root, ".fanout", "worktrees", "restore-api-101")
+	if err := os.MkdirAll(wt, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeRestoreState(t, root, []state.Pane{{
+		Parent:       "81",
+		IssueNum:     101,
+		Slug:         "restore-api-101",
+		DisplayName:  "Restore API",
+		PaneID:       "%old",
+		Agent:        "claude",
+		WorktreePath: wt,
+	}})
+	livePane := tmuxrun.LivePane{ID: "%new", CurrentPath: filepath.Join(wt, "internal"), Title: "Restore API"}
+
+	report, err := restoreRecordedPanesForRootWithSnapshot(root, "fanout", "fanout", func(string) (tuiRestoreSnapshot, error) {
+		return tuiRestoreSnapshot{
+			Live: map[string]tmuxrun.LivePane{
+				livePane.ID: livePane,
+			},
+			PanesByTitle: map[string][]tmuxrun.LivePane{
+				"Restore API": {livePane},
+			},
+		}, nil
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := readRestoreState(t, root)
+	if len(got.Panes) != 1 || got.Panes[0].PaneID != "%new" {
+		t.Fatalf("state panes = %+v, want rebound pane id %%new", got.Panes)
+	}
+	if report.Rebound != 1 || report.Restored != 0 || report.RemovedShells != 0 {
+		t.Fatalf("report = %+v, want one rebound", report)
+	}
+}
+
+func TestRestoreRecordedPanesRemovesStaleShellRows(t *testing.T) {
+	root := t.TempDir()
+	writeRestoreState(t, root, []state.Pane{{
+		Parent:       "@shell",
+		IssueNum:     -1,
+		Kind:         state.PaneKindShell,
+		PaneID:       "%9",
+		ShellKey:     "shell-1",
+		DisplayName:  "terminal",
+		WorktreePath: root,
+	}})
+
+	report, err := restoreRecordedPanesForRootWithSnapshot(root, "fanout", "fanout", func(string) (tuiRestoreSnapshot, error) {
+		return tuiRestoreSnapshot{}, nil
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := readRestoreState(t, root)
+	if len(got.Panes) != 0 {
+		t.Fatalf("state panes = %+v, want stale shell removed", got.Panes)
+	}
+	if report.RemovedShells != 1 {
+		t.Fatalf("RemovedShells = %d, want 1", report.RemovedShells)
+	}
+}
+
+func TestRestoreRecordedPanesKeepsLiveShellWhenShellKeyMissing(t *testing.T) {
+	root := t.TempDir()
+	writeRestoreState(t, root, []state.Pane{{
+		Parent:       "@shell",
+		IssueNum:     -1,
+		Kind:         state.PaneKindShell,
+		PaneID:       "%9",
+		ShellKey:     "shell-1",
+		DisplayName:  "terminal",
+		WorktreePath: root,
+	}})
+
+	report, err := restoreRecordedPanesForRootWithSnapshot(root, "fanout", "fanout", func(string) (tuiRestoreSnapshot, error) {
+		return tuiRestoreSnapshot{
+			Live: map[string]tmuxrun.LivePane{
+				"%9": {ID: "%9", CurrentPath: root, Title: "terminal"},
+			},
+		}, nil
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := readRestoreState(t, root)
+	if len(got.Panes) != 1 || got.Panes[0].PaneID != "%9" {
+		t.Fatalf("state panes = %+v, want live shell row preserved", got.Panes)
+	}
+	if report.Skipped != 1 || report.RemovedShells != 0 {
+		t.Fatalf("report = %+v, want one skipped shell and no removal", report)
+	}
+}
+
+func TestRestoreRecordedPanesRemovesShellWhenLiveShellKeyDiffers(t *testing.T) {
+	root := t.TempDir()
+	writeRestoreState(t, root, []state.Pane{{
+		Parent:       "@shell",
+		IssueNum:     -1,
+		Kind:         state.PaneKindShell,
+		PaneID:       "%9",
+		ShellKey:     "shell-1",
+		DisplayName:  "terminal",
+		WorktreePath: root,
+	}})
+
+	report, err := restoreRecordedPanesForRootWithSnapshot(root, "fanout", "fanout", func(string) (tuiRestoreSnapshot, error) {
+		return tuiRestoreSnapshot{
+			Live: map[string]tmuxrun.LivePane{
+				"%9": {ID: "%9", CurrentPath: root, Title: "terminal", ShellKey: "shell-2"},
+			},
+		}, nil
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := readRestoreState(t, root)
+	if len(got.Panes) != 0 {
+		t.Fatalf("state panes = %+v, want reused shell row removed", got.Panes)
+	}
+	if report.RemovedShells != 1 {
+		t.Fatalf("RemovedShells = %d, want 1", report.RemovedShells)
+	}
+}
+
+func TestRestoreRecordedPanesSkipsRootWithoutStateFile(t *testing.T) {
+	root := t.TempDir()
+	snapshotCalled := false
+
+	report, err := restoreRecordedPanesForRootWithSnapshot(root, "fanout", "fanout", func(string) (tuiRestoreSnapshot, error) {
+		snapshotCalled = true
+		return tuiRestoreSnapshot{}, nil
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snapshotCalled {
+		t.Fatal("snapshot loader was called for a root without state")
+	}
+	if report.Changed() {
+		t.Fatalf("report = %+v, want no changes", report)
+	}
+	if _, err := os.Stat(filepath.Join(root, ".fanout")); !os.IsNotExist(err) {
+		t.Fatalf(".fanout stat error = %v, want missing directory", err)
+	}
+}
+
+func TestRestoreRecordedPanesDoesNotRecreateLivePaneWithPathMismatch(t *testing.T) {
+	root := t.TempDir()
+	wt := filepath.Join(root, ".fanout", "worktrees", "restore-api-101")
+	if err := os.MkdirAll(wt, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeRestoreState(t, root, []state.Pane{{
+		Parent:       "81",
+		IssueNum:     101,
+		Slug:         "restore-api-101",
+		DisplayName:  "Restore API",
+		PaneID:       "%old",
+		Agent:        "claude",
+		WorktreePath: wt,
+	}})
+
+	report, err := restoreRecordedPanesForRootWithSnapshot(root, "fanout", "fanout", func(string) (tuiRestoreSnapshot, error) {
+		return tuiRestoreSnapshot{
+			Live: map[string]tmuxrun.LivePane{
+				"%old": {ID: "%old", CurrentPath: "/tmp", Title: "Restore API"},
+			},
+		}, nil
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := readRestoreState(t, root)
+	if len(got.Panes) != 1 || got.Panes[0].PaneID != "%old" {
+		t.Fatalf("state panes = %+v, want original live pane id preserved", got.Panes)
+	}
+	if report.Skipped != 1 || report.Restored != 0 || report.Rebound != 0 {
+		t.Fatalf("report = %+v, want one skipped pane and no restore", report)
+	}
+}
+
+func TestRestoreRecordedPanesSkipsDuplicateIssueClaimedByAnotherRoot(t *testing.T) {
+	root := t.TempDir()
+	wt := filepath.Join(root, ".fanout", "worktrees", "restore-api-101")
+	if err := os.MkdirAll(wt, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeRestoreState(t, root, []state.Pane{{
+		Parent:       "081",
+		IssueNum:     101,
+		Slug:         "restore-api-101",
+		DisplayName:  "Restore API",
+		PaneID:       "%old",
+		Agent:        "claude",
+		WorktreePath: wt,
+	}})
+	claimed := map[string]bool{"issue\x0081\x00101": true}
+
+	report, err := restoreRecordedPanesForRootWithSnapshot(root, "fanout", "fanout", func(string) (tuiRestoreSnapshot, error) {
+		return tuiRestoreSnapshot{}, nil
+	}, claimed)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := readRestoreState(t, root)
+	if len(got.Panes) != 1 || got.Panes[0].PaneID != "%old" {
+		t.Fatalf("state panes = %+v, want duplicate row left unchanged", got.Panes)
+	}
+	if report.Skipped != 1 || report.Restored != 0 {
+		t.Fatalf("report = %+v, want duplicate skipped without restore", report)
+	}
+}
+
+func TestPreclaimLiveRestoreIdentitiesClaimsLiveSibling(t *testing.T) {
+	root := t.TempDir()
+	sibling := t.TempDir()
+	wt := filepath.Join(sibling, ".fanout", "worktrees", "restore-api-101")
+	if err := os.MkdirAll(wt, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeRestoreState(t, sibling, []state.Pane{{
+		Parent:       "081",
+		IssueNum:     101,
+		Slug:         "restore-api-101",
+		DisplayName:  "Restore API",
+		PaneID:       "%live",
+		Agent:        "claude",
+		WorktreePath: wt,
+	}})
+
+	claimed := preclaimLiveRestoreIdentities([]string{root, sibling}, tuiRestoreSnapshot{
+		Live: map[string]tmuxrun.LivePane{
+			"%live": {ID: "%live", CurrentPath: filepath.Join(wt, "subdir"), Title: "Restore API"},
+		},
+	})
+
+	if !claimed["issue\x0081\x00101"] {
+		t.Fatalf("claimed = %#v, want live sibling issue claimed", claimed)
+	}
+}
+
+func TestRestoreRecordedPanesRecreatesMissingAgentPaneWithResumeCommand(t *testing.T) {
+	root := t.TempDir()
+	wt := filepath.Join(root, ".fanout", "worktrees", "restore-api-101")
+	if err := os.MkdirAll(wt, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	logPath := installRestoreTmuxAndAgentScripts(t, "claude")
+	writeRestoreState(t, root, []state.Pane{{
+		Parent:       "81",
+		IssueNum:     101,
+		Slug:         "restore-api-101",
+		DisplayName:  "Restore API",
+		PaneID:       "%old",
+		Agent:        "claude",
+		WorktreePath: wt,
+	}})
+
+	report, err := restoreRecordedPanesForRootWithSnapshot(root, "fanout", "fanout", func(string) (tuiRestoreSnapshot, error) {
+		return tuiRestoreSnapshot{}, nil
+	}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := readRestoreState(t, root)
+	if len(got.Panes) != 1 || got.Panes[0].PaneID != "%restored" || got.Panes[0].AgentStatus != "running" {
+		t.Fatalf("state panes = %+v, want restored running pane %%restored", got.Panes)
+	}
+	if report.Restored != 1 {
+		t.Fatalf("Restored = %d, want 1", report.Restored)
+	}
+	logBody, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(logBody), "split-window") || !strings.Contains(string(logBody), "--continue") {
+		t.Fatalf("tmux log = %q, want split-window with claude --continue", string(logBody))
+	}
+}
+
+func TestRestoreAgentCommandUsesSavedCodexPlanThread(t *testing.T) {
+	root := t.TempDir()
+	installRestoreAgentScript(t, "codex")
+
+	command, statusPath, err := restoreAgentCommand(state.Pane{
+		IssueNum:       7,
+		Agent:          "codex",
+		CodexPlanMode:  true,
+		CodexThreadID:  "thread-7",
+		CodexSessionID: "session-7",
+	}, root, "fanout")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, want := range []string{"__codex-plan-tui", "--resume-thread-id", "thread-7", "--resume-session-id", "session-7", "--status-file"} {
+		if !strings.Contains(command, want) {
+			t.Fatalf("command = %q, missing %q", command, want)
+		}
+	}
+	if statusPath == "" || !strings.Contains(statusPath, "fanout-codex-plan-") {
+		t.Fatalf("statusPath = %q, want generated codex plan status path", statusPath)
+	}
+}
+
+func TestRestoreAgentCommandRejectsCodexPlanWithoutThread(t *testing.T) {
+	_, _, err := restoreAgentCommand(state.Pane{
+		Agent:         "codex",
+		CodexPlanMode: true,
+		DisplayName:   "Plan pane",
+	}, t.TempDir(), "fanout")
+
+	if err == nil || !strings.Contains(err.Error(), "missing codex thread id") {
+		t.Fatalf("restoreAgentCommand() error = %v, want missing thread id", err)
+	}
+}
+
+func writeRestoreState(t *testing.T, root string, panes []state.Pane) {
+	t.Helper()
+	locked, err := state.LockProject(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = locked.Unlock() }()
+	locked.SchemaVersion = state.SchemaVersion
+	locked.Panes = panes
+	if err := locked.Save(); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readRestoreState(t *testing.T, root string) state.Store {
+	t.Helper()
+	store, err := state.LoadProject(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return store
+}
+
+func installRestoreTmuxAndAgentScripts(t *testing.T, agentName string) string {
+	t.Helper()
+	binDir := t.TempDir()
+	logPath := filepath.Join(binDir, "tmux.log")
+	tmuxScript := `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$TMUX_RESTORE_LOG"
+case "${1:-}" in
+  split-window)
+    printf '%%restored\n'
+    ;;
+  select-pane|set-option|kill-pane)
+    ;;
+  *)
+    ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(binDir, "tmux"), []byte(tmuxScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	agentScript := "#!/usr/bin/env bash\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(binDir, agentName), []byte(agentScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TMUX_RESTORE_LOG", logPath)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return logPath
+}
+
+func installRestoreAgentScript(t *testing.T, agentName string) {
+	t.Helper()
+	binDir := t.TempDir()
+	agentScript := "#!/usr/bin/env bash\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(binDir, agentName), []byte(agentScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -11,13 +11,14 @@ import (
 )
 
 type Definition struct {
-	Name    string
-	Command string
+	Name       string
+	Command    string
+	ResumeArgs []string
 }
 
 var registry = map[string]Definition{
-	"claude": {Name: "claude", Command: "claude"},
-	"codex":  {Name: "codex", Command: "codex"},
+	"claude": {Name: "claude", Command: "claude", ResumeArgs: []string{"--continue"}},
+	"codex":  {Name: "codex", Command: "codex", ResumeArgs: []string{"resume", "--last"}},
 }
 
 // ValidateKnown returns an error if name is not in fanout's MVP registry.
@@ -74,12 +75,43 @@ func BuildResolvedCommand(name, prompt string) (string, error) {
 	return "PATH=" + ShellQuote(os.Getenv("PATH")) + " " + BuildCommandWithExecutable(path, prompt), nil
 }
 
+// BuildResumeCommand returns the generic resume command for a supported agent.
+func BuildResumeCommand(name string) (string, error) {
+	def, ok := registry[name]
+	if !ok {
+		return "", ValidateKnown(name)
+	}
+	return buildCommandWithArgs(def.Command, def.ResumeArgs), nil
+}
+
+// BuildResolvedResumeCommand returns the live resume command using the resolved
+// executable path from the caller's environment.
+func BuildResolvedResumeCommand(name string) (string, error) {
+	path, err := ResolveExecutable(name)
+	if err != nil {
+		return "", err
+	}
+	def, ok := registry[name]
+	if !ok {
+		return "", ValidateKnown(name)
+	}
+	return "PATH=" + ShellQuote(os.Getenv("PATH")) + " " + buildCommandWithArgs(path, def.ResumeArgs), nil
+}
+
 // BuildCommandWithExecutable builds a shell command for a known executable path.
 func BuildCommandWithExecutable(executable, prompt string) string {
 	if strings.TrimSpace(prompt) == "" {
 		return ShellQuote(executable)
 	}
 	return ShellQuote(executable) + " " + ShellQuote(prompt)
+}
+
+func buildCommandWithArgs(executable string, args []string) string {
+	parts := []string{ShellQuote(executable)}
+	for _, arg := range args {
+		parts = append(parts, ShellQuote(arg))
+	}
+	return strings.Join(parts, " ")
 }
 
 func Supported() []string {

--- a/internal/agent/agent_test.go
+++ b/internal/agent/agent_test.go
@@ -23,6 +23,24 @@ func TestBuildCommandRejectsUnknownAgent(t *testing.T) {
 	}
 }
 
+func TestBuildResumeCommandUsesAgentResumeArgs(t *testing.T) {
+	got, err := BuildResumeCommand("codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "codex resume --last" {
+		t.Fatalf("BuildResumeCommand(codex) = %q, want codex resume --last", got)
+	}
+
+	got, err = BuildResumeCommand("claude")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "claude --continue" {
+		t.Fatalf("BuildResumeCommand(claude) = %q, want claude --continue", got)
+	}
+}
+
 func TestBuildResolvedCommandUsesAbsoluteExecutablePathAndPathPrefix(t *testing.T) {
 	tmp := t.TempDir()
 	binDir := filepath.Join(tmp, "bin with space")
@@ -42,5 +60,27 @@ func TestBuildResolvedCommandUsesAbsoluteExecutablePathAndPathPrefix(t *testing.
 	want := "PATH=" + ShellQuote(os.Getenv("PATH")) + " " + ShellQuote(exe) + " prompt"
 	if got != want {
 		t.Fatalf("BuildResolvedCommand() = %q, want %q", got, want)
+	}
+}
+
+func TestBuildResolvedResumeCommandUsesAbsoluteExecutablePathAndPathPrefix(t *testing.T) {
+	tmp := t.TempDir()
+	binDir := filepath.Join(tmp, "bin with space")
+	if err := os.Mkdir(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	exe := filepath.Join(binDir, "codex")
+	if err := os.WriteFile(exe, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	got, err := BuildResolvedResumeCommand("codex")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "PATH=" + ShellQuote(os.Getenv("PATH")) + " " + ShellQuote(exe) + " resume --last"
+	if got != want {
+		t.Fatalf("BuildResolvedResumeCommand() = %q, want %q", got, want)
 	}
 }

--- a/internal/displayname/metadata.go
+++ b/internal/displayname/metadata.go
@@ -10,11 +10,13 @@ import (
 )
 
 type FanoutMetadata struct {
-	Agent        string
-	DisplayName  string
-	BranchName   string
-	Slug         string
-	WorktreePath string
+	Agent          string
+	DisplayName    string
+	BranchName     string
+	Slug           string
+	WorktreePath   string
+	CodexThreadID  string
+	CodexSessionID string
 }
 
 // WriteFanoutMetadata persists the pane name fields beside the generated
@@ -45,6 +47,12 @@ func WriteFanoutMetadata(worktreePath string, meta FanoutMetadata) error {
 	m["branchName"] = meta.BranchName
 	m["slug"] = meta.Slug
 	m["worktreePath"] = meta.WorktreePath
+	if meta.CodexThreadID != "" {
+		m["codexThreadId"] = meta.CodexThreadID
+	}
+	if meta.CodexSessionID != "" {
+		m["codexSessionId"] = meta.CodexSessionID
+	}
 	out, err := json.MarshalIndent(m, "", "  ")
 	if err != nil {
 		return err

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -46,12 +46,17 @@ type Pane struct {
 	// で起動したペインかどうか。ダッシュボードの GET /api/plan が plan 抽出の
 	// 対象ペインを限定するために参照する。additive なフィールドなので
 	// SchemaVersion は据え置き(旧版 fanout は未知キーとして無視して読める)。
-	CodexPlanMode bool   `json:"codexPlanMode,omitempty"`
-	Wave          string `json:"wave,omitempty"`
-	DisplayName   string `json:"displayName"`
-	WorktreePath  string `json:"worktreePath"`
-	Prompt        string `json:"prompt"`
-	CreatedAt     string `json:"createdAt"`
+	CodexPlanMode bool `json:"codexPlanMode,omitempty"`
+	// CodexThreadID/CodexSessionID preserve the app-server-backed Codex thread
+	// created for Plan Mode panes so a recreated pane can resume the exact same
+	// agent session instead of falling back to codex resume --last.
+	CodexThreadID  string `json:"codexThreadId,omitempty"`
+	CodexSessionID string `json:"codexSessionId,omitempty"`
+	Wave           string `json:"wave,omitempty"`
+	DisplayName    string `json:"displayName"`
+	WorktreePath   string `json:"worktreePath"`
+	Prompt         string `json:"prompt"`
+	CreatedAt      string `json:"createdAt"`
 	// AgentStatus は起動時に "running" を記録する。終了検知デーモンは無いので
 	// 表示側は tmux の動的判定(起動ラッパーが設定する pane user option
 	// @fanout_agent_state)を優先し、tmux 不通時のみこの記録値に fallback する。
@@ -165,6 +170,11 @@ func (l *LockedStore) RemoveTaskPane(parent, taskID string) error {
 	if !l.removeTask(parent, taskID) {
 		return nil
 	}
+	return save(l.path, l.Store)
+}
+
+// Save writes the currently locked store back to disk.
+func (l *LockedStore) Save() error {
 	return save(l.path, l.Store)
 }
 

--- a/internal/tui/issues.go
+++ b/internal/tui/issues.go
@@ -47,10 +47,11 @@ type issueStatus struct {
 }
 
 type stateLoadedMsg struct {
-	panes        []paneView
-	at           time.Time
-	err          error
-	scheduleNext bool
+	panes         []paneView
+	at            time.Time
+	err           error
+	restoreNotice string
+	scheduleNext  bool
 }
 
 type ghLoadedMsg struct {
@@ -69,9 +70,15 @@ type worktreeStatView struct {
 func (m model) loadStateCmd(scheduleNext bool) tea.Cmd {
 	projectRoot := m.opts.ProjectRoot
 	issues := cloneIssueStatuses(m.issues)
+	restorePanes := m.opts.RestorePanes
 	return func() tea.Msg {
+		var restoreNotice string
+		var restoreErr error
+		if restorePanes != nil {
+			restoreNotice, restoreErr = restorePanes()
+		}
 		panes, err := loadPaneViews(projectRoot, issues)
-		return stateLoadedMsg{panes: panes, at: time.Now(), err: err, scheduleNext: scheduleNext}
+		return stateLoadedMsg{panes: panes, at: time.Now(), err: errors.Join(restoreErr, err), restoreNotice: restoreNotice, scheduleNext: scheduleNext}
 	}
 }
 

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -46,6 +46,7 @@ type Options struct {
 	Hooks               hooks.Config
 	LaunchPane          LaunchFunc
 	LaunchShell         ShellLaunchFunc
+	RestorePanes        func() (string, error)
 	// Relayout re-tiles the TUI's tmux window into the fanout grid. It is wired
 	// to panelayout.Apply(target, Resize) in production and left nil in tests
 	// (then resize handling is a no-op).

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -118,6 +118,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.allPanes = msg.panes
 		m.lastState = msg.at
+		if msg.restoreNotice != "" {
+			m.notice = msg.restoreNotice
+		}
 		m.refreshRows()
 		peekCmd := m.peekSelectedCmd(false)
 		if msg.scheduleNext {

--- a/site/content/docs/monitoring.ja.md
+++ b/site/content/docs/monitoring.ja.md
@@ -17,7 +17,7 @@ yomi: monitoring
 fanout   # start the persistent tmux console
 ```
 
-素のシェルから起動したときは、現在のリポジトリ用の deterministic な fanout 管理 tmux session を作成または attach し、その session 内でコンソールを開始します。tmux 内から起動したときは、現在のペインをそのままコンソール画面にします。
+素のシェルから起動したときは、現在のリポジトリ用の deterministic な fanout 管理 tmux session を作成または attach し、その session 内でコンソールを開始します。tmux 内から起動したときは、現在のペインをそのままコンソール画面にします。起動時と state 更新ごとに、コンソールは tmux 上に残っている記録済み worktree ペインへ再バインドし、消えた worktree ペインは agent CLI の resume で作り直します。使うのは `claude --continue`、`codex resume --last`、または Plan ペインに保存した Codex Plan Mode thread です。
 
 コンソールは `<git-root>/.fanout/state.json` を読み、記録済みペイン ID が tmux 上にまだ存在するかを確認し、`fanout <parent> --status` と同じ GitHub CLI 経路で issue と closed-by PR の状態を定期更新します。エージェント側に計測の仕込みは要りません。各行にはペインの worktree の総作業量を `+X/-Y` で示します。これは記録した base ブランチとの merge-base に対する `git diff --shortstat` で、コミット済みと未 commit の合計です（base 未記録の旧行は `origin/HEAD` から `HEAD` に fallback します）。あわせて `git status --porcelain` 由来の `dirty` / `clean` を出すので、未 commit の作業を抱えたペインをその場で見分けられます。
 
@@ -42,7 +42,7 @@ footer は短く保ちます。通常画面で `?` を押すと、全ショー�
 | `X` | 同じ親の merged/closed な子をまとめて cleanup する（確認を挟み、`--cleanup` と同じコア処理を使う）。 |
 | `q` | コンソールを離脱する。tmux session と子ペインはそのまま残る。 |
 
-> 記録はあるものの tmux 上に存在しないペインの行は `stale!` と表示され、フォーカス操作とピーク操作の対象から外れます。
+> worktree 行が `stale!` になるのは、worktree が無い、agent command が無いなど fanout が復元できない場合です。shell terminal は resume できないため、対応する tmux ペインが無ければ TUI が state 行を削除します。
 
 ## --status（JSON）
 

--- a/site/content/docs/monitoring.md
+++ b/site/content/docs/monitoring.md
@@ -17,7 +17,7 @@ To watch every pane from your terminal, run `fanout` with no arguments to start 
 fanout   # start the persistent tmux console
 ```
 
-From a plain shell it creates a deterministic fanout-managed tmux session for the current repository, starts the console in that session, and attaches to it. From inside tmux it turns the current pane into the console.
+From a plain shell it creates a deterministic fanout-managed tmux session for the current repository, starts the console in that session, and attaches to it. From inside tmux it turns the current pane into the console. On startup and each state refresh, the console rebinds recorded worktree panes that still exist in tmux and recreates missing worktree panes by resuming their agent CLI: `claude --continue`, `codex resume --last`, or the saved Codex Plan Mode thread for Plan panes.
 
 The console reads `<git-root>/.fanout/state.json`, checks whether recorded pane IDs still exist in tmux, and periodically refreshes issue / closed-by PR state through the same GitHub CLI source used by `fanout <parent> --status` — no agent instrumentation required. Each row shows the pane worktree's total work size as `+X/-Y`: `git diff --shortstat` against the merge-base with the recorded base branch, so committed and uncommitted changes both count (rows recorded before the base branch was tracked fall back to `origin/HEAD`, then `HEAD`). It also shows `dirty`/`clean` from `git status --porcelain`, so you can spot a pane holding uncommitted work at a glance.
 
@@ -42,7 +42,7 @@ The footer stays short; press `?` in the monitor to open the full shortcut help.
 | `X` | Clean up merged/closed children of the same parent — confirmation prompt, then the same core path as `--cleanup`. |
 | `q` | Leave the console. The tmux session and child panes are left running. |
 
-> Rows whose recorded pane no longer exists in tmux are marked `stale!` and are skipped by the focus and peek actions.
+> Worktree rows become `stale!` only when fanout cannot restore them, such as a missing worktree or unavailable agent command. Recorded shell terminals are not resumable; if their tmux pane is gone, the TUI removes the state row.
 
 ## --status (JSON)
 


### PR DESCRIPTION
## TL;DR

fanout TUI の再起動時に、既存 state から worktree pane を復元できるようにしました。tmux 上に残っている pane は再バインドし、消えた agent pane は agent の resume 経路で作り直します。

## 変更内容

- no-arg TUI の state refresh 前に復元処理を追加
- `claude --continue` / `codex resume --last` / 保存済み Codex Plan Mode session による agent session 復元を追加
- Codex Plan Mode pane の `threadId` / `sessionId` を state と worktree metadata に保存
- shell terminal は復元せず、tmux pane が消えた場合のみ state 行を削除
- pane ID 再利用、cross-worktree 重複、保存失敗時 rollback を考慮した復元テストを追加
- README と monitoring docs の英日ペアを更新

## 背景

fanout や tmux が落ちたあとに TUI を再起動しても、既存の worktree / agent session を復元する経路がありませんでした。dmux と同じく、まず生きている tmux pane を title/path で再バインドし、必要な worktree pane だけを再作成する動きにしています。

## 検証

- `go test ./cmd/fanout ./internal/agent ./internal/state ./internal/displayname ./internal/tui`
- `make lint`
- `make test`
- `post-work-review`（最終 digest で actionable finding なし、driver は `clean=unknown`）

Review effort: 3
