### PR TITLE
test: name + t.Run でテーブル駆動テストを読みやすくする

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,6 +254,32 @@ Build the binary with `make build-go` and validate with `make test`.
   `.claude/settings.json`. Run `/post-work-review` before creating a PR, or use
   `FANOUT_SKIP_PR_REVIEW=1` only when the documented escape hatch is intended.
 
+## Test Conventions
+
+Table-driven tests must be readable case-by-case from `go test -v` alone, not
+just from the function name. `internal/team/detect_test.go` is the model.
+
+- Give every case a `name` field and wrap the loop in
+  `t.Run(tt.name, func(t *testing.T) { ... })`. This makes each case a named
+  subtest: `go test -run TestX/case_name` runs one case and failures report
+  which case broke.
+- `name` describes the behavior or the edge being pinned, not the input echoed
+  back — `"trims surrounding whitespace"`, not `"  running  "`.
+- Use field-named struct literals (`{name: ..., in: ..., want: ...}`) once a
+  case struct has more than three or four fields. Positional literals past that
+  are unreadable and break on every field addition.
+- Do not key a case table with `map[...]`: iteration order is undefined and the
+  keys cannot become subtest names. Use a slice with a `name` field.
+- Keep failure messages in the `funcName(input) = got, want` form already used
+  across the suite.
+- Comment a case line only when its purpose is not obvious from the values
+  (boundary, precedence, why this specific input). Do not annotate self-evident
+  cases — the `name` already carries them. Preserve provenance comments on
+  opaque golden values (e.g. `// captured from real tmux 3.6a`) and the one-line
+  comment above a test that states what it guarantees.
+- Leave existing loop-variable naming as-is (`cases`/`tc` and `tests`/`tt` both
+  occur); do not churn files just to unify it. New tables prefer `tests`/`tt`.
+
 ## Documentation Writing
 
 When writing or updating user-facing docs (`README*.md`, `site/content/docs/**`,

--- a/cmd/fanout/dashboard_test.go
+++ b/cmd/fanout/dashboard_test.go
@@ -7,20 +7,23 @@ import (
 )
 
 func TestIsDashboardRequest(t *testing.T) {
-	cases := []struct {
+	tests := []struct {
+		name string
 		args []string
 		want bool
 	}{
-		{[]string{"dashboard"}, true},
-		{[]string{"dashboard", "--web"}, true},
-		{[]string{"--status", "1"}, false},
-		{[]string{"100"}, false},
-		{nil, false},
+		{name: "bare dashboard verb", args: []string{"dashboard"}, want: true},
+		{name: "dashboard with web flag", args: []string{"dashboard", "--web"}, want: true},
+		{name: "status flag is not dashboard", args: []string{"--status", "1"}, want: false},
+		{name: "issue number is not dashboard", args: []string{"100"}, want: false},
+		{name: "no args is not dashboard", args: nil, want: false},
 	}
-	for _, c := range cases {
-		if got := isDashboardRequest(c.args); got != c.want {
-			t.Errorf("isDashboardRequest(%v) = %v, want %v", c.args, got, c.want)
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isDashboardRequest(tt.args); got != tt.want {
+				t.Errorf("isDashboardRequest(%v) = %v, want %v", tt.args, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/cmd/fanout/pane_test.go
+++ b/cmd/fanout/pane_test.go
@@ -700,22 +700,24 @@ func TestWaitForCodexPlanTUIReadyTimesOutWithoutStatus(t *testing.T) {
 }
 
 func TestParentDisplay(t *testing.T) {
-	cases := []struct {
+	tests := []struct {
+		name   string
 		parent string
 		want   string
 	}{
-		{"123", "#123"},
-		{"81", "#81"},
-		{"plan:launch-plan", "plan:launch-plan"},
-		{manualPaneParentRef, "@manual"},
-		{watchPaneParentRef, "@watch"},
-		{"https://github.com/orgs/octo/projects/3", "orgs/octo/projects/3"},
-		{"", ""},
+		{name: "numeric issue gets a hash prefix", parent: "123", want: "#123"},
+		{name: "plan parent passes through", parent: "plan:launch-plan", want: "plan:launch-plan"},
+		{name: "manual parent shows @manual", parent: manualPaneParentRef, want: "@manual"},
+		{name: "watch parent shows @watch", parent: watchPaneParentRef, want: "@watch"},
+		{name: "project url is stripped to its path", parent: "https://github.com/orgs/octo/projects/3", want: "orgs/octo/projects/3"},
+		{name: "empty parent stays empty", parent: "", want: ""},
 	}
-	for _, tc := range cases {
-		if got := parentDisplay(tc.parent); got != tc.want {
-			t.Errorf("parentDisplay(%q) = %q, want %q", tc.parent, got, tc.want)
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parentDisplay(tt.parent); got != tt.want {
+				t.Errorf("parentDisplay(%q) = %q, want %q", tt.parent, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/panelayout/layout_test.go
+++ b/internal/panelayout/layout_test.go
@@ -21,14 +21,20 @@ func sidebarCfg() Config {
 // layout-probe runs during development); they pin both Checksum and Render to
 // tmux's actual algorithm and geometry, not just to our understanding of it.
 func TestChecksumMatchesRealTmux(t *testing.T) {
-	cases := []struct{ body, want string }{
-		{"200x50,0,0{100x50,0,0,1079,99x50,101,0,1080}", "2cc9"},
-		{"200x50,0,0{40x50,0,0,1093,159x50,41,0{79x50,41,0,1094,79x50,121,0,1095}}", "fab2"},
+	tests := []struct {
+		name string
+		body string
+		want string
+	}{
+		{name: "two sibling panes share a row", body: "200x50,0,0{100x50,0,0,1079,99x50,101,0,1080}", want: "2cc9"},
+		{name: "nested split inside the second cell", body: "200x50,0,0{40x50,0,0,1093,159x50,41,0{79x50,41,0,1094,79x50,121,0,1095}}", want: "fab2"},
 	}
-	for _, tc := range cases {
-		if got := Checksum(tc.body); got != tc.want {
-			t.Errorf("Checksum(%q) = %q, want %q", tc.body, got, tc.want)
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Checksum(tt.body); got != tt.want {
+				t.Errorf("Checksum(%q) = %q, want %q", tt.body, got, tt.want)
+			}
+		})
 	}
 }
 
@@ -128,17 +134,22 @@ func TestRenderSpacerRow(t *testing.T) {
 
 func TestRenderErrors(t *testing.T) {
 	cfg := gridCfg()
-	cases := []RenderInput{
-		{Win: Window{200, 50}, ContentPaneIDs: nil, Cols: 1, Cfg: cfg},
-		{Win: Window{200, 50}, ContentPaneIDs: []string{"1"}, Cols: 0, Cfg: cfg},
-		{Win: Window{0, 50}, ContentPaneIDs: []string{"1"}, Cols: 1, Cfg: cfg},
+	tests := []struct {
+		name string
+		in   RenderInput
+	}{
+		{name: "nil pane ids", in: RenderInput{Win: Window{200, 50}, ContentPaneIDs: nil, Cols: 1, Cfg: cfg}},
+		{name: "zero cols", in: RenderInput{Win: Window{200, 50}, ContentPaneIDs: []string{"1"}, Cols: 0, Cfg: cfg}},
+		{name: "zero-width window", in: RenderInput{Win: Window{0, 50}, ContentPaneIDs: []string{"1"}, Cols: 1, Cfg: cfg}},
 		// 60 grid panes in 1 column can't fit positive height in 50 rows.
-		{Win: Window{200, 50}, ContentPaneIDs: ids(60), Cols: 1, Cfg: cfg},
+		{name: "60 panes cannot fit one column", in: RenderInput{Win: Window{200, 50}, ContentPaneIDs: ids(60), Cols: 1, Cfg: cfg}},
 	}
-	for i, in := range cases {
-		if _, err := Render(in); err == nil {
-			t.Errorf("case %d: expected error, got nil", i)
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := Render(tt.in); err == nil {
+				t.Errorf("Render(%+v) = nil error, want error", tt.in)
+			}
+		})
 	}
 }
 
@@ -155,12 +166,13 @@ func TestDecidePlan(t *testing.T) {
 		spacer  bool
 		spacerW int
 	}{
-		{"1 pane", Window{200, 50}, 1, gridCfg(), 1, 1, []int{1}, true, false, 0},
-		{"2 panes one row", Window{200, 50}, 2, gridCfg(), 2, 1, []int{2}, true, false, 0},
-		{"3 panes one row", Window{200, 50}, 3, gridCfg(), 3, 1, []int{3}, true, false, 0},
-		{"4 panes 2x2", Window{200, 50}, 4, gridCfg(), 2, 2, []int{2, 2}, true, false, 0},
-		{"5 panes spacer", Window{250, 50}, 5, gridCfg(), 3, 2, []int{3, 2}, true, true, 48},
-		{"sidebar 2 panes", Window{200, 50}, 2, sidebarCfg(), 2, 1, []int{2}, true, false, 0},
+		{name: "1 pane", win: Window{200, 50}, n: 1, cfg: gridCfg(), cols: 1, rows: 1, dist: []int{1}, comfort: true},
+		{name: "2 panes one row", win: Window{200, 50}, n: 2, cfg: gridCfg(), cols: 2, rows: 1, dist: []int{2}, comfort: true},
+		{name: "3 panes one row", win: Window{200, 50}, n: 3, cfg: gridCfg(), cols: 3, rows: 1, dist: []int{3}, comfort: true},
+		{name: "4 panes 2x2", win: Window{200, 50}, n: 4, cfg: gridCfg(), cols: 2, rows: 2, dist: []int{2, 2}, comfort: true},
+		// Short last row would stretch past the comfort width, so a 48-wide spacer is appended.
+		{name: "5 panes spacer", win: Window{250, 50}, n: 5, cfg: gridCfg(), cols: 3, rows: 2, dist: []int{3, 2}, comfort: true, spacer: true, spacerW: 48},
+		{name: "sidebar 2 panes", win: Window{200, 50}, n: 2, cfg: sidebarCfg(), cols: 2, rows: 1, dist: []int{2}, comfort: true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -194,13 +206,21 @@ func TestDecidePlanTieBreakPrefersFewerColumns(t *testing.T) {
 }
 
 func TestDecidePlanZero(t *testing.T) {
-	for _, in := range []struct {
-		w Window
-		n int
-	}{{Window{200, 50}, 0}, {Window{0, 50}, 3}, {Window{200, 0}, 3}} {
-		if got := DecidePlan(in.w, in.n, gridCfg()); got.Cols != 0 || got.Rows != 0 {
-			t.Errorf("DecidePlan(%v,%d) = %+v, want zero", in.w, in.n, got)
-		}
+	tests := []struct {
+		name string
+		w    Window
+		n    int
+	}{
+		{name: "zero panes", w: Window{200, 50}, n: 0},
+		{name: "zero-width window", w: Window{0, 50}, n: 3},
+		{name: "zero-height window", w: Window{200, 0}, n: 3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DecidePlan(tt.w, tt.n, gridCfg()); got.Cols != 0 || got.Rows != 0 {
+				t.Errorf("DecidePlan(%v, %d) = %+v, want zero cols/rows", tt.w, tt.n, got)
+			}
+		})
 	}
 }
 

--- a/internal/sessionview/aggregate_test.go
+++ b/internal/sessionview/aggregate_test.go
@@ -539,22 +539,30 @@ func TestBuildTmuxTitleOnlyWhenAlive(t *testing.T) {
 	}
 }
 
+// TestNormalizeAgentState pins normalizeAgentState to the lowercase literals the
+// launch wrapper sets ("running"/"done"); every other input collapses to "".
 func TestNormalizeAgentState(t *testing.T) {
-	cases := map[string]string{
-		"":           "",
-		"running":    "running",
-		"done":       "done",
-		" running ":  "running", // 余分な空白は剥がす
-		"claude":     "",        // ラッパー外の値は不明扱い
-		"bash":       "",
-		"x\ty":       "", // pane 内プロセスが偽装した文字列も不明扱い
-		"RUNNING":    "", // 値はラッパーが設定する小文字リテラルのみ
-		"done extra": "",
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "empty stays empty", in: "", want: ""},
+		{name: "running passes through", in: "running", want: "running"},
+		{name: "done passes through", in: "done", want: "done"},
+		{name: "surrounding whitespace is trimmed", in: " running ", want: "running"},
+		{name: "value from outside the wrapper is unknown", in: "claude", want: ""},
+		{name: "process name is unknown", in: "bash", want: ""},
+		{name: "string spoofed by an in-pane process is unknown", in: "x\ty", want: ""},
+		{name: "only the lowercase literal is accepted", in: "RUNNING", want: ""},
+		{name: "trailing garbage is rejected", in: "done extra", want: ""},
 	}
-	for raw, want := range cases {
-		if got := normalizeAgentState(raw); got != want {
-			t.Errorf("normalizeAgentState(%q) = %q, want %q", raw, got, want)
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := normalizeAgentState(tt.in); got != tt.want {
+				t.Errorf("normalizeAgentState(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
 	}
 }
 
@@ -1074,23 +1082,26 @@ func TestBuildSyntheticEmittedOncePerAliasedParent(t *testing.T) {
 }
 
 func TestSyntheticTmuxStateMatchesTUIStrings(t *testing.T) {
-	cases := []struct {
+	tests := []struct {
+		name       string
 		issueState string
 		blocked    bool
 		want       string
 	}{
-		{"CLOSED", false, "closed"},
-		{"closed", true, "closed"}, // closed は blocked より優先(TUI と同順)
-		{"OPEN", true, "deferred"},
-		{"OPEN", false, "queued"},
-		{"open", false, "queued"},
-		{IssueStateUnknown, false, "unknown"},
-		{"", false, "unknown"},
+		{name: "closed issue is closed", issueState: "CLOSED", blocked: false, want: "closed"},
+		{name: "closed wins over blocked", issueState: "closed", blocked: true, want: "closed"}, // closed は blocked より優先(TUI と同順)
+		{name: "open and blocked is deferred", issueState: "OPEN", blocked: true, want: "deferred"},
+		{name: "open and unblocked is queued", issueState: "OPEN", blocked: false, want: "queued"},
+		{name: "lowercase open is queued", issueState: "open", blocked: false, want: "queued"},
+		{name: "unknown issue state is unknown", issueState: IssueStateUnknown, blocked: false, want: "unknown"},
+		{name: "empty issue state is unknown", issueState: "", blocked: false, want: "unknown"},
 	}
-	for _, tc := range cases {
-		if got := SyntheticTmuxState(tc.issueState, tc.blocked); got != tc.want {
-			t.Errorf("SyntheticTmuxState(%q, %v) = %q, want %q", tc.issueState, tc.blocked, got, tc.want)
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SyntheticTmuxState(tt.issueState, tt.blocked); got != tt.want {
+				t.Errorf("SyntheticTmuxState(%q, %v) = %q, want %q", tt.issueState, tt.blocked, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/tui/newpane_complete_test.go
+++ b/internal/tui/newpane_complete_test.go
@@ -129,34 +129,37 @@ func TestRankRepoFiles(t *testing.T) {
 		"docs/news.md",
 		"cmd/main.go",
 	}
-	cases := []struct {
+	tests := []struct {
+		name  string
 		query string
 		want  []string
 	}{
 		{
-			// all basename-prefix matches -> shorter path first
+			name:  "basename-prefix matches rank by path length",
 			query: "new",
 			want:  []string{"docs/news.md", "cmd/fanout/newpane.go", "internal/tui/newpane.go", "internal/tui/new_test.go"},
 		},
 		{
-			// basename substring (not prefix) -> shorter path first
+			name:  "basename substring matches rank by path length",
 			query: "pane",
 			want:  []string{"cmd/fanout/newpane.go", "internal/tui/newpane.go"},
 		},
 		{
-			// path substring only
+			name:  "path substring matches",
 			query: "tui",
 			want:  []string{"internal/tui/newpane.go", "internal/tui/new_test.go"},
 		},
 	}
-	for _, tc := range cases {
-		got, total := rankRepoFiles(files, tc.query, 8)
-		if !reflect.DeepEqual(got, tc.want) {
-			t.Fatalf("rankRepoFiles(%q) = %v, want %v", tc.query, got, tc.want)
-		}
-		if total != len(tc.want) {
-			t.Fatalf("rankRepoFiles(%q) total = %d, want %d", tc.query, total, len(tc.want))
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, total := rankRepoFiles(files, tt.query, 8)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("rankRepoFiles(%q) = %v, want %v", tt.query, got, tt.want)
+			}
+			if total != len(tt.want) {
+				t.Fatalf("rankRepoFiles(%q) total = %d, want %d", tt.query, total, len(tt.want))
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## 背景

Go のテーブル駆動テストの一部がケースに名前を持たず、`t.Run` でのサブテスト化もされていなかった。そのため `go test -v` で出るのは関数名だけで、どのケースを検証しているか・どのケースが失敗したかが読めなかった。`map` ベースのケース表（反復順が不定）や 10 フィールドの位置引数リテラル（どの値がどのフィールドか追えない）も混在していた。

Go の定石である **テーブル駆動テスト + 名前付きサブテスト** に揃え、各ケースが `go test -v` だけで読めるようにする。

## 変更内容

挙動・カバレッジは変更なし（test + docs のみ）。

| File | 変更 |
|---|---|
| `CLAUDE.md` | `## Test Conventions` セクション新設（name+t.Run / フィールド名指定 / map 禁止 / 自明なケースに注釈しない） |
| `internal/sessionview/aggregate_test.go` | `TestNormalizeAgentState` を `map`→スライス+name+t.Run、`TestSyntheticTmuxState…` を name+t.Run 化。意図コメントは name に引き継ぎ |
| `internal/panelayout/layout_test.go` | `Checksum`/`RenderErrors`/`DecidePlanZero` を name+t.Run、`DecidePlan` を位置引数→フィールド名指定 |
| `cmd/fanout/pane_test.go` | `TestParentDisplay` を name+t.Run 化、`"123"` と同一コードパスの重複ケース `"81"` を削除 |
| `cmd/fanout/dashboard_test.go` | `TestIsDashboardRequest` を name+t.Run 化 |
| `internal/tui/newpane_complete_test.go` | `TestRankRepoFiles` を name+t.Run 化、name と重複する冗長コメント削除 |

## 効果

- `go test -v` に各ケース名が並ぶ（例: `TestNormalizeAgentState/surrounding_whitespace_is_trimmed`）
- `go test -run TestParentDisplay/.*plan` で 1 ケースだけ実行できる
- 失敗時にどのケースが落ちたか即わかる

## 検証

- `go build ./...` + `go test ./...` → 全 green
- `make fmt`（整形による追加変更なし） / `make lint`（golangci-lint v2、0 issues）
- post-work-review（code-review xhigh + codex review）通過済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)