### PR TITLE
feat(skills): post-work-review に Pass 0 (プロジェクト検証) とチェックリスト自己チェックを追加

### DIFF
--- a/claude/skills/post-work-review/SKILL.md
+++ b/claude/skills/post-work-review/SKILL.md
@@ -23,6 +23,9 @@ description: 実装作業が一段落したコードを「仕上げ」モード�
 [ユーザー: /post-work-review or 「review して仕上げて」]
         │
         ▼
+[Pass 0] プロジェクト検証 (lint / test) ── 検証手段が無ければ skip
+        │
+        ▼
 [Pass 1] code-review プラグイン  ── 指摘を集める → 修正
         │
         ▼
@@ -46,12 +49,21 @@ description: 実装作業が一段落したコードを「仕上げ」モード�
 [Step 5] レビュー済みコミットを marker に記録 (PR ゲートの signal)
 ```
 
+## Pass 0 — プロジェクト検証 (lint / test)
+
+レビューに入る前にプロジェクト標準の検証を回し、機械的な失敗を先に潰す。壊れたコードへの二系統レビューはトークンの浪費で、CI 失敗の大半 (golden 不一致・lint 指摘) はローカルで再現できる。
+
+1. 検証コマンドを解決する: repo の CLAUDE.md / AGENTS.md / Makefile から lint・test 相当のターゲットを探す。見つからなければ Pass 0 を skip し、その旨を 1 行報告して Pass 1 へ。
+2. 実行し、**今回の diff に起因する失敗**を直してから先へ進む。base 由来の既存失敗や環境起因の失敗 (ツールチェーン欠如など) は 1 行報告して先へ進み、スコープ外のコードは直さない。golden / スナップショットの意図的な更新が要る失敗は、repo に regen 手順があればそれに従い、regen 差分を目視してから commit 対象に含める。
+3. web / フロントエンドを触った diff は対応する web 系 lint も回す。
+
 ## Pass 1 — code-review プラグインで掃除
 
 1. ユーザーに「Pass 1 として code-review を回します」と 1 文で宣言する。長い前置きは不要。
 2. **Skill ツール経由で `code-review` を呼ぶ**: `Skill(skill="code-review")`。引数は付けない (デフォルトの effort で十分。`--comment` は付けない — PR が無いローカル作業中にも使う skill なので、コメント posting は本質ではない。レビュー本文の収集だけが目的)。
 3. 返ってきた指摘を読み、修正すべき項目を選別する。**全ての指摘を機械的に直すのではなく**、明らかな bug / 規約違反 / セキュリティ問題を優先する。スタイル提案レベルは Pass 2 のあとに一括判断してよい (codex で同じことが再度挙がるなら直す価値がある)。
-4. 修正する項目をユーザーに 1〜2 文で宣言してから Edit に入る (例:「null チェック漏れ 2 箇所と未使用 import を直します」)。修正後は短く完了報告。
+4. repo にレビューチェックリスト (fanout では `docs/review-checklist.ja.md`) があれば、diff に対して各項目を自己チェックし、取りこぼしを修正対象に加える。無ければ飛ばす。
+5. 修正する項目をユーザーに 1〜2 文で宣言してから Edit に入る (例:「null チェック漏れ 2 箇所と未使用 import を直します」)。修正後は短く完了報告。
 
 ### code-review-strict との区別 (重要)
 
@@ -146,6 +158,7 @@ Pass 2 ループが clean 判定 / ユーザー停止指示 / oscillation 検知
 
 1. **最低 1 つのレビューパスが成功している**: Pass 1 (code-review) が正常完了したか、Pass 2 (codex) が少なくとも 1 反復回って結果を返している。Pass 1 がエラーで、かつ Pass 2 も codex 未検出 / エラーで実行できなかった場合は、成功したレビューが 0 件なので **marker を書かず**、レビュー未完了である旨をユーザーに伝えて終了する(ゲートは閉じたまま)。
 2. **working tree が clean**: Pass 1/Pass 2 の修正が全て commit 済みであること。dirty なまま marker を書くと、未コミットの修正は PR (= push 済みコミット) に乗らないのに HEAD が「レビュー済み」とマークされ、ゲートが unreviewed なコードの PR 作成を通してしまう。
+3. **Pass 0 を実行した場合、今回の diff に起因する検証失敗が残っていない**: Pass 1 / Pass 2 の修正でコードを変えたら、変更範囲に対応する検証 (最低限 lint、テスト対象を触ったら test) を再実行してから marker を書く。Pass 0 で 1 行報告して先へ進んだ base 由来・環境起因の失敗は marker をブロックしない。Pass 0 を skip した repo ではこの前提は課さない。
 
 ```bash
 if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
@@ -166,6 +179,7 @@ fi
 
 ループ終了時 (clean 判定 / ユーザー停止指示 / oscillation 検知のいずれか) に、以下を 2〜3 文で報告する:
 
+- Pass 0 の検証結果 (検証手段が無く skip した場合はその旨)
 - Pass 1 で何件直したか
 - Pass 2 が何反復回って終わったか (codex 未検出で skip した場合はその旨)
 - 最終的に codex が approve したか、それともユーザー判断で停止したか

--- a/codex/agents/post-work-reviewer.md
+++ b/codex/agents/post-work-reviewer.md
@@ -28,6 +28,26 @@ reviewer contract and the direct review bundle contract.
   present.
 - Return JSON only. Do not wrap it in Markdown.
 
+## High-yield checks
+
+Recurring defect patterns from past reviews — check each against the diff:
+
+- Failure paths treated as success: requeue / cleanup / state transitions must
+  survive errors; early returns must not skip teardown.
+- Identity used without matching recorded state: tmux panes / worktrees must
+  be checked against `.fanout/state.json` rows, not trusted by name or
+  position.
+- git diff edge cases: untracked files, symlinks, C-quoted paths, textconv.
+- Counter and budget accounting: double counting, exhaustion behavior, reset
+  conditions.
+- Deciding before pagination completes: do not branch on partial
+  `gh api --paginate` results.
+- Display width: measure multibyte / full-width text by display width, not
+  byte length (TUI and formatted output).
+- Language-paired docs: when the repo maintains paired documents (such as
+  `README.md`/`README.ja.md` or `site/content/docs/**` `.md`/`.ja.md`), an
+  edit to one side must update its pair. Skip in repos without such pairs.
+
 ## JSON output
 
 Return one object with this shape:

--- a/codex/agents/post-work-reviewer.toml
+++ b/codex/agents/post-work-reviewer.toml
@@ -32,6 +32,26 @@ reviewer contract and the direct review bundle contract.
   present.
 - Return JSON only. Do not wrap it in Markdown.
 
+## High-yield checks
+
+Recurring defect patterns from past reviews — check each against the diff:
+
+- Failure paths treated as success: requeue / cleanup / state transitions must
+  survive errors; early returns must not skip teardown.
+- Identity used without matching recorded state: tmux panes / worktrees must
+  be checked against `.fanout/state.json` rows, not trusted by name or
+  position.
+- git diff edge cases: untracked files, symlinks, C-quoted paths, textconv.
+- Counter and budget accounting: double counting, exhaustion behavior, reset
+  conditions.
+- Deciding before pagination completes: do not branch on partial
+  `gh api --paginate` results.
+- Display width: measure multibyte / full-width text by display width, not
+  byte length (TUI and formatted output).
+- Language-paired docs: when the repo maintains paired documents (such as
+  `README.md`/`README.ja.md` or `site/content/docs/**` `.md`/`.ja.md`), an
+  edit to one side must update its pair. Skip in repos without such pairs.
+
 ## JSON output
 
 Return one object with this shape:

--- a/codex/skills/post-work-review/SKILL.md
+++ b/codex/skills/post-work-review/SKILL.md
@@ -62,6 +62,21 @@ pass that same environment variable explicitly to every driver command in this
 procedure. Do not assume a shell-like `$post-work-review` prefix reached the
 driver.
 
+## Project validation before the gate
+
+Before `prepare`, resolve the project's lint and test commands (AGENTS.md,
+CLAUDE.md, Makefile) and run them yourself. Fix failures caused by the change
+under review; report pre-existing or environment-caused failures (such as a
+missing toolchain) in one line and continue instead of editing out-of-scope
+code. When gating a committed branch (the tree was clean before validation),
+commit the fixes this validation produces before running `prepare` — a tree
+left dirty makes the driver narrow its scope to `uncommitted|HEAD` and `mark`
+later rejects with `non_branch_review_scope`. When reviewing uncommitted work
+(the tree was already dirty), leave the fixes uncommitted; the
+`uncommitted|HEAD` bundle includes them together with the work under review.
+Skip with a one-line note when the project has none. This validation runs
+outside the isolated reviewer/verifier calls and never replaces them.
+
 ## Procedure
 
 1. Prepare one broad review bundle:


### PR DESCRIPTION
## Summary

**#389 の上にスタック** (このブランチは #389 のコミットを含む。**#389 を先にマージ**すると diff が skill 変更のみに縮む)。

セッション履歴解析 (butaosuinu/fanout#373 のコメント) で、CI 失敗の主因 (Tier 2 golden 不一致 12 件 + golangci-lint 6 件) が全件ローカル再現可能だったことへの対策:

- **claude 版 SKILL.md**: レビュー前に repo の lint/test を解決して回す **Pass 0** を新設。今回の diff に起因する失敗だけを直し、base 由来・環境起因の失敗は 1 行報告して続行 (スコープ外コードは触らない)。Pass 1 に repo チェックリスト (`docs/review-checklist.ja.md`) の自己チェック手順を追加。marker 前提に「diff 起因の検証失敗が残っていない」を追加 (Pass 0 の失敗許容と整合)
- **codex 版 SKILL.md**: ゲート前のプロジェクト検証段落を追加。branch ゲート時は検証修正を commit してから `prepare` (dirty のままだと driver が `uncommitted|HEAD` にスコープを狭め `mark` が `non_branch_review_scope` で拒否)、dirty な pre-commit レビュー時は uncommitted のまま bundle に含める
- **codex/agents/post-work-reviewer.{md,toml}**: 頻出指摘 7 パターンを High-yield checks として追加。reviewer 実体は `.toml` の `developer_instructions` のため両方に同期。言語ペア docs チェックはペア運用のある repo に限定

`codex/tools/post-work-review.sh` (手戻り hotspot) には触れていない。

## Verification

- `make lint` && `make test` green (skill .md / .toml のみの変更)
- codex review 5 反復 (reviewer TOML 同期・marker 条件整合・dirty 経路保全・ペアチェック条件化を反映) → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HMRTDpzKULmUWNghR6ZpuK