### PR TITLE
docs: PR 前レビューチェックリストを新設し再発防止ガイドを強化

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,16 +13,7 @@
       "Bash(gh run view:*)",
       "Bash(gh issue list:*)",
       "Bash(gh issue view:*)",
-      "Bash(make lint)",
-      "Bash(make lint-web)",
-      "Bash(make test)",
-      "Bash(make test-web)",
-      "Bash(make test-tier1)",
-      "Bash(make test-tier2)",
-      "Bash(make build-go)",
-      "Bash(make build-web)",
-      "Bash(make fmt)",
-      "Bash(make fmt-web)"
+      "Bash(make lint-shell)"
     ]
   },
   "hooks": {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,30 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(git status:*)",
+      "Bash(git rev-parse:*)",
+      "Bash(git check-ignore:*)",
+      "Bash(git worktree list:*)",
+      "Bash(gh pr list:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr diff:*)",
+      "Bash(gh pr checks:*)",
+      "Bash(gh run list:*)",
+      "Bash(gh run view:*)",
+      "Bash(gh issue list:*)",
+      "Bash(gh issue view:*)",
+      "Bash(make lint)",
+      "Bash(make lint-web)",
+      "Bash(make test)",
+      "Bash(make test-web)",
+      "Bash(make test-tier1)",
+      "Bash(make test-tier2)",
+      "Bash(make build-go)",
+      "Bash(make build-web)",
+      "Bash(make fmt)",
+      "Bash(make fmt-web)"
+    ]
+  },
   "hooks": {
     "PreToolUse": [
       {

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -147,6 +147,16 @@ orchestration, `plan.go` filtering, `status.go`, `lifecycle.go`, `report.go`).
   race-safe replacement for `(parent, issueNum)` idempotency.
 - When changing dry-run output, update Tier 2 goldens with
   `FANOUT_GOLDEN_UPDATE=1 make test-tier2` and review the diff.
+- Walk `docs/review-checklist.ja.md` before creating a PR — the top CI
+  failures and review findings all recur (`make lint` / `make test` as
+  described above).
+- `go:embed` snapshots whatever is on disk at build time: after editing
+  `web/src`, build via `make build-go`, not raw `go build`, or the binary
+  ships a stale bundle.
+- Preserve fail-fast in `executePlan`: stop after the first failed child
+  launch.
+- Complete the post-work-review gate (the installed driver, invoked per
+  `codex/skills/post-work-review`) before commit-and-PR.
 
 ## Documentation Writing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,8 +155,10 @@ orchestration, `plan.go` filtering, `status.go`, `lifecycle.go`, `report.go`).
   ships a stale bundle.
 - Preserve fail-fast in `executePlan`: stop after the first failed child
   launch.
-- Complete the post-work-review gate (the installed driver, invoked per
-  `codex/skills/post-work-review`) before commit-and-PR.
+- Commit all fixes first, then run the post-work-review gate (the installed
+  driver, invoked per `codex/skills/post-work-review`) against that final
+  HEAD before `gh pr create` — the marker is tied to the exact commit
+  reviewed, so committing anything afterward invalidates it.
 
 ## Documentation Writing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -250,9 +250,17 @@ Build the binary with `make build-go` and validate with `make test`.
   `--unblocked-only`. If branch generation, task `branch` overrides, or
   `--branch-prefix` behavior changes, update the plan status fixtures and
   docs together.
+- Run `make lint` and `make test` before creating a PR (`make lint-web` too
+  when `web/` changed) — the top CI failures, Tier 2 golden drift and
+  golangci-lint findings, all reproduce locally. Then walk
+  `docs/review-checklist.ja.md`; the same review findings recur.
 - `gh pr create` is gated by the repo's `PreToolUse(Bash)` hook registered in
-  `.claude/settings.json`. Run `/post-work-review` before creating a PR, or use
-  `FANOUT_SKIP_PR_REVIEW=1` only when the documented escape hatch is intended.
+  `.claude/settings.json`. Retrying a denied command with nothing changed
+  never succeeds — fix the stated cause, then re-run it: complete
+  `/post-work-review` (the marker must match HEAD), issue `gh pr create` as a
+  standalone command with no `cd`/`pushd`/`env --chdir` chained in (any cwd
+  inside the target worktree works), and keep the PR base at the default
+  branch. `FANOUT_SKIP_PR_REVIEW=1` is only for the documented escape hatch.
 
 ## Test Conventions
 

--- a/docs/review-checklist.ja.md
+++ b/docs/review-checklist.ja.md
@@ -1,0 +1,28 @@
+# PR 前レビューチェックリスト
+
+過去のセッション履歴 102 件・CI 失敗 22 run・codex bot レビュー指摘 170 件の
+解析(2026-07、issue #373 のコメント)で繰り返し現れたパターン。PR を作る前に
+diff へ自問する。
+
+## 頻出 7 パターン
+
+1. **失敗パスを成功扱いしない** — エラー時に requeue / cleanup / 状態遷移が
+   継続するか。early return で後始末を飛ばしていないか。
+2. **identity は state と照合してから使う** — pane / worktree を名前や位置で
+   信用せず、`.fanout/state.json` の行と突き合わせる。
+3. **git diff のエッジケース** — untracked / symlink / C-quoted パス /
+   textconv。前提にしている diff 形式が全ケースで成り立つか。
+4. **カウンタ・予算のアカウンティング** — 二重計上、枯渇時の挙動、リセット
+   条件。
+5. **paginate / fetch 完了前に判定しない** — `gh api --paginate` や複数ページ
+   取得の途中結果で分岐しない。
+6. **表示幅** — マルチバイト・全角は byte 長ではなく表示幅で計算する
+   (TUI / 整形出力)。
+7. **英日ドキュメント同期** — `README*.md` / `site/content/docs/**` を触ったら
+   ペアも更新する。
+
+## 機械チェック
+
+- `make lint` と `make test` を回す。`web/` を触ったら `make lint-web` も。
+- dry-run / status 出力を変えたら `FANOUT_GOLDEN_UPDATE=1 make test-tier2` で
+  golden を regen して diff を目視する。


### PR DESCRIPTION
## Summary

過去の Claude Code セッション 102 件・CI 失敗 22 run・codex レビュー 170 指摘の解析 (butaosuinu/fanout#373 のコメント参照) に基づく再発防止のドキュメント層。

- **docs/review-checklist.ja.md 新設**: subsystem 横断で再発していたレビュー指摘 7 パターン + 機械チェック (lint / test / golden regen)
- **CLAUDE.md**: PR 前の `make lint` + `make test` 実行とチェックリスト参照を追記。PR ゲート項目を実挙動に合わせて拡張 (状態を変えないリトライは通らない / cd 連結不可・worktree 内なら任意 cwd 可 / base は既定ブランチ)
- **AGENTS.md**: `## Be Careful` を CLAUDE.md と同期 (チェックリスト参照・go:embed stale bundle・executePlan fail-fast・post-work-review ゲート)
- **.claude/settings.json**: 解析で頻出した読み取り専用 git/gh コマンドと make ターゲットを `permissions.allow` に追加 (承認摩擦 ~24 件の対策)。書き込み経路のある `rg` (`--pre`) / `git fetch` (refspec) / `git log|diff|show` (`--output`) は意図的に除外

## Verification

- `make lint` && `make test` green (ドキュメント + 設定のみの変更)
- PR ゲート hook に payload 直叩きで記述と実挙動の一致を確認 (cd 連結 → dirmsg deny / marker なし → 未レビュー deny / 非対象コマンド → allow)
- doc-style 自己チェック (AI-tell 語 grep 0 件)、README* 非接触 (英日ペア同期義務なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HMRTDpzKULmUWNghR6ZpuK