### PR TITLE
feat(tui): 数字ジャンプ 1-9 と Z (focus+zoom) を追加

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -137,7 +137,7 @@ watcher は repo 全体から label 付き issue を探し、one-shot session �
 | `fanout 123 --unblocked-only` | ブロッカーが closed の子だけをファンアウト — 次の wave |
 | `fanout 123 --dry-run` | git / tmux / state / briefing file を変更せず計画だけ表示 |
 | `fanout plan spec.json --agent claude` | GitHub の子 issue でなくローカル plan spec をファンアウト |
-| `fanout` | 常駐 TUI コンソールを起動(Session ジャンプ・focus・peek・terminal・prompt / issue / plan からの Session 起動・同一 worktree への追加・復元・lifecycle キー) |
+| `fanout` | 常駐 TUI コンソールを起動(Session ジャンプ・数字ジャンプ 1-9・focus・zoom・peek・terminal・prompt / issue / plan からの Session 起動・同一 worktree への追加・復元・lifecycle キー) |
 | `fanout 123 --status` | ペイン・PR review・CI 状態を JSON または table で |
 | `fanout dashboard --web` | localhost で read-only Web ダッシュボードを配信 |
 | `fanout 123 --merge 4` | 子 branch を fast-forward merge(`--close` / `--cleanup` でペインを畳む) |

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ it discovers labeled issues across the repository and starts one-shot sessions.
 | `fanout 123 --unblocked-only` | Fan out only children whose blockers are closed — the next wave |
 | `fanout 123 --dry-run` | Print the plan without modifying git, tmux, state, or briefing files |
 | `fanout plan spec.json --agent claude` | Fan out a local plan spec instead of GitHub child issues |
-| `fanout` | Start the persistent TUI console (Session jump, focus, peek, terminal, prompt / issue / plan session launch, same-worktree attach, restore, lifecycle keys) |
+| `fanout` | Start the persistent TUI console (Session jump, numeric jump 1-9, focus, zoom, peek, terminal, prompt / issue / plan session launch, same-worktree attach, restore, lifecycle keys) |
 | `fanout 123 --status` | Pane, PR review, and CI state as JSON or a table |
 | `fanout dashboard --web` | Serve the read-only web dashboard on localhost |
 | `fanout 123 --merge 4` | Fast-forward merge a child branch (`--close` / `--cleanup` fold panes away) |

--- a/internal/tmuxrun/tmuxrun.go
+++ b/internal/tmuxrun/tmuxrun.go
@@ -858,6 +858,28 @@ func SelectPane(paneID string) error {
 	return nil
 }
 
+// ZoomPane zooms paneID's window onto it via resize-pane -Z. The tmux flag is
+// a toggle, so an already-zoomed window is left zoomed instead of being
+// toggled back to the split layout; callers focus the pane first, which makes
+// paneID the zoomed pane in that case.
+func ZoomPane(paneID string) error {
+	paneID = strings.TrimSpace(paneID)
+	if paneID == "" {
+		return fmt.Errorf("pane id is required")
+	}
+	out, err := exec.Command("tmux", "display-message", "-p", "-t", paneID, "#{window_zoomed_flag}").Output()
+	if err != nil {
+		return fmt.Errorf("tmux display-message: %w", err)
+	}
+	if strings.TrimSpace(string(out)) == "1" {
+		return nil
+	}
+	if err := exec.Command("tmux", "resize-pane", "-Z", "-t", paneID).Run(); err != nil {
+		return fmt.Errorf("tmux resize-pane -Z: %w", err)
+	}
+	return nil
+}
+
 // FocusPane makes pane active in its window and selects that window in the session.
 func FocusPane(pane PaneInfo) error {
 	if strings.TrimSpace(pane.ID) == "" {

--- a/internal/tmuxrun/tmuxrun_test.go
+++ b/internal/tmuxrun/tmuxrun_test.go
@@ -958,6 +958,44 @@ func TestSelectPaneSwitchesClientToPaneTarget(t *testing.T) {
 	assertTmuxArgs(t, argsPath, []string{"switch-client", "-t", "%9"})
 }
 
+func TestZoomPaneZoomsWhenWindowNotZoomed(t *testing.T) {
+	argsPath := installTmuxShim(t, `if [ "$1" = "display-message" ]; then
+	printf '0\n'
+	exit 0
+fi
+printf '%s\n' "$@" > "$TMUXRUN_ARGS"
+`)
+
+	if err := ZoomPane("%9"); err != nil {
+		t.Fatalf("ZoomPane() failed: %v", err)
+	}
+	assertTmuxArgs(t, argsPath, []string{"resize-pane", "-Z", "-t", "%9"})
+}
+
+// Guards that ZoomPane never toggles an already-zoomed window back to the
+// split layout: the shim fails any command other than the zoom-flag query.
+func TestZoomPaneSkipsToggleWhenWindowAlreadyZoomed(t *testing.T) {
+	installTmuxShim(t, `if [ "$1" = "display-message" ]; then
+	printf '1\n'
+	exit 0
+fi
+exit 1
+`)
+
+	if err := ZoomPane("%9"); err != nil {
+		t.Fatalf("ZoomPane() on zoomed window failed: %v", err)
+	}
+}
+
+func TestZoomPaneRejectsEmptyPaneID(t *testing.T) {
+	installTmuxShim(t, `exit 0
+`)
+
+	if err := ZoomPane("  "); err == nil {
+		t.Fatal("ZoomPane(\"  \") = nil, want error")
+	}
+}
+
 func TestIsPaneAliveBuildsArgs(t *testing.T) {
 	argsPath := installTmuxShim(t, `printf '%s\n' "$@" > "$TMUXRUN_ARGS"
 `)

--- a/internal/tui/focus.go
+++ b/internal/tui/focus.go
@@ -15,6 +15,7 @@ import (
 type paneFocusedMsg struct {
 	paneID         string
 	err            error
+	zoomErr        error
 	keyboardPaused bool
 }
 
@@ -93,6 +94,14 @@ func (m model) selectedPane() (paneView, bool) {
 }
 
 func (m *model) focusSelectedCmd() tea.Cmd {
+	return m.focusSelected(false)
+}
+
+func (m *model) zoomSelectedCmd() tea.Cmd {
+	return m.focusSelected(true)
+}
+
+func (m *model) focusSelected(zoom bool) tea.Cmd {
 	pane, ok := m.selectedPane()
 	if !ok {
 		m.notice = "no pane selected"
@@ -107,6 +116,7 @@ func (m *model) focusSelectedCmd() tea.Cmd {
 	alive := m.opts.PaneAlive
 	shellAlive := m.opts.ShellPaneAlive
 	focus := m.opts.FocusPane
+	zoomPane := m.opts.ZoomPane
 	keyboard := m.opts.keyboard
 	m.notice = fmt.Sprintf("focusing %s...", paneID)
 	return func() tea.Msg {
@@ -118,7 +128,11 @@ func (m *model) focusSelectedCmd() tea.Cmd {
 			keyboard.Enable()
 			return paneFocusedMsg{paneID: paneID, err: err}
 		}
-		return paneFocusedMsg{paneID: paneID, keyboardPaused: true}
+		msg := paneFocusedMsg{paneID: paneID, keyboardPaused: true}
+		if zoom {
+			msg.zoomErr = zoomPane(paneID)
+		}
+		return msg
 	}
 }
 

--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -19,12 +19,14 @@ func (m model) helpView() string {
 		{"t", "Project root terminal"},
 		{"j/k", "Move selection"},
 		{"[ / ]", "Prev / next Session"},
+		{"1-9", "Jump to Nth pane"},
 		{"/", "Filter rows"},
 		{"Enter/o", "Focus pane"},
+		{"Z", "Focus + zoom pane"},
 		{"p", "Peek output"},
-		{"c", "Close pane"},
+		{"c/x", "Close pane"},
 		{"m", "Merge branch"},
-		{"x", "Cleanup parent"},
+		{"X", "Cleanup parent"},
 		{"q", "Quit TUI"},
 	}
 	newPane := []helpEntry{

--- a/internal/tui/session.go
+++ b/internal/tui/session.go
@@ -31,6 +31,19 @@ func (m model) jumpSession(delta int) (tea.Model, tea.Cmd) {
 	return m, m.peekSelectedCmd(false)
 }
 
+func (m model) jumpToOrdinal(n int) (tea.Model, tea.Cmd) {
+	if n > len(m.panes) {
+		m.notice = fmt.Sprintf("no pane %d in the current list", n)
+		return m, nil
+	}
+	m.moveTableCursorTo(n - 1)
+	m.refreshDetail()
+	// Schedule a peek alongside the focus, like every other cursor move, so
+	// the detail panel is fresh when the focus is skipped or fails.
+	focusCmd := m.focusSelectedCmd()
+	return m, tea.Batch(focusCmd, m.peekSelectedCmd(false))
+}
+
 func (m *model) moveTableCursorTo(target int) {
 	current := m.table.Cursor()
 	switch {

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -62,6 +62,7 @@ type Options struct {
 	// (then resize handling is a no-op).
 	Relayout          func() error
 	FocusPane         func(string) error
+	ZoomPane          func(string) error
 	PaneAlive         func(string) bool
 	ShellPaneAlive    func(paneID, shellKey string) bool
 	CapturePaneOutput func(string, int) (string, error)
@@ -223,6 +224,9 @@ func normalizeOptions(opts Options) Options {
 	}
 	if opts.FocusPane == nil {
 		opts.FocusPane = tmuxrun.SelectPane
+	}
+	if opts.ZoomPane == nil {
+		opts.ZoomPane = tmuxrun.ZoomPane
 	}
 	if opts.PaneAlive == nil {
 		opts.PaneAlive = tmuxrun.IsPaneAlive

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -1067,6 +1067,382 @@ func TestFocusSelectedPaneRestoresKeyboardProtocolsOnFocusError(t *testing.T) {
 	}
 }
 
+// runCmd executes cmd, flattening one level of tea.Batch, and returns the
+// produced messages.
+func runCmd(cmd tea.Cmd) []tea.Msg {
+	if cmd == nil {
+		return nil
+	}
+	msg := cmd()
+	batch, ok := msg.(tea.BatchMsg)
+	if !ok {
+		return []tea.Msg{msg}
+	}
+	msgs := make([]tea.Msg, 0, len(batch))
+	for _, sub := range batch {
+		if sub != nil {
+			msgs = append(msgs, sub())
+		}
+	}
+	return msgs
+}
+
+func findPaneFocusedMsg(t *testing.T, msgs []tea.Msg) paneFocusedMsg {
+	t.Helper()
+	for _, msg := range msgs {
+		if focused, ok := msg.(paneFocusedMsg); ok {
+			return focused
+		}
+	}
+	t.Fatalf("no paneFocusedMsg in %#v", msgs)
+	return paneFocusedMsg{}
+}
+
+func TestNumericJumpSelectsAndFocusesNthPane(t *testing.T) {
+	var focused string
+	m := newModel(Options{
+		FocusPane: func(paneID string) error {
+			focused = paneID
+			return nil
+		},
+		PaneAlive:         func(string) bool { return true },
+		CapturePaneOutput: func(string, int) (string, error) { return "", nil },
+	})
+	m.allPanes = []paneView{
+		{IssueNum: 1, Name: "one", PaneID: "%1", TmuxState: "live"},
+		{IssueNum: 2, Name: "two", PaneID: "%2", TmuxState: "live"},
+		{IssueNum: 3, Name: "three", PaneID: "%3", TmuxState: "live"},
+	}
+	m.refreshRows()
+
+	updated, cmd := m.Update(keyRunes("3"))
+	m = updated.(model)
+	if got := m.table.Cursor(); got != 2 {
+		t.Fatalf("cursor after 3 = %d, want 2", got)
+	}
+	if cmd == nil {
+		t.Fatal("numeric jump returned nil command, want focus command")
+	}
+	if msg := findPaneFocusedMsg(t, runCmd(cmd)); msg.err != nil {
+		t.Fatalf("focus msg err = %v, want nil", msg.err)
+	}
+	if focused != "%3" {
+		t.Fatalf("focused pane = %q, want %%3", focused)
+	}
+}
+
+// Guards that the numeric jump indexes the filtered list, not all panes.
+func TestNumericJumpIndexesFilteredList(t *testing.T) {
+	var focused string
+	m := newModel(Options{
+		FocusPane: func(paneID string) error {
+			focused = paneID
+			return nil
+		},
+		PaneAlive:         func(string) bool { return true },
+		CapturePaneOutput: func(string, int) (string, error) { return "", nil },
+	})
+	m.allPanes = []paneView{
+		{IssueNum: 1, Name: "alpha", PaneID: "%1", TmuxState: "live"},
+		{IssueNum: 2, Name: "bravo", PaneID: "%2", TmuxState: "live"},
+		{IssueNum: 3, Name: "charlie", PaneID: "%3", TmuxState: "live"},
+	}
+	m.filterQuery = "bravo"
+	m.refreshRows()
+
+	updated, cmd := m.Update(keyRunes("1"))
+	m = updated.(model)
+	if cmd == nil {
+		t.Fatal("numeric jump returned nil command, want focus command")
+	}
+	if msg := findPaneFocusedMsg(t, runCmd(cmd)); msg.err != nil {
+		t.Fatalf("focus msg err = %v, want nil", msg.err)
+	}
+	if focused != "%2" {
+		t.Fatalf("focused pane = %q, want %%2 (first filtered row)", focused)
+	}
+
+	focused = ""
+	updated, cmd = m.Update(keyRunes("2"))
+	m = updated.(model)
+	if cmd != nil {
+		t.Fatal("jump past the filtered list returned command, want nil")
+	}
+	if !strings.Contains(m.notice, "no pane 2") {
+		t.Fatalf("notice = %q, want out-of-range message", m.notice)
+	}
+	if focused != "" {
+		t.Fatalf("focused pane = %q, want no focus", focused)
+	}
+}
+
+// Guards that the numeric jump refreshes the detail-panel peek like every
+// other cursor move, so a skipped or failed focus does not leave it stale.
+func TestNumericJumpSchedulesPeekAlongsideFocus(t *testing.T) {
+	m := newModel(Options{
+		FocusPane:         func(string) error { return nil },
+		PaneAlive:         func(string) bool { return true },
+		CapturePaneOutput: func(string, int) (string, error) { return "captured", nil },
+	})
+	m.allPanes = []paneView{
+		{IssueNum: 1, Name: "one", PaneID: "%1", TmuxState: "live"},
+		{IssueNum: 2, Name: "two", PaneID: "%2", TmuxState: "live"},
+	}
+	m.refreshRows()
+
+	updated, cmd := m.Update(keyRunes("2"))
+	m = updated.(model)
+	if !m.peek.Loading || m.peek.PaneID != "%2" {
+		t.Fatalf("peek after jump = %#v, want loading for %%2", m.peek)
+	}
+	peeked := false
+	for _, msg := range runCmd(cmd) {
+		if loaded, ok := msg.(panePeekLoadedMsg); ok && loaded.paneID == "%2" {
+			peeked = true
+		}
+	}
+	if !peeked {
+		t.Fatal("numeric jump scheduled no peek for the target pane")
+	}
+}
+
+func TestNumericJumpOutOfRangeShowsNotice(t *testing.T) {
+	focusCalls := 0
+	m := newModel(Options{
+		FocusPane: func(string) error {
+			focusCalls++
+			return nil
+		},
+		PaneAlive: func(string) bool { return true },
+	})
+	m.allPanes = []paneView{
+		{IssueNum: 1, Name: "one", PaneID: "%1", TmuxState: "live"},
+		{IssueNum: 2, Name: "two", PaneID: "%2", TmuxState: "live"},
+	}
+	m.refreshRows()
+
+	updated, cmd := m.Update(keyRunes("9"))
+	m = updated.(model)
+	if cmd != nil {
+		t.Fatal("out-of-range jump returned command, want nil")
+	}
+	if !strings.Contains(m.notice, "no pane 9") {
+		t.Fatalf("notice = %q, want out-of-range message", m.notice)
+	}
+	if got := m.table.Cursor(); got != 0 {
+		t.Fatalf("cursor after out-of-range jump = %d, want 0", got)
+	}
+	if focusCalls != 0 {
+		t.Fatalf("FocusPane calls = %d, want 0", focusCalls)
+	}
+}
+
+// Guards that the close menu's 1-3 option choices win over the numeric jump.
+func TestNumericKeysDuringCloseMenuSelectOptionsNotJump(t *testing.T) {
+	focusCalls := 0
+	m := newModel(Options{
+		ProjectRoot: "/repo",
+		lifecycle:   &fakeLifecycleRunner{code: exitcode.OK},
+		FocusPane: func(string) error {
+			focusCalls++
+			return nil
+		},
+		PaneAlive: func(string) bool { return true },
+	})
+	m.allPanes = []paneView{
+		{Parent: "84", IssueNum: 101, Name: "one", PaneID: "%1", TmuxState: "live"},
+		{Parent: "84", IssueNum: 102, Name: "two", PaneID: "%2", TmuxState: "live"},
+	}
+	m.refreshRows()
+
+	updated, _ := m.Update(keyRunes("c"))
+	m = updated.(model)
+	updated, cmd := m.Update(keyRunes("2"))
+	m = updated.(model)
+	if cmd != nil {
+		t.Fatal("close choice returned command, want nil")
+	}
+	if m.pendingAction == nil || m.pendingAction.closeMode != lifecycle.CloseWorktree {
+		t.Fatalf("pendingAction = %#v, want close-worktree choice", m.pendingAction)
+	}
+	if got := m.table.Cursor(); got != 0 {
+		t.Fatalf("cursor after close-menu 2 = %d, want 0", got)
+	}
+	if focusCalls != 0 {
+		t.Fatalf("FocusPane calls = %d, want 0", focusCalls)
+	}
+}
+
+// Guards that filter editing captures digits instead of the numeric jump.
+func TestNumericKeysDuringFilterEditingTypeIntoQuery(t *testing.T) {
+	focusCalls := 0
+	m := newModel(Options{
+		FocusPane: func(string) error {
+			focusCalls++
+			return nil
+		},
+		PaneAlive: func(string) bool { return true },
+	})
+	m.allPanes = []paneView{
+		{IssueNum: 1, Name: "one", PaneID: "%1", TmuxState: "live"},
+		{IssueNum: 2, Name: "two", PaneID: "%2", TmuxState: "live"},
+	}
+	m.refreshRows()
+
+	updated, _ := m.Update(keyRunes("/"))
+	m = updated.(model)
+	updated, cmd := m.Update(keyRunes("2"))
+	m = updated.(model)
+	if cmd != nil {
+		t.Fatal("filter digit returned command, want nil")
+	}
+	if m.filterQuery != "2" {
+		t.Fatalf("filterQuery = %q, want \"2\"", m.filterQuery)
+	}
+	if focusCalls != 0 {
+		t.Fatalf("FocusPane calls = %d, want 0", focusCalls)
+	}
+}
+
+func TestZoomKeyFocusesThenZoomsSelectedPane(t *testing.T) {
+	var calls []string
+	m := newModel(Options{
+		FocusPane: func(paneID string) error {
+			calls = append(calls, "focus:"+paneID)
+			return nil
+		},
+		ZoomPane: func(paneID string) error {
+			calls = append(calls, "zoom:"+paneID)
+			return nil
+		},
+		PaneAlive: func(string) bool { return true },
+	})
+	m.allPanes = []paneView{{IssueNum: 1, Name: "one", PaneID: "%1", TmuxState: "live"}}
+	m.refreshRows()
+
+	updated, cmd := m.Update(keyRunes("Z"))
+	m = updated.(model)
+	if cmd == nil {
+		t.Fatal("Z returned nil command, want focus+zoom command")
+	}
+	raw := cmd()
+	msg, ok := raw.(paneFocusedMsg)
+	if !ok {
+		t.Fatalf("Z msg = %T, want paneFocusedMsg", raw)
+	}
+	if want := []string{"focus:%1", "zoom:%1"}; !reflect.DeepEqual(calls, want) {
+		t.Fatalf("calls = %v, want %v", calls, want)
+	}
+	next, _ := m.Update(msg)
+	m = next.(model)
+	if !strings.Contains(m.notice, "focused %1") {
+		t.Fatalf("notice = %q, want focused message", m.notice)
+	}
+}
+
+func TestZoomKeySkipsZoomWhenFocusFails(t *testing.T) {
+	zoomCalls := 0
+	m := newModel(Options{
+		FocusPane: func(string) error { return errors.New("focus failed") },
+		ZoomPane: func(string) error {
+			zoomCalls++
+			return nil
+		},
+		PaneAlive: func(string) bool { return true },
+	})
+	m.allPanes = []paneView{{IssueNum: 1, Name: "one", PaneID: "%1", TmuxState: "live"}}
+	m.refreshRows()
+
+	updated, cmd := m.Update(keyRunes("Z"))
+	m = updated.(model)
+	if cmd == nil {
+		t.Fatal("Z returned nil command, want focus+zoom command")
+	}
+	raw := cmd()
+	msg, ok := raw.(paneFocusedMsg)
+	if !ok {
+		t.Fatalf("Z msg = %T, want paneFocusedMsg", raw)
+	}
+	if msg.err == nil {
+		t.Fatal("msg.err = nil, want focus error")
+	}
+	if zoomCalls != 0 {
+		t.Fatalf("ZoomPane calls after failed focus = %d, want 0", zoomCalls)
+	}
+}
+
+func TestZoomFailureKeepsFocusAndShowsNotice(t *testing.T) {
+	m := newModel(Options{
+		FocusPane: func(string) error { return nil },
+		ZoomPane:  func(string) error { return errors.New("zoom failed") },
+		PaneAlive: func(string) bool { return true },
+	})
+	m.allPanes = []paneView{{IssueNum: 1, Name: "one", PaneID: "%1", TmuxState: "live"}}
+	m.refreshRows()
+
+	updated, cmd := m.Update(keyRunes("Z"))
+	m = updated.(model)
+	if cmd == nil {
+		t.Fatal("Z returned nil command, want focus+zoom command")
+	}
+	raw := cmd()
+	msg, ok := raw.(paneFocusedMsg)
+	if !ok {
+		t.Fatalf("Z msg = %T, want paneFocusedMsg", raw)
+	}
+	if msg.err != nil {
+		t.Fatalf("msg.err = %v, want nil when only zoom fails", msg.err)
+	}
+	next, _ := m.Update(msg)
+	m = next.(model)
+	if !m.keyboardPaused {
+		t.Fatal("keyboardPaused = false, want true when focus succeeded")
+	}
+	if !strings.Contains(m.notice, "zoom failed") {
+		t.Fatalf("notice = %q, want zoom failure message", m.notice)
+	}
+}
+
+// Guards that enter / o keep plain focus behavior and never zoom.
+func TestEnterAndOFocusKeysDoNotZoom(t *testing.T) {
+	for _, key := range []string{"enter", "o"} {
+		t.Run(key, func(t *testing.T) {
+			zoomCalls := 0
+			var focused string
+			m := newModel(Options{
+				FocusPane: func(paneID string) error {
+					focused = paneID
+					return nil
+				},
+				ZoomPane: func(string) error {
+					zoomCalls++
+					return nil
+				},
+				PaneAlive: func(string) bool { return true },
+			})
+			m.allPanes = []paneView{{IssueNum: 1, Name: "one", PaneID: "%1", TmuxState: "live"}}
+			m.refreshRows()
+
+			updated, cmd := m.Update(keyRunes(key))
+			m = updated.(model)
+			if cmd == nil {
+				t.Fatalf("%s returned nil command, want focus command", key)
+			}
+			if raw := cmd(); raw == nil {
+				t.Fatalf("%s msg = nil, want paneFocusedMsg", key)
+			} else if _, ok := raw.(paneFocusedMsg); !ok {
+				t.Fatalf("%s msg = %T, want paneFocusedMsg", key, raw)
+			}
+			if focused != "%1" {
+				t.Fatalf("focused pane = %q, want %%1", focused)
+			}
+			if zoomCalls != 0 {
+				t.Fatalf("ZoomPane calls = %d, want 0", zoomCalls)
+			}
+		})
+	}
+}
+
 func TestEnableKeyboardProtocolsCmd(t *testing.T) {
 	protocols := &fakeKeyboardProtocols{}
 	m := newModel(Options{keyboard: protocols})

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -102,6 +102,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "enter", "o":
 			cmd := m.focusSelectedCmd()
 			return m, cmd
+		case "1", "2", "3", "4", "5", "6", "7", "8", "9":
+			return m.jumpToOrdinal(int(msg.String()[0] - '0'))
+		case "Z":
+			cmd := m.zoomSelectedCmd()
+			return m, cmd
 		case "p":
 			cmd := m.peekSelectedCmd(true)
 			return m, cmd
@@ -345,7 +350,11 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.refreshRows()
 			}
 		} else {
-			m.notice = fmt.Sprintf("focused %s; return to the fanout tui pane to continue", msg.paneID)
+			zoomNote := ""
+			if msg.zoomErr != nil {
+				zoomNote = fmt.Sprintf(" (zoom failed: %v)", msg.zoomErr)
+			}
+			m.notice = fmt.Sprintf("focused %s%s; return to the fanout tui pane to continue", msg.paneID, zoomNote)
 		}
 		return m, nil
 	case panePeekLoadedMsg:

--- a/site/content/docs/monitoring.ja.md
+++ b/site/content/docs/monitoring.ja.md
@@ -37,6 +37,8 @@ footer は短く保ちます。通常画面で `?` を押すと、全ショー�
 | `A` | 選択中の行に記録された worktree で shell terminal を開く。shell 行は `@manual` entry として記録され、focus と peek はできるが merge 進捗には数えない。 |
 | `t` | project root で shell terminal を開く。close は tmux ペインと state 行だけを消し、git worktree は削除しない。 |
 | `Enter` / `o` | 選択中の live 行のペインにフォーカスする。 |
+| `1`-`9` | 表示リストの N 行目へジャンプして、そのペインにフォーカスする。範囲外の数字は notice を表示する。 |
+| `Z` | 選択中のペインにフォーカスして zoom する（`resize-pane -Z`）。次の relayout（ペインの作成・削除、tmux window のリサイズ）で zoom は解除されるので、必要ならもう一度 `Z` を押す。 |
 | `p` | detail panel の read-only 出力スナップショットを更新する。 |
 | `c` / `x` | 選択中のペインの close option を開く。ペインだけを閉じる、ペインと worktree を閉じる、local branch も削除する、から選ぶ。 |
 | `m` | 選択中のペインの branch を fast-forward merge する（確認を挟み、`--merge` と同じコア処理を使う）。 |

--- a/site/content/docs/monitoring.md
+++ b/site/content/docs/monitoring.md
@@ -37,6 +37,8 @@ The footer stays short; press `?` in the monitor to open the full shortcut help.
 | `A` | Open a shell terminal in the selected row's recorded worktree. Shell rows are recorded as `@manual` entries, can be focused and peeked, and do not count toward merge progress. |
 | `t` | Open a shell terminal at the project root. Closing it kills the tmux pane and removes the state row; it never removes a git worktree. |
 | `Enter` / `o` | Focus the selected live row's pane. |
+| `1`-`9` | Jump to the Nth row of the current list and focus its pane. Out-of-range numbers show a notice. |
+| `Z` | Focus the selected pane and zoom it (`resize-pane -Z`). The next relayout — a pane created or closed, or the tmux window resized — unzooms it; press `Z` again to re-zoom. |
 | `p` | Refresh the read-only output snapshot shown in the detail panel. |
 | `c` / `x` | Open close options for the selected pane: close only the pane, close the pane and remove the worktree, or also delete the local branch. |
 | `m` | Fast-forward merge the selected pane's branch — confirmation prompt, then the same core path as `--merge`. |


### PR DESCRIPTION
## TL;DR

TUI monitor モードに数字キー `1`〜`9`(表示リストの N 行目へ選択 + focus を一撃)と `Z`(focus + zoom)を追加する。`internal/tmuxrun.ZoomPane` は `window_zoomed_flag` を見てから `resize-pane -Z` するので、zoom 済み window をトグルで解除しない。

Review effort: 2

## Why

親 #383(TUI compact switcher)の C3。TUI からのペイン移動は j/k + enter の 2 段階で、ペイン数が増えると遅い。数字ジャンプで「見えている行番号 → 即ジャンプ」、`Z` で縮退 tiled レイアウト時にも 1 キーで全画面確認できるようにする。設計の正典は docs/tui-compact-switcher.ja.md「数字ジャンプ」「zoom」節。

## Changes by file

<details><summary>Changed files</summary>

| File | What changed | Why |
|---|---|---|
| `internal/tmuxrun/tmuxrun.go` | `ZoomPane` を追加。`display-message -p '#{window_zoomed_flag}'` が 1 なら no-op、0 なら `resize-pane -Z` | `resize-pane -Z` はトグルなので、zoom 済みペインで `Z` を押しても解除されないようにする |
| `internal/tmuxrun/tmuxrun_test.go` | `ZoomPane` の shim テスト 3 件(未 zoom で resize-pane 発行 / zoom 済みでトグル抑止 / 空 pane id 拒否) | args golden と no-toggle 保証の pin |
| `internal/tui/tui.go` | `Options.ZoomPane` を追加し `normalizeOptions` で `tmuxrun.ZoomPane` をデフォルト配線 | テストで fake を注入できる既存 `FocusPane` と同じパターン |
| `internal/tui/focus.go` | `focusSelectedCmd` を `focusSelected(zoom bool)` に一般化し `zoomSelectedCmd` を追加。`paneFocusedMsg` に `zoomErr` を追加 | focus 成功後にのみ zoom を呼ぶ。zoom 失敗は focus 成功を壊さず notice で通知 |
| `internal/tui/update.go` | monitor switch に `1`〜`9`(`jumpToOrdinal`)と `Z`(`zoomSelectedCmd`)を追加。`paneFocusedMsg` ハンドラで `zoomErr` を notice に含める | キーバインド本体。`pendingAction`(close の 1〜3)と `filterEditing` は monitor switch より先に return するため衝突しない |
| `internal/tui/session.go` | `jumpToOrdinal` を追加: 範囲外は notice、範囲内は `moveTableCursorTo` + focus + peek | peek を `[`/`]` や j/k と同様に伴わせ、focus がスキップ/失敗しても detail panel が古くならないようにする |
| `internal/tui/help.go` | `1-9` / `Z` の行を追加。既存の誤表記を修正: `x` は close なので `c/x` に統合し、cleanup は `X` と表記 | 同じテーブルの既存バグ(review で確認)。docs のキー表とも一致させる |
| `internal/tui/tui_test.go` | 数字ジャンプ(fake FocusPane で選択+即ジャンプ)、範囲外 notice、フィルタ済みリストのインデックス、close 選択肢 1〜3 非衝突 pin、フィルタ編集非衝突 pin、`Z` の focus→zoom 順序、focus 失敗時の zoom スキップ、zoom 失敗 notice、enter/o 不変 pin | 受け入れ条件のテスト一式 |
| `README.md` / `README.ja.md` | `fanout` コマンド行の括弧内リストに数字ジャンプと zoom を追記 | 英日同期 |
| `site/content/docs/monitoring.md` / `monitoring.ja.md` | キー表に `1`-`9` と `Z` の行を追加 | 英日同期。zoom が次の relayout(ペイン作成・削除・window リサイズ)で解除される仕様も明記 |

</details>

```mermaid
flowchart LR
    key1["キー 1-9"] --> jump["jumpToOrdinal\n(internal/tui/session.go)"]
    keyZ["キー Z"] --> zoomCmd["zoomSelectedCmd"]
    enter["Enter / o (不変)"] --> focusCmd["focusSelectedCmd"]
    jump -->|"moveTableCursorTo + peek"| focusCmd
    focusCmd --> fs["focusSelected(zoom bool)\n(internal/tui/focus.go)"]
    zoomCmd --> fs
    fs -->|"Options.FocusPane"| sp["tmuxrun.SelectPane"]
    fs -->|"focus 成功 && zoom=true\nOptions.ZoomPane"| zp["tmuxrun.ZoomPane\n(zoom 済みなら no-op,\n未 zoom なら resize-pane -Z)"]
```

## Test plan

- `make lint` — 0 issues(golangci-lint v2 + shellcheck)
- `make test` — Go unit(新テスト含む)+ vitest + bats 50 ケース全て pass。Tier 2 golden への影響なし(dry-run / status 出力は不変)
- `/code-review`(xhigh, multi-agent)で 7 件の指摘を確認し全て反映 → codex review で「明確な不具合なし」まで確認済み

Closes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017Ak3ofMKnAeF1X1tuqALxw
