### PR TITLE
feat(tui): 新規 Session popup に Issue / Plan モードを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,13 @@ Build the binary with `make build-go` and validate with `make test`.
   shells are relaunched into a deterministic fanout-managed tmux session;
   invocations already inside tmux use the current pane. It also wires the
   opt-in label watcher into the TUI runtime; no other command path starts the
-  watcher.
+  watcher. The `n` new-session popup has three modes: free prompt (manual
+  pane), issue (OPEN issue picker; children fan out via the watch launch
+  helpers with `UnblockedOnly`, childless issues become `@watch` panes), and
+  plan (`.fanout/plans` slug picker via `runPlanWithRuntime`), with a
+  per-child/task agent assignment step (`cmd/fanout/tui_issue.go`,
+  `cmd/fanout/tui_plan.go`, `internal/tui/newpane_picker.go`,
+  `internal/tui/newpane_assign.go`).
 - `internal/runtime` resolves the git repository root and the tmux target.
   Batch pane-creation mode must be invoked from inside tmux. By default fanout
   targets the invoking pane; `--session` targets a named tmux session.

--- a/README.ja.md
+++ b/README.ja.md
@@ -29,8 +29,10 @@ briefing から起動します。再実行しても同じ対象に 2 つ目の�
   だけをファンアウト。PR が merge されたら再実行すれば次の wave が開きます。
 - **常駐 TUI コンソール** — 引数なしの `fanout` で、ペイン / issue / PR を
   ライブ表示し、コンパクトな Session ナビゲータと focus・peek・terminal・
-  複数 agent の手動起動・同一 worktree への agent 追加・lifecycle キー・消えた
-  worktree ペインの自動復元を備えたコンソールを開きます。
+  同一 worktree への agent 追加・lifecycle キー・消えた worktree ペインの
+  自動復元を備えたコンソールを開きます。新規 Session popup は自由記述 prompt
+  のほか、一覧から選んだ OPEN issue や保存済み plan からも開始でき、子ごとに
+  agent を選べます(あるタスクは claude、別のタスクは codex、のように)。
 - **ラベル watcher** — opt-in すると、TUI 常駐中に信頼できる `fanout:auto`
   issue を one-shot fanout session に投入します。
 - **Web ダッシュボード** — localhost で動く read-only のダッシュボード(ライブ
@@ -135,7 +137,7 @@ watcher は repo 全体から label 付き issue を探し、one-shot session �
 | `fanout 123 --unblocked-only` | ブロッカーが closed の子だけをファンアウト — 次の wave |
 | `fanout 123 --dry-run` | git / tmux / state / briefing file を変更せず計画だけ表示 |
 | `fanout plan spec.json --agent claude` | GitHub の子 issue でなくローカル plan spec をファンアウト |
-| `fanout` | 常駐 TUI コンソールを起動(Session ジャンプ・focus・peek・terminal・複数 agent の手動起動・同一 worktree への追加・復元・lifecycle キー) |
+| `fanout` | 常駐 TUI コンソールを起動(Session ジャンプ・focus・peek・terminal・prompt / issue / plan からの Session 起動・同一 worktree への追加・復元・lifecycle キー) |
 | `fanout 123 --status` | ペイン・PR review・CI 状態を JSON または table で |
 | `fanout dashboard --web` | localhost で read-only Web ダッシュボードを配信 |
 | `fanout 123 --merge 4` | 子 branch を fast-forward merge(`--close` / `--cleanup` でペインを畳む) |

--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@ English and 日本語.
   unblocked children; rerun as PRs merge and the next wave opens.
 - **Persistent TUI console** — run `fanout` with no arguments for a live
   pane / issue / PR view with a compact Session navigator plus focus, peek,
-  terminal, multi-agent manual launch, same-worktree agent attach, lifecycle
-  keys, and automatic restore of missing worktree panes.
+  terminal, same-worktree agent attach, lifecycle keys, and automatic restore
+  of missing worktree panes. The new-session popup starts work from a free
+  prompt, an OPEN issue picked from a list, or a stored plan — with a per-child
+  agent choice (claude for one task, codex for another).
 - **Label watcher** — opt in to a TUI-resident watcher that turns trusted
   `fanout:auto` issues into one-shot fanout sessions.
 - **Web dashboard** — a read-only localhost dashboard with live updates; pop it
@@ -133,7 +135,7 @@ it discovers labeled issues across the repository and starts one-shot sessions.
 | `fanout 123 --unblocked-only` | Fan out only children whose blockers are closed — the next wave |
 | `fanout 123 --dry-run` | Print the plan without modifying git, tmux, state, or briefing files |
 | `fanout plan spec.json --agent claude` | Fan out a local plan spec instead of GitHub child issues |
-| `fanout` | Start the persistent TUI console (Session jump, focus, peek, terminal, multi-agent manual launch, same-worktree attach, restore, lifecycle keys) |
+| `fanout` | Start the persistent TUI console (Session jump, focus, peek, terminal, prompt / issue / plan session launch, same-worktree attach, restore, lifecycle keys) |
 | `fanout 123 --status` | Pane, PR review, and CI state as JSON or a table |
 | `fanout dashboard --web` | Serve the read-only web dashboard on localhost |
 | `fanout 123 --merge 4` | Fast-forward merge a child branch (`--close` / `--cleanup` fold panes away) |

--- a/cmd/fanout/plancmd.go
+++ b/cmd/fanout/plancmd.go
@@ -143,6 +143,14 @@ func cmdPlan(args []string, lg *log.Logger, commandName string) exitcode.Code {
 	}
 	cfg.Agent = cliCfg.Agent
 
+	_, code = runPlanWithRuntime(cfg, rt, lg, commandName)
+	return code
+}
+
+// runPlanWithRuntime runs the live/dry-run plan lane against an already
+// resolved runtime. cmdPlan owns parsing, dependency checks, and runtime
+// resolution; the TUI plan launcher reuses this with a synthesized runtime.
+func runPlanWithRuntime(cfg planCommandConfig, rt *runtimeInfo, lg *log.Logger, commandName string) (taskExecutionResult, exitcode.Code) {
 	resolvedSettings := settings.Resolve(rt.info.ProjectRoot, settings.CLIOverrides{
 		AutoPullRequest:    cfg.AutoPullRequest,
 		PRReviewGate:       cfg.PRReviewGate,
@@ -157,22 +165,22 @@ func cmdPlan(args []string, lg *log.Logger, commandName string) exitcode.Code {
 	spec, err := planspec.LoadWithoutResolvedNameChecks(cfg.SpecPath)
 	if err != nil {
 		lg.Err("%v", err)
-		return exitcode.Env
+		return taskExecutionResult{}, exitcode.Env
 	}
 	cfg.BaseBranch, err = resolvePlanBaseBranch(cfg, spec, rt.info.ProjectRoot)
 	if err != nil {
 		lg.Err("%v", err)
-		return exitcode.Env
+		return taskExecutionResult{}, exitcode.Env
 	}
 	if err := validatePlanExecutionNames(spec, cfg); err != nil {
 		lg.Err("validate plan execution names %s: %v", cfg.SpecPath, err)
-		return exitcode.Env
+		return taskExecutionResult{}, exitcode.Env
 	}
-	cliCfg = cfg.cliConfig()
+	cliCfg := cfg.cliConfig()
 
 	store, recorder, code := loadPlanState(cfg, rt.info.ProjectRoot, lg)
 	if code != exitcode.OK {
-		return code
+		return taskExecutionResult{}, code
 	}
 	if recorder != nil {
 		defer func() {
@@ -202,28 +210,28 @@ func cmdPlan(args []string, lg *log.Logger, commandName string) exitcode.Code {
 
 	if plan.AfterFilter == 0 {
 		if code := copyLivePlanSpec(); code != exitcode.OK {
-			return code
+			return taskExecutionResult{}, code
 		}
 		lg.Info("all plan tasks filtered out by --only/--skip. nothing to do.")
-		return exitcode.OK
+		return taskExecutionResult{}, exitcode.OK
 	}
 	if plan.UnfannedCount == 0 {
 		if code := copyLivePlanSpec(); code != exitcode.OK {
-			return code
+			return taskExecutionResult{}, code
 		}
 		if len(plan.AlreadyComplete) == 0 {
 			lg.Ok("all %d plan task(s) already have a fanout pane. nothing to do.", len(plan.AlreadyFanned))
 		} else {
 			lg.Ok("all %d selected plan task(s) already have a fanout pane or are complete. nothing to do.", plan.AfterFilter)
 		}
-		return exitcode.OK
+		return taskExecutionResult{}, exitcode.OK
 	}
 	if err := validateTaskAgents(cliCfg, plan.Targets, plan.LimitDeferred); err != nil {
 		lg.Err("%s", err.Error())
-		return exitcode.Env
+		return taskExecutionResult{}, exitcode.Env
 	}
 	if code := copyLivePlanSpec(); code != exitcode.OK {
-		return code
+		return taskExecutionResult{}, code
 	}
 
 	logAlreadyFannedTasks(plan.AlreadyFanned, lg)
@@ -261,9 +269,9 @@ func cmdPlan(args []string, lg *log.Logger, commandName string) exitcode.Code {
 	}
 
 	if result.Failed > 0 {
-		return exitcode.Env
+		return result, exitcode.Env
 	}
-	return exitcode.OK
+	return result, exitcode.OK
 }
 
 func parsePlanCommand(args []string, lg *log.Logger) (planCommandConfig, exitcode.Code) {
@@ -682,6 +690,32 @@ func resolvePlanSpecPath(projectRoot, arg string) string {
 		return arg
 	}
 	return filepath.Join(projectRoot, ".fanout", "plans", arg+".json")
+}
+
+// listPlanSlugs enumerates .fanout/plans/*.json as bare slugs, sorted. A
+// missing directory is not an error: a repository that never ran fanout plan
+// simply has no plans to offer.
+func listPlanSlugs(projectRoot string) ([]string, error) {
+	entries, err := os.ReadDir(filepath.Join(projectRoot, ".fanout", "plans"))
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var slugs []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name, ok := strings.CutSuffix(entry.Name(), ".json")
+		if !ok || name == "" {
+			continue
+		}
+		slugs = append(slugs, name)
+	}
+	slices.Sort(slugs)
+	return slugs, nil
 }
 
 func loadPlanState(cfg planCommandConfig, projectRoot string, lg *log.Logger) (state.Store, *state.LockedStore, exitcode.Code) {

--- a/cmd/fanout/plancmd.go
+++ b/cmd/fanout/plancmd.go
@@ -709,7 +709,9 @@ func listPlanSlugs(projectRoot string) ([]string, error) {
 			continue
 		}
 		name, ok := strings.CutSuffix(entry.Name(), ".json")
-		if !ok || name == "" {
+		// A remaining .json suffix cannot round-trip: resolvePlanSpecPath
+		// would treat the bare slug as a spec path.
+		if !ok || name == "" || strings.HasSuffix(name, ".json") {
 			continue
 		}
 		slugs = append(slugs, name)

--- a/cmd/fanout/plancmd_test.go
+++ b/cmd/fanout/plancmd_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -64,6 +65,67 @@ func TestValidatePlanExecutionNamesRejectsFinalDuplicates(t *testing.T) {
 				t.Fatalf("validatePlanExecutionNames() error = %v, want %q", err, tc.wantErr)
 			}
 		})
+	}
+}
+
+// TestListPlanSlugs guarantees the TUI plan picker sees exactly the bare
+// slugs stored under .fanout/plans, in sorted order.
+func TestListPlanSlugs(t *testing.T) {
+	tests := []struct {
+		name  string
+		files []string
+		dirs  []string
+		want  []string
+	}{
+		{
+			name:  "sorts json slugs and skips other entries",
+			files: []string{"zeta.json", "alpha.json", "note.txt", ".json"},
+			dirs:  []string{"nested.json"},
+			want:  []string{"alpha", "zeta"},
+		},
+		{
+			name:  "empty directory yields no slugs",
+			files: nil,
+			want:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			plansDir := filepath.Join(root, ".fanout", "plans")
+			if err := os.MkdirAll(plansDir, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			for _, name := range tt.files {
+				if err := os.WriteFile(filepath.Join(plansDir, name), []byte("{}"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			for _, name := range tt.dirs {
+				if err := os.MkdirAll(filepath.Join(plansDir, name), 0o755); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			got, err := listPlanSlugs(root)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("listPlanSlugs(%s) = %v, want %v", root, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestListPlanSlugsMissingDirectoryIsNotAnError(t *testing.T) {
+	got, err := listPlanSlugs(t.TempDir())
+	if err != nil {
+		t.Fatalf("listPlanSlugs() error = %v, want nil", err)
+	}
+	if got != nil {
+		t.Fatalf("listPlanSlugs() = %v, want nil", got)
 	}
 }
 

--- a/cmd/fanout/plancmd_test.go
+++ b/cmd/fanout/plancmd_test.go
@@ -84,6 +84,13 @@ func TestListPlanSlugs(t *testing.T) {
 			want:  []string{"alpha", "zeta"},
 		},
 		{
+			// "x.json.json" would list as slug "x.json", which
+			// resolvePlanSpecPath treats as a spec path, not a slug.
+			name:  "skips slugs that cannot round-trip through resolvePlanSpecPath",
+			files: []string{"x.json.json", "ok.json"},
+			want:  []string{"ok"},
+		},
+		{
 			name:  "empty directory yields no slugs",
 			files: nil,
 			want:  nil,

--- a/cmd/fanout/tui.go
+++ b/cmd/fanout/tui.go
@@ -91,10 +91,18 @@ func cmdTUI(commandName string, lg *log.Logger) exitcode.Code {
 		LaunchPane:          newTUILaunchPaneFunc(projectRoot, session, commandName, hookConfig),
 		NewPanePrompt:       newTUINewPanePromptFunc(projectRoot, commandName),
 		LaunchAttach:        newTUIAttachAgentFunc(projectRoot, session, commandName, hookConfig),
-		LaunchShell:         newTUILaunchShellFunc(projectRoot, session),
-		RestorePanes:        newTUIRestoreFunc(projectRoot, session, commandName),
-		Relayout:            func() error { return panelayout.Apply(tuiLaunchTarget(session), panelayout.Resize) },
-		Notifier:            notifier,
+		// List providers also feed the in-process fallback form (NewPanePrompt
+		// unavailable); the popup process wires its own copies.
+		ListOpenIssues:    newTUIListOpenIssuesFunc(projectRoot),
+		ListPlanSlugs:     newTUIListPlanSlugsFunc(projectRoot),
+		ListIssueChildren: newTUIListIssueChildrenFunc(projectRoot),
+		ListPlanTasks:     newTUIListPlanTasksFunc(projectRoot),
+		LaunchIssue:       newTUIIssueLaunchFunc(projectRoot, session, commandName, resolvedSettings, hookConfig),
+		LaunchPlan:        newTUIPlanLaunchFunc(projectRoot, session, commandName),
+		LaunchShell:       newTUILaunchShellFunc(projectRoot, session),
+		RestorePanes:      newTUIRestoreFunc(projectRoot, session, commandName),
+		Relayout:          func() error { return panelayout.Apply(tuiLaunchTarget(session), panelayout.Resize) },
+		Notifier:          notifier,
 	}); err != nil {
 		lg.Err("tui: %v", err)
 		return exitcode.Env

--- a/cmd/fanout/tui_issue.go
+++ b/cmd/fanout/tui_issue.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+
+	"github.com/butaosuinu/fanout/internal/agent"
+	"github.com/butaosuinu/fanout/internal/cliflags"
+	"github.com/butaosuinu/fanout/internal/ghissue"
+	"github.com/butaosuinu/fanout/internal/hooks"
+	"github.com/butaosuinu/fanout/internal/settings"
+	"github.com/butaosuinu/fanout/internal/state"
+	fanouttui "github.com/butaosuinu/fanout/internal/tui"
+	"github.com/butaosuinu/fanout/internal/watch"
+)
+
+// newTUIListOpenIssuesFunc lists OPEN issues for the new-session picker and
+// marks the ones that already have a recorded fanout pane.
+func newTUIListOpenIssuesFunc(projectRoot string) func() ([]fanouttui.IssueListItem, error) {
+	return func() ([]fanouttui.IssueListItem, error) {
+		gh := ghissue.Runner{Cwd: projectRoot}
+		issues, err := gh.ListOpenIssues()
+		if err != nil {
+			return nil, err
+		}
+		recorded := recordedIssueNumbers(projectRoot)
+		items := make([]fanouttui.IssueListItem, 0, len(issues))
+		for _, issue := range issues {
+			labels := make([]string, 0, len(issue.Labels))
+			for _, label := range issue.Labels {
+				labels = append(labels, label.Name)
+			}
+			items = append(items, fanouttui.IssueListItem{
+				Number:     issue.Number,
+				Title:      issue.Title,
+				Labels:     labels,
+				HasSession: recorded[issue.Number],
+			})
+		}
+		return items, nil
+	}
+}
+
+// recordedIssueNumbers reads state without locking (a display-only read) and
+// returns the issue numbers recorded as a pane or as a fan-out parent. A read
+// failure degrades to "no session hints" rather than failing the picker.
+func recordedIssueNumbers(projectRoot string) map[int]bool {
+	store, err := state.LoadProject(projectRoot)
+	if err != nil {
+		return nil
+	}
+	recorded := map[int]bool{}
+	for _, pane := range store.Panes {
+		if pane.IssueNum > 0 {
+			recorded[pane.IssueNum] = true
+		}
+		if parent, err := strconv.Atoi(pane.Parent); err == nil && parent > 0 {
+			recorded[parent] = true
+		}
+	}
+	return recorded
+}
+
+// newTUIListIssueChildrenFunc lists the OPEN children the agent-assignment
+// step offers. It reuses the watcher's child union (sub-issues + parent body
+// task list) but skips per-child blocker hydration: an override for a child
+// that ends up deferred is harmless, so the list does not need launch-exact
+// filtering.
+func newTUIListIssueChildrenFunc(projectRoot string) func(parent int) ([]fanouttui.ChildTarget, error) {
+	return func(parent int) ([]fanouttui.ChildTarget, error) {
+		gh := ghissue.Runner{Cwd: projectRoot}
+		loaded, err := loadWatchParentChildren(gh, parent)
+		if err != nil {
+			return nil, err
+		}
+		open := openIssues(loaded.Children)
+		targets := make([]fanouttui.ChildTarget, 0, len(open))
+		for _, child := range open {
+			targets = append(targets, fanouttui.ChildTarget{
+				Number: child.Number,
+				Title:  child.Title,
+				Wave:   child.Wave,
+			})
+		}
+		return targets, nil
+	}
+}
+
+func newTUIIssueLaunchFunc(projectRoot, session, commandName string, resolvedSettings settings.Settings, hookConfig hooks.Config) fanouttui.IssueLaunchFunc {
+	return func(issueNum int, defaultAgent string, overrides map[string]string) (string, error) {
+		return launchIssueSessionFromTUI(projectRoot, session, commandName, resolvedSettings, hookConfig, issueNum, defaultAgent, overrides)
+	}
+}
+
+// launchIssueSessionFromTUI starts a session for one issue picked in the TUI:
+// a full fan-out when the issue has OPEN children (the watcher's parent lane),
+// a single pane otherwise (the watcher's standalone lane).
+func launchIssueSessionFromTUI(projectRoot, session, commandName string, resolvedSettings settings.Settings, hookConfig hooks.Config, issueNum int, defaultAgent string, overrides map[string]string) (string, error) {
+	if issueNum <= 0 {
+		return "", fmt.Errorf("issue number is required")
+	}
+	if err := validateTUIAgentSelection(defaultAgent, overrides); err != nil {
+		return "", err
+	}
+	gh := ghissue.Runner{Cwd: projectRoot}
+	// Re-fetch the issue: the picker list may be stale, and the detail carries
+	// the body the standalone briefing needs.
+	detail, err := gh.IssueDetail(issueNum)
+	if err != nil {
+		return "", err
+	}
+	if detail.State != "OPEN" {
+		return "", fmt.Errorf("issue #%d is not OPEN", issueNum)
+	}
+	openChildren, err := countOpenChildTargets(gh, issueNum)
+	if err != nil {
+		return "", err
+	}
+	cfg := tuiIssueLaunchConfig(issueNum, defaultAgent, overrides)
+	if openChildren == 0 {
+		if launchErr := launchStandaloneIssuePane(projectRoot, session, commandName, cfg, resolvedSettings, hookConfig, detail); launchErr != nil {
+			if errors.Is(launchErr, watch.ErrAlreadyFanned) {
+				return "", fmt.Errorf("issue #%d already has a fanout pane", issueNum)
+			}
+			return "", launchErr
+		}
+		return fmt.Sprintf("started session for #%d", issueNum), nil
+	}
+	result, err := launchParentIssueFanout(projectRoot, session, commandName, cfg)
+	if err != nil {
+		return "", err
+	}
+	notice := fmt.Sprintf("fanned out #%d", issueNum)
+	if result.Deferred {
+		notice += "; blocked/deferred children remain - re-select the issue later"
+	}
+	return notice, nil
+}
+
+// validateTUIAgentSelection checks the default agent plus every override
+// value before any launch work starts, so a bad selection surfaces as one
+// clear error instead of a mid-fan-out failure.
+func validateTUIAgentSelection(defaultAgent string, overrides map[string]string) error {
+	names := make([]string, 0, len(overrides)+1)
+	names = append(names, defaultAgent)
+	for _, name := range overrides {
+		names = append(names, name)
+	}
+	seen := map[string]bool{}
+	for _, name := range names {
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		if err := agent.ValidateKnown(name); err != nil {
+			return err
+		}
+		if err := agent.ValidateInstalled(name); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// tuiIssueLaunchConfig mirrors newWatchLaunchConfig but carries the user's
+// agent selection. UnblockedOnly stays true: the picker shows no blocker
+// info, and launchParentIssueFanout's deferred re-detection assumes it.
+func tuiIssueLaunchConfig(issueNum int, defaultAgent string, overrides map[string]string) *cliflags.Config {
+	cfg := &cliflags.Config{
+		Parent:          issueNum,
+		ParentRef:       strconv.Itoa(issueNum),
+		ParentMode:      cliflags.ModeIssue,
+		Agent:           defaultAgent,
+		SleepBetween:    cliflags.DefaultSleepBetween,
+		PopupTimeoutSec: cliflags.DefaultPopupTimeout,
+		ProjectStatus:   cliflags.DefaultProjectStatus,
+		Format:          cliflags.DefaultFormat,
+		UnblockedOnly:   true,
+	}
+	for target, name := range overrides {
+		cfg.AgentOverrides = cliflags.UpsertAgentOverride(cfg.AgentOverrides, target, name)
+	}
+	return cfg
+}

--- a/cmd/fanout/tui_issue.go
+++ b/cmd/fanout/tui_issue.go
@@ -127,36 +127,52 @@ func launchIssueSessionFromTUI(projectRoot, session, commandName string, resolve
 		}
 		return fmt.Sprintf("started session for #%d", issueNum), nil
 	}
+	before := recordedPaneCountForParent(projectRoot, cfg.ParentRef)
 	result, err := launchParentIssueFanout(projectRoot, session, commandName, cfg)
 	if err != nil {
 		return "", err
 	}
-	notice := fmt.Sprintf("fanned out #%d", issueNum)
+	created := recordedPaneCountForParent(projectRoot, cfg.ParentRef) - before
+	notice := fmt.Sprintf("fanned out #%d: created %d pane(s)", issueNum, created)
+	if created <= 0 {
+		notice = fmt.Sprintf("#%d: no new panes (children already have one)", issueNum)
+	}
 	if result.Deferred {
 		notice += "; blocked/deferred children remain - re-select the issue later"
 	}
 	return notice, nil
 }
 
-// validateTUIAgentSelection checks the default agent plus every override
-// value before any launch work starts, so a bad selection surfaces as one
-// clear error instead of a mid-fan-out failure.
-func validateTUIAgentSelection(defaultAgent string, overrides map[string]string) error {
-	names := make([]string, 0, len(overrides)+1)
-	names = append(names, defaultAgent)
-	for _, name := range overrides {
-		names = append(names, name)
+// recordedPaneCountForParent counts state rows under one fan-out parent; the
+// before/after difference is the created-pane count runWithRuntime does not
+// return. A read failure degrades to 0 rather than failing the launch report.
+func recordedPaneCountForParent(projectRoot, parentRef string) int {
+	store, err := state.LoadProject(projectRoot)
+	if err != nil {
+		return 0
 	}
-	seen := map[string]bool{}
-	for _, name := range names {
+	return len(store.FannedNumbersForParent(parentRef))
+}
+
+// validateTUIAgentSelection rejects unknown agent names up front so a typo
+// surfaces as one clear error. Installation is checked only for the default
+// agent: an override may sit on a blocked/deferred target the launch skips,
+// and the launch lanes (validateIssueAgents / validateTaskAgents) already
+// install-check the agents of the targets they actually launch.
+func validateTUIAgentSelection(defaultAgent string, overrides map[string]string) error {
+	if err := agent.ValidateKnown(defaultAgent); err != nil {
+		return err
+	}
+	if err := agent.ValidateInstalled(defaultAgent); err != nil {
+		return err
+	}
+	seen := map[string]bool{defaultAgent: true}
+	for _, name := range overrides {
 		if seen[name] {
 			continue
 		}
 		seen[name] = true
 		if err := agent.ValidateKnown(name); err != nil {
-			return err
-		}
-		if err := agent.ValidateInstalled(name); err != nil {
 			return err
 		}
 	}

--- a/cmd/fanout/tui_issue.go
+++ b/cmd/fanout/tui_issue.go
@@ -129,10 +129,15 @@ func launchIssueSessionFromTUI(projectRoot, session, commandName string, resolve
 	}
 	before := recordedPaneCountForParent(projectRoot, cfg.ParentRef)
 	result, err := launchParentIssueFanout(projectRoot, session, commandName, cfg)
+	created := recordedPaneCountForParent(projectRoot, cfg.ParentRef) - before
 	if err != nil {
+		if created > 0 {
+			// The fail-fast loop may have created panes before the failure;
+			// they are running agents, so a pure failure report would mislead.
+			return "", fmt.Errorf("created %d pane(s), then failed: %w", created, err)
+		}
 		return "", err
 	}
-	created := recordedPaneCountForParent(projectRoot, cfg.ParentRef) - before
 	notice := fmt.Sprintf("fanned out #%d: created %d pane(s)", issueNum, created)
 	if created <= 0 {
 		notice = fmt.Sprintf("#%d: no new panes (children already have one)", issueNum)

--- a/cmd/fanout/tui_issue_test.go
+++ b/cmd/fanout/tui_issue_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -141,9 +143,30 @@ esac
 }
 
 func TestLaunchIssueSessionFromTUIRejectsUnknownAgent(t *testing.T) {
+	installFakeExecutable(t, "claude")
 	_, err := launchIssueSessionFromTUI(t.TempDir(), "fanout-test", "fanout", settings.Defaults(), hooks.EmptyConfig(), 501, "claude", map[string]string{"502": "gemini"})
 	if err == nil || !strings.Contains(err.Error(), "gemini") {
 		t.Fatalf("launchIssueSessionFromTUI() error = %v, want unknown-agent rejection", err)
+	}
+}
+
+// TestValidateTUIAgentSelectionSkipsInstallCheckForOverrides pins the CLI
+// parity: an override may target a deferred child, so only the default agent
+// must be installed here — launch-lane validation covers actual targets.
+func TestValidateTUIAgentSelectionSkipsInstallCheckForOverrides(t *testing.T) {
+	// An exclusive PATH with only a fake claude, so a codex CLI on the host
+	// cannot mask the uninstalled-agent paths.
+	binDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(binDir, "claude"), []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir)
+
+	if err := validateTUIAgentSelection("claude", map[string]string{"502": "codex"}); err != nil {
+		t.Fatalf("validateTUIAgentSelection() error = %v, want uninstalled override tolerated", err)
+	}
+	if err := validateTUIAgentSelection("codex", nil); err == nil {
+		t.Fatal("validateTUIAgentSelection() = nil, want uninstalled default agent rejected")
 	}
 }
 

--- a/cmd/fanout/tui_issue_test.go
+++ b/cmd/fanout/tui_issue_test.go
@@ -1,0 +1,185 @@
+package main
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/butaosuinu/fanout/internal/hooks"
+	"github.com/butaosuinu/fanout/internal/settings"
+	"github.com/butaosuinu/fanout/internal/state"
+	fanouttui "github.com/butaosuinu/fanout/internal/tui"
+)
+
+func TestNewTUIListOpenIssuesFuncMarksRecordedSessions(t *testing.T) {
+	repo := t.TempDir()
+	initTUITestGitRepo(t, repo)
+	locked, err := state.LockProject(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = locked.RecordPane(state.Pane{Parent: "700", IssueNum: 501, Slug: "child-501", PaneID: "%1"}); err != nil {
+		t.Fatal(err)
+	}
+	if err = locked.Unlock(); err != nil {
+		t.Fatal(err)
+	}
+	installTUIWatcherGHScript(t, `
+case "$args" in
+"issue list --state open --limit 100 --json number,title,state,labels")
+  printf '[{"number":501,"title":"recorded child","state":"open","labels":[{"name":"bug"}]},{"number":502,"title":"fresh","state":"open","labels":[]},{"number":700,"title":"fanned parent","state":"open","labels":[]}]'
+  ;;
+*)
+  printf 'unexpected gh args: %s\n' "$args" >&2
+  exit 64
+  ;;
+esac
+`)
+
+	got, err := newTUIListOpenIssuesFunc(repo)()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []fanouttui.IssueListItem{
+		{Number: 501, Title: "recorded child", Labels: []string{"bug"}, HasSession: true},
+		{Number: 502, Title: "fresh", Labels: []string{}},
+		{Number: 700, Title: "fanned parent", Labels: []string{}, HasSession: true},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("newTUIListOpenIssuesFunc() = %#v, want %#v", got, want)
+	}
+}
+
+func TestNewTUIListIssueChildrenFuncReturnsOpenChildrenWithWaves(t *testing.T) {
+	installTUIWatcherGHScript(t, `
+case "$args" in
+"api --paginate --slurp repos/{owner}/{repo}/issues/500/sub_issues?per_page=100")
+  printf '[[{"number":501,"title":"frontend","state":"open"},{"number":502,"title":"done","state":"closed"}]]'
+  ;;
+"issue view 500 --json body -q .body")
+  printf '%s\n' '### Wave 1' '- [ ] #501 frontend' '- [x] #502 done'
+  ;;
+*)
+  printf 'unexpected gh args: %s\n' "$args" >&2
+  exit 64
+  ;;
+esac
+`)
+
+	got, err := newTUIListIssueChildrenFunc(t.TempDir())(500)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// ghissue.TaskListWaves normalizes headings like "### Wave 1" to "wave1".
+	want := []fanouttui.ChildTarget{{Number: 501, Title: "frontend", Wave: "wave1"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("newTUIListIssueChildrenFunc() = %#v, want %#v", got, want)
+	}
+}
+
+func TestLaunchIssueSessionFromTUIRejectsClosedIssue(t *testing.T) {
+	installFakeExecutable(t, "claude")
+	installTUIWatcherGHScript(t, `
+case "$args" in
+"issue view 501 --json number,title,state,body,labels")
+  printf '{"number":501,"title":"stale row","state":"CLOSED","body":"","labels":[]}'
+  ;;
+*)
+  printf 'unexpected gh args: %s\n' "$args" >&2
+  exit 64
+  ;;
+esac
+`)
+
+	_, err := launchIssueSessionFromTUI(t.TempDir(), "fanout-test", "fanout", settings.Defaults(), hooks.EmptyConfig(), 501, "claude", nil)
+	if err == nil || !strings.Contains(err.Error(), "issue #501 is not OPEN") {
+		t.Fatalf("launchIssueSessionFromTUI() error = %v, want not-OPEN rejection", err)
+	}
+}
+
+// TestLaunchIssueSessionFromTUITranslatesAlreadyFanned pins the standalone
+// lane: a childless issue whose pane is already recorded surfaces a readable
+// message instead of the raw sentinel error.
+func TestLaunchIssueSessionFromTUITranslatesAlreadyFanned(t *testing.T) {
+	repo := t.TempDir()
+	initTUITestGitRepo(t, repo)
+	locked, err := state.LockProject(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err = locked.RecordPane(state.Pane{Parent: "@watch", IssueNum: 501, Slug: "existing-501", PaneID: "%1"}); err != nil {
+		t.Fatal(err)
+	}
+	if err = locked.Unlock(); err != nil {
+		t.Fatal(err)
+	}
+	installFakeExecutable(t, "claude")
+	installTUIWatcherGHScript(t, `
+case "$args" in
+"issue view 501 --json number,title,state,body,labels")
+  printf '{"number":501,"title":"standalone","state":"OPEN","body":"body","labels":[]}'
+  ;;
+"api --paginate --slurp repos/{owner}/{repo}/issues/501/sub_issues?per_page=100")
+  printf '[[]]'
+  ;;
+"issue view 501 --json body -q .body")
+  printf 'body\n'
+  ;;
+*)
+  printf 'unexpected gh args: %s\n' "$args" >&2
+  exit 64
+  ;;
+esac
+`)
+
+	_, err = launchIssueSessionFromTUI(repo, "fanout-test", "fanout", settings.Defaults(), hooks.EmptyConfig(), 501, "claude", nil)
+	if err == nil || !strings.Contains(err.Error(), "issue #501 already has a fanout pane") {
+		t.Fatalf("launchIssueSessionFromTUI() error = %v, want already-has-pane message", err)
+	}
+}
+
+func TestLaunchIssueSessionFromTUIRejectsUnknownAgent(t *testing.T) {
+	_, err := launchIssueSessionFromTUI(t.TempDir(), "fanout-test", "fanout", settings.Defaults(), hooks.EmptyConfig(), 501, "claude", map[string]string{"502": "gemini"})
+	if err == nil || !strings.Contains(err.Error(), "gemini") {
+		t.Fatalf("launchIssueSessionFromTUI() error = %v, want unknown-agent rejection", err)
+	}
+}
+
+// TestTUIIssueLaunchConfigCarriesAgentSelection guarantees the TUI selection
+// reaches the fan-out exactly like repeatable --agent flags would.
+func TestTUIIssueLaunchConfigCarriesAgentSelection(t *testing.T) {
+	tests := []struct {
+		name         string
+		defaultAgent string
+		overrides    map[string]string
+		wantEffect   map[int]string
+	}{
+		{
+			name:         "default only",
+			defaultAgent: "claude",
+			wantEffect:   map[int]string{43: "claude", 44: "claude"},
+		},
+		{
+			name:         "override flips one child",
+			defaultAgent: "claude",
+			overrides:    map[string]string{"44": "codex"},
+			wantEffect:   map[int]string{43: "claude", 44: "codex"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := tuiIssueLaunchConfig(42, tt.defaultAgent, tt.overrides)
+			if cfg.Parent != 42 || cfg.ParentRef != "42" || !cfg.UnblockedOnly {
+				t.Fatalf("cfg identity = %d/%q unblockedOnly=%v, want 42/42/true", cfg.Parent, cfg.ParentRef, cfg.UnblockedOnly)
+			}
+			for num, want := range tt.wantEffect {
+				if got := cfg.EffectiveAgentForIssue(num); got != want {
+					t.Fatalf("EffectiveAgentForIssue(%d) = %q, want %q", num, got, want)
+				}
+			}
+		})
+	}
+}

--- a/cmd/fanout/tui_plan.go
+++ b/cmd/fanout/tui_plan.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/butaosuinu/fanout/internal/cliflags"
+	"github.com/butaosuinu/fanout/internal/exitcode"
+	"github.com/butaosuinu/fanout/internal/ghissue"
+	"github.com/butaosuinu/fanout/internal/log"
+	"github.com/butaosuinu/fanout/internal/planspec"
+	fanoutruntime "github.com/butaosuinu/fanout/internal/runtime"
+	fanouttui "github.com/butaosuinu/fanout/internal/tui"
+)
+
+func newTUIListPlanSlugsFunc(projectRoot string) func() ([]string, error) {
+	return func() ([]string, error) {
+		return listPlanSlugs(projectRoot)
+	}
+}
+
+// newTUIListPlanTasksFunc loads a stored plan spec and returns its task rows
+// for the agent-assignment step. Completion is not computed here: it costs
+// one `gh pr list` per task, and an override for a completed task is
+// harmless.
+func newTUIListPlanTasksFunc(projectRoot string) func(slug string) ([]fanouttui.PlanTaskItem, error) {
+	return func(slug string) ([]fanouttui.PlanTaskItem, error) {
+		spec, err := planspec.LoadWithoutResolvedNameChecks(resolvePlanSpecPath(projectRoot, slug))
+		if err != nil {
+			return nil, err
+		}
+		items := make([]fanouttui.PlanTaskItem, 0, len(spec.Tasks))
+		for _, task := range spec.Tasks {
+			items = append(items, fanouttui.PlanTaskItem{ID: task.ID, Title: task.Title, Wave: task.Wave})
+		}
+		return items, nil
+	}
+}
+
+func newTUIPlanLaunchFunc(projectRoot, session, commandName string) fanouttui.PlanLaunchFunc {
+	return func(slug, defaultAgent string, overrides map[string]string) (string, error) {
+		return launchPlanFromTUI(projectRoot, session, commandName, slug, defaultAgent, overrides)
+	}
+}
+
+// launchPlanFromTUI runs the live `fanout plan <slug>` lane against the TUI's
+// session, reusing runPlanWithRuntime with a synthesized runtime.
+func launchPlanFromTUI(projectRoot, session, commandName, slug, defaultAgent string, overrides map[string]string) (string, error) {
+	if strings.TrimSpace(slug) == "" {
+		return "", fmt.Errorf("plan slug is required")
+	}
+	if err := validateTUIAgentSelection(defaultAgent, overrides); err != nil {
+		return "", err
+	}
+	var stdout, stderr bytes.Buffer
+	launchLogger := log.NewWith(&stdout, &stderr, false)
+	cfg := planCommandConfig{
+		SpecArg:      slug,
+		Agent:        defaultAgent,
+		SleepBetween: cliflags.DefaultSleepBetween,
+		Format:       cliflags.DefaultFormat,
+	}
+	for target, name := range overrides {
+		cfg.AgentOverrides = cliflags.UpsertAgentOverride(cfg.AgentOverrides, target, name)
+	}
+	rt := &runtimeInfo{
+		info: &fanoutruntime.Info{
+			Session:     session,
+			Target:      tuiLaunchTarget(session),
+			ProjectRoot: projectRoot,
+		},
+		gh: ghissue.Runner{Cwd: projectRoot},
+	}
+	result, code := runPlanWithRuntime(cfg, rt, launchLogger, commandName)
+	if code != exitcode.OK {
+		return "", bufferedLaunchError(stdout, stderr, "launch plan")
+	}
+	if result.Created == 0 {
+		return fmt.Sprintf("plan %s: nothing to do (all tasks already have a pane or are complete)", slug), nil
+	}
+	return fmt.Sprintf("plan %s: created %d pane(s)", slug, result.Created), nil
+}

--- a/cmd/fanout/tui_plan.go
+++ b/cmd/fanout/tui_plan.go
@@ -74,7 +74,13 @@ func launchPlanFromTUI(projectRoot, session, commandName, slug, defaultAgent str
 	}
 	result, code := runPlanWithRuntime(cfg, rt, launchLogger, commandName)
 	if code != exitcode.OK {
-		return "", bufferedLaunchError(stdout, stderr, "launch plan")
+		launchErr := bufferedLaunchError(stdout, stderr, "launch plan")
+		if result.Created > 0 {
+			// The fail-fast loop may have created panes before the failure;
+			// they are running agents, so a pure failure report would mislead.
+			return "", fmt.Errorf("created %d pane(s), then failed: %w", result.Created, launchErr)
+		}
+		return "", launchErr
 	}
 	if result.Created == 0 {
 		return fmt.Sprintf("plan %s: nothing to do (all tasks already have a pane or are complete)", slug), nil

--- a/cmd/fanout/tui_plan_test.go
+++ b/cmd/fanout/tui_plan_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/butaosuinu/fanout/internal/state"
+	fanouttui "github.com/butaosuinu/fanout/internal/tui"
+)
+
+const tuiPlanTestSpec = `{
+  "version": 1,
+  "plan": {
+    "slug": "launch-plan",
+    "title": "Launch plan",
+    "base_branch": "main"
+  },
+  "tasks": [
+    {
+      "id": "base-types",
+      "title": "Define base types",
+      "briefing": "## Goal\nDefine base types"
+    },
+    {
+      "id": "api-client",
+      "title": "Extract API client",
+      "briefing": "## Goal\nExtract API client",
+      "blocked_by": ["base-types"],
+      "wave": "2"
+    }
+  ]
+}`
+
+func writeTUIPlanTestSpec(t *testing.T, repo string) {
+	t.Helper()
+	plansDir := filepath.Join(repo, ".fanout", "plans")
+	if err := os.MkdirAll(plansDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(plansDir, "launch-plan.json"), []byte(tuiPlanTestSpec), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestNewTUIListPlanTasksFuncReadsSpec(t *testing.T) {
+	repo := t.TempDir()
+	writeTUIPlanTestSpec(t, repo)
+
+	got, err := newTUIListPlanTasksFunc(repo)("launch-plan")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []fanouttui.PlanTaskItem{
+		{ID: "base-types", Title: "Define base types"},
+		{ID: "api-client", Title: "Extract API client", Wave: "2"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("newTUIListPlanTasksFunc() = %#v, want %#v", got, want)
+	}
+}
+
+func TestNewTUIListPlanTasksFuncReportsMissingSpec(t *testing.T) {
+	if _, err := newTUIListPlanTasksFunc(t.TempDir())("no-such-plan"); err == nil {
+		t.Fatal("newTUIListPlanTasksFunc() succeeded for a missing spec")
+	}
+}
+
+// TestLaunchPlanFromTUINothingToDo drives runPlanWithRuntime end to end with
+// every task already recorded, pinning the notice the TUI shows instead of a
+// silent no-op.
+func TestLaunchPlanFromTUINothingToDo(t *testing.T) {
+	repo := t.TempDir()
+	initTUITestGitRepo(t, repo)
+	writeTUIPlanTestSpec(t, repo)
+	locked, err := state.LockProject(repo)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, taskID := range []string{"base-types", "api-client"} {
+		if err = locked.RecordPane(state.Pane{Parent: "plan:launch-plan", TaskID: taskID, Slug: "launch-plan-" + taskID, PaneID: "%1"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err = locked.Unlock(); err != nil {
+		t.Fatal(err)
+	}
+	installFakeExecutable(t, "claude")
+
+	notice, err := launchPlanFromTUI(repo, "fanout-test", "fanout", "launch-plan", "claude", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(notice, "plan launch-plan: nothing to do") {
+		t.Fatalf("launchPlanFromTUI() notice = %q, want nothing-to-do", notice)
+	}
+}
+
+func TestLaunchPlanFromTUIReportsSpecLoadError(t *testing.T) {
+	repo := t.TempDir()
+	initTUITestGitRepo(t, repo)
+	installFakeExecutable(t, "claude")
+
+	_, err := launchPlanFromTUI(repo, "fanout-test", "fanout", "no-such-plan", "claude", nil)
+	if err == nil {
+		t.Fatal("launchPlanFromTUI() succeeded for a missing spec")
+	}
+}
+
+func TestLaunchPlanFromTUIRejectsEmptySlug(t *testing.T) {
+	if _, err := launchPlanFromTUI(t.TempDir(), "fanout-test", "fanout", "  ", "claude", nil); err == nil {
+		t.Fatal("launchPlanFromTUI() succeeded for an empty slug")
+	}
+}

--- a/cmd/fanout/tui_popup.go
+++ b/cmd/fanout/tui_popup.go
@@ -241,6 +241,14 @@ func tuiNewPanePopupShellCommand(commandName, projectRoot, resultFile, doneFile,
 	// Enhanced keyboard input is on by default. Always forward the current value,
 	// including opt-out values, so the helper mirrors the parent TUI.
 	prefix := fanouttui.EnhancedKeysEnv + "=" + shellQuote(os.Getenv(fanouttui.EnhancedKeysEnv))
+	// display-popup runs under the tmux server's environment, not the parent
+	// fanout process's. Forward PATH so the issue/plan pickers find `gh` (and
+	// git) wherever the parent did. Secrets (GH_TOKEN etc.) are deliberately
+	// not inlined: the command line is visible via ps; token-less setups rely
+	// on gh's config-file auth, which needs only HOME.
+	if path := os.Getenv("PATH"); path != "" {
+		prefix = "PATH=" + shellQuote(path) + " " + prefix
+	}
 	parts = append([]string{prefix}, parts...)
 	command := strings.Join(parts, " ")
 	markDone := "printf '' > " + shellQuote(doneFile)

--- a/cmd/fanout/tui_popup.go
+++ b/cmd/fanout/tui_popup.go
@@ -33,10 +33,15 @@ type tuiNewPanePopupGeometry struct {
 }
 
 type tuiNewPanePopupResult struct {
-	Canceled bool     `json:"canceled,omitempty"`
-	Prompt   string   `json:"prompt,omitempty"`
-	Agents   []string `json:"agents,omitempty"`
-	Error    string   `json:"error,omitempty"`
+	Canceled       bool              `json:"canceled,omitempty"`
+	Mode           string            `json:"mode,omitempty"` // "" (prompt) | "issue" | "plan"
+	Prompt         string            `json:"prompt,omitempty"`
+	Issue          int               `json:"issue,omitempty"`
+	Plan           string            `json:"plan,omitempty"`
+	Agents         []string          `json:"agents,omitempty"`
+	DefaultAgent   string            `json:"defaultAgent,omitempty"`
+	AgentOverrides map[string]string `json:"agentOverrides,omitempty"`
+	Error          string            `json:"error,omitempty"`
 }
 
 func isTUINewPanePopupRequest(args []string) bool {
@@ -59,13 +64,26 @@ func cmdTUINewPanePopup(args []string, lg *log.Logger) exitcode.Code {
 		return exitcode.Invocation
 	}
 	req, canceled, err := fanouttui.RunNewPanePrompt(fanouttui.NewPanePromptOptions{
-		ProjectRoot:   *projectRoot,
-		DefaultAgent:  *defaultAgent,
-		Width:         *width,
-		Height:        *height,
-		ListRepoFiles: worktree.ListFiles,
+		ProjectRoot:       *projectRoot,
+		DefaultAgent:      *defaultAgent,
+		Width:             *width,
+		Height:            *height,
+		ListRepoFiles:     worktree.ListFiles,
+		ListOpenIssues:    newTUIListOpenIssuesFunc(*projectRoot),
+		ListPlanSlugs:     newTUIListPlanSlugsFunc(*projectRoot),
+		ListIssueChildren: newTUIListIssueChildrenFunc(*projectRoot),
+		ListPlanTasks:     newTUIListPlanTasksFunc(*projectRoot),
 	})
-	result := tuiNewPanePopupResult{Canceled: canceled, Prompt: req.Prompt, Agents: req.Agents}
+	result := tuiNewPanePopupResult{
+		Canceled:       canceled,
+		Mode:           string(req.Mode),
+		Prompt:         req.Prompt,
+		Issue:          req.Issue,
+		Plan:           req.Plan,
+		Agents:         req.Agents,
+		DefaultAgent:   req.DefaultAgent,
+		AgentOverrides: req.AgentOverrides,
+	}
 	code := exitcode.OK
 	if err != nil {
 		result = tuiNewPanePopupResult{Error: err.Error()}
@@ -166,7 +184,15 @@ func newTUINewPanePromptFunc(projectRoot, commandName string) fanouttui.NewPaneP
 		if displayErr != nil {
 			return fanouttui.LaunchRequest{}, false, displayErr
 		}
-		return fanouttui.LaunchRequest{Prompt: result.Prompt, Agents: result.Agents}, false, nil
+		return fanouttui.LaunchRequest{
+			Mode:           fanouttui.LaunchMode(result.Mode),
+			Prompt:         result.Prompt,
+			Issue:          result.Issue,
+			Plan:           result.Plan,
+			Agents:         result.Agents,
+			DefaultAgent:   result.DefaultAgent,
+			AgentOverrides: result.AgentOverrides,
+		}, false, nil
 	}
 }
 

--- a/cmd/fanout/tui_test.go
+++ b/cmd/fanout/tui_test.go
@@ -233,6 +233,9 @@ func TestTUINewPanePopupShellCommandMarksDoneAndPropagatesEnhancedKeys(t *testin
 		"/tmp/result.done",
 		tuiNewPanePopupCommand,
 		"--result-file /tmp/result.json",
+		// The popup runs under the tmux server env; PATH must come from the
+		// parent so the issue/plan pickers can exec gh.
+		"PATH=" + shellQuote(os.Getenv("PATH")),
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("popup shell command missing %q:\n%s", want, got)

--- a/cmd/fanout/tui_test.go
+++ b/cmd/fanout/tui_test.go
@@ -127,24 +127,50 @@ func TestTUINewPanePopupGeometryUsesClientDimensions(t *testing.T) {
 }
 
 func TestTUINewPanePopupResultRoundTrip(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "result.json")
-	want := tuiNewPanePopupResult{Prompt: "Inspect API", Agents: []string{"codex"}}
-	if err := writeTUINewPanePopupResult(path, want); err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		name   string
+		result tuiNewPanePopupResult
+	}{
+		{
+			name:   "prompt mode keeps the legacy fields",
+			result: tuiNewPanePopupResult{Prompt: "Inspect API", Agents: []string{"codex"}},
+		},
+		{
+			name: "issue mode carries number and agent overrides",
+			result: tuiNewPanePopupResult{
+				Mode:           "issue",
+				Issue:          42,
+				DefaultAgent:   "claude",
+				AgentOverrides: map[string]string{"43": "codex"},
+			},
+		},
+		{
+			name:   "plan mode carries the slug",
+			result: tuiNewPanePopupResult{Mode: "plan", Plan: "launch-plan", DefaultAgent: "codex"},
+		},
 	}
-	got, err := readTUINewPanePopupResult(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got.Prompt != want.Prompt || !reflect.DeepEqual(got.Agents, want.Agents) || got.Canceled {
-		t.Fatalf("popup result = %#v, want %#v", got, want)
-	}
-	info, err := os.Stat(path)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got := info.Mode().Perm(); got != 0o600 {
-		t.Fatalf("popup result mode = %o, want 600", got)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "result.json")
+			if err := writeTUINewPanePopupResult(path, tt.result); err != nil {
+				t.Fatal(err)
+			}
+			got, err := readTUINewPanePopupResult(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(got, tt.result) {
+				t.Fatalf("popup result = %#v, want %#v", got, tt.result)
+			}
+			info, err := os.Stat(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := info.Mode().Perm(); got != 0o600 {
+				t.Fatalf("popup result mode = %o, want 600", got)
+			}
+		})
 	}
 }
 

--- a/cmd/fanout/tui_watch.go
+++ b/cmd/fanout/tui_watch.go
@@ -72,9 +72,16 @@ func (w *tuiWatcher) RunCycle() (watch.Report, error) {
 }
 
 func launchWatchStandalone(projectRoot, session, commandName string, resolvedSettings settings.Settings, hookConfig hooks.Config, issue ghissue.Issue) error {
+	cfg := newWatchLaunchConfig(resolvedSettings, issue.Number, 0)
+	return launchStandaloneIssuePane(projectRoot, session, commandName, cfg, resolvedSettings, hookConfig, issue)
+}
+
+// launchStandaloneIssuePane creates one pane for a single issue with no OPEN
+// children. The watcher and the TUI issue launcher share it; cfg carries the
+// caller's agent selection.
+func launchStandaloneIssuePane(projectRoot, session, commandName string, cfg *cliflags.Config, resolvedSettings settings.Settings, hookConfig hooks.Config, issue ghissue.Issue) error {
 	var stdout, stderr bytes.Buffer
 	launchLogger := log.NewWith(&stdout, &stderr, false)
-	cfg := newWatchLaunchConfig(resolvedSettings, issue.Number, 0)
 	store, recorder, code := loadRunState(cfg, projectRoot, launchLogger)
 	if code != exitcode.OK {
 		return bufferedLaunchError(stdout, stderr, "load fanout state")
@@ -100,10 +107,17 @@ func launchWatchStandalone(projectRoot, session, commandName string, resolvedSet
 }
 
 func launchWatchParent(projectRoot, session, commandName string, resolvedSettings settings.Settings, issue ghissue.Issue, limit int) (watch.ParentLaunchResult, error) {
+	cfg := newWatchLaunchConfig(resolvedSettings, issue.Number, limit)
+	return launchParentIssueFanout(projectRoot, session, commandName, cfg)
+}
+
+// launchParentIssueFanout runs the full issue-mode fan-out for cfg.Parent
+// against a synthesized runtime targeting the TUI session. The watcher and
+// the TUI issue launcher share it.
+func launchParentIssueFanout(projectRoot, session, commandName string, cfg *cliflags.Config) (watch.ParentLaunchResult, error) {
 	gh := ghissue.Runner{Cwd: projectRoot}
 	var stdout, stderr bytes.Buffer
 	launchLogger := log.NewWith(&stdout, &stderr, false)
-	cfg := newWatchLaunchConfig(resolvedSettings, issue.Number, limit)
 	rt := &runtimeInfo{
 		info: &fanoutruntime.Info{
 			Session:     session,

--- a/internal/ghissue/ghissue.go
+++ b/internal/ghissue/ghissue.go
@@ -250,6 +250,27 @@ func (r Runner) ListOpenIssuesWithLabel(label string) ([]Issue, error) {
 	return issues, nil
 }
 
+// ListOpenIssues returns up to 100 OPEN issues for interactive pickers. Bodies
+// are omitted: pickers render number/title/labels only, and launch paths
+// re-fetch details (IssueDetail) at launch time so a stale list entry cannot
+// carry a stale briefing body.
+func (r Runner) ListOpenIssues() ([]Issue, error) {
+	out, err := r.gh(
+		"issue", "list",
+		"--state", "open",
+		"--limit", "100",
+		"--json", "number,title,state,labels",
+	)
+	if err != nil {
+		return nil, err
+	}
+	issues, err := parseIssueList(out)
+	if err != nil {
+		return nil, fmt.Errorf("parse gh issue list: %w", err)
+	}
+	return issues, nil
+}
+
 // SwapIssueLabels moves one issue from remove to add with one `gh issue edit`
 // call so GitHub observes a single label mutation round.
 func (r Runner) SwapIssueLabels(num int, remove, add string) error {

--- a/internal/ghissue/ghissue_test.go
+++ b/internal/ghissue/ghissue_test.go
@@ -149,6 +149,38 @@ func TestListOpenIssuesWithLabelReturnsParseError(t *testing.T) {
 	}
 }
 
+func TestListOpenIssuesRunsGHIssueListWithoutBody(t *testing.T) {
+	argsPath := installFakeGH(t, `[{"number":12,"title":"tui picker","state":"open","labels":[{"name":"enhancement"}]}]`)
+
+	got, err := (Runner{}).ListOpenIssues()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := []Issue{{Number: 12, Title: "tui picker", State: "OPEN", Labels: []Label{{Name: "enhancement"}}}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("ListOpenIssues() = %#v, want %#v", got, want)
+	}
+	assertFakeGHArgs(t, argsPath, []string{
+		"issue", "list",
+		"--state", "open",
+		"--limit", "100",
+		"--json", "number,title,state,labels",
+	})
+}
+
+func TestListOpenIssuesReturnsParseError(t *testing.T) {
+	installFakeGH(t, `not-json`)
+
+	got, err := (Runner{}).ListOpenIssues()
+	if err == nil {
+		t.Fatalf("ListOpenIssues() = %#v, want error", got)
+	}
+	if !strings.Contains(err.Error(), "parse gh issue list") {
+		t.Fatalf("ListOpenIssues() error = %v", err)
+	}
+}
+
 func TestSwapIssueLabelsRunsSingleEdit(t *testing.T) {
 	argsPath := installFakeGH(t, ``)
 

--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -30,12 +30,12 @@ func (m model) helpView() string {
 	newPane := []helpEntry{
 		{"Ctrl+J", "Prompt newline"},
 		{"Tab", "Move fields"},
-		{"Up/Down", "Pick agent"},
+		{"Up/Down", "Pick agent / row"},
 		{"Space", "Toggle agent"},
-		{"Left/Right", "Change count"},
+		{"Left/Right", "Mode / agent"},
 		{"@", "File completion"},
-		{"Enter", "Create panes"},
-		{"Esc", "Cancel"},
+		{"Enter", "Create / next"},
+		{"Esc", "Cancel / back"},
 	}
 	columnWidth := m.helpColumnWidth()
 	lines := []string{

--- a/internal/tui/newpane.go
+++ b/internal/tui/newpane.go
@@ -144,6 +144,7 @@ type newPaneForm struct {
 	planPicker  pickerState
 	agentChoice int
 	assign      assignState
+	assignGen   int // monotonic load generation; survives esc so stale loads drop
 	selIssue    int
 	selPlan     string
 

--- a/internal/tui/newpane.go
+++ b/internal/tui/newpane.go
@@ -15,15 +15,42 @@ import (
 	"github.com/charmbracelet/lipgloss"
 )
 
-// LaunchRequest describes one manual pane launch requested from the TUI.
+// LaunchMode selects the new-session lane. The zero value is the classic
+// free-prompt manual pane so pre-mode requests keep their meaning.
+type LaunchMode string
+
+const (
+	LaunchModePrompt LaunchMode = ""
+	LaunchModeIssue  LaunchMode = "issue"
+	LaunchModePlan   LaunchMode = "plan"
+)
+
+// LaunchRequest describes one launch requested from the TUI new-session form.
 type LaunchRequest struct {
-	Prompt string
+	Mode   LaunchMode
+	Prompt string // Mode == prompt
+	Issue  int    // Mode == issue: the selected issue number
+	Plan   string // Mode == plan: the selected plan slug
+	// Agents holds the prompt-mode launch list (one pane per entry).
 	Agents []string
+	// DefaultAgent and AgentOverrides carry the issue/plan-mode agent
+	// selection. Overrides are keyed by child issue number ("123") or plan
+	// task id and hold only rows that differ from DefaultAgent, mirroring
+	// repeatable --agent target=name flags.
+	DefaultAgent   string
+	AgentOverrides map[string]string
 }
 
 // LaunchFunc creates a manual fanout pane for a TUI request. It returns an
 // optional notice (e.g. a tolerated base-refresh skip) to surface on success.
 type LaunchFunc func(LaunchRequest) (notice string, err error)
+
+// IssueLaunchFunc starts a session for one GitHub issue: a fan-out when the
+// issue has OPEN children, a single pane otherwise.
+type IssueLaunchFunc func(issueNum int, defaultAgent string, overrides map[string]string) (notice string, err error)
+
+// PlanLaunchFunc runs `fanout plan <slug>` semantics for a stored plan spec.
+type PlanLaunchFunc func(slug string, defaultAgent string, overrides map[string]string) (notice string, err error)
 
 // NewPanePromptRequest describes a request to collect a manual pane prompt from
 // an external prompt surface, such as a tmux display-popup.
@@ -42,6 +69,11 @@ type NewPanePromptOptions struct {
 	Width         int
 	Height        int
 	ListRepoFiles func(root string) ([]string, error)
+	// List providers for the issue/plan modes; a nil provider hides its mode.
+	ListOpenIssues    func() ([]IssueListItem, error)
+	ListPlanSlugs     func() ([]string, error)
+	ListIssueChildren func(parent int) ([]ChildTarget, error)
+	ListPlanTasks     func(slug string) ([]PlanTaskItem, error)
 }
 
 const newPanePopupOpeningNotice = "opening new pane popup..."
@@ -71,9 +103,28 @@ type AttachLaunchFunc func(AttachLaunchRequest) (notice string, err error)
 type newPaneField int
 
 const (
-	newPaneFieldPrompt newPaneField = iota
+	newPaneFieldMode newPaneField = iota
+	newPaneFieldMain
 	newPaneFieldAgent
-	newPaneFieldCount
+)
+
+// newPaneMode is the form's input lane: the classic free prompt, the OPEN
+// issue picker, or the stored plan picker.
+type newPaneMode int
+
+const (
+	newPaneModePrompt newPaneMode = iota
+	newPaneModeIssue
+	newPaneModePlan
+)
+
+// newPaneStep is the wizard position: the mode form (step 1) or the
+// per-target agent assignment that issue/plan submissions open (step 2).
+type newPaneStep int
+
+const (
+	newPaneStepForm newPaneStep = iota
+	newPaneStepAssign
 )
 
 type newPaneForm struct {
@@ -84,6 +135,17 @@ type newPaneForm struct {
 	launching  bool
 	err        string
 	attach     *AttachTarget
+
+	// Issue/plan mode state. agentChoice is the single default-agent
+	// selection those modes use instead of the prompt-mode count selector.
+	mode        newPaneMode
+	step        newPaneStep
+	issuePicker pickerState
+	planPicker  pickerState
+	agentChoice int
+	assign      assignState
+	selIssue    int
+	selPlan     string
 
 	// @-mention file completion state, active only while focus is on the
 	// prompt field. compQuery is the text typed after '@' (the '@' itself is
@@ -115,11 +177,15 @@ func RunNewPanePrompt(opts NewPanePromptOptions) (LaunchRequest, bool, error) {
 	}
 	keyboard := newShiftEnterProtocols(os.Stdout, enhancedKeyboardKeysEnabled())
 	m := newModel(Options{
-		ProjectRoot:   opts.ProjectRoot,
-		DefaultAgent:  opts.DefaultAgent,
-		ListRepoFiles: opts.ListRepoFiles,
-		LaunchPane:    func(LaunchRequest) (string, error) { return "", nil },
-		keyboard:      keyboard,
+		ProjectRoot:       opts.ProjectRoot,
+		DefaultAgent:      opts.DefaultAgent,
+		ListRepoFiles:     opts.ListRepoFiles,
+		ListOpenIssues:    opts.ListOpenIssues,
+		ListPlanSlugs:     opts.ListPlanSlugs,
+		ListIssueChildren: opts.ListIssueChildren,
+		ListPlanTasks:     opts.ListPlanTasks,
+		LaunchPane:        func(LaunchRequest) (string, error) { return "", nil },
+		keyboard:          keyboard,
 	})
 	m.promptOnly = true
 	m.width = width
@@ -262,10 +328,11 @@ func newNewPaneForm(defaultAgent string, width int) newPaneForm {
 		defaultAgent = defaultLaunchAgent
 	}
 	return newPaneForm{
-		prompt:     prompt,
-		agentCount: defaultAgentCounts(defaultAgent),
-		agentIndex: defaultAgentIndex(defaultAgent),
-		focus:      newPaneFieldPrompt,
+		prompt:      prompt,
+		agentCount:  defaultAgentCounts(defaultAgent),
+		agentIndex:  defaultAgentIndex(defaultAgent),
+		agentChoice: defaultAgentIndex(defaultAgent),
+		focus:       newPaneFieldMain,
 	}
 }
 
@@ -281,11 +348,14 @@ func (m model) updateNewPane(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if msg.String() == "ctrl+c" {
 		return m.quit()
 	}
+	if m.newPane.step == newPaneStepAssign {
+		return m.updateNewPaneAssign(msg)
+	}
 	// While the @-completion popup is open it owns navigation/confirm/cancel
 	// keys; anything it does not handle (printable chars, backspace, cursor
 	// moves) falls through to normal editing with the updated completion state
 	// carried forward.
-	if m.newPane.focus == newPaneFieldPrompt && m.newPane.completing {
+	if m.newPane.focus == newPaneFieldMain && m.newPane.mode == newPaneModePrompt && m.newPane.completing {
 		next, handled := m.updatePromptCompletion(msg)
 		if handled {
 			return next, nil
@@ -305,13 +375,26 @@ func (m model) updateNewPane(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.moveNewPaneFocus(msg.String())
 		return m, nil
 	case "left", "right", " ":
-		if m.newPane.focus == newPaneFieldAgent {
-			m.adjustNewPaneAgent(msg.String())
+		switch m.newPane.focus {
+		case newPaneFieldMode:
+			return m, m.cycleNewPaneMode(msg.String())
+		case newPaneFieldAgent:
+			if m.newPane.mode == newPaneModePrompt {
+				m.adjustNewPaneAgent(msg.String())
+			} else {
+				m.cycleNewPaneAgentChoice(msg.String())
+			}
+			return m, nil
+		default:
+			// Main field: the key falls through to the text/filter routing below.
+		}
+	case "up", "down", "ctrl+p", "ctrl+n":
+		if m.newPane.focus == newPaneFieldMain && m.newPane.mode != newPaneModePrompt {
+			m.moveActivePicker(pickerMoveDelta(msg.String()))
 			return m, nil
 		}
-	case "up", "down":
-		if m.newPane.focus != newPaneFieldPrompt {
-			if m.newPane.focus == newPaneFieldAgent {
+		if (msg.String() == "up" || msg.String() == "down") && m.newPane.focus != newPaneFieldMain {
+			if m.newPane.focus == newPaneFieldAgent && m.newPane.mode == newPaneModePrompt {
 				m.moveNewPaneAgent(msg.String())
 			} else {
 				m.moveNewPaneFocus(msg.String())
@@ -323,8 +406,8 @@ func (m model) updateNewPane(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	}
 
 	var cmd tea.Cmd
-	switch m.newPane.focus {
-	case newPaneFieldPrompt:
+	switch {
+	case m.newPane.focus == newPaneFieldMain && m.newPane.mode == newPaneModePrompt:
 		m.newPane.prompt, cmd = m.newPane.prompt.Update(msg)
 		// Open completion when '@' is typed at a word boundary. Inspecting the
 		// textarea after the insert keeps this robust to soft-wrapping.
@@ -332,24 +415,44 @@ func (m model) updateNewPane(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 			m.atWordBoundaryBeforeCursor() {
 			m.beginCompletion()
 		}
+	case m.newPane.focus == newPaneFieldMain:
+		m.updateActivePickerFilter(msg)
 	default:
-		// The agent field is a toggle, not a text input; no message routing.
+		// The mode and agent rows are toggles, not text inputs; no message routing.
 	}
 	return m, cmd
 }
 
 func (m *model) moveNewPaneFocus(key string) {
+	order := m.newPaneFocusOrder()
+	idx := 0
+	for i, field := range order {
+		if field == m.newPane.focus {
+			idx = i
+			break
+		}
+	}
 	switch key {
 	case "shift+tab", "up":
-		m.newPane.focus = (m.newPane.focus + newPaneFieldCount - 1) % newPaneFieldCount
+		idx = (idx + len(order) - 1) % len(order)
 	default:
-		m.newPane.focus = (m.newPane.focus + 1) % newPaneFieldCount
+		idx = (idx + 1) % len(order)
 	}
-	if m.newPane.focus == newPaneFieldPrompt {
+	m.newPane.focus = order[idx]
+	if m.newPane.focus == newPaneFieldMain && m.newPane.mode == newPaneModePrompt {
 		m.newPane.prompt.Focus()
 	} else {
 		m.newPane.prompt.Blur()
 	}
+}
+
+// newPaneFocusOrder hides the Mode row when only the classic prompt mode is
+// wired, so the original two-field form keeps its focus cycle.
+func (m model) newPaneFocusOrder() []newPaneField {
+	if len(m.availableNewPaneModes()) > 1 {
+		return []newPaneField{newPaneFieldMode, newPaneFieldMain, newPaneFieldAgent}
+	}
+	return []newPaneField{newPaneFieldMain, newPaneFieldAgent}
 }
 
 func (m *model) moveNewPaneAgent(key string) {
@@ -383,6 +486,9 @@ func (m *model) adjustNewPaneAgent(key string) {
 }
 
 func (m *model) submitNewPane() tea.Cmd {
+	if m.newPane.mode != newPaneModePrompt {
+		return m.submitNewPanePicker()
+	}
 	prompt := strings.TrimSpace(m.newPane.prompt.Value())
 	if prompt == "" {
 		m.newPane.err = "prompt is required"
@@ -449,6 +555,14 @@ func (m *model) openNewPanePopupCmd() tea.Cmd {
 }
 
 func (m *model) launchNewPaneRequest(req LaunchRequest) tea.Cmd {
+	switch req.Mode {
+	case LaunchModeIssue:
+		return m.launchIssueSessionRequest(req)
+	case LaunchModePlan:
+		return m.launchPlanSessionRequest(req)
+	default:
+		// Prompt mode continues below.
+	}
 	req.Prompt = strings.TrimSpace(req.Prompt)
 	agents := make([]string, 0, len(req.Agents))
 	for _, agentName := range req.Agents {
@@ -480,27 +594,48 @@ func (m *model) launchNewPaneRequest(req LaunchRequest) tea.Cmd {
 }
 
 func (m model) newPaneView() string {
+	if m.newPane.step == newPaneStepAssign {
+		return m.newPaneAssignView()
+	}
 	title := "New agent pane"
-	verb := "create"
 	if m.newPane.attach != nil {
 		title = "Attach agent to worktree"
-		verb = "attach"
 	}
-	lines := []string{
-		titleStyle.Render(title),
-		m.newPaneFieldView(newPaneFieldPrompt, "Prompt", m.newPane.prompt.View(), true),
+	lines := []string{titleStyle.Render(title)}
+	if len(m.availableNewPaneModes()) > 1 {
+		lines = append(lines, m.newPaneFieldView(newPaneFieldMode, "Mode", m.newPaneModeTabsView(), false))
 	}
-	if m.newPane.focus == newPaneFieldPrompt && m.newPane.completing {
-		lines = append(lines, m.completionPopupView())
+	switch m.newPane.mode {
+	case newPaneModeIssue:
+		lines = append(lines,
+			m.newPaneFieldView(newPaneFieldMain, "Issue", m.pickerView(m.newPane.issuePicker, "no open issues"), true),
+			m.newPaneFieldView(newPaneFieldAgent, "Agent", m.singleAgentSelectorView(), false),
+		)
+	case newPaneModePlan:
+		lines = append(lines,
+			m.newPaneFieldView(newPaneFieldMain, "Plan", m.pickerView(m.newPane.planPicker, "no plans found in .fanout/plans"), true),
+			m.newPaneFieldView(newPaneFieldAgent, "Agent", m.singleAgentSelectorView(), false),
+		)
+	default:
+		lines = append(lines, m.newPaneFieldView(newPaneFieldMain, "Prompt", m.newPane.prompt.View(), true))
+		if m.newPane.focus == newPaneFieldMain && m.newPane.completing {
+			lines = append(lines, m.completionPopupView())
+		}
+		lines = append(lines, m.newPaneFieldView(newPaneFieldAgent, "Agent", m.agentSelectorView(), false))
 	}
-	lines = append(lines,
-		m.newPaneFieldView(newPaneFieldAgent, "Agent", m.agentSelectorView(), false),
-	)
 	if m.newPane.launching {
 		lines = append(lines, dimStyle.Render("creating pane..."))
 	}
 	if m.newPane.err != "" {
 		lines = append(lines, errStyle.Render("error: "+m.newPane.err))
+	}
+	lines = append(lines, dimStyle.Render(m.newPaneHint()))
+	return modalStyle.Width(m.modalWidth()).Render(strings.Join(lines, "\n"))
+}
+
+func (m model) newPaneHint() string {
+	if m.newPane.mode != newPaneModePrompt {
+		return "enter next  type to filter  tab field  esc cancel"
 	}
 	// Only advertise Shift+Enter when enhanced keyboard input is active; otherwise
 	// it submits the form and the hint would mislead. Ctrl+J always inserts a newline.
@@ -508,8 +643,11 @@ func (m model) newPaneView() string {
 	if enhancedKeyboardKeysEnabled() {
 		newlineHint = "shift+enter/ctrl+j newline"
 	}
-	lines = append(lines, dimStyle.Render("enter "+verb+"  "+newlineHint+"  tab field  esc cancel"))
-	return modalStyle.Width(m.modalWidth()).Render(strings.Join(lines, "\n"))
+	verb := "create"
+	if m.newPane.attach != nil {
+		verb = "attach"
+	}
+	return "enter " + verb + "  " + newlineHint + "  tab field  esc cancel"
 }
 
 func (m model) newPaneFieldView(field newPaneField, label, value string, boxed bool) string {
@@ -545,6 +683,33 @@ func (m model) agentSelectorView() string {
 		lines = append(lines, marker+token)
 	}
 	return strings.Join(lines, "\n")
+}
+
+// singleAgentSelectorView renders the issue/plan-mode default-agent choice: a
+// one-of selector, unlike the prompt-mode per-agent counts (a fan-out shares
+// one default agent across children; per-target overrides live in step 2).
+func (m model) singleAgentSelectorView() string {
+	parts := make([]string, 0, len(launchAgents))
+	for i, agentName := range launchAgents {
+		token := "( ) " + agentName
+		if i == m.newPane.agentChoice {
+			token = titleStyle.Render("(x) " + agentName)
+		} else {
+			token = dimStyle.Render(token)
+		}
+		parts = append(parts, token)
+	}
+	return strings.Join(parts, "  ")
+}
+
+func (m *model) cycleNewPaneAgentChoice(key string) {
+	n := len(launchAgents)
+	switch key {
+	case "left":
+		m.newPane.agentChoice = (m.newPane.agentChoice + n - 1) % n
+	default:
+		m.newPane.agentChoice = (m.newPane.agentChoice + 1) % n
+	}
 }
 
 const maxAgentLaunchCount = 3

--- a/internal/tui/newpane_assign.go
+++ b/internal/tui/newpane_assign.go
@@ -25,13 +25,15 @@ type PlanTaskItem struct {
 }
 
 // assignState is the step-2 per-target agent assignment. target identifies
-// the pending selection ("#123" or a slug) so a stale load cannot populate a
-// newer selection's rows.
+// the pending selection ("#123" or a slug) and gen its load generation, so a
+// stale load — even one for the same target after an esc + re-enter — cannot
+// populate a newer selection's rows or finalize with outdated data.
 type assignState struct {
 	loading bool
 	err     string
 	target  string
 	title   string
+	gen     int
 	rows    []assignRow
 	index   int
 }
@@ -46,6 +48,7 @@ type assignRow struct {
 type newPaneAssignLoadedMsg struct {
 	mode     newPaneMode
 	target   string
+	gen      int
 	children []ChildTarget
 	tasks    []PlanTaskItem
 	err      error
@@ -92,8 +95,10 @@ func (m *model) submitNewPanePicker() tea.Cmd {
 }
 
 func (m *model) beginAssignStep(target, title string) tea.Cmd {
+	m.newPane.assignGen++
+	gen := m.newPane.assignGen
 	m.newPane.step = newPaneStepAssign
-	m.newPane.assign = assignState{loading: true, target: target, title: title}
+	m.newPane.assign = assignState{loading: true, target: target, title: title, gen: gen}
 	mode := m.newPane.mode
 	switch mode {
 	case newPaneModeIssue:
@@ -101,14 +106,14 @@ func (m *model) beginAssignStep(target, title string) tea.Cmd {
 		num := m.newPane.selIssue
 		return func() tea.Msg {
 			children, err := list(num)
-			return newPaneAssignLoadedMsg{mode: mode, target: target, children: children, err: err}
+			return newPaneAssignLoadedMsg{mode: mode, target: target, gen: gen, children: children, err: err}
 		}
 	case newPaneModePlan:
 		list := m.opts.ListPlanTasks
 		slug := m.newPane.selPlan
 		return func() tea.Msg {
 			tasks, err := list(slug)
-			return newPaneAssignLoadedMsg{mode: mode, target: target, tasks: tasks, err: err}
+			return newPaneAssignLoadedMsg{mode: mode, target: target, gen: gen, tasks: tasks, err: err}
 		}
 	default:
 		return nil

--- a/internal/tui/newpane_assign.go
+++ b/internal/tui/newpane_assign.go
@@ -297,6 +297,26 @@ func (m *model) launchPlanSessionRequest(req LaunchRequest) tea.Cmd {
 	return nil
 }
 
+// assignViewOverhead is the non-row height of the assign view: title,
+// subtitle, hint, an error line, scroll markers, and the modal frame.
+const assignViewOverhead = 8
+
+// assignRowWindow returns the visible row range, sliding so the selected row
+// stays in view; a taller-than-pty list would be top-clipped by the renderer.
+func (m model) assignRowWindow() (start, end int) {
+	rows := len(m.newPane.assign.rows)
+	visible := pickerMaxRows
+	if m.height > 0 {
+		visible = clampInt(m.height-assignViewOverhead, 3, pickerMaxRows)
+	}
+	if rows <= visible {
+		return 0, rows
+	}
+	start = clampInt(m.newPane.assign.index-visible+1, 0, rows-visible)
+	start = min(start, m.newPane.assign.index)
+	return start, start + visible
+}
+
 func (m model) newPaneAssignView() string {
 	a := m.newPane.assign
 	lines := []string{
@@ -310,7 +330,12 @@ func (m model) newPaneAssignView() string {
 		lines = append(lines, errStyle.Render("error: "+a.err))
 	default:
 		width := m.inputContentWidth()
-		for i, row := range a.rows {
+		start, end := m.assignRowWindow()
+		if start > 0 {
+			lines = append(lines, dimStyle.Render(fmt.Sprintf("  ↑ %d more", start)))
+		}
+		for i := start; i < end; i++ {
+			row := a.rows[i]
 			marker := "  "
 			if i == a.index {
 				marker = "> "
@@ -327,6 +352,9 @@ func (m model) newPaneAssignView() string {
 				label += " (wave " + row.wave + ")"
 			}
 			lines = append(lines, marker+token+" "+truncateToWidth(label, width-10))
+		}
+		if end < len(a.rows) {
+			lines = append(lines, dimStyle.Render(fmt.Sprintf("  ↓ %d more", len(a.rows)-end)))
 		}
 	}
 	if m.newPane.launching {

--- a/internal/tui/newpane_assign.go
+++ b/internal/tui/newpane_assign.go
@@ -1,0 +1,345 @@
+package tui
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+// ChildTarget is one OPEN child issue offered by the issue-mode agent
+// assignment step.
+type ChildTarget struct {
+	Number int
+	Title  string
+	Wave   string
+}
+
+// PlanTaskItem is one plan-spec task offered by the plan-mode agent
+// assignment step.
+type PlanTaskItem struct {
+	ID    string
+	Title string
+	Wave  string
+}
+
+// assignState is the step-2 per-target agent assignment. target identifies
+// the pending selection ("#123" or a slug) so a stale load cannot populate a
+// newer selection's rows.
+type assignState struct {
+	loading bool
+	err     string
+	target  string
+	title   string
+	rows    []assignRow
+	index   int
+}
+
+type assignRow struct {
+	target   string // child issue number ("123") or plan task id
+	label    string
+	wave     string
+	agentIdx int // launchAgents index
+}
+
+type newPaneAssignLoadedMsg struct {
+	mode     newPaneMode
+	target   string
+	children []ChildTarget
+	tasks    []PlanTaskItem
+	err      error
+}
+
+// submitNewPanePicker handles enter on the issue/plan picker: it validates
+// the list state, then either opens the agent assignment step or (when no
+// target lister is wired) submits with the default agent alone.
+func (m *model) submitNewPanePicker() tea.Cmd {
+	p := m.activePicker()
+	if p == nil {
+		return nil
+	}
+	if p.loading {
+		m.newPane.err = "list is still loading"
+		return nil
+	}
+	if p.err != "" {
+		m.newPane.err = "list failed: " + p.err
+		return nil
+	}
+	item, ok := p.selectedItem()
+	if !ok {
+		m.newPane.err = "nothing selected"
+		return nil
+	}
+	m.newPane.err = ""
+	switch m.newPane.mode {
+	case newPaneModeIssue:
+		m.newPane.selIssue = item.number
+		if m.opts.ListIssueChildren == nil {
+			return m.finalizeNewPaneModeSubmit()
+		}
+		return m.beginAssignStep(item.key, item.key+" "+item.title)
+	case newPaneModePlan:
+		m.newPane.selPlan = item.key
+		if m.opts.ListPlanTasks == nil {
+			return m.finalizeNewPaneModeSubmit()
+		}
+		return m.beginAssignStep(item.key, "plan "+item.key)
+	default:
+		return nil
+	}
+}
+
+func (m *model) beginAssignStep(target, title string) tea.Cmd {
+	m.newPane.step = newPaneStepAssign
+	m.newPane.assign = assignState{loading: true, target: target, title: title}
+	mode := m.newPane.mode
+	switch mode {
+	case newPaneModeIssue:
+		list := m.opts.ListIssueChildren
+		num := m.newPane.selIssue
+		return func() tea.Msg {
+			children, err := list(num)
+			return newPaneAssignLoadedMsg{mode: mode, target: target, children: children, err: err}
+		}
+	case newPaneModePlan:
+		list := m.opts.ListPlanTasks
+		slug := m.newPane.selPlan
+		return func() tea.Msg {
+			tasks, err := list(slug)
+			return newPaneAssignLoadedMsg{mode: mode, target: target, tasks: tasks, err: err}
+		}
+	default:
+		return nil
+	}
+}
+
+func buildAssignRows(msg newPaneAssignLoadedMsg, defaultAgentIdx int) []assignRow {
+	switch msg.mode {
+	case newPaneModeIssue:
+		rows := make([]assignRow, 0, len(msg.children))
+		for _, child := range msg.children {
+			rows = append(rows, assignRow{
+				target:   strconv.Itoa(child.Number),
+				label:    fmt.Sprintf("#%d %s", child.Number, child.Title),
+				wave:     child.Wave,
+				agentIdx: defaultAgentIdx,
+			})
+		}
+		return rows
+	case newPaneModePlan:
+		rows := make([]assignRow, 0, len(msg.tasks))
+		for _, task := range msg.tasks {
+			label := task.ID
+			if task.Title != "" {
+				label += "  " + task.Title
+			}
+			rows = append(rows, assignRow{
+				target:   task.ID,
+				label:    label,
+				wave:     task.Wave,
+				agentIdx: defaultAgentIdx,
+			})
+		}
+		return rows
+	default:
+		return nil
+	}
+}
+
+func (m model) updateNewPaneAssign(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	a := &m.newPane.assign
+	switch msg.String() {
+	case "esc":
+		m.newPane.step = newPaneStepForm
+		m.newPane.assign = assignState{}
+		m.newPane.err = ""
+		return m, nil
+	case "up", "ctrl+p":
+		m.moveAssignRow(-1)
+		return m, nil
+	case "down", "ctrl+n":
+		m.moveAssignRow(1)
+		return m, nil
+	case "left":
+		m.cycleAssignRowAgent(-1)
+		return m, nil
+	case "right", " ":
+		m.cycleAssignRowAgent(1)
+		return m, nil
+	case "enter":
+		if a.loading {
+			m.newPane.err = "targets are still loading"
+			return m, nil
+		}
+		if a.err != "" {
+			return m, m.beginAssignStep(a.target, a.title)
+		}
+		m.newPane.err = ""
+		return m, m.finalizeNewPaneModeSubmit()
+	}
+	return m, nil
+}
+
+func (m *model) moveAssignRow(delta int) {
+	n := len(m.newPane.assign.rows)
+	if n == 0 {
+		return
+	}
+	m.newPane.assign.index = (m.newPane.assign.index + delta + n) % n
+}
+
+func (m *model) cycleAssignRowAgent(delta int) {
+	a := &m.newPane.assign
+	if a.index < 0 || a.index >= len(a.rows) {
+		return
+	}
+	n := len(launchAgents)
+	a.rows[a.index].agentIdx = (a.rows[a.index].agentIdx + delta + n) % n
+}
+
+// assignOverrides returns only rows whose agent differs from the default, so
+// the launch mirrors what repeatable --agent target=name flags would pass.
+func (m model) assignOverrides() map[string]string {
+	var overrides map[string]string
+	for _, row := range m.newPane.assign.rows {
+		if row.agentIdx == m.newPane.agentChoice {
+			continue
+		}
+		if overrides == nil {
+			overrides = map[string]string{}
+		}
+		overrides[row.target] = launchAgents[clampInt(row.agentIdx, 0, len(launchAgents)-1)]
+	}
+	return overrides
+}
+
+// finalizeNewPaneModeSubmit builds the issue/plan LaunchRequest and hands it
+// to the prompt result (popup) or the launch dispatch (in-process form).
+func (m *model) finalizeNewPaneModeSubmit() tea.Cmd {
+	req := LaunchRequest{
+		DefaultAgent:   launchAgents[clampInt(m.newPane.agentChoice, 0, len(launchAgents)-1)],
+		AgentOverrides: m.assignOverrides(),
+	}
+	switch m.newPane.mode {
+	case newPaneModeIssue:
+		req.Mode = LaunchModeIssue
+		req.Issue = m.newPane.selIssue
+	case newPaneModePlan:
+		req.Mode = LaunchModePlan
+		req.Plan = m.newPane.selPlan
+	default:
+		return nil
+	}
+	if !m.promptOnly {
+		if req.Mode == LaunchModeIssue && m.opts.LaunchIssue == nil {
+			m.newPane.err = "issue launcher is not configured"
+			return nil
+		}
+		if req.Mode == LaunchModePlan && m.opts.LaunchPlan == nil {
+			m.newPane.err = "plan launcher is not configured"
+			return nil
+		}
+	}
+	m.newPane.err = ""
+	m.newPane.launching = true
+	if m.promptOnly {
+		m.promptResult = req
+		m.promptDone = true
+		return tea.Quit
+	}
+	return m.launchNewPaneRequest(req)
+}
+
+func (m *model) launchIssueSessionRequest(req LaunchRequest) tea.Cmd {
+	agentName := strings.TrimSpace(req.DefaultAgent)
+	switch {
+	case req.Issue <= 0:
+		m.notice = "new session: issue number is required"
+	case agentName == "":
+		m.notice = "new session: select an agent"
+	case m.opts.LaunchIssue == nil:
+		m.notice = "new session: issue launcher is not configured"
+	default:
+		m.newPane.launching = true
+		m.notice = fmt.Sprintf("starting session for #%d...", req.Issue)
+		launch := m.opts.LaunchIssue
+		num, overrides := req.Issue, req.AgentOverrides
+		return func() tea.Msg {
+			notice, err := launch(num, agentName, overrides)
+			return launchPaneMsg{notice: notice, count: 1, err: err}
+		}
+	}
+	return nil
+}
+
+func (m *model) launchPlanSessionRequest(req LaunchRequest) tea.Cmd {
+	agentName := strings.TrimSpace(req.DefaultAgent)
+	slug := strings.TrimSpace(req.Plan)
+	switch {
+	case slug == "":
+		m.notice = "new session: plan slug is required"
+	case agentName == "":
+		m.notice = "new session: select an agent"
+	case m.opts.LaunchPlan == nil:
+		m.notice = "new session: plan launcher is not configured"
+	default:
+		m.newPane.launching = true
+		m.notice = fmt.Sprintf("starting plan %s...", slug)
+		launch := m.opts.LaunchPlan
+		overrides := req.AgentOverrides
+		return func() tea.Msg {
+			notice, err := launch(slug, agentName, overrides)
+			return launchPaneMsg{notice: notice, count: 1, err: err}
+		}
+	}
+	return nil
+}
+
+func (m model) newPaneAssignView() string {
+	a := m.newPane.assign
+	lines := []string{
+		titleStyle.Render("Assign agents"),
+		dimStyle.Render(a.title),
+	}
+	switch {
+	case a.loading:
+		lines = append(lines, dimStyle.Render("loading targets…"))
+	case a.err != "":
+		lines = append(lines, errStyle.Render("error: "+a.err))
+	default:
+		width := m.inputContentWidth()
+		for i, row := range a.rows {
+			marker := "  "
+			if i == a.index {
+				marker = "> "
+			}
+			agentName := launchAgents[clampInt(row.agentIdx, 0, len(launchAgents)-1)]
+			token := "[" + agentName + "]"
+			if row.agentIdx != m.newPane.agentChoice {
+				token = titleStyle.Render(token)
+			} else {
+				token = dimStyle.Render(token)
+			}
+			label := row.label
+			if row.wave != "" {
+				label += " (wave " + row.wave + ")"
+			}
+			lines = append(lines, marker+token+" "+truncateToWidth(label, width-10))
+		}
+	}
+	if m.newPane.launching {
+		lines = append(lines, dimStyle.Render("creating pane..."))
+	}
+	if m.newPane.err != "" {
+		lines = append(lines, errStyle.Render("error: "+m.newPane.err))
+	}
+	switch {
+	case a.err != "":
+		lines = append(lines, dimStyle.Render("enter retry  esc back"))
+	case !a.loading:
+		lines = append(lines, dimStyle.Render("enter launch  ←/→ agent  ↑/↓ row  esc back"))
+	}
+	return modalStyle.Width(m.modalWidth()).Render(strings.Join(lines, "\n"))
+}

--- a/internal/tui/newpane_picker.go
+++ b/internal/tui/newpane_picker.go
@@ -140,8 +140,23 @@ func (m *model) activePicker() *pickerState {
 }
 
 func (m *model) recomputePicker(p *pickerState) {
-	p.results, p.total = rankPickerItems(p.items, p.query, pickerMaxRows)
+	p.results, p.total = rankPickerItems(p.items, p.query, m.pickerVisibleRows())
 	p.index = 0
+}
+
+// pickerFormOverhead is the non-list height of the picker form: title, mode
+// row, field labels, the list box frame, filter and "+N more" lines, the
+// agent row, the hint line, and the modal frame.
+const pickerFormOverhead = 14
+
+// pickerVisibleRows adapts the result cap to the available height so the
+// form never renders taller than the popup pty — bubbletea keeps only the
+// last lines, which would clip the modal top.
+func (m model) pickerVisibleRows() int {
+	if m.height <= 0 {
+		return pickerMaxRows
+	}
+	return clampInt(m.height-pickerFormOverhead, 3, pickerMaxRows)
 }
 
 func (m *model) moveActivePicker(delta int) {
@@ -182,6 +197,13 @@ func (m *model) updateActivePickerFilter(msg tea.KeyMsg) {
 			m.recomputePicker(p)
 		}
 	default:
+		// A lone space arrives as tea.KeySpace, not KeyRunes; without it
+		// multi-word title queries ("fix ui") are impossible.
+		if msg.Type == tea.KeySpace {
+			p.query += " "
+			m.recomputePicker(p)
+			return
+		}
 		if msg.Type == tea.KeyRunes && len(msg.Runes) > 0 {
 			p.query += string(msg.Runes)
 			m.recomputePicker(p)
@@ -231,10 +253,16 @@ func pickerMatchRank(item pickerItem, q string) int {
 	if q == "" {
 		return 0
 	}
-	if strings.HasPrefix(strings.ToLower(strings.TrimPrefix(item.key, "#")), q) {
+	key := strings.ToLower(strings.TrimPrefix(item.key, "#"))
+	if strings.HasPrefix(key, q) {
 		return 0
 	}
 	if item.title != "" && strings.Contains(strings.ToLower(item.title), q) {
+		return 1
+	}
+	// Key substring keeps title-less items (plan slugs) filterable by any
+	// fragment, not just a prefix.
+	if strings.Contains(key, q) {
 		return 1
 	}
 	for _, label := range item.labels {

--- a/internal/tui/newpane_picker.go
+++ b/internal/tui/newpane_picker.go
@@ -1,0 +1,349 @@
+package tui
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// pickerMaxRows caps how many list rows the issue/plan picker shows at once.
+const pickerMaxRows = 8
+
+// IssueListItem is one OPEN repository issue offered by the issue picker.
+type IssueListItem struct {
+	Number int
+	Title  string
+	Labels []string
+	// HasSession marks issues that already have a recorded fanout pane. The
+	// row stays selectable — re-selecting a parent launches its remaining
+	// children — but renders dimmed with a note.
+	HasSession bool
+}
+
+// pickerState is the incremental-filter list one non-prompt mode owns.
+type pickerState struct {
+	loading bool
+	loaded  bool
+	err     string
+	items   []pickerItem
+	query   string
+	results []int // items indices, ranked, capped at pickerMaxRows
+	index   int   // selection position within results
+	total   int   // full match count for the "+N more" hint
+}
+
+type pickerItem struct {
+	key    string // display and match key: "#123" or a plan slug
+	number int    // issue number; 0 for plan slugs
+	title  string
+	labels []string
+	note   string
+}
+
+type (
+	newPaneIssuesLoadedMsg struct {
+		items []IssueListItem
+		err   error
+	}
+	newPanePlansLoadedMsg struct {
+		slugs []string
+		err   error
+	}
+)
+
+// availableNewPaneModes lists the form modes the wiring supports. Prompt is
+// always first; issue/plan appear only when their list providers are wired.
+// Attach binds the launch to a specific worktree from a free prompt, so
+// issue/plan modes never apply there — offer prompt only.
+func (m model) availableNewPaneModes() []newPaneMode {
+	if m.newPane.attach != nil {
+		return []newPaneMode{newPaneModePrompt}
+	}
+	modes := []newPaneMode{newPaneModePrompt}
+	if m.opts.ListOpenIssues != nil {
+		modes = append(modes, newPaneModeIssue)
+	}
+	if m.opts.ListPlanSlugs != nil {
+		modes = append(modes, newPaneModePlan)
+	}
+	return modes
+}
+
+// cycleNewPaneMode advances the mode row and kicks off the target mode's list
+// load when it has not completed yet (a prior failure retries here).
+func (m *model) cycleNewPaneMode(key string) tea.Cmd {
+	modes := m.availableNewPaneModes()
+	if len(modes) <= 1 {
+		return nil
+	}
+	idx := 0
+	for i, mode := range modes {
+		if mode == m.newPane.mode {
+			idx = i
+			break
+		}
+	}
+	if key == "left" {
+		idx = (idx + len(modes) - 1) % len(modes)
+	} else {
+		idx = (idx + 1) % len(modes)
+	}
+	m.newPane.mode = modes[idx]
+	m.newPane.err = ""
+	return m.ensureModeListLoaded()
+}
+
+func (m *model) ensureModeListLoaded() tea.Cmd {
+	switch m.newPane.mode {
+	case newPaneModeIssue:
+		p := &m.newPane.issuePicker
+		if p.loading || p.loaded || m.opts.ListOpenIssues == nil {
+			return nil
+		}
+		p.loading = true
+		p.err = ""
+		list := m.opts.ListOpenIssues
+		return func() tea.Msg {
+			items, err := list()
+			return newPaneIssuesLoadedMsg{items: items, err: err}
+		}
+	case newPaneModePlan:
+		p := &m.newPane.planPicker
+		if p.loading || p.loaded || m.opts.ListPlanSlugs == nil {
+			return nil
+		}
+		p.loading = true
+		p.err = ""
+		list := m.opts.ListPlanSlugs
+		return func() tea.Msg {
+			slugs, err := list()
+			return newPanePlansLoadedMsg{slugs: slugs, err: err}
+		}
+	default:
+		return nil
+	}
+}
+
+func (m *model) activePicker() *pickerState {
+	switch m.newPane.mode {
+	case newPaneModeIssue:
+		return &m.newPane.issuePicker
+	case newPaneModePlan:
+		return &m.newPane.planPicker
+	default:
+		return nil
+	}
+}
+
+func (m *model) recomputePicker(p *pickerState) {
+	p.results, p.total = rankPickerItems(p.items, p.query, pickerMaxRows)
+	p.index = 0
+}
+
+func (m *model) moveActivePicker(delta int) {
+	p := m.activePicker()
+	if p == nil {
+		return
+	}
+	n := len(p.results)
+	if n == 0 {
+		return
+	}
+	p.index = (p.index + delta + n) % n
+}
+
+func pickerMoveDelta(key string) int {
+	if key == "up" || key == "ctrl+p" {
+		return -1
+	}
+	return 1
+}
+
+// updateActivePickerFilter feeds printable keys into the active picker's
+// incremental filter; backspace shrinks it and ctrl+u clears it.
+func (m *model) updateActivePickerFilter(msg tea.KeyMsg) {
+	p := m.activePicker()
+	if p == nil {
+		return
+	}
+	switch msg.String() {
+	case "backspace", "ctrl+h":
+		if p.query != "" {
+			p.query = trimLastRune(p.query)
+			m.recomputePicker(p)
+		}
+	case "ctrl+u":
+		if p.query != "" {
+			p.query = ""
+			m.recomputePicker(p)
+		}
+	default:
+		if msg.Type == tea.KeyRunes && len(msg.Runes) > 0 {
+			p.query += string(msg.Runes)
+			m.recomputePicker(p)
+		}
+	}
+}
+
+func (p pickerState) selectedItem() (pickerItem, bool) {
+	if p.index < 0 || p.index >= len(p.results) {
+		return pickerItem{}, false
+	}
+	return p.items[p.results[p.index]], true
+}
+
+// rankPickerItems returns indices of the top matches plus the total match
+// count (the rankFileEntries contract). Rank 0: the key (issue number or
+// slug) prefix-matches; 1: the title contains the query; 2: a label contains
+// it. Source order is preserved within a rank: gh returns issues
+// newest-first and plan slugs arrive sorted.
+func rankPickerItems(items []pickerItem, query string, maxResults int) (top []int, total int) {
+	q := strings.TrimPrefix(strings.ToLower(strings.TrimSpace(query)), "#")
+	type scored struct {
+		idx  int
+		rank int
+	}
+	matches := make([]scored, 0, len(items))
+	for i, item := range items {
+		rank := pickerMatchRank(item, q)
+		if rank < 0 {
+			continue
+		}
+		matches = append(matches, scored{idx: i, rank: rank})
+	}
+	sort.SliceStable(matches, func(i, j int) bool { return matches[i].rank < matches[j].rank })
+	total = len(matches)
+	if maxResults > 0 && len(matches) > maxResults {
+		matches = matches[:maxResults]
+	}
+	top = make([]int, len(matches))
+	for i, s := range matches {
+		top[i] = s.idx
+	}
+	return top, total
+}
+
+func pickerMatchRank(item pickerItem, q string) int {
+	if q == "" {
+		return 0
+	}
+	if strings.HasPrefix(strings.ToLower(strings.TrimPrefix(item.key, "#")), q) {
+		return 0
+	}
+	if item.title != "" && strings.Contains(strings.ToLower(item.title), q) {
+		return 1
+	}
+	for _, label := range item.labels {
+		if strings.Contains(strings.ToLower(label), q) {
+			return 2
+		}
+	}
+	return -1
+}
+
+func issuePickerItems(items []IssueListItem) []pickerItem {
+	out := make([]pickerItem, 0, len(items))
+	for _, item := range items {
+		note := ""
+		if item.HasSession {
+			note = "has session"
+		}
+		out = append(out, pickerItem{
+			key:    "#" + strconv.Itoa(item.Number),
+			number: item.Number,
+			title:  item.Title,
+			labels: item.Labels,
+			note:   note,
+		})
+	}
+	return out
+}
+
+func planPickerItems(slugs []string) []pickerItem {
+	out := make([]pickerItem, 0, len(slugs))
+	for _, slug := range slugs {
+		out = append(out, pickerItem{key: slug})
+	}
+	return out
+}
+
+func (m model) newPaneModeTabsView() string {
+	names := map[newPaneMode]string{
+		newPaneModePrompt: "Prompt",
+		newPaneModeIssue:  "Issue",
+		newPaneModePlan:   "Plan",
+	}
+	parts := make([]string, 0, 3)
+	for _, mode := range m.availableNewPaneModes() {
+		if mode == m.newPane.mode {
+			parts = append(parts, titleStyle.Render("["+names[mode]+"]"))
+		} else {
+			parts = append(parts, dimStyle.Render(" "+names[mode]+" "))
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
+func (m model) pickerView(p pickerState, emptyText string) string {
+	if p.loading {
+		return dimStyle.Render("loading…")
+	}
+	if p.err != "" {
+		return errStyle.Render("list failed: " + p.err)
+	}
+	if len(p.items) == 0 {
+		return dimStyle.Render(emptyText)
+	}
+	width := m.inputContentWidth()
+	filter := "filter: " + p.query
+	if p.query == "" {
+		filter = dimStyle.Render("filter: (type to narrow)")
+	}
+	lines := []string{filter}
+	if len(p.results) == 0 {
+		lines = append(lines, dimStyle.Render("  no match"))
+	}
+	for i, idx := range p.results {
+		item := p.items[idx]
+		text := item.key
+		if item.title != "" {
+			text += " " + item.title
+		}
+		if len(item.labels) > 0 {
+			text += " [" + strings.Join(item.labels, ",") + "]"
+		}
+		if item.note != "" {
+			text += " (" + item.note + ")"
+		}
+		text = truncateToWidth(text, width-2)
+		switch {
+		case i == p.index:
+			lines = append(lines, "> "+titleStyle.Render(text))
+		case item.note != "":
+			lines = append(lines, "  "+dimStyle.Render(text))
+		default:
+			lines = append(lines, "  "+text)
+		}
+	}
+	if p.total > len(p.results) {
+		lines = append(lines, dimStyle.Render(fmt.Sprintf("  +%d more (type to narrow)", p.total-len(p.results))))
+	}
+	return strings.Join(lines, "\n")
+}
+
+// truncateToWidth keeps the head of s, eliding the tail with an ellipsis when
+// it exceeds limit display columns.
+func truncateToWidth(s string, limit int) string {
+	if limit <= 1 || lipgloss.Width(s) <= limit {
+		return s
+	}
+	runes := []rune(s)
+	for len(runes) > 0 && lipgloss.Width(string(runes)) > limit-1 {
+		runes = runes[:len(runes)-1]
+	}
+	return string(runes) + "…"
+}

--- a/internal/tui/newpane_picker_test.go
+++ b/internal/tui/newpane_picker_test.go
@@ -1,0 +1,472 @@
+package tui
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+)
+
+func TestRankPickerItems(t *testing.T) {
+	items := []pickerItem{
+		{key: "#41", title: "Add API client", labels: []string{"backend"}},
+		{key: "#42", title: "Fix UI overflow", labels: []string{"frontend", "bug"}},
+		{key: "#420", title: "Retro notes"},
+	}
+
+	tests := []struct {
+		name      string
+		query     string
+		max       int
+		want      []int
+		wantTotal int
+	}{
+		{name: "empty query keeps source order", query: "", max: 8, want: []int{0, 1, 2}, wantTotal: 3},
+		{name: "number prefix outranks title match", query: "42", max: 8, want: []int{1, 2}, wantTotal: 2},
+		{name: "leading hash is ignored", query: "#41", max: 8, want: []int{0}, wantTotal: 1},
+		{name: "title substring matches case-insensitively", query: "ui over", max: 8, want: []int{1}, wantTotal: 1},
+		{name: "label substring ranks last", query: "backend", max: 8, want: []int{0}, wantTotal: 1},
+		{name: "no match yields empty results", query: "zzz", max: 8, want: []int{}, wantTotal: 0},
+		{name: "maxResults caps top but total counts all", query: "", max: 2, want: []int{0, 1}, wantTotal: 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, total := rankPickerItems(items, tt.query, tt.max)
+			if !reflect.DeepEqual(got, tt.want) || total != tt.wantTotal {
+				t.Fatalf("rankPickerItems(%q) = %v, %d, want %v, %d", tt.query, got, total, tt.want, tt.wantTotal)
+			}
+		})
+	}
+}
+
+// TestNewPaneModeSwitchLoadsListOnce guarantees the issue list loads on first
+// entry, retries after a failure, and is not re-fetched once loaded.
+func TestNewPaneModeSwitchLoadsListOnce(t *testing.T) {
+	calls := 0
+	m := newModel(Options{
+		ListOpenIssues: func() ([]IssueListItem, error) {
+			calls++
+			if calls == 1 {
+				return nil, errors.New("gh boom")
+			}
+			return []IssueListItem{{Number: 42, Title: "Fix UI"}}, nil
+		},
+	})
+	m.openNewPaneForm()
+	m.newPane.focus = newPaneFieldMode
+
+	step := func(key tea.KeyMsg) tea.Cmd {
+		updated, cmd := m.Update(key)
+		m = updated.(model)
+		return cmd
+	}
+	deliver := func(cmd tea.Cmd) {
+		t.Helper()
+		if cmd == nil {
+			t.Fatal("expected a load command")
+		}
+		updated, _ := m.Update(cmd())
+		m = updated.(model)
+	}
+
+	// prompt -> issue: first load fails and must leave the mode retriable.
+	deliver(step(tea.KeyMsg{Type: tea.KeyRight}))
+	if m.newPane.issuePicker.err != "gh boom" || m.newPane.issuePicker.loaded {
+		t.Fatalf("after failed load: err = %q loaded = %v, want gh boom / false", m.newPane.issuePicker.err, m.newPane.issuePicker.loaded)
+	}
+
+	// issue -> prompt -> issue: re-entering retries the fetch.
+	if cmd := step(tea.KeyMsg{Type: tea.KeyRight}); cmd != nil {
+		t.Fatal("switching to prompt mode issued a load command")
+	}
+	deliver(step(tea.KeyMsg{Type: tea.KeyRight}))
+	if !m.newPane.issuePicker.loaded || m.newPane.issuePicker.err != "" {
+		t.Fatalf("after retry: loaded = %v err = %q, want true / empty", m.newPane.issuePicker.loaded, m.newPane.issuePicker.err)
+	}
+
+	// A loaded list is served from cache on re-entry.
+	step(tea.KeyMsg{Type: tea.KeyRight})
+	if cmd := step(tea.KeyMsg{Type: tea.KeyRight}); cmd != nil {
+		t.Fatal("re-entering a loaded mode issued a load command")
+	}
+	if calls != 2 {
+		t.Fatalf("ListOpenIssues calls = %d, want 2", calls)
+	}
+}
+
+// TestNewPaneIssuePickerToAssignFlow drives the whole promptOnly wizard:
+// filter the issue list, open the assignment step, flip one child to codex,
+// and submit a diff-only override map.
+func TestNewPaneIssuePickerToAssignFlow(t *testing.T) {
+	m := newModel(Options{
+		DefaultAgent: "claude",
+		ListOpenIssues: func() ([]IssueListItem, error) {
+			return []IssueListItem{
+				{Number: 41, Title: "Add API client"},
+				{Number: 42, Title: "Fix UI overflow"},
+			}, nil
+		},
+		ListIssueChildren: func(parent int) ([]ChildTarget, error) {
+			if parent != 42 {
+				return nil, errors.New("unexpected parent")
+			}
+			return []ChildTarget{
+				{Number: 43, Title: "Frontend", Wave: "1"},
+				{Number: 44, Title: "Backend", Wave: "1"},
+			}, nil
+		},
+	})
+	m.promptOnly = true
+	m.openNewPaneForm()
+	m.newPane.focus = newPaneFieldMode
+
+	step := func(key tea.KeyMsg) tea.Cmd {
+		updated, cmd := m.Update(key)
+		m = updated.(model)
+		return cmd
+	}
+	deliver := func(cmd tea.Cmd) {
+		t.Helper()
+		if cmd == nil {
+			t.Fatal("expected a command")
+		}
+		updated, _ := m.Update(cmd())
+		m = updated.(model)
+	}
+
+	deliver(step(tea.KeyMsg{Type: tea.KeyRight})) // switch to issue mode + load
+	step(tea.KeyMsg{Type: tea.KeyTab})            // focus the picker
+	step(keyRunes("42"))                          // narrow to #42
+	if len(m.newPane.issuePicker.results) != 1 {
+		t.Fatalf("filtered results = %v, want one", m.newPane.issuePicker.results)
+	}
+
+	deliver(step(tea.KeyMsg{Type: tea.KeyEnter})) // open assign + load children
+	if m.newPane.step != newPaneStepAssign {
+		t.Fatalf("step = %v, want assign", m.newPane.step)
+	}
+	if len(m.newPane.assign.rows) != 2 {
+		t.Fatalf("assign rows = %#v, want two children", m.newPane.assign.rows)
+	}
+
+	step(tea.KeyMsg{Type: tea.KeyDown})  // select #44
+	step(tea.KeyMsg{Type: tea.KeyRight}) // claude -> codex
+	step(tea.KeyMsg{Type: tea.KeyEnter}) // submit
+
+	if !m.promptDone || m.promptCanceled {
+		t.Fatalf("promptDone = %v promptCanceled = %v, want done", m.promptDone, m.promptCanceled)
+	}
+	want := LaunchRequest{
+		Mode:           LaunchModeIssue,
+		Issue:          42,
+		DefaultAgent:   "claude",
+		AgentOverrides: map[string]string{"44": "codex"},
+	}
+	if !reflect.DeepEqual(m.promptResult, want) {
+		t.Fatalf("promptResult = %#v, want %#v", m.promptResult, want)
+	}
+}
+
+// TestNewPaneIssueWithoutChildrenSkipsAssign guarantees a childless issue
+// submits straight from the picker as a single-pane session.
+func TestNewPaneIssueWithoutChildrenSkipsAssign(t *testing.T) {
+	m := newModel(Options{
+		ListOpenIssues: func() ([]IssueListItem, error) {
+			return []IssueListItem{{Number: 7, Title: "Standalone"}}, nil
+		},
+		ListIssueChildren: func(int) ([]ChildTarget, error) { return nil, nil },
+	})
+	m.promptOnly = true
+	m.openNewPaneForm()
+	m.newPane.focus = newPaneFieldMode
+
+	step := func(key tea.KeyMsg) tea.Cmd {
+		updated, cmd := m.Update(key)
+		m = updated.(model)
+		return cmd
+	}
+
+	loadCmd := step(tea.KeyMsg{Type: tea.KeyRight})
+	updated, _ := m.Update(loadCmd())
+	m = updated.(model)
+	assignCmd := step(tea.KeyMsg{Type: tea.KeyEnter})
+	updated, quitCmd := m.Update(assignCmd())
+	m = updated.(model)
+
+	if quitCmd == nil {
+		t.Fatal("empty child list did not finalize the submission")
+	}
+	if !m.promptDone {
+		t.Fatal("promptDone = false, want direct submit without assign step")
+	}
+	want := LaunchRequest{Mode: LaunchModeIssue, Issue: 7, DefaultAgent: "claude"}
+	if !reflect.DeepEqual(m.promptResult, want) {
+		t.Fatalf("promptResult = %#v, want %#v", m.promptResult, want)
+	}
+}
+
+func TestNewPanePlanAssignSubmit(t *testing.T) {
+	m := newModel(Options{
+		ListPlanSlugs: func() ([]string, error) { return []string{"alpha", "beta"}, nil },
+		ListPlanTasks: func(slug string) ([]PlanTaskItem, error) {
+			if slug != "beta" {
+				return nil, errors.New("unexpected slug")
+			}
+			return []PlanTaskItem{
+				{ID: "front", Title: "Frontend", Wave: "1"},
+				{ID: "back", Title: "Backend", Wave: "2"},
+			}, nil
+		},
+	})
+	m.promptOnly = true
+	m.openNewPaneForm()
+	m.newPane.focus = newPaneFieldMode
+
+	step := func(key tea.KeyMsg) tea.Cmd {
+		updated, cmd := m.Update(key)
+		m = updated.(model)
+		return cmd
+	}
+	deliver := func(cmd tea.Cmd) {
+		t.Helper()
+		if cmd == nil {
+			t.Fatal("expected a command")
+		}
+		updated, _ := m.Update(cmd())
+		m = updated.(model)
+	}
+
+	deliver(step(tea.KeyMsg{Type: tea.KeyRight})) // prompt -> plan (issue mode not wired)
+	step(tea.KeyMsg{Type: tea.KeyTab})
+	step(keyRunes("bet"))
+	deliver(step(tea.KeyMsg{Type: tea.KeyEnter}))
+	step(tea.KeyMsg{Type: tea.KeyRight}) // first task claude -> codex
+	step(tea.KeyMsg{Type: tea.KeyEnter})
+
+	want := LaunchRequest{
+		Mode:           LaunchModePlan,
+		Plan:           "beta",
+		DefaultAgent:   "claude",
+		AgentOverrides: map[string]string{"front": "codex"},
+	}
+	if !reflect.DeepEqual(m.promptResult, want) {
+		t.Fatalf("promptResult = %#v, want %#v", m.promptResult, want)
+	}
+}
+
+func TestNewPaneAssignEscReturnsToPicker(t *testing.T) {
+	m := newModel(Options{
+		ListOpenIssues: func() ([]IssueListItem, error) {
+			return []IssueListItem{{Number: 42, Title: "Fix UI"}}, nil
+		},
+		ListIssueChildren: func(int) ([]ChildTarget, error) {
+			return []ChildTarget{{Number: 43, Title: "Child"}}, nil
+		},
+	})
+	m.promptOnly = true
+	m.openNewPaneForm()
+	m.newPane.focus = newPaneFieldMode
+
+	step := func(key tea.KeyMsg) tea.Cmd {
+		updated, cmd := m.Update(key)
+		m = updated.(model)
+		return cmd
+	}
+
+	loadCmd := step(tea.KeyMsg{Type: tea.KeyRight})
+	updated, _ := m.Update(loadCmd())
+	m = updated.(model)
+	assignCmd := step(tea.KeyMsg{Type: tea.KeyEnter})
+	updated, _ = m.Update(assignCmd())
+	m = updated.(model)
+	if m.newPane.step != newPaneStepAssign {
+		t.Fatalf("step = %v, want assign", m.newPane.step)
+	}
+
+	step(tea.KeyMsg{Type: tea.KeyEsc})
+	if m.newPane.step != newPaneStepForm {
+		t.Fatalf("step after esc = %v, want form", m.newPane.step)
+	}
+	if m.promptDone || m.promptCanceled {
+		t.Fatal("esc from assign must return to the picker, not close the prompt")
+	}
+	if !m.newPane.issuePicker.loaded {
+		t.Fatal("picker state was lost when returning from assign")
+	}
+}
+
+func TestNewPaneIssueSubmitWhileLoadingSetsError(t *testing.T) {
+	m := newModel(Options{
+		ListOpenIssues: func() ([]IssueListItem, error) { return nil, nil },
+	})
+	m.openNewPaneForm()
+	m.newPane.mode = newPaneModeIssue
+	m.newPane.issuePicker.loading = true
+
+	updated, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	m = updated.(model)
+	if cmd != nil {
+		t.Fatal("enter while loading returned a command")
+	}
+	if m.newPane.err != "list is still loading" {
+		t.Fatalf("err = %q, want list is still loading", m.newPane.err)
+	}
+}
+
+// TestLaunchRequestDispatchesByMode guarantees the popup-result dispatch
+// routes each mode to its launcher and reports unwired launchers as notices.
+func TestLaunchRequestDispatchesByMode(t *testing.T) {
+	type call struct {
+		kind      string
+		target    string
+		agent     string
+		overrides map[string]string
+	}
+
+	tests := []struct {
+		name       string
+		req        LaunchRequest
+		wired      bool
+		wantCall   *call
+		wantNotice string
+	}{
+		{
+			name:     "issue mode calls LaunchIssue",
+			req:      LaunchRequest{Mode: LaunchModeIssue, Issue: 42, DefaultAgent: "claude", AgentOverrides: map[string]string{"43": "codex"}},
+			wired:    true,
+			wantCall: &call{kind: "issue", target: "42", agent: "claude", overrides: map[string]string{"43": "codex"}},
+		},
+		{
+			name:     "plan mode calls LaunchPlan",
+			req:      LaunchRequest{Mode: LaunchModePlan, Plan: "beta", DefaultAgent: "codex"},
+			wired:    true,
+			wantCall: &call{kind: "plan", target: "beta", agent: "codex"},
+		},
+		{
+			name:     "prompt mode keeps calling LaunchPane",
+			req:      LaunchRequest{Prompt: "do it", Agents: []string{"claude"}},
+			wired:    true,
+			wantCall: &call{kind: "prompt", target: "do it", agent: "claude"},
+		},
+		{
+			name:       "unwired issue launcher surfaces a notice",
+			req:        LaunchRequest{Mode: LaunchModeIssue, Issue: 42, DefaultAgent: "claude"},
+			wantNotice: "new session: issue launcher is not configured",
+		},
+		{
+			name:       "unwired plan launcher surfaces a notice",
+			req:        LaunchRequest{Mode: LaunchModePlan, Plan: "beta", DefaultAgent: "claude"},
+			wantNotice: "new session: plan launcher is not configured",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got *call
+			opts := Options{}
+			if tt.wired {
+				opts.LaunchIssue = func(num int, agent string, overrides map[string]string) (string, error) {
+					got = &call{kind: "issue", target: "42", agent: agent, overrides: overrides}
+					return "", nil
+				}
+				opts.LaunchPlan = func(slug, agent string, overrides map[string]string) (string, error) {
+					got = &call{kind: "plan", target: slug, agent: agent, overrides: overrides}
+					return "", nil
+				}
+				opts.LaunchPane = func(req LaunchRequest) (string, error) {
+					got = &call{kind: "prompt", target: req.Prompt, agent: req.Agents[0]}
+					return "", nil
+				}
+			}
+			m := newModel(opts)
+
+			cmd := m.launchNewPaneRequest(tt.req)
+			if tt.wantNotice != "" {
+				if cmd != nil {
+					t.Fatal("unwired launcher returned a command")
+				}
+				if m.notice != tt.wantNotice {
+					t.Fatalf("notice = %q, want %q", m.notice, tt.wantNotice)
+				}
+				return
+			}
+			if cmd == nil {
+				t.Fatal("wired launcher returned nil command")
+			}
+			if msg, ok := cmd().(launchPaneMsg); !ok || msg.err != nil {
+				t.Fatalf("cmd() = %#v, want launchPaneMsg without error", msg)
+			}
+			if !reflect.DeepEqual(got, tt.wantCall) {
+				t.Fatalf("launcher call = %#v, want %#v", got, tt.wantCall)
+			}
+		})
+	}
+}
+
+func TestSingleAgentSelectorCycles(t *testing.T) {
+	m := newModel(Options{})
+	m.openNewPaneForm()
+
+	m.cycleNewPaneAgentChoice("right")
+	if got := launchAgents[m.newPane.agentChoice]; got != "codex" {
+		t.Fatalf("after right agent = %q, want codex", got)
+	}
+	m.cycleNewPaneAgentChoice("right")
+	if got := launchAgents[m.newPane.agentChoice]; got != "claude" {
+		t.Fatalf("after wrap agent = %q, want claude", got)
+	}
+	m.cycleNewPaneAgentChoice("left")
+	if got := launchAgents[m.newPane.agentChoice]; got != "codex" {
+		t.Fatalf("after left agent = %q, want codex", got)
+	}
+}
+
+func TestNewPaneViewRendersPickerStates(t *testing.T) {
+	m := newModel(Options{
+		ListOpenIssues: func() ([]IssueListItem, error) { return nil, nil },
+		ListPlanSlugs:  func() ([]string, error) { return nil, nil },
+	})
+	m.openNewPaneForm()
+	m.newPane.mode = newPaneModeIssue
+
+	m.newPane.issuePicker.loading = true
+	if view := m.newPaneView(); !strings.Contains(view, "loading…") {
+		t.Fatalf("loading view missing spinner text:\n%s", view)
+	}
+
+	m.newPane.issuePicker.loading = false
+	m.newPane.issuePicker.err = "gh boom"
+	if view := m.newPaneView(); !strings.Contains(view, "list failed: gh boom") {
+		t.Fatalf("error view missing failure text:\n%s", view)
+	}
+
+	m.newPane.issuePicker.err = ""
+	m.newPane.issuePicker.loaded = true
+	m.newPane.issuePicker.items = issuePickerItems([]IssueListItem{
+		{Number: 42, Title: "Fix UI", HasSession: true},
+	})
+	m.recomputePicker(&m.newPane.issuePicker)
+	view := m.newPaneView()
+	for _, want := range []string{"#42 Fix UI", "(has session)", "[Issue]"} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("picker view missing %q:\n%s", want, view)
+		}
+	}
+}
+
+// TestNewPaneViewHidesModeRowWithoutProviders pins the compatibility path:
+// with no list providers wired the form keeps its classic prompt-only shape.
+func TestNewPaneViewHidesModeRowWithoutProviders(t *testing.T) {
+	m := newModel(Options{})
+	m.openNewPaneForm()
+
+	if view := m.newPaneView(); strings.Contains(view, "Mode") {
+		t.Fatalf("mode row rendered without providers:\n%s", view)
+	}
+	if order := m.newPaneFocusOrder(); len(order) != 2 {
+		t.Fatalf("focus order = %v, want two fields", order)
+	}
+}

--- a/internal/tui/newpane_picker_test.go
+++ b/internal/tui/newpane_picker_test.go
@@ -458,6 +458,49 @@ func TestNewPaneViewRendersPickerStates(t *testing.T) {
 	}
 }
 
+// TestNewPaneAssignDropsStaleSameTargetLoad pins the esc-while-loading race:
+// re-entering the same issue must ignore the first, superseded load even
+// though both carry the same target.
+func TestNewPaneAssignDropsStaleSameTargetLoad(t *testing.T) {
+	m := newModel(Options{
+		ListOpenIssues: func() ([]IssueListItem, error) {
+			return []IssueListItem{{Number: 42, Title: "Fix UI"}}, nil
+		},
+		ListIssueChildren: func(int) ([]ChildTarget, error) {
+			return []ChildTarget{{Number: 43, Title: "Child"}}, nil
+		},
+	})
+	m.promptOnly = true
+	m.openNewPaneForm()
+	m.newPane.focus = newPaneFieldMode
+
+	step := func(key tea.KeyMsg) tea.Cmd {
+		updated, cmd := m.Update(key)
+		m = updated.(model)
+		return cmd
+	}
+
+	loadCmd := step(tea.KeyMsg{Type: tea.KeyRight})
+	updated, _ := m.Update(loadCmd())
+	m = updated.(model)
+
+	staleCmd := step(tea.KeyMsg{Type: tea.KeyEnter}) // first attempt: load in flight
+	staleMsg := staleCmd()
+	step(tea.KeyMsg{Type: tea.KeyEsc})               // back to the picker mid-load
+	freshCmd := step(tea.KeyMsg{Type: tea.KeyEnter}) // second attempt, same target
+	updated, finalize := m.Update(staleMsg)          // stale load resolves late
+	m = updated.(model)
+	if finalize != nil || len(m.newPane.assign.rows) != 0 || !m.newPane.assign.loading {
+		t.Fatalf("stale load accepted: rows = %#v loading = %v", m.newPane.assign.rows, m.newPane.assign.loading)
+	}
+
+	updated, _ = m.Update(freshCmd())
+	m = updated.(model)
+	if len(m.newPane.assign.rows) != 1 {
+		t.Fatalf("fresh load rows = %#v, want one child", m.newPane.assign.rows)
+	}
+}
+
 // TestNewPanePickerFilterAcceptsSpaces pins multi-word title queries: a lone
 // space arrives as tea.KeySpace (not KeyRunes) and must extend the filter.
 func TestNewPanePickerFilterAcceptsSpaces(t *testing.T) {

--- a/internal/tui/newpane_picker_test.go
+++ b/internal/tui/newpane_picker_test.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"errors"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -369,7 +370,7 @@ func TestLaunchRequestDispatchesByMode(t *testing.T) {
 			opts := Options{}
 			if tt.wired {
 				opts.LaunchIssue = func(num int, agent string, overrides map[string]string) (string, error) {
-					got = &call{kind: "issue", target: "42", agent: agent, overrides: overrides}
+					got = &call{kind: "issue", target: strconv.Itoa(num), agent: agent, overrides: overrides}
 					return "", nil
 				}
 				opts.LaunchPlan = func(slug, agent string, overrides map[string]string) (string, error) {
@@ -457,7 +458,92 @@ func TestNewPaneViewRendersPickerStates(t *testing.T) {
 	}
 }
 
-// TestNewPaneViewHidesModeRowWithoutProviders pins the compatibility path:
+// TestNewPanePickerFilterAcceptsSpaces pins multi-word title queries: a lone
+// space arrives as tea.KeySpace (not KeyRunes) and must extend the filter.
+func TestNewPanePickerFilterAcceptsSpaces(t *testing.T) {
+	m := newModel(Options{
+		ListOpenIssues: func() ([]IssueListItem, error) {
+			return []IssueListItem{
+				{Number: 41, Title: "Add API client"},
+				{Number: 42, Title: "Fix UI overflow"},
+			}, nil
+		},
+	})
+	m.openNewPaneForm()
+	m.newPane.mode = newPaneModeIssue
+
+	updated, _ := m.Update(newPaneIssuesLoadedMsg{items: []IssueListItem{
+		{Number: 41, Title: "Add API client"},
+		{Number: 42, Title: "Fix UI overflow"},
+	}})
+	m = updated.(model)
+	for _, key := range []tea.KeyMsg{keyRunes("ui"), {Type: tea.KeySpace}, keyRunes("over")} {
+		updated, _ = m.Update(key)
+		m = updated.(model)
+	}
+
+	if got := m.newPane.issuePicker.query; got != "ui over" {
+		t.Fatalf("filter query = %q, want %q", got, "ui over")
+	}
+	if results := m.newPane.issuePicker.results; len(results) != 1 || m.newPane.issuePicker.items[results[0]].number != 42 {
+		t.Fatalf("filtered results = %v, want only #42", results)
+	}
+}
+
+// TestLaunchingGateQueuesQuit pins the fan-out escape hatch: while a launch
+// runs, q queues a quit instead of being silently swallowed.
+func TestLaunchingGateQueuesQuit(t *testing.T) {
+	m := newModel(Options{})
+	m.newPane.launching = true
+
+	updated, cmd := m.Update(keyRunes("q"))
+	m = updated.(model)
+	if cmd != nil {
+		t.Fatal("q during launch returned a command, want deferred quit")
+	}
+	if !m.quitAfterLaunch {
+		t.Fatal("quitAfterLaunch = false, want queued quit")
+	}
+
+	updated, cmd = m.Update(launchPaneMsg{notice: "done", count: 1})
+	m = updated.(model)
+	if cmd == nil {
+		t.Fatal("launchPaneMsg with queued quit returned nil command, want quit")
+	}
+	if msg := cmd(); msg != (tea.QuitMsg{}) {
+		t.Fatalf("cmd() = %#v, want tea.QuitMsg", msg)
+	}
+}
+
+// TestAssignRowWindowFollowsSelection pins the sliding window: a long target
+// list never renders taller than the popup and the cursor stays visible.
+func TestAssignRowWindowFollowsSelection(t *testing.T) {
+	m := newModel(Options{})
+	m.openNewPaneForm()
+	m.height = 18 // minimum popup pty: 18-8 overhead = 10 -> capped at 8
+	rows := make([]assignRow, 15)
+	for i := range rows {
+		rows[i] = assignRow{target: strconv.Itoa(i), label: "row"}
+	}
+	m.newPane.assign.rows = rows
+
+	if start, end := m.assignRowWindow(); start != 0 || end != 8 {
+		t.Fatalf("window at top = [%d,%d), want [0,8)", start, end)
+	}
+	m.newPane.assign.index = 12
+	start, end := m.assignRowWindow()
+	if m.newPane.assign.index < start || m.newPane.assign.index >= end {
+		t.Fatalf("window [%d,%d) does not contain selected row %d", start, end, m.newPane.assign.index)
+	}
+
+	m.newPane.mode = newPaneModeIssue
+	m.newPane.step = newPaneStepAssign
+	view := m.newPaneAssignView()
+	if !strings.Contains(view, "more") {
+		t.Fatalf("windowed assign view missing scroll marker:\n%s", view)
+	}
+}
+
 // with no list providers wired the form keeps its classic prompt-only shape.
 func TestNewPaneViewHidesModeRowWithoutProviders(t *testing.T) {
 	m := newModel(Options{})

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -49,6 +49,14 @@ type Options struct {
 	LaunchAttach        AttachLaunchFunc
 	LaunchShell         ShellLaunchFunc
 	RestorePanes        func() (string, error)
+	// New-session issue/plan mode wiring. A nil list provider hides its mode
+	// from the form; a nil launcher turns its submissions into a notice.
+	ListOpenIssues    func() ([]IssueListItem, error)
+	ListPlanSlugs     func() ([]string, error)
+	ListIssueChildren func(parent int) ([]ChildTarget, error)
+	ListPlanTasks     func(slug string) ([]PlanTaskItem, error)
+	LaunchIssue       IssueLaunchFunc
+	LaunchPlan        PlanLaunchFunc
 	// Relayout re-tiles the TUI's tmux window into the fanout grid. It is wired
 	// to panelayout.Apply(target, Resize) in production and left nil in tests
 	// (then resize handling is a no-op).

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -117,6 +117,7 @@ type model struct {
 	notifications    map[issueKey]issueTransitionSnapshot
 	notifyPrimed     bool
 	keyboardPaused   bool
+	quitAfterLaunch  bool
 	relayoutGen      int
 	promptOnly       bool
 	promptDone       bool

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -2537,7 +2537,7 @@ func TestHelpModalFitsStandardTerminalHeight(t *testing.T) {
 	m.mode = modeHelp
 
 	view := m.View()
-	for _, want := range []string{"[Enter]", "Create panes", "[Esc]", "Cancel", "Esc / q / ? close"} {
+	for _, want := range []string{"[Enter]", "Create / next", "[Esc]", "Cancel / back", "Esc / q / ? close"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("80x24 help view missing %q:\n%s", want, view)
 		}

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -32,6 +32,16 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		m.resumeKeyboardProtocols()
 		if (m.newPanePopupOpen || m.newPane.launching) && m.mode != modeNewPane {
+			// Issue/plan launches can run a whole fan-out (seconds per child), so
+			// mirror the lifecycle-action gate: keys stay blocked, but q/ctrl+c
+			// queue a quit instead of appearing hung.
+			if m.newPane.launching {
+				switch msg.String() {
+				case "q", "ctrl+c":
+					m.quitAfterLaunch = true
+					m.notice = "will quit after the launch finishes"
+				}
+			}
 			return m, nil
 		}
 		if m.pendingAction != nil {
@@ -206,6 +216,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, tea.Batch(m.loadStateCmd(false), m.loadGHCmd(false))
 	case launchPaneMsg:
 		m.newPane.launching = false
+		if m.quitAfterLaunch {
+			m.quitAfterLaunch = false
+			return m.quit()
+		}
 		if msg.err != nil {
 			if m.mode == modeNewPane {
 				m.newPane.err = msg.err.Error()
@@ -276,6 +290,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		m.newPane.assign.err = ""
+		m.newPane.err = "" // clear a "targets are still loading" line once they arrive
 		rows := buildAssignRows(msg, m.newPane.agentChoice)
 		if len(rows) == 0 {
 			// A childless issue launches as a single pane; an empty plan defers

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -241,6 +241,50 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 		return m, m.launchNewPaneRequest(msg.req)
+	case newPaneIssuesLoadedMsg:
+		p := &m.newPane.issuePicker
+		p.loading = false
+		if msg.err != nil {
+			// Leave loaded false so re-entering the mode retries the fetch.
+			p.err = msg.err.Error()
+			return m, nil
+		}
+		p.err = ""
+		p.loaded = true
+		p.items = issuePickerItems(msg.items)
+		m.recomputePicker(p)
+		return m, nil
+	case newPanePlansLoadedMsg:
+		p := &m.newPane.planPicker
+		p.loading = false
+		if msg.err != nil {
+			p.err = msg.err.Error()
+			return m, nil
+		}
+		p.err = ""
+		p.loaded = true
+		p.items = planPickerItems(msg.slugs)
+		m.recomputePicker(p)
+		return m, nil
+	case newPaneAssignLoadedMsg:
+		if m.mode != modeNewPane || m.newPane.step != newPaneStepAssign || m.newPane.assign.target != msg.target {
+			return m, nil // a stale load must not populate a newer selection
+		}
+		m.newPane.assign.loading = false
+		if msg.err != nil {
+			m.newPane.assign.err = msg.err.Error()
+			return m, nil
+		}
+		m.newPane.assign.err = ""
+		rows := buildAssignRows(msg, m.newPane.agentChoice)
+		if len(rows) == 0 {
+			// A childless issue launches as a single pane; an empty plan defers
+			// its error to the launch lane. Either way there is nothing to assign.
+			return m, m.finalizeNewPaneModeSubmit()
+		}
+		m.newPane.assign.rows = rows
+		m.newPane.assign.index = 0
+		return m, nil
 	case filesLoadedMsg:
 		m.repoFilesLoading = false
 		if msg.err != nil {

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -281,8 +281,12 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.recomputePicker(p)
 		return m, nil
 	case newPaneAssignLoadedMsg:
-		if m.mode != modeNewPane || m.newPane.step != newPaneStepAssign || m.newPane.assign.target != msg.target {
-			return m, nil // a stale load must not populate a newer selection
+		// The generation check also drops a stale load for the SAME target
+		// (esc while loading, then re-enter), which could otherwise finalize
+		// or overwrite the newer attempt.
+		if m.mode != modeNewPane || m.newPane.step != newPaneStepAssign ||
+			m.newPane.assign.target != msg.target || m.newPane.assign.gen != msg.gen {
+			return m, nil
 		}
 		m.newPane.assign.loading = false
 		if msg.err != nil {

--- a/site/content/docs/monitoring.ja.md
+++ b/site/content/docs/monitoring.ja.md
@@ -32,7 +32,7 @@ footer は短く保ちます。通常画面で `?` を押すと、全ショー�
 | キー | 動作 |
 |---|---|
 | `?` | キーボードショートカットのヘルプを開く。`Esc`、`q`、もう一度 `?` のいずれかで閉じる。 |
-| `n` | tmux popup を開き、複数行の必須 prompt、`claude` / `codex` の起動数を指定して manual agent ペインを作成する。`codex` は Codex Plan Mode で起動し、popup の prompt を inline で受け取る。`claude` は通常起動する。`Up` / `Down` で agent 行を選び、`Space` で 0 / 1 を切り替え、`Left` / `Right` で起動数を変える。prompt 欄では `Shift+Enter` または `Ctrl+J` で改行し、`Enter` で選択したペインを作成する。enhanced keyboard input は既定で有効（`FANOUT_TUI_ENHANCED_KEYS=0` で無効化）で、`Shift+Enter` を区別して送る terminal が必要なため fanout が tmux の `extended-keys` を有効化する。manual ペインは synthetic な `@manual` state entry として記録され、起動後に一覧へ表示される。 |
+| `n` | 新規 Session の tmux popup を開く。Mode 行で Prompt / Issue / Plan を切り替える。詳細は[新規 Session のモード](#新規-session-のモード)を参照。 |
 | `a` | 選択中の行に記録された worktree に、agent ペインを 1 つ以上追加する。git worktree は作らない。追加行は選択元の worktree と branch を共有し、focus と peek はできるが merge 進捗には数えない。`codex` は Codex Plan Mode で起動する。 |
 | `A` | 選択中の行に記録された worktree で shell terminal を開く。shell 行は `@manual` entry として記録され、focus と peek はできるが merge 進捗には数えない。 |
 | `t` | project root で shell terminal を開く。close は tmux ペインと state 行だけを消し、git worktree は削除しない。 |
@@ -44,6 +44,14 @@ footer は短く保ちます。通常画面で `?` を押すと、全ショー�
 | `q` | コンソールを離脱する。tmux session と子ペインはそのまま残る。 |
 
 > worktree 行が `stale!` になるのは、worktree が無い、agent command が無いなど fanout が復元できない場合です。shell terminal は resume できないため、対応する tmux ペインが無ければ TUI が state 行を削除します。
+
+### 新規 Session のモード
+
+`n` は Mode 行つきの tmux popup を開きます。Mode 行で `Left` / `Right` を押すとモードが切り替わり、`Tab` でフィールドを移動し、`Esc` でキャンセルします（agent 割り当て画面では 1 つ前に戻る）。
+
+- **Prompt** — 従来の manual ペイン。複数行の必須 prompt と `claude` / `codex` の起動数を指定する。`Up` / `Down` で agent 行を選び、`Space` で 0 / 1 を切り替え、`Left` / `Right` で起動数を変える。`codex` は Codex Plan Mode で起動し popup の prompt を inline で受け取る。`claude` は通常起動する。prompt 欄では `Shift+Enter` または `Ctrl+J` で改行し、`Enter` でペインを作成する。enhanced keyboard input は既定で有効（`FANOUT_TUI_ENHANCED_KEYS=0` で無効化）で、`Shift+Enter` を区別して送る terminal が必要なため fanout が tmux の `extended-keys` を有効化する。manual ペインは synthetic な `@manual` state entry として記録され、起動後に一覧へ表示される。
+- **Issue** — リポジトリの OPEN issue を一覧する（上限 100 件）。文字入力で番号・タイトル・ラベルで絞り込む。すでにペインが記録されている行は `(has session)` と表示されるが選択はできる。`Enter` で子 issue ごとの agent 割り当て画面が開き、`Left` / `Right` で行の agent を切り替え — 繰り返し指定の `--agent NUM=name` と同じ — もう一度 `Enter` で起動する。OPEN な子を持つ issue は `fanout <issue> --unblocked-only` 相当でファンアウトする。blocked な子は deferred のまま残るので、ブロッカーが閉じたら同じ issue を選び直す（全子を一度に起動したい場合は CLI を使う）。子のない issue は `@watch` 配下に記録される単独ペインを起動する。
+- **Plan** — `.fanout/plans/*.json` の slug を一覧し、選択した plan を `fanout plan <slug>` 相当で実行する。タスクごとの agent 割り当ても同様（`--agent task-id=name`）。
 
 ## --status（JSON）
 

--- a/site/content/docs/monitoring.md
+++ b/site/content/docs/monitoring.md
@@ -32,7 +32,7 @@ The footer stays short; press `?` in the monitor to open the full shortcut help.
 | Key | Action |
 |---|---|
 | `?` | Open the keyboard shortcut help. Press `Esc`, `q`, or `?` again to close it. |
-| `n` | Open a tmux popup to create manual agent panes from a required **multi-line** prompt and `claude` / `codex` launch counts. `codex` starts in Codex Plan Mode and receives the popup prompt inline; `claude` starts normally. Use `Up` / `Down` to pick an agent row, `Space` to toggle it, and `Left` / `Right` to change the count. In the prompt field, `Shift+Enter` or `Ctrl+J` inserts a newline and `Enter` creates the selected panes. Enhanced keyboard input is on by default (set `FANOUT_TUI_ENHANCED_KEYS=0` to opt out); `Shift+Enter` needs a terminal that reports it distinctly, for which fanout turns on tmux `extended-keys`. Manual panes are recorded as synthetic `@manual` state entries and appear in the list after launch. |
+| `n` | Open the new-session tmux popup. Its Mode row switches between Prompt, Issue, and Plan; see [New session modes](#new-session-modes). |
 | `a` | Attach one or more agent panes to the selected row's recorded worktree. No git worktree is created. The attached rows share the selected worktree and branch, can be focused and peeked, and do not count toward merge progress. `codex` starts in Codex Plan Mode. |
 | `A` | Open a shell terminal in the selected row's recorded worktree. Shell rows are recorded as `@manual` entries, can be focused and peeked, and do not count toward merge progress. |
 | `t` | Open a shell terminal at the project root. Closing it kills the tmux pane and removes the state row; it never removes a git worktree. |
@@ -44,6 +44,14 @@ The footer stays short; press `?` in the monitor to open the full shortcut help.
 | `q` | Leave the console. The tmux session and child panes are left running. |
 
 > Worktree rows become `stale!` only when fanout cannot restore them, such as a missing worktree or unavailable agent command. Recorded shell terminals are not resumable; if their tmux pane is gone, the TUI removes the state row.
+
+### New session modes
+
+`n` opens a tmux popup with a Mode row. `Left` / `Right` on that row switches the mode, `Tab` moves between fields, and `Esc` cancels (or steps back from the assignment screen).
+
+- **Prompt** — the classic manual pane: a required **multi-line** prompt plus `claude` / `codex` launch counts. Use `Up` / `Down` to pick an agent row, `Space` to toggle it, and `Left` / `Right` to change the count. `codex` starts in Codex Plan Mode and receives the popup prompt inline; `claude` starts normally. In the prompt field, `Shift+Enter` or `Ctrl+J` inserts a newline and `Enter` creates the selected panes. Enhanced keyboard input is on by default (set `FANOUT_TUI_ENHANCED_KEYS=0` to opt out); `Shift+Enter` needs a terminal that reports it distinctly, for which fanout turns on tmux `extended-keys`. Manual panes are recorded as synthetic `@manual` state entries and appear in the list after launch.
+- **Issue** — lists the repository's OPEN issues (up to 100). Typing narrows by number, title, or label; rows that already have a recorded pane show `(has session)` but stay selectable. `Enter` opens a per-child agent assignment screen where `Left` / `Right` flips one row's agent — the equivalent of repeatable `--agent NUM=name` flags — and `Enter` launches. An issue with OPEN children fans out like `fanout <issue> --unblocked-only`: blocked children stay deferred, so re-select the issue after their blockers close (or use the CLI to launch every child at once). An issue without children starts a single pane recorded under `@watch`.
+- **Plan** — lists stored `.fanout/plans/*.json` slugs and runs the selection like `fanout plan <slug>`, with the same per-task agent assignment (`--agent task-id=name`).
 
 ## --status (JSON)
 


### PR DESCRIPTION
## Summary
- TUI コンソール(`n` popup)に Prompt モードに加え **Issue モード**(OPEN issue 一覧から選択して起動)と **Plan モード**(`.fanout/plans/*.json` の slug から起動)を追加
- 選択後に子/タスクごとの agent 割り当て画面を挟み、`--agent NUM=name` / `task-id=name` 相当の子別指定が TUI からできる(フロントは claude、バックは codex、等)
- issue は OPEN 子あり→`fanout <issue> --unblocked-only` 相当の fan-out、子なし→`@watch` 配下の単独ペイン。plan は `fanout plan <slug>` 相当
- モデル指定(#368)は対象外だが、agent 値は文字列パススルーなので選択肢追加のみで将来対応可能

## Test plan
- [x] `make test`(Go 単体・web vitest・bats black-box、goldens 差分なし)
- [x] `make lint` 0 issues
- [x] 実 tmux でのスモークテスト: issue picker → assign → result JSON round-trip、plan picker → assign、esc 段階戻り、キャンセル
- [x] post-work-review 完了: code-review(xhigh)で 12 件修正、codex review 4 反復目で approve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013ESsjfP7gQ3KyRp7BSpFDn