### PR TITLE
feat(tui): AgentState 表示(agentStateGlyph / RUN 列 / 詳細 run=)

### DIFF
--- a/docs/tui-compact-switcher.ja.md
+++ b/docs/tui-compact-switcher.ja.md
@@ -4,7 +4,7 @@
 
 ## 問題: 40 桁サイドバーで一覧が読めない
 
-agent ペインを作ると auto-layout が TUI コンソールペインを幅 40 桁の左サイドバーに固定する(`internal/panelayout/layout.go` の `SidebarWidthDefault = 40`)。一方 TUI の一覧は bubbles table の 14 列で、列幅の合計は最小でも約 124 桁ある(`internal/tui/paneview.go` の `columnsForWidth`)。幅 40 では先頭の PARENT・ISSUE・WAVE あたりまでしか入らず、NAME・AGENT・STATE・PR・CI・BRANCH・PANE(ペイン ID)は画面外になる。fanout の主運用形態(コンソール + agent グリッド)で、コンソールの一覧はほぼ読めない。
+agent ペインを作ると auto-layout が TUI コンソールペインを幅 40 桁の左サイドバーに固定する(`internal/panelayout/layout.go` の `SidebarWidthDefault = 40`)。一方 TUI の一覧は bubbles table の 15 列で、列幅の合計は最小でも約 129 桁ある(`internal/tui/paneview.go` の `columnsForWidth`)。幅 40 では先頭の PARENT・ISSUE・WAVE あたりまでしか入らず、NAME・AGENT・STATE・PR・CI・BRANCH・PANE(ペイン ID)は画面外になる。fanout の主運用形態(コンソール + agent グリッド)で、コンソールの一覧はほぼ読めない。
 
 レイアウト分岐(`internal/tui/view.go` の `monitorLayout`)は、幅 120 以上で Session サイドバー、それ未満はトップストリップ、高さが足りないときはストリップ自体を落とす、の 3 通りある。ただしどの分岐でもテーブル + 固定 13 行の詳細という形は変わらず、狭い幅で表示形態そのものを切り替える仕組みがない。
 

--- a/internal/tui/focus.go
+++ b/internal/tui/focus.go
@@ -64,7 +64,7 @@ func (m model) detailContent() string {
 	}
 	lines := []string{
 		fmt.Sprintf("%s %s  %s", pane.Parent, pane.itemLabel(), pane.Name),
-		fmt.Sprintf("pane=%s tmux=%s title=%s kind=%s agent=%s", dash(pane.PaneID), pane.TmuxState, dash(pane.TmuxTitle), dash(pane.Kind), dash(pane.Agent)),
+		fmt.Sprintf("pane=%s tmux=%s title=%s kind=%s agent=%s run=%s", dash(pane.PaneID), pane.TmuxState, dash(pane.TmuxTitle), dash(pane.Kind), dash(pane.Agent), dash(pane.AgentState)),
 		fmt.Sprintf("issue=%s pr=%s ci=%s branch=%s", dash(pane.IssueState), dash(pane.PRSummary), dash(pane.CIStatus), dash(pane.BranchName)),
 		fmt.Sprintf("wave=%s blockers=%s", dash(pane.waveText()), dash(pane.Blockers)),
 		fmt.Sprintf("worktree=%s diff=%s dirty=%s", dash(pane.WorktreePath), dash(pane.DiffSummary), dash(pane.DirtyState)),
@@ -185,12 +185,14 @@ func (m *model) markPaneStale(paneID string) {
 	for i := range m.allPanes {
 		if m.allPanes[i].PaneID == paneID {
 			m.allPanes[i].TmuxState = "stale"
+			m.allPanes[i].AgentState = ""
 			break
 		}
 	}
 	for i := range m.panes {
 		if m.panes[i].PaneID == paneID {
 			m.panes[i].TmuxState = "stale"
+			m.panes[i].AgentState = ""
 			return
 		}
 	}

--- a/internal/tui/issues.go
+++ b/internal/tui/issues.go
@@ -373,11 +373,11 @@ func normalizedParent(parent string) string {
 	return strconv.Itoa(parentNum)
 }
 
-func buildPaneViews(panes []state.Pane, tmuxPanes []tmuxrun.PaneInfo, tmuxKnown bool, issues map[issueKey]issueStatus, worktrees map[string]worktreeStatView) []paneView {
+func buildPaneViews(panes []state.Pane, tmuxPanes []tmuxrun.LivePane, tmuxKnown bool, issues map[issueKey]issueStatus, worktrees map[string]worktreeStatView) []paneView {
 	const projectRoot = "/repo"
 	live := map[string]sessionview.LivePaneInfo{}
 	for _, pane := range tmuxPanes {
-		live[pane.ID] = sessionview.LivePaneInfo{Path: matchingWorktreePath(pane.ID, panes), Title: pane.Title}
+		live[pane.ID] = sessionview.LivePaneInfo{Path: matchingWorktreePath(pane.ID, panes), Title: pane.Title, AgentState: pane.AgentState}
 	}
 	liveCollector := func() (map[string]sessionview.LivePaneInfo, error) {
 		if !tmuxKnown {

--- a/internal/tui/paneview.go
+++ b/internal/tui/paneview.go
@@ -63,6 +63,38 @@ type hudSummary struct {
 	Blocked int
 }
 
+// agentStateGlyphs は @fanout_agent_state の値ごとの表示グリフ。5 値化
+// (docs/competitive-herdr.ja.md 提案 A)に備え working / idle / blocked を
+// 先行定義しており、5 値化時は sessionview の normalizeAgentState の許可リスト
+// 拡張だけで表示側の変更はゼロになる。
+var agentStateGlyphs = map[string]string{
+	"running": "●",
+	"done":    "✓",
+	"working": "◐",
+	"idle":    "○",
+	"blocked": "◆",
+}
+
+// agentStateGlyph はグリフの単一情報源。入力は AgentState と TmuxState のみで、
+// ペイン内容(capture-pane)からの状態推定はしない。stale ペインと pane 記録の
+// ない行の AgentState は残骸なので、map より先に弾く。tmux degraded
+// ("unknown")では state.json の記録値が最善情報としてそのまま出る。
+func agentStateGlyph(p paneView) string {
+	switch p.TmuxState {
+	case "stale":
+		return "✗"
+	case "-":
+		return "-"
+	}
+	if g, ok := agentStateGlyphs[p.AgentState]; ok {
+		return g
+	}
+	if p.TmuxState == "live" {
+		return "·"
+	}
+	return "-"
+}
+
 func (p paneView) tableRow() table.Row {
 	tmuxState := p.TmuxState
 	if tmuxState == "stale" {
@@ -75,6 +107,7 @@ func (p paneView) tableRow() table.Row {
 		truncate(dash(p.Blockers), 22),
 		truncate(p.Name, 28),
 		dash(p.Agent),
+		agentStateGlyph(p),
 		tmuxState,
 		dash(p.IssueState),
 		truncate(dash(p.PRSummary), 12),
@@ -132,6 +165,7 @@ func columnsForWidth(width int) []table.Column {
 		{Title: "BLOCKERS", Width: blockerWidth},
 		{Title: "NAME", Width: nameWidth},
 		{Title: "AGENT", Width: 7},
+		{Title: "RUN", Width: 5},
 		{Title: "TMUX", Width: 7},
 		{Title: "STATE", Width: 8},
 		{Title: "PR", Width: 12},

--- a/internal/tui/paneview_test.go
+++ b/internal/tui/paneview_test.go
@@ -1,0 +1,67 @@
+package tui
+
+import "testing"
+
+// TestAgentStateGlyph pins the glyph mapping that both the RUN column and the
+// future compact switcher render from (docs/tui-compact-switcher.ja.md 状態グリフ).
+func TestAgentStateGlyph(t *testing.T) {
+	tests := []struct {
+		name string
+		pane paneView
+		want string
+	}{
+		{name: "running live pane", pane: paneView{TmuxState: "live", AgentState: "running"}, want: "●"},
+		{name: "done live pane", pane: paneView{TmuxState: "live", AgentState: "done"}, want: "✓"},
+		// 5 値化(competitive-herdr.ja.md 提案 A)の先行定義。
+		{name: "working is pre-mapped", pane: paneView{TmuxState: "live", AgentState: "working"}, want: "◐"},
+		{name: "idle is pre-mapped", pane: paneView{TmuxState: "live", AgentState: "idle"}, want: "○"},
+		{name: "blocked is pre-mapped", pane: paneView{TmuxState: "live", AgentState: "blocked"}, want: "◆"},
+		{name: "live pane without state", pane: paneView{TmuxState: "live"}, want: "·"},
+		{name: "live pane with unknown state value", pane: paneView{TmuxState: "live", AgentState: "garbage"}, want: "·"},
+		{name: "stale pane", pane: paneView{TmuxState: "stale"}, want: "✗"},
+		// 死んだペインに残った状態値は残骸: stale が勝つ。
+		{name: "stale wins over leftover done", pane: paneView{TmuxState: "stale", AgentState: "done"}, want: "✗"},
+		{name: "no recorded pane", pane: paneView{TmuxState: "-"}, want: "-"},
+		// pane 記録なし + degraded fallback の記録値: pane が無い以上 running とは出さない。
+		{name: "no recorded pane ignores leftover state", pane: paneView{TmuxState: "-", AgentState: "running"}, want: "-"},
+		// tmux degraded 時は state.json の記録値が fallback で入る。
+		{name: "degraded tmux keeps recorded state", pane: paneView{TmuxState: "unknown", AgentState: "running"}, want: "●"},
+		{name: "degraded tmux without state", pane: paneView{TmuxState: "unknown"}, want: "-"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := agentStateGlyph(tt.pane); got != tt.want {
+				t.Errorf("agentStateGlyph(%+v) = %q, want %q", tt.pane, got, tt.want)
+			}
+		})
+	}
+}
+
+// columnIndex resolves a table column position by title so tests do not
+// hardcode indexes that shift when columns are inserted.
+func columnIndex(t *testing.T, title string) int {
+	t.Helper()
+	for i, c := range columnsForWidth(120) {
+		if c.Title == title {
+			return i
+		}
+	}
+	t.Fatalf("columnsForWidth(120) has no %q column", title)
+	return -1
+}
+
+// TestTableRowMatchesColumns guards tableRow and columnsForWidth against
+// drifting apart when columns are added or reordered.
+func TestTableRowMatchesColumns(t *testing.T) {
+	columns := columnsForWidth(120)
+	row := paneView{TmuxState: "live", AgentState: "running"}.tableRow()
+	if len(row) != len(columns) {
+		t.Fatalf("len(tableRow()) = %d, len(columnsForWidth(120)) = %d, want equal", len(row), len(columns))
+	}
+	if got := row[columnIndex(t, "RUN")]; got != "●" {
+		t.Fatalf("RUN cell = %q, want ●", got)
+	}
+	if idx, agentIdx := columnIndex(t, "RUN"), columnIndex(t, "AGENT"); idx != agentIdx+1 {
+		t.Fatalf("RUN column index = %d, want %d (next to AGENT)", idx, agentIdx+1)
+	}
+}

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -57,8 +57,8 @@ func TestBuildPaneViewsMergesStateTmuxAndIssueStatuses(t *testing.T) {
 			WorktreePath: "/repo/.fanout/worktrees/first",
 		},
 	}
-	tmuxPanes := []tmuxrun.PaneInfo{
-		{ID: "%2", Title: "running title"},
+	tmuxPanes := []tmuxrun.LivePane{
+		{ID: "%2", Title: "running title", AgentState: "running"},
 	}
 	issues := map[issueKey]issueStatus{
 		{Parent: "200", Num: 2}: {
@@ -90,6 +90,9 @@ func TestBuildPaneViewsMergesStateTmuxAndIssueStatuses(t *testing.T) {
 	}
 	if second.TmuxState != "live" || second.TmuxTitle != "running title" {
 		t.Fatalf("tmux = %q/%q, want live/running title", second.TmuxState, second.TmuxTitle)
+	}
+	if second.AgentState != "running" {
+		t.Fatalf("AgentState = %q, want running forwarded from live pane", second.AgentState)
 	}
 	if second.IssueState != "CLOSED" || second.PRSummary != "#12 merged" || second.CIStatus != "pass" {
 		t.Fatalf("issue/pr/ci = %q/%q/%q, want CLOSED/#12 merged/pass", second.IssueState, second.PRSummary, second.CIStatus)
@@ -1187,7 +1190,7 @@ func TestFocusSelectedPaneMarksDeadPaneStale(t *testing.T) {
 		},
 		PaneAlive: func(string) bool { return false },
 	})
-	m.allPanes = []paneView{{IssueNum: 1, Name: "one", PaneID: "%1", TmuxState: "live"}}
+	m.allPanes = []paneView{{IssueNum: 1, Name: "one", PaneID: "%1", TmuxState: "live", AgentState: "running"}}
 	m.refreshRows()
 
 	cmd := m.focusSelectedCmd()
@@ -1204,8 +1207,24 @@ func TestFocusSelectedPaneMarksDeadPaneStale(t *testing.T) {
 	if m.panes[0].TmuxState != "stale" {
 		t.Fatalf("TmuxState = %q, want stale", m.panes[0].TmuxState)
 	}
-	if got := m.table.Rows()[0][6]; got != "stale!" {
+	if m.panes[0].AgentState != "" {
+		t.Fatalf("AgentState = %q, want cleared on stale", m.panes[0].AgentState)
+	}
+	if got := m.table.Rows()[0][columnIndex(t, "TMUX")]; got != "stale!" {
 		t.Fatalf("table tmux cell = %q, want stale!", got)
+	}
+	if got := m.table.Rows()[0][columnIndex(t, "RUN")]; got != "✗" {
+		t.Fatalf("table run cell = %q, want ✗", got)
+	}
+}
+
+func TestDetailContentShowsAgentState(t *testing.T) {
+	m := newModel(Options{})
+	m.allPanes = []paneView{{IssueNum: 1, Name: "one", PaneID: "%1", TmuxState: "live", AgentState: "running"}}
+	m.refreshRows()
+
+	if got := m.detailContent(); !strings.Contains(got, "run=running") {
+		t.Fatalf("detailContent() = %q, want run=running", got)
 	}
 }
 


### PR DESCRIPTION
## TL;DR

`@fanout_agent_state`(running / done)を TUI に表示する。グリフの単一情報源 `agentStateGlyph` を新設し、フルテーブルに RUN 列(AGENT の隣)、詳細ビューに `run=` フィールドを追加した。5 値化(competitive-herdr.ja.md 提案 A)に備えて working / idle / blocked のグリフも先行定義済み。

Review effort: 2

## Why

Issue #384 のとおり、`@fanout_agent_state` は sessionview から TUI まで届いているのに一覧にも詳細にも表示されず、`run:` フィルタでしか使えなかった。agent の稼働状態を一目で判別できるようにし、compact switcher(#387, wave2)が使うグリフの単一情報源を先に用意する。

## Changes by file

<details><summary>Changed files</summary>

| File | What changed | Why |
|---|---|---|
| `internal/tui/paneview.go` | `agentStateGlyphs` map と `agentStateGlyph` を新設(paneview.go:66-96)。`columnsForWidth` に RUN 列(index 6、AGENT の隣)を追加して 15 列化、`tableRow` に対応セルを挿入 | グリフの単一情報源と一覧表示。stale(`✗`)と pane 記録なし行(`-`)は残骸の AgentState より優先 |
| `internal/tui/focus.go` | `detailContent` line 1 に `run=` を追加(focus.go:67)。`markPaneStale` が AgentState もクリア(focus.go:188-199) | 詳細表示。ペイン死亡検知時にテーブル `✗` / 詳細 `run=running` の矛盾と `run:running` フィルタの誤マッチを防ぐ |
| `internal/tui/issues.go` | テストハーネス `buildPaneViews` の入力型を `tmuxrun.PaneInfo` → `tmuxrun.LivePane` に変更し AgentState を転送(issues.go:376-381) | production と同じ型で集約経路を通し、RUN 表示をテスト可能にする(旧 adapter は AgentState を暗黙に捨てていた) |
| `internal/tui/paneview_test.go` | 新規: `TestAgentStateGlyph`(グリフマッピングの pin)、`TestTableRowMatchesColumns`(列数パリティ + RUN 位置)、`columnIndex` ヘルパー | 受け入れ条件のテスト pin。列 index のハードコードを title 解決に置き換え |
| `internal/tui/tui_test.go` | stale テストに AgentState クリアと RUN `✗` の assert を追加、セル参照を `columnIndex` 化、`detailContent` の `run=` テストを追加 | RUN 列挿入による index シフト対応と新挙動の pin |
| `docs/tui-compact-switcher.ja.md` | 問題節の列数・桁数を 15 列 / 約 129 桁に追従(2 数値のみ) | RUN 列追加で正典 doc の現状記述が古くなるため |

</details>

> [!WARNING]
> グリフ(`●` `✓` `✗` `·` `◐` `○` `◆`)は East Asian Ambiguous 幅の文字で、ambiguous-width を全角描画する端末設定では RUN セルの見かけ幅が go-runewidth の計算とずれ、行内の列がずれる可能性がある。グリフ自体は正典 `docs/tui-compact-switcher.ja.md`「状態グリフ」節の規定どおり。

## Test plan

- `make lint` — 0 issues
- `make test` — Go unit + web vitest + bats Tier 1/2 すべて green(Tier 2 golden への影響なし — TUI は dry-run 出力に出ない)
- `/code-review`(xhigh workflow)で 6 指摘 → correctness 2 件 + cleanup 2 件を修正、グリフ幅(正典規定)とシグネチャ変更(issue が `agentStateGlyph(p paneView)` を明示)は見送り
- codex review — "I did not find any correctness issues introduced by this diff."

Closes #384

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P3U73g2deTKjUu2VMij7pa