### PR TITLE
TUI dashboard 起動結果を status line に表示

### DIFF
--- a/cmd/fanout/dashboard.go
+++ b/cmd/fanout/dashboard.go
@@ -38,7 +38,7 @@ const defaultWorktreeActionKey = "M"
 var (
 	openDashboardBrowser = openBrowser
 	showDashboardStatus  = func(msg string) error {
-		return tmuxctl.DisplayMessage(os.Getenv(tmuxrun.DashboardNotifyTargetEnv), msg)
+		return tmuxctl.DisplayMessageToClient(os.Getenv(tmuxrun.DashboardNotifyClientEnv), msg)
 	}
 	openBrowserWaitPeriod = 2 * time.Second
 )

--- a/cmd/fanout/dashboard.go
+++ b/cmd/fanout/dashboard.go
@@ -20,6 +20,7 @@ import (
 	"github.com/butaosuinu/fanout/internal/log"
 	"github.com/butaosuinu/fanout/internal/sessionview"
 	"github.com/butaosuinu/fanout/internal/settings"
+	"github.com/butaosuinu/fanout/internal/tmuxctl"
 	"github.com/butaosuinu/fanout/internal/tmuxrun"
 	"github.com/butaosuinu/fanout/internal/worktree"
 )
@@ -33,6 +34,14 @@ const defaultDashboardDirectKey = "F12"
 // defaultWorktreeActionKey is the tmux prefix key fanout binds to open the
 // focused pane's same-worktree action popup.
 const defaultWorktreeActionKey = "M"
+
+var (
+	openDashboardBrowser = openBrowser
+	showDashboardStatus  = func(msg string) error {
+		return tmuxctl.DisplayMessage(os.Getenv(tmuxrun.DashboardNotifyTargetEnv), msg)
+	}
+	openBrowserWaitPeriod = 2 * time.Second
+)
 
 type dashboardFlags struct {
 	port      int
@@ -316,8 +325,17 @@ func fileExists(path string) bool {
 }
 
 func openBrowserBestEffort(url string, lg *log.Logger) {
-	if err := openBrowser(url); err != nil {
+	if err := openDashboardBrowser(url); err != nil {
 		lg.Warn("dashboard: could not open browser (%v); visit %s manually", err, url)
+		showDashboardStatusBestEffort("fanout dashboard: browser open failed; visit "+url, lg)
+		return
+	}
+	showDashboardStatusBestEffort("fanout dashboard: "+url, lg)
+}
+
+func showDashboardStatusBestEffort(msg string, lg *log.Logger) {
+	if err := showDashboardStatus(msg); err != nil {
+		lg.Debug("dashboard status line: %v", err)
 	}
 }
 
@@ -334,10 +352,14 @@ func openBrowser(url string) error {
 	if err := cmd.Start(); err != nil {
 		return err
 	}
-	// Reap the opener: it exits almost immediately, but without Wait it would
-	// linger as a zombie for the (long) lifetime of the dashboard process.
-	go func() { _ = cmd.Wait() }()
-	return nil
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(openBrowserWaitPeriod):
+		return nil
+	}
 }
 
 func randomToken() (string, error) {

--- a/cmd/fanout/dashboard_test.go
+++ b/cmd/fanout/dashboard_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"errors"
+	"strings"
 	"testing"
 
 	"github.com/butaosuinu/fanout/internal/log"
@@ -72,6 +74,32 @@ func TestNoKeybindOverride(t *testing.T) {
 	}
 	if v := noKeybindOverride(true); v == nil || *v != false {
 		t.Fatalf("--no-keybind -> *false, got %v", v)
+	}
+}
+
+func TestOpenBrowserBestEffortShowsDashboardURL(t *testing.T) {
+	browser, status := stubDashboardOpenHooks(t, nil)
+
+	openBrowserBestEffort("http://127.0.0.1:1234/?token=abc", discardLogger())
+
+	if browser.openedURL != "http://127.0.0.1:1234/?token=abc" {
+		t.Fatalf("opened URL = %q", browser.openedURL)
+	}
+	if got := status.message; !strings.Contains(got, "fanout dashboard: http://127.0.0.1:1234/?token=abc") {
+		t.Fatalf("status message = %q", got)
+	}
+}
+
+func TestOpenBrowserBestEffortShowsOpenFailure(t *testing.T) {
+	browser, status := stubDashboardOpenHooks(t, errors.New("launcher unavailable"))
+
+	openBrowserBestEffort("http://127.0.0.1:4321/?token=def", discardLogger())
+
+	if browser.openedURL != "http://127.0.0.1:4321/?token=def" {
+		t.Fatalf("opened URL = %q", browser.openedURL)
+	}
+	if got := status.message; !strings.Contains(got, "browser open failed") || !strings.Contains(got, "http://127.0.0.1:4321/?token=def") {
+		t.Fatalf("status message = %q", got)
 	}
 }
 
@@ -155,4 +183,33 @@ func TestRandomTokenIsHexAndUnique(t *testing.T) {
 	if len(a) != 32 || a == b {
 		t.Fatalf("token a=%q b=%q (want 32 hex chars, unique)", a, b)
 	}
+}
+
+type dashboardBrowserStub struct {
+	openedURL string
+}
+
+type dashboardStatusStub struct {
+	message string
+}
+
+func stubDashboardOpenHooks(t *testing.T, browserErr error) (*dashboardBrowserStub, *dashboardStatusStub) {
+	t.Helper()
+	oldBrowser := openDashboardBrowser
+	oldStatus := showDashboardStatus
+	browser := &dashboardBrowserStub{}
+	status := &dashboardStatusStub{}
+	openDashboardBrowser = func(url string) error {
+		browser.openedURL = url
+		return browserErr
+	}
+	showDashboardStatus = func(msg string) error {
+		status.message = msg
+		return nil
+	}
+	t.Cleanup(func() {
+		openDashboardBrowser = oldBrowser
+		showDashboardStatus = oldStatus
+	})
+	return browser, status
 }

--- a/cmd/fanout/tui_test.go
+++ b/cmd/fanout/tui_test.go
@@ -58,10 +58,10 @@ func TestCmdTUIRegistersDashboardKeybinds(t *testing.T) {
 	}
 
 	log := readTUITmuxLog(t, argsPath)
-	if !tmuxLogHasCommand(log, "bind-key\nD\nnew-window") {
+	if !tmuxLogHasCommand(log, "bind-key\nD\nrun-shell") {
 		t.Fatalf("tmux log missing prefix dashboard keybind:\n%s", log)
 	}
-	if !tmuxLogHasCommand(log, "bind-key\n-n\nF12\nnew-window") {
+	if !tmuxLogHasCommand(log, "bind-key\n-n\nF12\nrun-shell") {
 		t.Fatalf("tmux log missing direct dashboard keybind:\n%s", log)
 	}
 }
@@ -119,7 +119,7 @@ func TestCmdTUINoDashboardKeybindHonorsEnv(t *testing.T) {
 
 func TestCmdTUINoDashboardKeybindKeepsConsoleKeybind(t *testing.T) {
 	// The other direction of toggle independence: disabling the dashboard
-	// keybind alone must suppress the new-window dashboard binds without
+	// keybind alone must suppress the fanout-dashboard binds without
 	// taking the console-return registration down with it.
 	repo := t.TempDir()
 	initTUITestGitRepo(t, repo)
@@ -139,7 +139,7 @@ func TestCmdTUINoDashboardKeybindKeepsConsoleKeybind(t *testing.T) {
 	}
 
 	log := readTUITmuxLog(t, argsPath)
-	if tmuxLogHasCommand(log, "new-window") {
+	if tmuxLogHasCommand(log, "fanout-dashboard") {
 		t.Fatalf("tmux log should not contain dashboard keybinds when disabled:\n%s", log)
 	}
 	if !tmuxLogHasCommand(log, "bind-key\n-n\nF11\nrun-shell") {
@@ -168,10 +168,12 @@ func TestCmdTUINoConsoleKeybindHonorsEnv(t *testing.T) {
 	}
 
 	log := readTUITmuxLog(t, argsPath)
-	if tmuxLogHasCommand(log, "run-shell") {
+	if tmuxLogHasCommand(log, "focus-console") ||
+		tmuxLogHasCommand(log, "bind-key\nT\nrun-shell") ||
+		tmuxLogHasCommand(log, "bind-key\n-n\nF11\nrun-shell") {
 		t.Fatalf("tmux log should not contain console keybinds when disabled:\n%s", log)
 	}
-	if !tmuxLogHasCommand(log, "bind-key\nD\nnew-window") {
+	if !tmuxLogHasCommand(log, "bind-key\nD\nrun-shell") {
 		t.Fatalf("tmux log missing dashboard keybind (must stay registered):\n%s", log)
 	}
 }

--- a/docs/tui-compact-switcher.ja.md
+++ b/docs/tui-compact-switcher.ja.md
@@ -63,7 +63,7 @@ bubbles table は捨てず、compact 時は `View()` の分岐でレンダリン
 
 ### コンソール復帰キー(F11 / prefix T)
 
-dashboard(`BindDashboardKeys`、F12 / prefix D)と同じく、tmux server にキーを登録して fanout バイナリを叩く方式で、root `F11` + prefix `T` を登録する(`internal/tmuxrun` に `BindConsoleKeys` を追加)。ただしバインドの形は dashboard と同じにはならない。dashboard は `new-window` にコマンドを直接渡し、シェル 1 段・クォート 1 段で済ませている(`BindDashboardKeys` のコメントが run-shell ラッパーの二重クォートを退けた判断を記録している)が、console 復帰でウィンドウを作るわけにはいかない。そこで `run-shell '<fanout-bin> focus-console --from "#{pane_id}"'` を使う。シェルは run-shell の 1 段だけで、バインド登録自体は argv 渡し(`exec.Command`)だから、クォートはバイナリパスの `shellQuote` 1 回で済む。`#{pane_id}` は押下時展開で `%N` 形式の安全な文字集合。スペース入りインストールパスの扱いは dashboard と同様にテストで pin する(`TestBindDashboardKeyQuotesBinaryPathWithSpaces` が雛形)。
+dashboard(`BindDashboardKeys`、F12 / prefix D)と同じく、tmux server にキーを登録して fanout バイナリを叩く方式で、root `F11` + prefix `T` を登録する(`internal/tmuxrun` に `BindConsoleKeys` を追加)。ただしバインドの形は dashboard と同じにはならない。dashboard は tmux 3.3 互換の `run-shell` で押下時の tmux format を展開し、`tmux -S #{q:socket_path} new-window -t #{q:session_id}:` で押下元の socket/session に detached window を作る。project root/current path の各分岐は `#{q:...}` で shell quote して `new-window -c` へ、`#{client_tty}` は `new-window -e` へ渡す。一方、console 復帰でウィンドウを作るわけにはいかない。そこで `run-shell '<fanout-bin> focus-console --from "#{pane_id}"'` を使う。シェルは run-shell の 1 段だけで、バインド登録自体は argv 渡し(`exec.Command`)だから、クォートはバイナリパスの `shellQuote` 1 回で済む。`#{pane_id}` は押下時展開で `%N` 形式の安全な文字集合。スペース入りインストールパスの扱いは dashboard と同様にテストで pin する。
 
 pane id をバインドに焼き込む方式は、コンソール再起動で stale になり複数リポジトリの登録が上書き合戦になるため採らない。バイナリ経由なら押下のたびに探索するので、コンソールが作り直されてもバインドは古びない。
 

--- a/internal/tmuxctl/tmuxctl_test.go
+++ b/internal/tmuxctl/tmuxctl_test.go
@@ -31,6 +31,30 @@ func TestDisplayMessageUsesTmuxStatusLine(t *testing.T) {
 	}
 }
 
+func TestDisplayMessageToClientTargetsClientStatusLine(t *testing.T) {
+	dir := t.TempDir()
+	argsPath := filepath.Join(dir, "args")
+	tmuxPath := filepath.Join(dir, "tmux")
+	script := "#!/bin/sh\nprintf '%s\\n' \"$@\" > " + shellQuote(argsPath) + "\n"
+	if err := os.WriteFile(tmuxPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write tmux shim: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if err := DisplayMessageToClient("/dev/ttys001", "fanout: #(touch /tmp/pwned)"); err != nil {
+		t.Fatalf("DisplayMessageToClient: %v", err)
+	}
+	data, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatalf("read args: %v", err)
+	}
+	got := strings.Split(strings.TrimSpace(string(data)), "\n")
+	want := []string{"display-message", "-c", "/dev/ttys001", "fanout: ##(touch /tmp/pwned)"}
+	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("tmux args = %#v, want %#v", got, want)
+	}
+}
+
 func shellQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
 }

--- a/internal/tmuxrun/tmuxrun.go
+++ b/internal/tmuxrun/tmuxrun.go
@@ -12,11 +12,12 @@ import (
 )
 
 const (
-	MinimumVersion      = "3.3"
-	userShellExpr       = `"${SHELL:-/bin/sh}"`
-	paneListFormat      = "#{pane_id}:#{window_id}:#{pane_index}:#{pane_active}:#{pane_title}"
-	livePanePathFormat  = "#{pane_id}\t#{pane_current_path}"
-	livePaneTitleFormat = "#{pane_id}\t#{pane_title}"
+	MinimumVersion           = "3.3"
+	DashboardNotifyTargetEnv = "FANOUT_DASHBOARD_NOTIFY_TARGET"
+	userShellExpr            = `"${SHELL:-/bin/sh}"`
+	paneListFormat           = "#{pane_id}:#{window_id}:#{pane_index}:#{pane_active}:#{pane_title}"
+	livePanePathFormat       = "#{pane_id}\t#{pane_current_path}"
+	livePaneTitleFormat      = "#{pane_id}\t#{pane_title}"
 	// agentStateOption is a tmux pane user option the BuildPaneLaunchCommand
 	// wrapper sets to "running" before the agent starts and "done" after it
 	// exits. It is the dashboard's agent-state signal: #{pane_current_command}
@@ -510,7 +511,7 @@ func BindDashboardKeys(prefixKey, directKey, fanoutBin string) error {
 	if strings.TrimSpace(prefixKey) == "" || strings.TrimSpace(directKey) == "" || strings.TrimSpace(fanoutBin) == "" {
 		return fmt.Errorf("tmux bind-key: prefix key, direct key, and fanout binary path are required")
 	}
-	launch := shellQuote(fanoutBin) + " dashboard --web --open"
+	launch := DashboardNotifyTargetEnv + "=#{pane_id} " + shellQuote(fanoutBin) + " dashboard --web --open"
 	startDir := "#{?@fanout_project_root,#{@fanout_project_root},#{pane_current_path}}"
 	prefixArgs := []string{
 		"bind-key", prefixKey, "new-window", "-d", "-n", "fanout-dashboard",

--- a/internal/tmuxrun/tmuxrun.go
+++ b/internal/tmuxrun/tmuxrun.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	MinimumVersion           = "3.3"
-	DashboardNotifyTargetEnv = "FANOUT_DASHBOARD_NOTIFY_TARGET"
+	DashboardNotifyClientEnv = "FANOUT_DASHBOARD_NOTIFY_CLIENT"
 	userShellExpr            = `"${SHELL:-/bin/sh}"`
 	paneListFormat           = "#{pane_id}:#{window_id}:#{pane_index}:#{pane_active}:#{pane_title}"
 	livePanePathFormat       = "#{pane_id}\t#{pane_current_path}"
@@ -485,20 +485,27 @@ func parseLivePaneField(out string) map[string]string {
 // BindDashboardKeys registers tmux key bindings that open the read-only web
 // dashboard. The prefix key is bound under the prefix table; the direct key is
 // bound in the root table so it works without tmux's prefix. Both bindings run
-// the same launch command directly through `new-window`
-// (not run-shell), so:
+// the same `run-shell` wrapper, so:
 //
-//   - tmux expands @fanout_project_root (when fanout recorded it on the pane)
-//     or `#{pane_current_path}` at keypress time, making a single global key
-//     open the dashboard for whichever repo the pressing pane belongs to
-//     (multi-repo / multi-session safe). The explicit pane option covers agent
-//     TUIs such as Codex where tmux's current-path signal can remain stuck on
-//     the parent shell's cwd. cmdDashboard then resolves that cwd to the main
-//     working tree, so pressing from a child worktree pane still reads the
-//     parent `.fanout/state.json`.
-//   - The command runs through exactly one shell (new-window's), so the binary
-//     path needs a single level of quoting — handling install paths with spaces
-//     without the fragile double-quoting a run-shell wrapper would require.
+//   - the wrapper uses @fanout_project_root (when fanout recorded it on the
+//     pane) or `#{pane_current_path}` at keypress time, shell-quoted in each
+//     conditional branch for new-window's -c argument. That makes a single
+//     global key open the dashboard for whichever repo the pressing pane
+//     belongs to (multi-repo / multi-session safe). The explicit pane option
+//     covers agent TUIs such as Codex where tmux's current-path signal can
+//     remain stuck on the parent shell's cwd. cmdDashboard then resolves that
+//     cwd to the main working tree, so pressing from a child worktree pane still
+//     reads the parent `.fanout/state.json`.
+//   - The new window receives the pressing tmux client's tty in an environment
+//     variable. cmdDashboard uses that as a target-client when reporting the URL
+//     back to tmux's status line; pane targets are only a format context for
+//     display-message, not the display destination.
+//   - run-shell expands the socket path, session id, and client tty before
+//     invoking the tmux client. The nested client uses `-S #{socket_path}` and
+//     `-t #{session_id}:`, so non-default sockets and multi-session servers
+//     still open the detached window beside the pressed pane. The wrapper
+//     avoids run-shell -c because fanout supports tmux 3.3, where that option
+//     does not exist.
 //
 // The detached `fanout-dashboard` window keeps the server alive past the
 // keypress; reuse-if-running makes repeated presses just reopen the existing
@@ -511,23 +518,28 @@ func BindDashboardKeys(prefixKey, directKey, fanoutBin string) error {
 	if strings.TrimSpace(prefixKey) == "" || strings.TrimSpace(directKey) == "" || strings.TrimSpace(fanoutBin) == "" {
 		return fmt.Errorf("tmux bind-key: prefix key, direct key, and fanout binary path are required")
 	}
-	launch := DashboardNotifyTargetEnv + "=#{pane_id} " + shellQuote(fanoutBin) + " dashboard --web --open"
-	startDir := "#{?@fanout_project_root,#{@fanout_project_root},#{pane_current_path}}"
+	startDir := "#{?@fanout_project_root,#{q:@fanout_project_root},#{q:pane_current_path}}"
+	launch := dashboardNewWindowShellCommand(fanoutBin, startDir)
 	prefixArgs := []string{
-		"bind-key", prefixKey, "new-window", "-d", "-n", "fanout-dashboard",
-		"-c", startDir, launch,
+		"bind-key", prefixKey, "run-shell", "-b", launch,
 	}
 	if err := exec.Command("tmux", prefixArgs...).Run(); err != nil {
 		return fmt.Errorf("tmux bind-key %s: %w", prefixKey, err)
 	}
 	directArgs := []string{
-		"bind-key", "-n", directKey, "new-window", "-d", "-n", "fanout-dashboard",
-		"-c", startDir, launch,
+		"bind-key", "-n", directKey, "run-shell", "-b", launch,
 	}
 	if err := exec.Command("tmux", directArgs...).Run(); err != nil {
 		return fmt.Errorf("tmux bind-key -n %s: %w", directKey, err)
 	}
 	return nil
+}
+
+func dashboardNewWindowShellCommand(fanoutBin, startDir string) string {
+	launch := strings.ReplaceAll(shellQuote(fanoutBin), "#", "##") + " dashboard --web --open"
+	notifyClientEnv := DashboardNotifyClientEnv + "=#{client_tty}"
+	return "__fanout_start_dir=" + startDir + `; __fanout_start_dir=$(printf '%s' "$__fanout_start_dir" | sed 's/#/####/g'); ` +
+		"tmux -S #{q:socket_path} new-window -d -n fanout-dashboard -t #{q:session_id}: -c \"$__fanout_start_dir\" -e " + shellQuote(notifyClientEnv) + " " + shellQuote(launch)
 }
 
 // BindConsoleKeys registers tmux key bindings that return focus to the fanout

--- a/internal/tmuxrun/tmuxrun_test.go
+++ b/internal/tmuxrun/tmuxrun_test.go
@@ -482,12 +482,12 @@ printf '%s\n' '---' >> "$TMUXRUN_ARGS"
 	wantPrefix := []string{
 		"bind-key", "D", "new-window", "-d", "-n", "fanout-dashboard",
 		"-c", "#{?@fanout_project_root,#{@fanout_project_root},#{pane_current_path}}",
-		"/abs/path/fanout dashboard --web --open",
+		"FANOUT_DASHBOARD_NOTIFY_TARGET=#{pane_id} /abs/path/fanout dashboard --web --open",
 	}
 	wantDirect := []string{
 		"bind-key", "-n", "F12", "new-window", "-d", "-n", "fanout-dashboard",
 		"-c", "#{?@fanout_project_root,#{@fanout_project_root},#{pane_current_path}}",
-		"/abs/path/fanout dashboard --web --open",
+		"FANOUT_DASHBOARD_NOTIFY_TARGET=#{pane_id} /abs/path/fanout dashboard --web --open",
 	}
 	if strings.Join(gotPrefix, "\x00") != strings.Join(wantPrefix, "\x00") {
 		t.Fatalf("prefix tmux args = %#v, want %#v", gotPrefix, wantPrefix)
@@ -521,7 +521,7 @@ printf '%s\n' "$@" > "$TMUXRUN_ARGS"
 	// new-window runs the launch arg through one shell, so the binary path is
 	// single-quoted to survive word-splitting on "My Tools".
 	launch := got[len(got)-1]
-	if launch != "'/opt/My Tools/fanout' dashboard --web --open" {
+	if launch != "FANOUT_DASHBOARD_NOTIFY_TARGET=#{pane_id} '/opt/My Tools/fanout' dashboard --web --open" {
 		t.Fatalf("launch arg = %q, want the binary path single-quoted", launch)
 	}
 }

--- a/internal/tmuxrun/tmuxrun_test.go
+++ b/internal/tmuxrun/tmuxrun_test.go
@@ -450,7 +450,7 @@ func TestListLivePanesDropsForgedAgentStateLineForAnotherPane(t *testing.T) {
 	}
 }
 
-func TestBindDashboardKeysRegistersDetachedWindows(t *testing.T) {
+func TestBindDashboardKeysRegistersRunShellWrappers(t *testing.T) {
 	dir := t.TempDir()
 	argsPath := filepath.Join(dir, "args.txt")
 	tmuxPath := filepath.Join(dir, "tmux")
@@ -477,17 +477,12 @@ printf '%s\n' '---' >> "$TMUXRUN_ARGS"
 	}
 	gotPrefix := strings.Split(commands[0], "\n")
 	gotDirect := strings.Split(commands[1], "\n")
-	// Each tmux argv on its own line: bind-key D new-window -d -n
-	// fanout-dashboard -c <root-or-current-path> <launch>.
+	launch := `__fanout_start_dir=#{?@fanout_project_root,#{q:@fanout_project_root},#{q:pane_current_path}}; __fanout_start_dir=$(printf '%s' "$__fanout_start_dir" | sed 's/#/####/g'); tmux -S #{q:socket_path} new-window -d -n fanout-dashboard -t #{q:session_id}: -c "$__fanout_start_dir" -e 'FANOUT_DASHBOARD_NOTIFY_CLIENT=#{client_tty}' '/abs/path/fanout dashboard --web --open'`
 	wantPrefix := []string{
-		"bind-key", "D", "new-window", "-d", "-n", "fanout-dashboard",
-		"-c", "#{?@fanout_project_root,#{@fanout_project_root},#{pane_current_path}}",
-		"FANOUT_DASHBOARD_NOTIFY_TARGET=#{pane_id} /abs/path/fanout dashboard --web --open",
+		"bind-key", "D", "run-shell", "-b", launch,
 	}
 	wantDirect := []string{
-		"bind-key", "-n", "F12", "new-window", "-d", "-n", "fanout-dashboard",
-		"-c", "#{?@fanout_project_root,#{@fanout_project_root},#{pane_current_path}}",
-		"FANOUT_DASHBOARD_NOTIFY_TARGET=#{pane_id} /abs/path/fanout dashboard --web --open",
+		"bind-key", "-n", "F12", "run-shell", "-b", launch,
 	}
 	if strings.Join(gotPrefix, "\x00") != strings.Join(wantPrefix, "\x00") {
 		t.Fatalf("prefix tmux args = %#v, want %#v", gotPrefix, wantPrefix)
@@ -497,32 +492,64 @@ printf '%s\n' '---' >> "$TMUXRUN_ARGS"
 	}
 }
 
-func TestBindDashboardKeyQuotesBinaryPathWithSpaces(t *testing.T) {
-	dir := t.TempDir()
-	argsPath := filepath.Join(dir, "args.txt")
-	tmuxPath := filepath.Join(dir, "tmux")
-	script := `#!/bin/sh
-printf '%s\n' "$@" > "$TMUXRUN_ARGS"
-`
-	if err := os.WriteFile(tmuxPath, []byte(script), 0o755); err != nil {
+func TestDashboardRunShellCommandCarriesExpandedClientAndStartDir(t *testing.T) {
+	workDir := filepath.Join(t.TempDir(), "work tree")
+	if err := os.Mkdir(workDir, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	t.Setenv("TMUXRUN_ARGS", argsPath)
-	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	command := dashboardNewWindowShellCommand("/opt/My Tools/fanout", shellQuote(workDir))
+	command = strings.ReplaceAll(command, "#{client_tty}", "/dev/ttys123")
+	wantLaunch := shellQuote(shellQuote("/opt/My Tools/fanout") + " dashboard --web --open")
 
-	if err := BindDashboardKeys("D", "F12", "/opt/My Tools/fanout"); err != nil {
-		t.Fatalf("BindDashboardKeys() failed: %v", err)
+	wantParts := []string{
+		"__fanout_start_dir=" + shellQuote(workDir),
+		`__fanout_start_dir=$(printf '%s' "$__fanout_start_dir" | sed 's/#/####/g')`,
+		"tmux -S #{q:socket_path} new-window -d -n fanout-dashboard",
+		"-t #{q:session_id}:",
+		`-c "$__fanout_start_dir"`,
+		"-e 'FANOUT_DASHBOARD_NOTIFY_CLIENT=/dev/ttys123'",
+		wantLaunch,
 	}
-	body, err := os.ReadFile(argsPath)
-	if err != nil {
-		t.Fatal(err)
+	for _, part := range wantParts {
+		if !strings.Contains(command, part) {
+			t.Fatalf("dashboard command %q missing %q", command, part)
+		}
 	}
-	got := strings.Split(strings.TrimRight(string(body), "\n"), "\n")
-	// new-window runs the launch arg through one shell, so the binary path is
-	// single-quoted to survive word-splitting on "My Tools".
-	launch := got[len(got)-1]
-	if launch != "FANOUT_DASHBOARD_NOTIFY_TARGET=#{pane_id} '/opt/My Tools/fanout' dashboard --web --open" {
-		t.Fatalf("launch arg = %q, want the binary path single-quoted", launch)
+	if strings.Contains(command, "#{client_tty}") || !strings.Contains(command, "#{q:socket_path}") {
+		t.Fatalf("dashboard command should carry expanded client and socket target: %q", command)
+	}
+}
+
+func TestDashboardRunShellCommandEscapesHashForTmuxFormatLayer(t *testing.T) {
+	command := dashboardNewWindowShellCommand("/opt/proj#2/fanout", "/repo")
+	wantLaunch := shellQuote(shellQuote("/opt/proj##2/fanout") + " dashboard --web --open")
+	if !strings.Contains(command, wantLaunch) {
+		t.Fatalf("dashboard command = %q, want escaped launch %q", command, wantLaunch)
+	}
+	if strings.Contains(command, "/opt/proj#2/fanout") {
+		t.Fatalf("dashboard command = %q, want literal '#' doubled for run-shell format expansion", command)
+	}
+	if !strings.Contains(command, "#{q:socket_path}") || !strings.Contains(command, "#{client_tty}") {
+		t.Fatalf("dashboard command = %q, want intentional tmux formats preserved", command)
+	}
+}
+
+func TestDashboardRunShellCommandEscapesStartDirHashForNestedTmux(t *testing.T) {
+	startDir := shellQuote("/tmp/project #(demo)")
+	command := dashboardNewWindowShellCommand("/opt/fanout", startDir)
+
+	wantParts := []string{
+		"__fanout_start_dir=" + startDir,
+		`__fanout_start_dir=$(printf '%s' "$__fanout_start_dir" | sed 's/#/####/g')`,
+		`-c "$__fanout_start_dir"`,
+	}
+	for _, part := range wantParts {
+		if !strings.Contains(command, part) {
+			t.Fatalf("dashboard command %q missing %q", command, part)
+		}
+	}
+	if strings.Contains(command, "-c "+startDir) {
+		t.Fatalf("dashboard command = %q, want start dir passed through escaped variable", command)
 	}
 }
 

--- a/site/content/docs/monitoring.ja.md
+++ b/site/content/docs/monitoring.ja.md
@@ -149,6 +149,8 @@ fanout dashboard --web [--port N] [--open] [--no-token] [--no-keybind]
 
 TUI 起動時、ライブ fan-out 後、ダッシュボード自体の起動時に fanout が tmux キーバインドを自動登録するので、どのペインからでも **`F12`** または **`prefix + D`** でダッシュボードを開けます。どちらのキーも detached な `fanout-dashboard` ウィンドウでサーバを起動するため、キー押下後も生き続け、2 回目以降は既存 URL を開き直すだけです。**`prefix + M`** では記録済みペインから同一 worktree 操作を開けます。
 
+ブラウザ opener が失敗した場合、fanout は tmux status line に dashboard URL を表示します。
+
 自動登録は `--no-dashboard-keybind`（fan-out 側）、`--no-keybind`（dashboard 側）、設定キー `dashboardKeybind`、`FANOUT_DASHBOARD_KEYBIND=0` でまとめて無効化できます（[Settings]({{< relref "/docs/settings" >}}) を参照してください）。
 
 ### prefix + M

--- a/site/content/docs/monitoring.md
+++ b/site/content/docs/monitoring.md
@@ -149,6 +149,8 @@ Run `fanout dashboard --help` for the full flag list.
 
 When the TUI starts, after a live fan-out, and whenever the dashboard itself starts, fanout registers tmux keybindings so that **`F12`** or **`prefix + D`** pops the dashboard from any pane. Both keys launch the server in a detached `fanout-dashboard` window, so it outlives the keypress; a second press just reopens the existing URL. It also registers **`prefix + M`** for same-worktree actions from the focused recorded pane.
 
+If the browser opener fails, fanout prints the dashboard URL in the tmux status line.
+
 Disable the auto-bindings with `--no-dashboard-keybind` (fan-out side), `--no-keybind` (dashboard side), the `dashboardKeybind` config key, or `FANOUT_DASHBOARD_KEYBIND=0` — see [Settings]({{< relref "/docs/settings" >}}).
 
 ### prefix + M


### PR DESCRIPTION
TL;DR: F12 / prefix + D の dashboard 起動結果を、押下元の TUI 側で見えるようにしました。

Review effort: 2

## 背景

TUI では `F12` / `prefix + D` の tmux keybind 自体は登録されています。
ただし keybind は detached な `fanout-dashboard` window で `fanout dashboard --web --open` を実行するため、ブラウザ opener が失敗しても押下元の TUI には結果が見えませんでした。
そのため、ユーザーには「キーを押しても何も起きていない」ように見えていました。

## 変更

- `dashboard --open` が dashboard URL を tmux status line に表示するようにしました。
- keybind 実行時に押下元 pane id を `FANOUT_DASHBOARD_NOTIFY_TARGET` で渡し、detached window ではなく押下元 pane へ status line 通知を出します。
- ブラウザ opener の即時失敗を検出し、失敗時も URL を status line に表示します。
- monitoring docs の英日両方に、opener 失敗時の URL 表示を追記しました。

## 検証

- `GOCACHE=/private/tmp/fanout-tuif12-go-cache go test ./cmd/fanout ./internal/tmuxrun ./internal/tmuxctl`
- `GOCACHE=/private/tmp/fanout-tuif12-go-cache make test`
- `make lint`
- `git diff --check`
- `post-work-review` final HEAD gate: `clean=true`, `marker_written=true`
