### PR TITLE
fix(tui): New agent pane popup の二重枠を解消

### DIFF
--- a/internal/tui/newpane.go
+++ b/internal/tui/newpane.go
@@ -602,7 +602,12 @@ func (m model) newPaneView() string {
 	if m.newPane.attach != nil {
 		title = "Attach agent to worktree"
 	}
-	lines := []string{titleStyle.Render(title)}
+	// In the tmux popup the -T frame already shows the title, so drop the
+	// duplicate in-content heading; the in-process fallback keeps it.
+	var lines []string
+	if !m.promptOnly {
+		lines = append(lines, titleStyle.Render(title))
+	}
 	if len(m.availableNewPaneModes()) > 1 {
 		lines = append(lines, m.newPaneFieldView(newPaneFieldMode, "Mode", m.newPaneModeTabsView(), false))
 	}
@@ -631,7 +636,17 @@ func (m model) newPaneView() string {
 		lines = append(lines, errStyle.Render("error: "+m.newPane.err))
 	}
 	lines = append(lines, dimStyle.Render(m.newPaneHint()))
-	return modalStyle.Width(m.modalWidth()).Render(strings.Join(lines, "\n"))
+	return m.renderNewPaneModal(strings.Join(lines, "\n"))
+}
+
+// renderNewPaneModal frames the new-pane content. The tmux popup already draws
+// a border, so promptOnly renders borderless (popupContentStyle) to avoid a
+// double frame; the in-process overlay keeps the modal border.
+func (m model) renderNewPaneModal(content string) string {
+	if m.promptOnly {
+		return popupContentStyle.Width(m.modalWidth()).Render(content)
+	}
+	return modalStyle.Width(m.modalWidth()).Render(content)
 }
 
 func (m model) newPaneHint() string {
@@ -768,7 +783,9 @@ func (m model) modalWidth() int {
 		return 80
 	}
 	if m.promptOnly {
-		return clampInt(m.width-2, 40, 104)
+		// No modal border in the popup, so the content may use the full pty width
+		// (lipgloss Width excludes the border the popup frame already draws).
+		return clampInt(m.width, 40, 106)
 	}
 	return clampInt(m.width-12, 40, 104)
 }

--- a/internal/tui/newpane_assign.go
+++ b/internal/tui/newpane_assign.go
@@ -374,5 +374,5 @@ func (m model) newPaneAssignView() string {
 	case !a.loading:
 		lines = append(lines, dimStyle.Render("enter launch  ←/→ agent  ↑/↓ row  esc back"))
 	}
-	return modalStyle.Width(m.modalWidth()).Render(strings.Join(lines, "\n"))
+	return m.renderNewPaneModal(strings.Join(lines, "\n"))
 }

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -24,6 +24,10 @@ var (
 	errStyle   = lipgloss.NewStyle().Foreground(colorBeni)
 	panelStyle = lipgloss.NewStyle().Border(lipgloss.NormalBorder(), true, false, false, false).BorderForeground(colorSuna)
 	modalStyle = lipgloss.NewStyle().Border(lipgloss.NormalBorder()).Padding(1, 2).BorderForeground(colorAsagi)
+	// popupContentStyle drops the modal border when the popup runs inside a tmux
+	// display-popup: the popup frame is the only border, so the content only
+	// keeps a 1-column left/right gutter.
+	popupContentStyle = lipgloss.NewStyle().Padding(0, 1)
 	// inputBoxStyle / inputBoxFocusStyle frame the modal's text inputs so the
 	// field bounds are visible; the border color also doubles as a focus cue.
 	inputBoxStyle      = lipgloss.NewStyle().Border(lipgloss.NormalBorder()).BorderForeground(colorSuna)

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 
 	"github.com/butaosuinu/fanout/internal/exitcode"
 	"github.com/butaosuinu/fanout/internal/ghissue"
@@ -3218,5 +3219,52 @@ func TestMergeDegradedIssueStatusKeepsWaveOfUnblockedPrevious(t *testing.T) {
 	want := issueStatus{Title: "child", State: "OPEN", Wave: 2, WaveLabel: "wave2", Blockers: "-", WaveDegraded: true}
 	if !reflect.DeepEqual(got[key], want) {
 		t.Fatalf("merged = %#v, want %#v", got[key], want)
+	}
+}
+
+// The tmux display-popup already frames the prompt-only popup, so its content
+// must drop the modal border and the duplicate "New agent pane" heading and use
+// the full pty width.
+func TestNewPanePromptOnlyViewFillsPopupWithoutModalFrame(t *testing.T) {
+	m := newModel(Options{})
+	m.promptOnly = true
+	m.width = 88
+	m.height = 18
+	m.openNewPaneForm()
+
+	view := m.View()
+	// Only the Prompt input box is framed; the modal outer border is gone.
+	if got := strings.Count(view, "┌"); got != 1 {
+		t.Fatalf("framed input boxes: got %d top-left corners, want 1:\n%s", got, view)
+	}
+	if strings.Contains(view, "New agent pane") {
+		t.Fatalf("popup view should not repeat the tmux -T title:\n%s", view)
+	}
+	if got := lipgloss.Width(view); got != 88 {
+		t.Fatalf("lipgloss.Width(view) = %d, want 88:\n%s", got, view)
+	}
+}
+
+// The assign step of the prompt-only popup must also drop the modal border while
+// keeping its "Assign agents" heading (that heading is step-2 information, not
+// the popup title).
+func TestNewPanePromptOnlyAssignViewDropsModalFrame(t *testing.T) {
+	m := newModel(Options{})
+	m.promptOnly = true
+	m.width = 88
+	m.height = 18
+	m.openNewPaneForm()
+	m.newPane.step = newPaneStepAssign
+	m.newPane.assign = assignState{
+		title: "#100 parent",
+		rows:  []assignRow{{target: "101", label: "#101 child", agentIdx: 0}},
+	}
+
+	view := m.View()
+	if got := strings.Count(view, "┌"); got != 0 {
+		t.Fatalf("assign view should be borderless in the popup: got %d top-left corners:\n%s", got, view)
+	}
+	if !strings.Contains(view, "Assign agents") {
+		t.Fatalf("assign view missing its heading:\n%s", view)
 	}
 }


### PR DESCRIPTION
## 概要

New agent pane の tmux display-popup は、外枠 (tmux `display-popup -T "New agent pane"` 自身の枠) と内枠 (lipgloss `modalStyle`) の二重描画になっていた。tmux 枠を唯一の枠として残し、popup 子プロセス (`promptOnly`) では内枠と重複タイトルを消してコンテンツを pty 幅いっぱいに広げる。インプロセス表示 (オーバーレイ) の見た目は従来どおり。

## 変更点

- `internal/tui/styles.go`: 枠なし・左右 1 桁余白の `popupContentStyle` (`Padding(0, 1)`) を追加。
- `internal/tui/newpane.go`:
  - `renderNewPaneModal` ヘルパーを新設 — `promptOnly` なら `popupContentStyle`、それ以外は従来 `modalStyle` で描画。
  - `newPaneView()` のタイトル行を `promptOnly` のとき出さない (tmux の `-T` タイトルと重複するため)。
  - `modalWidth()` の `promptOnly` 分岐を `clampInt(m.width-2, 40, 104)` → `clampInt(m.width, 40, 106)` に変更 (lipgloss の `Width` は border を含まないため、枠が消えた分 pty 幅を使い切る)。
- `internal/tui/newpane_assign.go`: assign step (step 2) の描画も `renderNewPaneModal` に差し替え。"Assign agents" 見出しは step 2 の情報なので `promptOnly` でも残す。
- `internal/tmuxrun` と `cmd/fanout` の geometry (`PromptWidth = Popup - 2` の inset) は変更なし。

## テスト

- 新規: `TestNewPanePromptOnlyViewFillsPopupWithoutModalFrame` (popup は Prompt 枠のみで `┌` が 1 個、"New agent pane" を含まない、`lipgloss.Width(view) == 88`)、`TestNewPanePromptOnlyAssignViewDropsModalFrame` (assign step で `┌` が 0 個かつ "Assign agents" を含む)。
- 既存の回帰ガード (`TestNewPaneViewRendersModalOverMonitor` / `TestNewPaneViewFramesTextInputs` / `TestNewPaneViewRendersCJKPromptInsideFrame`) は無修正で通過。
- `make lint` (0 issues) / `make test` (exit 0) green。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQ9SicrzZkEN589ySbZGzU