### PR TITLE
[codex] TUI 起動時に dashboard keybind を登録

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -33,7 +33,7 @@ briefing から起動します。再実行しても同じ対象に 2 つ目の�
 - **ラベル watcher** — opt-in すると、TUI 常駐中に信頼できる `fanout:auto`
   issue を one-shot fanout session に投入します。
 - **Web ダッシュボード** — localhost で動く read-only のダッシュボード(ライブ
-  更新)。どのペインからでも `prefix + D` でポップできます。
+  更新)。どのペインからでも `F12` または `prefix + D` でポップできます。
 - **状態確認とレポート** — `--status` の JSON / table で PR review・CI 状態を
   確認でき、任意で親 issue にダッシュボードコメントを投稿します。
 - **Lifecycle hook** — user config に書いた shell command を worktree、pane、

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ English and 日本語.
 - **Label watcher** — opt in to a TUI-resident watcher that turns trusted
   `fanout:auto` issues into one-shot fanout sessions.
 - **Web dashboard** — a read-only localhost dashboard with live updates; pop it
-  from any pane with `prefix + D`.
+  from any pane with `F12` or `prefix + D`.
 - **Status & reporting** — `--status` JSON / table with PR review and CI state,
   plus an optional dashboard comment on the parent issue.
 - **Lifecycle hooks** — user-configured shell commands around worktree, pane,

--- a/claude/skills/fanout/SKILL.md
+++ b/claude/skills/fanout/SKILL.md
@@ -34,7 +34,7 @@ fanout --check-update               # Read-only version comparison
 fanout update                       # Replace fanout via install.sh
 ```
 
-`fanout dashboard --web` is a standalone subcommand (no parent argument): it starts a read-only, 127.0.0.1-bound web dashboard that visualizes all fanned-out Sessions live (pane liveness, issue/PR state). It is human-facing — surface it to the user when they ask to "watch"/"monitor" parallel panes, but do not run it as part of the fan-out flow. After a live fan-out, fanout also binds `prefix + D` in tmux to open it; launched panes record their owner project root so the key still opens the right dashboard from agent TUIs such as Codex when tmux reports a stale `pane_current_path`. Pass `--no-dashboard-keybind` to suppress that.
+`fanout dashboard --web` is a standalone subcommand (no parent argument): it starts a read-only, 127.0.0.1-bound web dashboard that visualizes all fanned-out Sessions live (pane liveness, issue/PR state). It is human-facing — surface it to the user when they ask to "watch"/"monitor" parallel panes, but do not run it as part of the fan-out flow. When the TUI starts and after a live fan-out, fanout also binds `F12` and `prefix + D` in tmux to open it; launched panes record their owner project root so the keys still open the right dashboard from agent TUIs such as Codex when tmux reports a stale `pane_current_path`. Pass `--no-dashboard-keybind` to suppress those bindings.
 
 `fanout plan <spec.json|plan-slug>` is the issue-less plan-task lane. If the
 user asks to fan out an implementation plan, route through the `fanout-plan`

--- a/cmd/fanout/dashboard.go
+++ b/cmd/fanout/dashboard.go
@@ -24,8 +24,11 @@ import (
 	"github.com/butaosuinu/fanout/internal/worktree"
 )
 
-// defaultDashboardKey is the tmux prefix key fanout binds to open the dashboard.
+// defaultDashboardKey is the tmux prefix-table key fanout binds to open the dashboard.
 const defaultDashboardKey = "D"
+
+// defaultDashboardDirectKey opens the dashboard without tmux's prefix key.
+const defaultDashboardDirectKey = "F12"
 
 type dashboardFlags struct {
 	port      int
@@ -68,8 +71,8 @@ func cmdDashboard(args []string, lg *log.Logger) exitcode.Code {
 		lg.Debug("dashboard: ensure local exclude: %v", err)
 	}
 
-	// Serialize startup so two near-simultaneous launches (e.g. a double
-	// prefix+D press) reuse one server instead of each binding its own port.
+	// Serialize startup so two near-simultaneous keypress launches reuse one
+	// server instead of each binding its own port.
 	// Best-effort: if the lock can't be taken, proceed unsynchronized.
 	startupLock, lockErr := dashboard.LockStartup(root)
 	if lockErr != nil {
@@ -262,18 +265,18 @@ func bindDashboardKey(lg *log.Logger, enabled bool) {
 	// (@fanout_project_root when fanout recorded it, otherwise
 	// #{pane_current_path}) and cmdDashboard maps that to the main worktree, so
 	// no repo root needs to be baked in here.
-	if err := tmuxrun.BindDashboardKey(defaultDashboardKey, bin); err != nil {
+	if err := tmuxrun.BindDashboardKeys(defaultDashboardKey, defaultDashboardDirectKey, bin); err != nil {
 		lg.Debug("dashboard keybind: %v (not in tmux?)", err)
 		return
 	}
-	lg.Info("tmux keybind: press prefix + %s to open the dashboard", defaultDashboardKey)
+	lg.Info("tmux keybind: press %s or prefix + %s to open the dashboard", defaultDashboardDirectKey, defaultDashboardKey)
 }
 
 // dashboardProjectRoot resolves the repo root whose .fanout/state.json the
 // dashboard should read. fanout records state at the toplevel of the worktree it
 // ran in, and its fanned child panes live at <root>/.fanout/worktrees/<slug>.
 // So: use the current worktree toplevel when it has state; if instead we are
-// inside a .fanout/worktrees/<slug> child (a fanned pane, e.g. via prefix+D),
+// inside a .fanout/worktrees/<slug> child (a fanned pane, e.g. via a keybind),
 // recover that parent root. Crucially the climb is bounded to that one structure
 // — it never escapes into an unrelated ancestor checkout that merely happens to
 // have its own .fanout/state.json. A never-fanned worktree falls back to itself.
@@ -354,7 +357,8 @@ Options:
   --no-token      Disable the access token (loopback-only, single-user laptops).
                   By default a random token gates /api/* and is embedded in the
                   printed URL.
-  --no-keybind    Do not register the tmux 'prefix + D' keybinding this run.
+  --no-keybind    Do not register the tmux 'F12' / 'prefix + D' keybindings
+                  this run.
   -h, --help      Show this message.
 
 The dashboard reuses a server that is already running (recorded in

--- a/cmd/fanout/main.go
+++ b/cmd/fanout/main.go
@@ -228,10 +228,10 @@ func runWithRuntime(cfg *cliflags.Config, lg *log.Logger, rt *runtimeInfo, comma
 	result := executePlan(cfg, lg, rt.info, rt.gh, plan.Targets, resolvedSettings, hookConfig, recorder, otherParentFanned, c, commandName, teamCtx)
 	printSummary(plan, result, cfg, lg, c, commandName)
 
-	// Register the tmux keybinding so the user can pop the read-only dashboard
-	// (prefix + D) from any fanout pane. The binding resolves the repo from the
-	// pressing pane at keypress, so it works from child worktree panes and across
-	// repos. Best-effort, live runs only.
+	// Register the tmux keybindings so the user can pop the read-only
+	// dashboard (F12 or prefix + D) from any fanout pane. The binding resolves
+	// the repo from the pressing pane at keypress, so it works from child
+	// worktree panes and across repos. Best-effort, live runs only.
 	if !cfg.DryRun && result.Created > 0 {
 		bindDashboardKey(lg, resolvedSettings.DashboardKeybind)
 	}

--- a/cmd/fanout/tui.go
+++ b/cmd/fanout/tui.go
@@ -22,6 +22,8 @@ import (
 
 const tuiPaneTitle = "fanout tui"
 
+var runTUI = fanouttui.Run
+
 func isTUIRequest(args []string) bool {
 	return len(args) == 0
 }
@@ -62,7 +64,8 @@ func cmdTUI(commandName string, lg *log.Logger) exitcode.Code {
 	}
 	restoreTitle := markTUIRunning(projectRoot)
 	defer restoreTitle()
-	if err := fanouttui.Run(fanouttui.Options{
+	bindDashboardKey(lg, resolvedSettings.DashboardKeybind)
+	if err := runTUI(fanouttui.Options{
 		ProjectRoot:         projectRoot,
 		Session:             session,
 		StateInterval:       2 * time.Second,

--- a/cmd/fanout/tui_test.go
+++ b/cmd/fanout/tui_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/butaosuinu/fanout/internal/cliflags"
+	"github.com/butaosuinu/fanout/internal/exitcode"
 	"github.com/butaosuinu/fanout/internal/ghissue"
 	"github.com/butaosuinu/fanout/internal/hooks"
 	"github.com/butaosuinu/fanout/internal/settings"
@@ -34,6 +35,56 @@ func TestTUIAgentOrDefault(t *testing.T) {
 				t.Fatalf("tuiAgentOrDefault(%q) = %q, want %q", tc.raw, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestCmdTUIRegistersDashboardKeybinds(t *testing.T) {
+	repo := t.TempDir()
+	initTUITestGitRepo(t, repo)
+	commitTUITestGitRepo(t, repo)
+	writeTUITestStateFile(t, repo)
+	t.Chdir(repo)
+	t.Setenv("TMUX", "tmux-session")
+	t.Setenv("TMUX_PANE", "%tui")
+	argsPath := installTUIDashboardTmuxShim(t)
+	restoreRunTUI := stubRunTUI(t)
+	defer restoreRunTUI()
+
+	code := cmdTUI("fanout", discardLogger())
+	if code != exitcode.OK {
+		t.Fatalf("cmdTUI() = %d, want OK", code)
+	}
+
+	log := readTUITmuxLog(t, argsPath)
+	if !tmuxLogHasCommand(log, "bind-key\nD\nnew-window") {
+		t.Fatalf("tmux log missing prefix dashboard keybind:\n%s", log)
+	}
+	if !tmuxLogHasCommand(log, "bind-key\n-n\nF12\nnew-window") {
+		t.Fatalf("tmux log missing direct dashboard keybind:\n%s", log)
+	}
+}
+
+func TestCmdTUINoDashboardKeybindHonorsEnv(t *testing.T) {
+	repo := t.TempDir()
+	initTUITestGitRepo(t, repo)
+	commitTUITestGitRepo(t, repo)
+	writeTUITestStateFile(t, repo)
+	t.Chdir(repo)
+	t.Setenv("TMUX", "tmux-session")
+	t.Setenv("TMUX_PANE", "%tui")
+	t.Setenv("FANOUT_DASHBOARD_KEYBIND", "0")
+	argsPath := installTUIDashboardTmuxShim(t)
+	restoreRunTUI := stubRunTUI(t)
+	defer restoreRunTUI()
+
+	code := cmdTUI("fanout", discardLogger())
+	if code != exitcode.OK {
+		t.Fatalf("cmdTUI() = %d, want OK", code)
+	}
+
+	log := readTUITmuxLog(t, argsPath)
+	if strings.Contains(log, "bind-key\n") {
+		t.Fatalf("tmux log should not contain dashboard keybinds when disabled:\n%s", log)
 	}
 }
 
@@ -669,6 +720,84 @@ esac
 	}
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	t.Setenv("TMUX_SHIM_PANE_ID", paneID)
+}
+
+func installTUIDashboardTmuxShim(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	argsPath := filepath.Join(dir, "tmux-args.txt")
+	script := `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$@" >> "$TMUX_SHIM_ARGS"
+printf '%s\n' '---' >> "$TMUX_SHIM_ARGS"
+case "${1:-}" in
+  display-message)
+    if [[ "$*" == *session_name* ]]; then
+      printf 'fanout-test\n'
+    elif [[ "$*" == *pane_title* ]]; then
+      printf 'old title\n'
+    elif [[ "$*" == *window_width* ]]; then
+      printf '@1\t200\t50\n'
+    elif [[ "$*" == *window_id* ]]; then
+      printf '@1\n'
+    fi
+    ;;
+  list-panes)
+    if [[ "$*" == *fanout_role* ]]; then
+      printf '%%tui\t0\t1\tconsole\t\n'
+    fi
+    ;;
+  bind-key|set-option|select-pane|select-layout|kill-pane)
+    ;;
+  *)
+    ;;
+esac
+`
+	path := filepath.Join(dir, "tmux")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TMUX_SHIM_ARGS", argsPath)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return argsPath
+}
+
+func stubRunTUI(t *testing.T) func() {
+	t.Helper()
+	original := runTUI
+	runTUI = func(fanouttui.Options) error { return nil }
+	return func() {
+		runTUI = original
+	}
+}
+
+func writeTUITestStateFile(t *testing.T, repo string) {
+	t.Helper()
+	dir := filepath.Join(repo, ".fanout")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "state.json"), []byte(`{"panes":[]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readTUITmuxLog(t *testing.T, argsPath string) string {
+	t.Helper()
+	body, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(body)
+}
+
+func tmuxLogHasCommand(log, needle string) bool {
+	for command := range strings.SplitSeq(strings.TrimSuffix(log, "\n---\n"), "\n---\n") {
+		if strings.Contains(command, needle) {
+			return true
+		}
+	}
+	return false
 }
 
 func installTUIWatcherGHScript(t *testing.T, body string) string {

--- a/codex/skills/fanout/SKILL.md
+++ b/codex/skills/fanout/SKILL.md
@@ -36,7 +36,7 @@ fanout --check-update               # Read-only version comparison
 fanout update                       # Replace fanout via install.sh
 ```
 
-`fanout dashboard --web` is a standalone subcommand (no parent argument): a read-only, 127.0.0.1-bound web dashboard that visualizes all fanned-out Sessions live (pane liveness, issue/PR state). It is human-facing — surface it when the user wants to watch/monitor parallel panes, not as part of the fan-out flow. After a live fan-out, fanout also binds `prefix + D` in tmux to open it; launched panes record their owner project root so the key still opens the right dashboard from agent TUIs such as Codex when tmux reports a stale `pane_current_path`. `--no-dashboard-keybind` suppresses the binding.
+`fanout dashboard --web` is a standalone subcommand (no parent argument): a read-only, 127.0.0.1-bound web dashboard that visualizes all fanned-out Sessions live (pane liveness, issue/PR state). It is human-facing — surface it when the user wants to watch/monitor parallel panes, not as part of the fan-out flow. When the TUI starts and after a live fan-out, fanout also binds `F12` and `prefix + D` in tmux to open it; launched panes record their owner project root so the keys still open the right dashboard from agent TUIs such as Codex when tmux reports a stale `pane_current_path`. `--no-dashboard-keybind` suppresses the bindings.
 
 `fanout plan <spec.json|plan-slug>` is the issue-less plan-task lane. If the
 user asks to fan out an implementation plan, use the `fanout-plan` skill

--- a/internal/cliflags/usage.go
+++ b/internal/cliflags/usage.go
@@ -109,9 +109,9 @@ Options:
                       Include or omit structured PR-body plus gated Mermaid
                       guidance in auto-PR child briefings. Default: on.
   --dashboard-keybind / --no-dashboard-keybind
-                      Register (or skip) a tmux 'prefix + D' keybinding after a
-                      live fan-out so the read-only web dashboard can be opened
-                      from any pane. Default: on.
+                      Register (or skip) tmux 'F12' / 'prefix + D' keybindings
+                      after a live fan-out so the read-only web dashboard can be
+                      opened from any pane. Default: on.
   --team              Opt in to sibling-pane messaging for this run: add a
                       "Coordinating with your sibling panes" section (roster +
                       shared SQLite DB path) to every child briefing and seed

--- a/internal/dashboard/runfile.go
+++ b/internal/dashboard/runfile.go
@@ -152,9 +152,9 @@ func pidAlive(pid int) bool {
 }
 
 // LockStartup takes an exclusive lock that serializes the reuse-check → bind →
-// run-file-write critical section, so two near-simultaneous launches (e.g. a
-// double `prefix + D` press) cannot both pass the "no server running" check and
-// each bind a fresh ephemeral port, leaving duplicate servers. Release it with
+// run-file-write critical section, so two near-simultaneous keypress launches
+// cannot both pass the "no server running" check and each bind a fresh
+// ephemeral port, leaving duplicate servers. Release it with
 // UnlockStartup once the run file is written and the listener is bound.
 func LockStartup(projectRoot string) (*os.File, error) {
 	lockPath := RunFilePath(projectRoot) + ".lock"

--- a/internal/tmuxrun/tmuxrun.go
+++ b/internal/tmuxrun/tmuxrun.go
@@ -270,8 +270,10 @@ func parseLivePaneField(out string) map[string]string {
 	return fields
 }
 
-// BindDashboardKey registers a tmux key binding (under the prefix table) that
-// opens the read-only web dashboard. It binds the key directly to `new-window`
+// BindDashboardKeys registers tmux key bindings that open the read-only web
+// dashboard. The prefix key is bound under the prefix table; the direct key is
+// bound in the root table so it works without tmux's prefix. Both bindings run
+// the same launch command directly through `new-window`
 // (not run-shell), so:
 //
 //   - tmux expands @fanout_project_root (when fanout recorded it on the pane)
@@ -291,20 +293,27 @@ func parseLivePaneField(out string) map[string]string {
 // URL. The binding lives in the running tmux server (it never edits
 // ~/.tmux.conf) and re-registering is idempotent.
 //
-// fanoutBin should be an absolute path (os.Executable) so the binding does not
+// fanoutBin should be an absolute path (os.Executable) so the bindings do not
 // depend on PATH.
-func BindDashboardKey(key, fanoutBin string) error {
-	if strings.TrimSpace(key) == "" || strings.TrimSpace(fanoutBin) == "" {
-		return fmt.Errorf("tmux bind-key: key and fanout binary path are required")
+func BindDashboardKeys(prefixKey, directKey, fanoutBin string) error {
+	if strings.TrimSpace(prefixKey) == "" || strings.TrimSpace(directKey) == "" || strings.TrimSpace(fanoutBin) == "" {
+		return fmt.Errorf("tmux bind-key: prefix key, direct key, and fanout binary path are required")
 	}
 	launch := shellQuote(fanoutBin) + " dashboard --web --open"
 	startDir := "#{?@fanout_project_root,#{@fanout_project_root},#{pane_current_path}}"
-	args := []string{
-		"bind-key", key, "new-window", "-d", "-n", "fanout-dashboard",
+	prefixArgs := []string{
+		"bind-key", prefixKey, "new-window", "-d", "-n", "fanout-dashboard",
 		"-c", startDir, launch,
 	}
-	if err := exec.Command("tmux", args...).Run(); err != nil {
-		return fmt.Errorf("tmux bind-key %s: %w", key, err)
+	if err := exec.Command("tmux", prefixArgs...).Run(); err != nil {
+		return fmt.Errorf("tmux bind-key %s: %w", prefixKey, err)
+	}
+	directArgs := []string{
+		"bind-key", "-n", directKey, "new-window", "-d", "-n", "fanout-dashboard",
+		"-c", startDir, launch,
+	}
+	if err := exec.Command("tmux", directArgs...).Run(); err != nil {
+		return fmt.Errorf("tmux bind-key -n %s: %w", directKey, err)
 	}
 	return nil
 }

--- a/internal/tmuxrun/tmuxrun_test.go
+++ b/internal/tmuxrun/tmuxrun_test.go
@@ -353,12 +353,13 @@ func TestListLivePanesDropsForgedAgentStateLineForAnotherPane(t *testing.T) {
 	}
 }
 
-func TestBindDashboardKeyRegistersDetachedWindow(t *testing.T) {
+func TestBindDashboardKeysRegistersDetachedWindows(t *testing.T) {
 	dir := t.TempDir()
 	argsPath := filepath.Join(dir, "args.txt")
 	tmuxPath := filepath.Join(dir, "tmux")
 	script := `#!/bin/sh
-printf '%s\n' "$@" > "$TMUXRUN_ARGS"
+printf '%s\n' "$@" >> "$TMUXRUN_ARGS"
+printf '%s\n' '---' >> "$TMUXRUN_ARGS"
 `
 	if err := os.WriteFile(tmuxPath, []byte(script), 0o755); err != nil {
 		t.Fatal(err)
@@ -366,23 +367,36 @@ printf '%s\n' "$@" > "$TMUXRUN_ARGS"
 	t.Setenv("TMUXRUN_ARGS", argsPath)
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	if err := BindDashboardKey("D", "/abs/path/fanout"); err != nil {
-		t.Fatalf("BindDashboardKey() failed: %v", err)
+	if err := BindDashboardKeys("D", "F12", "/abs/path/fanout"); err != nil {
+		t.Fatalf("BindDashboardKeys() failed: %v", err)
 	}
 	body, err := os.ReadFile(argsPath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	got := strings.Split(strings.TrimRight(string(body), "\n"), "\n")
+	commands := strings.Split(strings.TrimSuffix(string(body), "\n---\n"), "\n---\n")
+	if len(commands) != 2 {
+		t.Fatalf("tmux command count = %d, want 2\n%s", len(commands), body)
+	}
+	gotPrefix := strings.Split(commands[0], "\n")
+	gotDirect := strings.Split(commands[1], "\n")
 	// Each tmux argv on its own line: bind-key D new-window -d -n
 	// fanout-dashboard -c <root-or-current-path> <launch>.
-	want := []string{
+	wantPrefix := []string{
 		"bind-key", "D", "new-window", "-d", "-n", "fanout-dashboard",
 		"-c", "#{?@fanout_project_root,#{@fanout_project_root},#{pane_current_path}}",
 		"/abs/path/fanout dashboard --web --open",
 	}
-	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
-		t.Fatalf("tmux args = %#v, want %#v", got, want)
+	wantDirect := []string{
+		"bind-key", "-n", "F12", "new-window", "-d", "-n", "fanout-dashboard",
+		"-c", "#{?@fanout_project_root,#{@fanout_project_root},#{pane_current_path}}",
+		"/abs/path/fanout dashboard --web --open",
+	}
+	if strings.Join(gotPrefix, "\x00") != strings.Join(wantPrefix, "\x00") {
+		t.Fatalf("prefix tmux args = %#v, want %#v", gotPrefix, wantPrefix)
+	}
+	if strings.Join(gotDirect, "\x00") != strings.Join(wantDirect, "\x00") {
+		t.Fatalf("direct tmux args = %#v, want %#v", gotDirect, wantDirect)
 	}
 }
 
@@ -399,8 +413,8 @@ printf '%s\n' "$@" > "$TMUXRUN_ARGS"
 	t.Setenv("TMUXRUN_ARGS", argsPath)
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	if err := BindDashboardKey("D", "/opt/My Tools/fanout"); err != nil {
-		t.Fatalf("BindDashboardKey() failed: %v", err)
+	if err := BindDashboardKeys("D", "F12", "/opt/My Tools/fanout"); err != nil {
+		t.Fatalf("BindDashboardKeys() failed: %v", err)
 	}
 	body, err := os.ReadFile(argsPath)
 	if err != nil {
@@ -415,12 +429,15 @@ printf '%s\n' "$@" > "$TMUXRUN_ARGS"
 	}
 }
 
-func TestBindDashboardKeyRejectsEmptyArgs(t *testing.T) {
-	if err := BindDashboardKey("", "/abs/fanout"); err == nil {
-		t.Fatal("BindDashboardKey(empty key) should error")
+func TestBindDashboardKeysRejectsEmptyArgs(t *testing.T) {
+	if err := BindDashboardKeys("", "F12", "/abs/fanout"); err == nil {
+		t.Fatal("BindDashboardKeys(empty prefix key) should error")
 	}
-	if err := BindDashboardKey("D", ""); err == nil {
-		t.Fatal("BindDashboardKey(empty bin) should error")
+	if err := BindDashboardKeys("D", "", "/abs/fanout"); err == nil {
+		t.Fatal("BindDashboardKeys(empty direct key) should error")
+	}
+	if err := BindDashboardKeys("D", "F12", ""); err == nil {
+		t.Fatal("BindDashboardKeys(empty bin) should error")
 	}
 }
 

--- a/site/content/docs/cli.ja.md
+++ b/site/content/docs/cli.ja.md
@@ -215,7 +215,7 @@ agent wrapper は同梱 skill 経由で plan fan-out へ routing します。Cla
 | `--agent-teams-hint` / `--no-agent-teams-hint` | — | Claude 専用の Agent Teams ヒントを子 briefing に含めるか外すか。既定: on。 |
 | `--codex-plan-mode` / `--no-codex-plan-mode` | — | `--agent codex` のとき、positional の `codex "<prompt>"` ではなく Codex app-server の `plan` thread を作成し、prompt 付きの interactive Codex TUI で resume する。既定: off。詳細は[エージェント連携]({{< relref "/docs/agents" >}})。 |
 | `--pr-visualization` / `--no-pr-visualization` | — | auto-PR の子 briefing に構造化 PR 本文とゲート付き Mermaid の指示を含めるか外すか。既定: on。 |
-| `--dashboard-keybind` / `--no-dashboard-keybind` | — | ライブ fan-out 後に tmux の `prefix + D` キーバインドを登録する（またはスキップする）。どのペインからでも読み取り専用 Web ダッシュボードを開けるようにする。既定: on。 |
+| `--dashboard-keybind` / `--no-dashboard-keybind` | — | ライブ fan-out 後に tmux の `F12` / `prefix + D` キーバインドを登録する（またはスキップする）。どのペインからでも読み取り専用 Web ダッシュボードを開けるようにする。既定: on。 |
 
 ## 読み取りとライフサイクルのモード
 
@@ -314,7 +314,7 @@ fanout dashboard --web [--port N] [--open] [--no-token] [--no-keybind]
 | `--port` | `N` | バインドする port。既定: `0`（OS 割り当ての ephemeral port）。確定した URL が表示される。 |
 | `--open` | — | 既定ブラウザで URL を開く。既に起動中のサーバ（`.fanout/dashboard.json` に記録）があればそれを再利用し、二重起動しない。 |
 | `--no-token` | — | `/api/*` をゲートする起動毎のランダムトークンを外す。単一ユーザ端末向け。 |
-| `--no-keybind` | — | ダッシュボード起動時の tmux `prefix + D` キーバインド登録をスキップする。 |
+| `--no-keybind` | — | ダッシュボード起動時の tmux `F12` / `prefix + D` キーバインド登録をスキップする。 |
 
 全フラグは `fanout dashboard --help` を参照してください。
 
@@ -379,7 +379,7 @@ fanout check-update
 | `FANOUT_BRIEFING_CODE_REVIEW` | Claude `/code-review` 指示（`briefingCodeReview`）の環境変数レイヤ。 |
 | `FANOUT_AGENT_TEAMS_HINT` | Claude Agent Teams ヒント（`agentTeamsHint`）の環境変数レイヤ。 |
 | `FANOUT_PR_VISUALIZATION` | 構造化 PR 本文とゲート付き Mermaid 指示（`prVisualization`）の環境変数レイヤ。 |
-| `FANOUT_DASHBOARD_KEYBIND` | ダッシュボード `prefix + D` tmux キーバインド（`dashboardKeybind`）の環境変数レイヤ。 |
+| `FANOUT_DASHBOARD_KEYBIND` | ダッシュボード `F12` / `prefix + D` tmux キーバインド（`dashboardKeybind`）の環境変数レイヤ。 |
 | `FANOUT_WATCHER` | watcher opt-in（`watcher`）の環境変数レイヤ。 |
 | `FANOUT_WATCHER_TRIGGER_LABEL` | watcher trigger label（`watcherTriggerLabel`）の環境変数レイヤ。 |
 | `FANOUT_WATCHER_RUNNING_LABEL` | watcher running label（`watcherRunningLabel`）の環境変数レイヤ。 |

--- a/site/content/docs/cli.md
+++ b/site/content/docs/cli.md
@@ -206,7 +206,7 @@ explicitly skipped.
 
 ## Settings flags
 
-These paired switches toggle fanout's opinionated behaviors for one run — the child-briefing instructions and dashboard keybinding fanout injects, flipped on or off in place. A CLI flag always wins over the environment-variable and config-file layers. What each behavior actually injects — and the full resolution order — is documented in [Settings]({{< relref "/docs/settings" >}}).
+These paired switches toggle fanout's opinionated behaviors for one run — the child-briefing instructions and dashboard keybindings fanout injects, flipped on or off in place. A CLI flag always wins over the environment-variable and config-file layers. What each behavior actually injects — and the full resolution order — is documented in [Settings]({{< relref "/docs/settings" >}}).
 
 | Flag | Argument | Description |
 |---|---|---|
@@ -216,7 +216,7 @@ These paired switches toggle fanout's opinionated behaviors for one run — the 
 | `--agent-teams-hint` / `--no-agent-teams-hint` | — | Include or omit the Claude-only Agent Teams hint in child briefings. Default: on. |
 | `--codex-plan-mode` / `--no-codex-plan-mode` | — | For `--agent codex`, create a Codex app-server `plan` thread and resume it with the prompt through an interactive Codex TUI instead of positional `codex "<prompt>"`. Default: off. Details in [Agent Integrations]({{< relref "/docs/agents" >}}). |
 | `--pr-visualization` / `--no-pr-visualization` | — | Include or omit structured PR-body plus gated Mermaid guidance in auto-PR child briefings. Default: on. |
-| `--dashboard-keybind` / `--no-dashboard-keybind` | — | Register (or skip) the tmux `prefix + D` keybinding after a live fan-out, so the read-only web dashboard can be opened from any pane. Default: on. |
+| `--dashboard-keybind` / `--no-dashboard-keybind` | — | Register (or skip) the tmux `F12` / `prefix + D` keybindings after a live fan-out, so the read-only web dashboard can be opened from any pane. Default: on. |
 
 ## Read and lifecycle modes
 
@@ -315,7 +315,7 @@ Starts the read-only localhost web dashboard: bound to `127.0.0.1`, GET-only, to
 | `--port` | `N` | Port to bind. Default: `0` (an OS-assigned ephemeral port); the chosen URL is printed. |
 | `--open` | — | Open the URL in the default browser. Reuses a server that is already running (recorded in `.fanout/dashboard.json`) instead of starting a second one. |
 | `--no-token` | — | Drop the random per-start token that gates `/api/*`. For single-user machines. |
-| `--no-keybind` | — | Skip registering the tmux `prefix + D` keybinding when the dashboard starts. |
+| `--no-keybind` | — | Skip registering the tmux `F12` / `prefix + D` keybindings when the dashboard starts. |
 
 Run `fanout dashboard --help` for the full flag list.
 
@@ -380,7 +380,7 @@ Read-only: fetches the latest release tag from `butaosuinu/fanout`, compares it 
 | `FANOUT_BRIEFING_CODE_REVIEW` | Environment layer for the Claude `/code-review` instruction (`briefingCodeReview`). |
 | `FANOUT_AGENT_TEAMS_HINT` | Environment layer for the Claude Agent Teams hint (`agentTeamsHint`). |
 | `FANOUT_PR_VISUALIZATION` | Environment layer for the structured PR-body and gated Mermaid guidance (`prVisualization`). |
-| `FANOUT_DASHBOARD_KEYBIND` | Environment layer for the dashboard `prefix + D` tmux keybinding (`dashboardKeybind`). |
+| `FANOUT_DASHBOARD_KEYBIND` | Environment layer for the dashboard `F12` / `prefix + D` tmux keybindings (`dashboardKeybind`). |
 | `FANOUT_WATCHER` | Environment layer for watcher opt-in (`watcher`). |
 | `FANOUT_WATCHER_TRIGGER_LABEL` | Environment layer for the watcher trigger label (`watcherTriggerLabel`). |
 | `FANOUT_WATCHER_RUNNING_LABEL` | Environment layer for the watcher running label (`watcherRunningLabel`). |

--- a/site/content/docs/monitoring.ja.md
+++ b/site/content/docs/monitoring.ja.md
@@ -115,7 +115,7 @@ fanout 123 --status --post-dashboard
 
 ## Web ダッシュボード（fanout dashboard --web）
 
-チームやブラウザで全 Session を共有しながら見たいときは、`fanout dashboard --web` で**読み取り専用**の Web ダッシュボードを起動します。fanout の **Session**（`.fanout/state.json` に記録されたペインを親 issue 単位でまとめたもの）をブラウザに出し、SSE でライブ更新します。各行ではペインの生存（`tmux list-panes`）、ライブの tmux ペインのタイトル、`running` / `done` の agent 実行状態バッジ、wave 列と未解決 blocker 列（親 issue グラフ由来）、issue 状態、PR マージ状態、CI 状態、diff/dirty を見られます。データ源は `--status` と同じで、リポジトリ内の全親について一度に再利用します。まだファンアウトしていない子 issue は synthetic な未開始行として並びます。GitHub の状態は一切変更せず、tmux も*読み取る*だけです。便宜は 2 つだけです。起動中サーバを `.fanout/dashboard.json` に記録して 2 回目の起動で再利用すること、そして後述の `prefix + D` tmux キーバインドを登録すること（`--no-keybind` でオプトアウト可）です。
+チームやブラウザで全 Session を共有しながら見たいときは、`fanout dashboard --web` で**読み取り専用**の Web ダッシュボードを起動します。fanout の **Session**（`.fanout/state.json` に記録されたペインを親 issue 単位でまとめたもの）をブラウザに出し、SSE でライブ更新します。各行ではペインの生存（`tmux list-panes`）、ライブの tmux ペインのタイトル、`running` / `done` の agent 実行状態バッジ、wave 列と未解決 blocker 列（親 issue グラフ由来）、issue 状態、PR マージ状態、CI 状態、diff/dirty を見られます。データ源は `--status` と同じで、リポジトリ内の全親について一度に再利用します。まだファンアウトしていない子 issue は synthetic な未開始行として並びます。GitHub の状態は一切変更せず、tmux も*読み取る*だけです。便宜は 2 つだけです。起動中サーバを `.fanout/dashboard.json` に記録して 2 回目の起動で再利用すること、そして後述の `F12` / `prefix + D` tmux キーバインドを登録すること（`--no-keybind` でオプトアウト可）です。
 
 ```bash
 fanout dashboard --web [--port N] [--open] [--no-token] [--no-keybind]
@@ -128,11 +128,11 @@ fanout dashboard --web [--port N] [--open] [--no-token] [--no-keybind]
 
 全フラグは `fanout dashboard --help` を参照してください。
 
-### prefix + D
+### F12 / prefix + D
 
-ライブ fan-out の後（およびダッシュボード自体の起動時）に fanout が tmux キーバインドを自動登録するので、どのペインからでも **`prefix + D`** でダッシュボードを開けます。このキーは detached な `fanout-dashboard` ウィンドウでサーバを起動するため、キー押下後も生き続け、2 回目以降は既存 URL を開き直すだけです。
+TUI 起動時、ライブ fan-out 後、ダッシュボード自体の起動時に fanout が tmux キーバインドを自動登録するので、どのペインからでも **`F12`** または **`prefix + D`** でダッシュボードを開けます。どちらのキーも detached な `fanout-dashboard` ウィンドウでサーバを起動するため、キー押下後も生き続け、2 回目以降は既存 URL を開き直すだけです。
 
-自動登録は `--no-dashboard-keybind`（fan-out 側）、`--no-keybind`（dashboard 側）、設定キー `dashboardKeybind`、`FANOUT_DASHBOARD_KEYBIND=0` で無効化できます（[Settings]({{< relref "/docs/settings" >}}) を参照してください）。
+自動登録は `--no-dashboard-keybind`（fan-out 側）、`--no-keybind`（dashboard 側）、設定キー `dashboardKeybind`、`FANOUT_DASHBOARD_KEYBIND=0` でまとめて無効化できます（[Settings]({{< relref "/docs/settings" >}}) を参照してください）。
 
 ### 縮退動作
 

--- a/site/content/docs/monitoring.md
+++ b/site/content/docs/monitoring.md
@@ -115,7 +115,7 @@ It puts `<!-- fanout:dashboard parent=N -->` at the start of the comment body, f
 
 ## Web dashboard (fanout dashboard --web)
 
-When you want to share every Session in a browser or with a team, `fanout dashboard --web` starts a **read-only** web dashboard. It visualizes fanout **Sessions** — the panes recorded in `.fanout/state.json`, grouped by parent issue — and keeps them live in the browser over SSE. Each row shows pane liveness (from `tmux list-panes`), the live tmux pane title, a `running` / `done` agent-state badge, wave / open-blocker columns (from the parent issue graph), issue state, PR merge status, CI status, and diff/dirty. The data source is the same as `--status`, reused across every parent in the repo at once. Children that have not been fanned out yet appear as synthetic not-started rows. It never mutates GitHub state and only ever *reads* tmux, with two deliberate conveniences: it records the running server in `.fanout/dashboard.json` so a second launch reuses it, and it registers the `prefix + D` tmux keybinding described below (opt out with `--no-keybind`).
+When you want to share every Session in a browser or with a team, `fanout dashboard --web` starts a **read-only** web dashboard. It visualizes fanout **Sessions** — the panes recorded in `.fanout/state.json`, grouped by parent issue — and keeps them live in the browser over SSE. Each row shows pane liveness (from `tmux list-panes`), the live tmux pane title, a `running` / `done` agent-state badge, wave / open-blocker columns (from the parent issue graph), issue state, PR merge status, CI status, and diff/dirty. The data source is the same as `--status`, reused across every parent in the repo at once. Children that have not been fanned out yet appear as synthetic not-started rows. It never mutates GitHub state and only ever *reads* tmux, with two deliberate conveniences: it records the running server in `.fanout/dashboard.json` so a second launch reuses it, and it registers the `F12` / `prefix + D` tmux keybindings described below (opt out with `--no-keybind`).
 
 ```bash
 fanout dashboard --web [--port N] [--open] [--no-token] [--no-keybind]
@@ -128,11 +128,11 @@ fanout dashboard --web [--port N] [--open] [--no-token] [--no-keybind]
 
 Run `fanout dashboard --help` for the full flag list.
 
-### prefix + D
+### F12 / prefix + D
 
-After a live fan-out — and whenever the dashboard itself starts — fanout registers a tmux keybinding so that **`prefix + D`** pops the dashboard from any pane. The key launches the server in a detached `fanout-dashboard` window, so it outlives the keypress; a second press just reopens the existing URL.
+When the TUI starts, after a live fan-out, and whenever the dashboard itself starts, fanout registers tmux keybindings so that **`F12`** or **`prefix + D`** pops the dashboard from any pane. Both keys launch the server in a detached `fanout-dashboard` window, so it outlives the keypress; a second press just reopens the existing URL.
 
-Disable the auto-binding with `--no-dashboard-keybind` (fan-out side), `--no-keybind` (dashboard side), the `dashboardKeybind` config key, or `FANOUT_DASHBOARD_KEYBIND=0` — see [Settings]({{< relref "/docs/settings" >}}).
+Disable the auto-bindings with `--no-dashboard-keybind` (fan-out side), `--no-keybind` (dashboard side), the `dashboardKeybind` config key, or `FANOUT_DASHBOARD_KEYBIND=0` — see [Settings]({{< relref "/docs/settings" >}}).
 
 ### Graceful degradation
 

--- a/site/content/docs/settings.ja.md
+++ b/site/content/docs/settings.ja.md
@@ -25,7 +25,7 @@ fanout の挙動はチームの好みで変えたくなる箇所がいくつか�
 - `briefingCodeReview`: Claude の子に、コミット前に変更へ `/code-review` スラッシュコマンドを走らせるよう指示します。
 - `agentTeamsHint`: Claude の子に Claude Code Agent Teams を使う余地があると伝えます。Claude 以外の子には影響しません。
 - `prVisualization`: 子が開く PR の本文を構造化し、条件付きで Mermaid 図を入れる指示を加えます（後述）。
-- `dashboardKeybind`: tmux に `prefix + D` でダッシュボードを開くキーバインドを登録します。
+- `dashboardKeybind`: tmux に `F12` / `prefix + D` でダッシュボードを開くキーバインドを登録します。
 
 watcher と通知 channel は別系統の設定です。watcher はラベル巡回による自動起動の opt-in 制御、通知 channel は TUI の状態遷移をどこへ知らせるかの選択です。
 
@@ -38,7 +38,7 @@ watcher と通知 channel は別系統の設定です。watcher はラベル巡�
 | Claude `/code-review` 指示 | `briefingCodeReview` | `FANOUT_BRIEFING_CODE_REVIEW` | `--briefing-code-review` / `--no-briefing-code-review` | `true` |
 | Claude Agent Teams ヒント | `agentTeamsHint` | `FANOUT_AGENT_TEAMS_HINT` | `--agent-teams-hint` / `--no-agent-teams-hint` | `true` |
 | 構造化 PR 本文とゲート付き Mermaid の briefing 指示 | `prVisualization` | `FANOUT_PR_VISUALIZATION` | `--pr-visualization` / `--no-pr-visualization` | `true` |
-| ダッシュボード `prefix + D` tmux キーバインド | `dashboardKeybind` | `FANOUT_DASHBOARD_KEYBIND` | `--dashboard-keybind` / `--no-dashboard-keybind` | `true` |
+| ダッシュボード `F12` / `prefix + D` tmux キーバインド | `dashboardKeybind` | `FANOUT_DASHBOARD_KEYBIND` | `--dashboard-keybind` / `--no-dashboard-keybind` | `true` |
 | watcher opt-in | `watcher` | `FANOUT_WATCHER` | n/a | `false` |
 | watcher trigger label | `watcherTriggerLabel` | `FANOUT_WATCHER_TRIGGER_LABEL` | n/a | `fanout:auto` |
 | watcher running label | `watcherRunningLabel` | `FANOUT_WATCHER_RUNNING_LABEL` | n/a | `fanout:running` |

--- a/site/content/docs/settings.md
+++ b/site/content/docs/settings.md
@@ -25,7 +25,7 @@ The behavior toggles are instructions that ship on by default but a team may wan
 - `briefingCodeReview`: tells Claude children to run the `/code-review` slash command on their changes before committing.
 - `agentTeamsHint`: tells Claude children that Claude Code Agent Teams is available. It has no effect on non-Claude children.
 - `prVisualization`: asks children to structure the PR body they open and, conditionally, include a Mermaid diagram (see below).
-- `dashboardKeybind`: registers the `prefix + D` tmux keybinding that opens the dashboard.
+- `dashboardKeybind`: registers the `F12` / `prefix + D` tmux keybindings that open the dashboard.
 
 The watcher and notification channels are a separate track: the watcher gates opt-in label-driven launches, and notification channels pick where TUI state transitions go.
 
@@ -38,7 +38,7 @@ The watcher and notification channels are a separate track: the watcher gates op
 | Claude `/code-review` instruction | `briefingCodeReview` | `FANOUT_BRIEFING_CODE_REVIEW` | `--briefing-code-review` / `--no-briefing-code-review` | `true` |
 | Claude Agent Teams hint | `agentTeamsHint` | `FANOUT_AGENT_TEAMS_HINT` | `--agent-teams-hint` / `--no-agent-teams-hint` | `true` |
 | Structured PR body and gated Mermaid briefing guidance | `prVisualization` | `FANOUT_PR_VISUALIZATION` | `--pr-visualization` / `--no-pr-visualization` | `true` |
-| Dashboard `prefix + D` tmux keybinding | `dashboardKeybind` | `FANOUT_DASHBOARD_KEYBIND` | `--dashboard-keybind` / `--no-dashboard-keybind` | `true` |
+| Dashboard `F12` / `prefix + D` tmux keybindings | `dashboardKeybind` | `FANOUT_DASHBOARD_KEYBIND` | `--dashboard-keybind` / `--no-dashboard-keybind` | `true` |
 | Watcher opt-in | `watcher` | `FANOUT_WATCHER` | n/a | `false` |
 | Watcher trigger label | `watcherTriggerLabel` | `FANOUT_WATCHER_TRIGGER_LABEL` | n/a | `fanout:auto` |
 | Watcher running label | `watcherRunningLabel` | `FANOUT_WATCHER_RUNNING_LABEL` | n/a | `fanout:running` |


### PR DESCRIPTION
## TL;DR
TUI 起動時にも web dashboard の tmux keybind を登録し、`prefix + D` に加えて `F12` から直接開けるようにしました。

## 背景
web dashboard の keybind 登録は dashboard 起動時と live fan-out 後だけにあり、TUI 起動だけでは登録されませんでした。
そのため、TUI/manual/Plan Mode から入った session では、同じ tmux server 内で過去に別経路から bind 済みだった場合を除き、`prefix + D` で dashboard を開けませんでした。

## 変更内容
- TUI 起動時に `dashboardKeybind` 設定を見て dashboard keybind を登録
- `prefix + D` を残しつつ、prefix なしで押せる `F12` を追加
- `--no-keybind` / `FANOUT_DASHBOARD_KEYBIND=0` では両方の keybind を無効化
- README、site docs、Claude/Codex skill の dashboard 記述を `F12` / `prefix + D` に同期

## 検証
- `GOCACHE=$(pwd)/.cache/go-build go test ./cmd/fanout ./internal/tmuxrun`
- `GOCACHE=$(pwd)/.cache/go-build make test`
- `GOCACHE=$(pwd)/.cache/go-build make lint`
- `git diff --check`