### PR TITLE
feat(tui): console 復帰キーバインド(F11 / prefix T)と fanout focus-console

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -32,7 +32,8 @@ briefing から起動します。再実行しても同じ対象に 2 つ目の�
   同一 worktree への agent 追加・lifecycle キー・消えた worktree ペインの
   自動復元を備えたコンソールを開きます。新規 Session popup は自由記述 prompt
   のほか、一覧から選んだ OPEN issue や保存済み plan からも開始でき、子ごとに
-  agent を選べます(あるタスクは claude、別のタスクは codex、のように)。
+  agent を選べます(あるタスクは claude、別のタスクは codex、のように)。どの
+  ペインからでも `F11` または `prefix + T` でコンソールに戻れます。
 - **ラベル watcher** — opt-in すると、TUI 常駐中に信頼できる `fanout:auto`
   issue を one-shot fanout session に投入します。
 - **Web ダッシュボード** — localhost で動く read-only のダッシュボード(ライブ

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ English and 日本語.
   terminal, same-worktree agent attach, lifecycle keys, and automatic restore
   of missing worktree panes. The new-session popup starts work from a free
   prompt, an OPEN issue picked from a list, or a stored plan — with a per-child
-  agent choice (claude for one task, codex for another).
+  agent choice (claude for one task, codex for another). Return to the console
+  from any pane with `F11` or `prefix + T`.
 - **Label watcher** — opt in to a TUI-resident watcher that turns trusted
   `fanout:auto` issues into one-shot fanout sessions.
 - **Web dashboard** — a read-only localhost dashboard with live updates; pop it

--- a/cmd/fanout/focusconsole.go
+++ b/cmd/fanout/focusconsole.go
@@ -1,0 +1,199 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/butaosuinu/fanout/internal/exitcode"
+	"github.com/butaosuinu/fanout/internal/log"
+	"github.com/butaosuinu/fanout/internal/tmuxctl"
+	"github.com/butaosuinu/fanout/internal/tmuxrun"
+)
+
+// defaultConsoleKey / defaultConsoleDirectKey are the tmux keys bindConsoleKey
+// registers for returning to the fanout TUI console, the counterpart of the
+// dashboard's F12 / prefix + D. Capital T leaves tmux's default lowercase
+// `prefix + t` (clock-mode) untouched.
+const (
+	defaultConsoleKey       = "T"
+	defaultConsoleDirectKey = "F11"
+)
+
+func isFocusConsoleRequest(args []string) bool {
+	return len(args) > 0 && args[0] == "focus-console"
+}
+
+const focusConsoleUsage = `Usage: fanout focus-console [--from <pane-id>] [--client <client-name>]
+
+Switch to the live fanout TUI console pane. This is what the tmux keys
+F11 / prefix + T run; it can also be invoked manually from any pane.
+
+Options:
+  --from <pane-id>        Pane whose recorded repo picks among multiple
+                          consoles. Defaults to $TMUX_PANE.
+  --client <client-name>  tmux client to switch. Defaults to the current
+                          client.
+`
+
+type focusConsoleFlags struct {
+	fromID string
+	client string
+	help   bool
+}
+
+// cmdFocusConsole implements `fanout focus-console`: find the live fanout TUI
+// console pane and switch the pressing client to it. It is the target of the
+// BindConsoleKeys tmux bindings, which pass the pressing pane as --from (so
+// the console recorded for that pane's repo wins in multi-repo setups) and the
+// pressing client as --client (so a multi-client server switches the terminal
+// the key was pressed on, not the most recently active one). When no console
+// is live it notifies via the status line and exits zero — a non-zero exit
+// would make run-shell pop an error view over the pressing pane.
+func cmdFocusConsole(args []string, lg *log.Logger) exitcode.Code {
+	flags, code := parseFocusConsoleFlags(args, lg)
+	if code != exitcode.OK {
+		return code
+	}
+	if flags.help {
+		fmt.Fprint(os.Stdout, focusConsoleUsage)
+		return exitcode.OK
+	}
+	panes, err := tmuxrun.ListLivePanes()
+	if err != nil {
+		lg.Err("focus-console: %v", err)
+		return exitcode.Env
+	}
+	var from tmuxrun.LivePane
+	for _, pane := range panes {
+		if pane.ID == flags.fromID {
+			from = pane
+			break
+		}
+	}
+	console, ok := pickConsolePane(from, panes)
+	if !ok {
+		if err := tmuxctl.DisplayMessageToClient(flags.client, "fanout: no live console; run 'fanout' to start one"); err != nil {
+			lg.Debug("focus-console: %v", err)
+		}
+		return exitcode.OK
+	}
+	if err := tmuxrun.SelectPaneForClient(flags.client, console.ID); err != nil {
+		lg.Err("focus-console: %v", err)
+		return exitcode.Env
+	}
+	return exitcode.OK
+}
+
+func parseFocusConsoleFlags(args []string, lg *log.Logger) (focusConsoleFlags, exitcode.Code) {
+	var flags focusConsoleFlags
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--help", "-h", "help":
+			flags.help = true
+			return flags, exitcode.OK
+		case "--from":
+			if i+1 >= len(args) {
+				lg.Err("focus-console: --from requires an argument")
+				return flags, exitcode.Invocation
+			}
+			i++
+			flags.fromID = strings.TrimSpace(args[i])
+		case "--client":
+			if i+1 >= len(args) {
+				lg.Err("focus-console: --client requires an argument")
+				return flags, exitcode.Invocation
+			}
+			i++
+			flags.client = strings.TrimSpace(args[i])
+		default:
+			lg.Err("focus-console: unknown option %s", args[i])
+			return flags, exitcode.Invocation
+		}
+	}
+	// The keybinding always passes --from (run-shell's environment has no
+	// TMUX_PANE); the fallback covers manual invocations from a pane shell.
+	if flags.fromID == "" {
+		flags.fromID = strings.TrimSpace(os.Getenv("TMUX_PANE"))
+	}
+	return flags, exitcode.OK
+}
+
+// pickConsolePane selects the console pane the console-return keys land on.
+// Candidates must carry BOTH @fanout_role=console and the fixed TUI pane
+// title (the findTUIPane match). The double check is not forgery protection —
+// a pane's own process can stamp both, and focus-console is a UX primitive
+// that only moves display focus, not a security boundary — it screens out
+// misconfiguration and half-cleaned panes. A crashed TUI still leaves a stale
+// console-looking pane that the keys will land on; restarting fanout there
+// recovers (same known limit as findTUIPane's title reuse check).
+//
+// Priority: ① candidates whose @fanout_project_root matches the pressing
+// pane's recorded root, with same-session candidates winning ties — root
+// outranks session so one global key stays multi-repo safe when consoles for
+// several repos share a tmux session; ② same session as the pressing pane
+// (session ids are tmux-generated, so this comparison does not trust pane
+// contents); ③ the first candidate. A pressing pane with no recorded root
+// (e.g. a pane fanout never touched) starts at ②.
+func pickConsolePane(from tmuxrun.LivePane, panes []tmuxrun.LivePane) (tmuxrun.LivePane, bool) {
+	var candidates []tmuxrun.LivePane
+	for _, pane := range panes {
+		if pane.Role == tmuxrun.RoleConsole && pane.Title == tuiPaneTitle {
+			candidates = append(candidates, pane)
+		}
+	}
+	if len(candidates) == 0 {
+		return tmuxrun.LivePane{}, false
+	}
+	if fromRoot := strings.TrimSpace(from.ProjectRoot); fromRoot != "" {
+		var rootMatches []tmuxrun.LivePane
+		for _, pane := range candidates {
+			if samePath(pane.ProjectRoot, fromRoot) {
+				rootMatches = append(rootMatches, pane)
+			}
+		}
+		if len(rootMatches) > 0 {
+			if same, ok := firstPaneInSession(rootMatches, from.SessionID); ok {
+				return same, true
+			}
+			return rootMatches[0], true
+		}
+	}
+	if same, ok := firstPaneInSession(candidates, from.SessionID); ok {
+		return same, true
+	}
+	return candidates[0], true
+}
+
+func firstPaneInSession(panes []tmuxrun.LivePane, sessionID string) (tmuxrun.LivePane, bool) {
+	sessionID = strings.TrimSpace(sessionID)
+	if sessionID == "" {
+		return tmuxrun.LivePane{}, false
+	}
+	for _, pane := range panes {
+		if pane.SessionID == sessionID {
+			return pane, true
+		}
+	}
+	return tmuxrun.LivePane{}, false
+}
+
+// bindConsoleKey registers the console-return tmux keys. Unlike
+// bindDashboardKey it runs only at live TUI start: the binding's target is the
+// console itself, so a run that does not put a console on screen has nothing
+// for the keys to return to.
+func bindConsoleKey(lg *log.Logger, enabled bool) {
+	if !enabled {
+		return
+	}
+	bin, err := os.Executable()
+	if err != nil {
+		lg.Debug("console keybind: cannot resolve fanout binary path: %v", err)
+		return
+	}
+	if err := tmuxrun.BindConsoleKeys(defaultConsoleKey, defaultConsoleDirectKey, bin); err != nil {
+		lg.Debug("console keybind: %v (not in tmux?)", err)
+		return
+	}
+	lg.Info("tmux keybind: press %s or prefix + %s to return to the fanout console", defaultConsoleDirectKey, defaultConsoleKey)
+}

--- a/cmd/fanout/focusconsole_test.go
+++ b/cmd/fanout/focusconsole_test.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/butaosuinu/fanout/internal/exitcode"
+	"github.com/butaosuinu/fanout/internal/log"
+	"github.com/butaosuinu/fanout/internal/tmuxrun"
+)
+
+// TestPickConsolePane pins the console-return selection order — project root
+// beats session beats listing order — and the role + title double match.
+func TestPickConsolePane(t *testing.T) {
+	console := func(id, root, session string) tmuxrun.LivePane {
+		return tmuxrun.LivePane{ID: id, Title: tuiPaneTitle, Role: tmuxrun.RoleConsole, ProjectRoot: root, SessionID: session}
+	}
+	tests := []struct {
+		name  string
+		from  tmuxrun.LivePane
+		panes []tmuxrun.LivePane
+		want  string // pane id; "" means no console found
+	}{
+		{
+			name:  "no live panes yields no console",
+			from:  tmuxrun.LivePane{ID: "%1", SessionID: "$1"},
+			panes: nil,
+			want:  "",
+		},
+		{
+			name: "console role without the TUI title is excluded",
+			from: tmuxrun.LivePane{ID: "%1", SessionID: "$1"},
+			panes: []tmuxrun.LivePane{
+				{ID: "%2", Title: "zsh", Role: tmuxrun.RoleConsole, SessionID: "$1"},
+			},
+			want: "",
+		},
+		{
+			name: "TUI title without the console role is excluded",
+			from: tmuxrun.LivePane{ID: "%1", SessionID: "$1"},
+			panes: []tmuxrun.LivePane{
+				{ID: "%2", Title: tuiPaneTitle, SessionID: "$1"},
+			},
+			want: "",
+		},
+		{
+			// Root outranks session: one global key must stay correct when
+			// consoles for several repos share a tmux session.
+			name: "root match in another session beats same-session other-repo console",
+			from: tmuxrun.LivePane{ID: "%1", ProjectRoot: "/repo/a", SessionID: "$1"},
+			panes: []tmuxrun.LivePane{
+				console("%2", "/repo/b", "$1"),
+				console("%3", "/repo/a", "$2"),
+			},
+			want: "%3",
+		},
+		{
+			name: "multiple root matches prefer the same session",
+			from: tmuxrun.LivePane{ID: "%1", ProjectRoot: "/repo/a", SessionID: "$1"},
+			panes: []tmuxrun.LivePane{
+				console("%2", "/repo/a", "$2"),
+				console("%3", "/repo/a", "$1"),
+			},
+			want: "%3",
+		},
+		{
+			name: "root matches all in other sessions fall back to the first of them",
+			from: tmuxrun.LivePane{ID: "%1", ProjectRoot: "/repo/a", SessionID: "$1"},
+			panes: []tmuxrun.LivePane{
+				console("%2", "/repo/a", "$3"),
+				console("%3", "/repo/a", "$2"),
+			},
+			want: "%2",
+		},
+		{
+			name: "unclean recorded root still matches", // samePath cleans both sides
+			from: tmuxrun.LivePane{ID: "%1", ProjectRoot: "/repo/a/", SessionID: "$1"},
+			panes: []tmuxrun.LivePane{
+				console("%2", "/repo/b", "$1"),
+				console("%3", "/repo/a", "$2"),
+			},
+			want: "%3",
+		},
+		{
+			name: "pressing pane without a recorded root falls back to same session",
+			from: tmuxrun.LivePane{ID: "%1", SessionID: "$2"},
+			panes: []tmuxrun.LivePane{
+				console("%2", "/repo/a", "$1"),
+				console("%3", "/repo/b", "$2"),
+			},
+			want: "%3",
+		},
+		{
+			name: "recorded root with no matching console falls back to same session",
+			from: tmuxrun.LivePane{ID: "%1", ProjectRoot: "/repo/c", SessionID: "$2"},
+			panes: []tmuxrun.LivePane{
+				console("%2", "/repo/a", "$1"),
+				console("%3", "/repo/b", "$2"),
+			},
+			want: "%3",
+		},
+		{
+			name: "no root and no session match falls back to the first candidate",
+			from: tmuxrun.LivePane{ID: "%1", SessionID: "$9"},
+			panes: []tmuxrun.LivePane{
+				console("%2", "/repo/a", "$1"),
+				console("%3", "/repo/b", "$2"),
+			},
+			want: "%2",
+		},
+		{
+			name: "zero pressing pane still lands on the first candidate", // --from pane vanished between keypress and lookup
+			from: tmuxrun.LivePane{},
+			panes: []tmuxrun.LivePane{
+				console("%2", "/repo/a", "$1"),
+			},
+			want: "%2",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := pickConsolePane(tt.from, tt.panes)
+			if tt.want == "" {
+				if ok {
+					t.Fatalf("pickConsolePane() = %#v, want no console", got)
+				}
+				return
+			}
+			if !ok || got.ID != tt.want {
+				t.Fatalf("pickConsolePane() = %q, %v, want %q", got.ID, ok, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseFocusConsoleFlags(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		env      string // TMUX_PANE
+		want     focusConsoleFlags
+		wantCode exitcode.Code
+	}{
+		{name: "explicit --from wins over TMUX_PANE", args: []string{"--from", "%5"}, env: "%9", want: focusConsoleFlags{fromID: "%5"}, wantCode: exitcode.OK},
+		{name: "trims surrounding whitespace", args: []string{"--from", " %5 "}, want: focusConsoleFlags{fromID: "%5"}, wantCode: exitcode.OK},
+		{name: "missing --from falls back to TMUX_PANE", env: "%9", want: focusConsoleFlags{fromID: "%9"}, wantCode: exitcode.OK},
+		{name: "no --from and no TMUX_PANE proceeds with an empty id", want: focusConsoleFlags{}, wantCode: exitcode.OK},
+		{name: "--client records the pressing client", args: []string{"--from", "%5", "--client", "/dev/ttys004"}, want: focusConsoleFlags{fromID: "%5", client: "/dev/ttys004"}, wantCode: exitcode.OK},
+		{name: "--help short-circuits without touching tmux", args: []string{"--help"}, want: focusConsoleFlags{help: true}, wantCode: exitcode.OK},
+		{name: "--from without a value errors", args: []string{"--from"}, wantCode: exitcode.Invocation},
+		{name: "--client without a value errors", args: []string{"--client"}, wantCode: exitcode.Invocation},
+		{name: "unknown option errors", args: []string{"--pane", "%5"}, wantCode: exitcode.Invocation},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("TMUX_PANE", tt.env)
+			got, code := parseFocusConsoleFlags(tt.args, log.New(false))
+			if code != tt.wantCode {
+				t.Fatalf("parseFocusConsoleFlags(%v) code = %v, want %v", tt.args, code, tt.wantCode)
+			}
+			if code == exitcode.OK && got != tt.want {
+				t.Fatalf("parseFocusConsoleFlags(%v) = %#v, want %#v", tt.args, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/fanout/main.go
+++ b/cmd/fanout/main.go
@@ -63,6 +63,9 @@ func main() {
 	if isDashboardRequest(os.Args[1:]) {
 		os.Exit(int(cmdDashboard(os.Args[2:], lg)))
 	}
+	if isFocusConsoleRequest(os.Args[1:]) {
+		os.Exit(int(cmdFocusConsole(os.Args[2:], lg)))
+	}
 	if isWorktreeActionRequest(os.Args[1:]) {
 		os.Exit(int(cmdWorktreeAction(os.Args[1:], lg, commandName)))
 	}

--- a/cmd/fanout/tui.go
+++ b/cmd/fanout/tui.go
@@ -77,6 +77,7 @@ func cmdTUI(commandName string, lg *log.Logger) exitcode.Code {
 	restoreTitle := markTUIRunning(projectRoot)
 	defer restoreTitle()
 	bindDashboardKey(lg, resolvedSettings.DashboardKeybind)
+	bindConsoleKey(lg, resolvedSettings.ConsoleKeybind)
 	if err := runTUI(fanouttui.Options{
 		ProjectRoot:         projectRoot,
 		Session:             session,

--- a/cmd/fanout/tui_test.go
+++ b/cmd/fanout/tui_test.go
@@ -66,7 +66,61 @@ func TestCmdTUIRegistersDashboardKeybinds(t *testing.T) {
 	}
 }
 
+func TestCmdTUIRegistersConsoleKeybinds(t *testing.T) {
+	repo := t.TempDir()
+	initTUITestGitRepo(t, repo)
+	commitTUITestGitRepo(t, repo)
+	writeTUITestStateFile(t, repo)
+	t.Chdir(repo)
+	t.Setenv("TMUX", "tmux-session")
+	t.Setenv("TMUX_PANE", "%tui")
+	argsPath := installTUIDashboardTmuxShim(t)
+	restoreRunTUI := stubRunTUI(t)
+	defer restoreRunTUI()
+
+	code := cmdTUI("fanout", discardLogger())
+	if code != exitcode.OK {
+		t.Fatalf("cmdTUI() = %d, want OK", code)
+	}
+
+	log := readTUITmuxLog(t, argsPath)
+	if !tmuxLogHasCommand(log, "bind-key\nT\nrun-shell") {
+		t.Fatalf("tmux log missing prefix console keybind:\n%s", log)
+	}
+	if !tmuxLogHasCommand(log, "bind-key\n-n\nF11\nrun-shell") {
+		t.Fatalf("tmux log missing direct console keybind:\n%s", log)
+	}
+}
+
 func TestCmdTUINoDashboardKeybindHonorsEnv(t *testing.T) {
+	repo := t.TempDir()
+	initTUITestGitRepo(t, repo)
+	commitTUITestGitRepo(t, repo)
+	writeTUITestStateFile(t, repo)
+	t.Chdir(repo)
+	t.Setenv("TMUX", "tmux-session")
+	t.Setenv("TMUX_PANE", "%tui")
+	t.Setenv("FANOUT_DASHBOARD_KEYBIND", "0")
+	t.Setenv("FANOUT_CONSOLE_KEYBIND", "0")
+	argsPath := installTUIDashboardTmuxShim(t)
+	restoreRunTUI := stubRunTUI(t)
+	defer restoreRunTUI()
+
+	code := cmdTUI("fanout", discardLogger())
+	if code != exitcode.OK {
+		t.Fatalf("cmdTUI() = %d, want OK", code)
+	}
+
+	log := readTUITmuxLog(t, argsPath)
+	if strings.Contains(log, "bind-key\n") {
+		t.Fatalf("tmux log should not contain keybinds when both are disabled:\n%s", log)
+	}
+}
+
+func TestCmdTUINoDashboardKeybindKeepsConsoleKeybind(t *testing.T) {
+	// The other direction of toggle independence: disabling the dashboard
+	// keybind alone must suppress the new-window dashboard binds without
+	// taking the console-return registration down with it.
 	repo := t.TempDir()
 	initTUITestGitRepo(t, repo)
 	commitTUITestGitRepo(t, repo)
@@ -85,8 +139,40 @@ func TestCmdTUINoDashboardKeybindHonorsEnv(t *testing.T) {
 	}
 
 	log := readTUITmuxLog(t, argsPath)
-	if strings.Contains(log, "bind-key\n") {
+	if tmuxLogHasCommand(log, "new-window") {
 		t.Fatalf("tmux log should not contain dashboard keybinds when disabled:\n%s", log)
+	}
+	if !tmuxLogHasCommand(log, "bind-key\n-n\nF11\nrun-shell") {
+		t.Fatalf("tmux log missing console keybind (must stay registered):\n%s", log)
+	}
+}
+
+func TestCmdTUINoConsoleKeybindHonorsEnv(t *testing.T) {
+	// Console and dashboard keybinds are independently switchable: disabling
+	// the console one must not take the dashboard registration down with it.
+	repo := t.TempDir()
+	initTUITestGitRepo(t, repo)
+	commitTUITestGitRepo(t, repo)
+	writeTUITestStateFile(t, repo)
+	t.Chdir(repo)
+	t.Setenv("TMUX", "tmux-session")
+	t.Setenv("TMUX_PANE", "%tui")
+	t.Setenv("FANOUT_CONSOLE_KEYBIND", "0")
+	argsPath := installTUIDashboardTmuxShim(t)
+	restoreRunTUI := stubRunTUI(t)
+	defer restoreRunTUI()
+
+	code := cmdTUI("fanout", discardLogger())
+	if code != exitcode.OK {
+		t.Fatalf("cmdTUI() = %d, want OK", code)
+	}
+
+	log := readTUITmuxLog(t, argsPath)
+	if tmuxLogHasCommand(log, "run-shell") {
+		t.Fatalf("tmux log should not contain console keybinds when disabled:\n%s", log)
+	}
+	if !tmuxLogHasCommand(log, "bind-key\nD\nnew-window") {
+		t.Fatalf("tmux log missing dashboard keybind (must stay registered):\n%s", log)
 	}
 }
 

--- a/internal/cliflags/usage.go
+++ b/internal/cliflags/usage.go
@@ -155,6 +155,9 @@ Options:
                       live — pane liveness, issue state, PR merge status.
                       127.0.0.1-bound, GET-only, token-gated. See
                       'fanout dashboard --help'.
+  focus-console       Subcommand. Switch back to the live fanout TUI console
+                      pane; the tmux keys F11 / prefix + T run this. See
+                      'fanout focus-console --help'.
   msg                 Subcommand. Peer messaging between fanout panes over a
                       per-parent SQLite DB: send/post/mark-read/register plus
                       peers/inbox/board read views. See 'fanout msg --help'.

--- a/internal/settings/settings.go
+++ b/internal/settings/settings.go
@@ -23,6 +23,7 @@ type Settings struct {
 	AgentTeamsHint         bool
 	PRVisualization        bool
 	DashboardKeybind       bool
+	ConsoleKeybind         bool
 	Watcher                bool
 	WatcherTriggerLabel    string
 	WatcherRunningLabel    string
@@ -52,6 +53,7 @@ type overrides struct {
 	AgentTeamsHint         *bool
 	PRVisualization        *bool
 	DashboardKeybind       *bool
+	ConsoleKeybind         *bool
 	Watcher                *bool
 	WatcherTriggerLabel    *string
 	WatcherRunningLabel    *string
@@ -75,6 +77,7 @@ func Defaults() Settings {
 		AgentTeamsHint:         true,
 		PRVisualization:        true,
 		DashboardKeybind:       true,
+		ConsoleKeybind:         true,
 		WatcherTriggerLabel:    "fanout:auto",
 		WatcherRunningLabel:    "fanout:running",
 		WatcherIntervalSeconds: 60,
@@ -132,6 +135,9 @@ func apply(s *Settings, o overrides) {
 	}
 	if o.DashboardKeybind != nil {
 		s.DashboardKeybind = *o.DashboardKeybind
+	}
+	if o.ConsoleKeybind != nil {
+		s.ConsoleKeybind = *o.ConsoleKeybind
 	}
 	if o.Watcher != nil {
 		s.Watcher = *o.Watcher
@@ -254,6 +260,7 @@ func loadFile(path string, warnf WarnFunc) overrides {
 		"agentTeamsHint":     func(v *bool) { out.AgentTeamsHint = v },
 		"prVisualization":    func(v *bool) { out.PRVisualization = v },
 		"dashboardKeybind":   func(v *bool) { out.DashboardKeybind = v },
+		"consoleKeybind":     func(v *bool) { out.ConsoleKeybind = v },
 		"watcher":            func(v *bool) { out.Watcher = v },
 	}
 	stringKeys := map[string]func(*string){
@@ -333,6 +340,7 @@ func envOverrides(warnf WarnFunc) overrides {
 	read("FANOUT_AGENT_TEAMS_HINT", func(v *bool) { out.AgentTeamsHint = v })
 	read("FANOUT_PR_VISUALIZATION", func(v *bool) { out.PRVisualization = v })
 	read("FANOUT_DASHBOARD_KEYBIND", func(v *bool) { out.DashboardKeybind = v })
+	read("FANOUT_CONSOLE_KEYBIND", func(v *bool) { out.ConsoleKeybind = v })
 	read("FANOUT_WATCHER", func(v *bool) { out.Watcher = v })
 	readString := func(name string, set func(*string)) {
 		raw, ok := os.LookupEnv(name)

--- a/internal/settings/settings_test.go
+++ b/internal/settings/settings_test.go
@@ -57,6 +57,7 @@ func TestResolvePriorityCLIEnvRepoUserBuiltin(t *testing.T) {
 		AgentTeamsHint:         true,
 		PRVisualization:        false,
 		DashboardKeybind:       true,
+		ConsoleKeybind:         true,
 		WatcherTriggerLabel:    "fanout:auto",
 		WatcherRunningLabel:    "fanout:running",
 		WatcherIntervalSeconds: 60,
@@ -294,6 +295,29 @@ func TestResolveWarnsAndIgnoresInvalidWatcherInts(t *testing.T) {
 	assertWarningContains(t, warnings, "settings env FANOUT_WATCHER_MAX_SESSIONS: invalid integer \"many\"")
 }
 
+func TestResolveConsoleKeybindPriority(t *testing.T) {
+	repo := t.TempDir()
+	xdg := setEmptyUserConfig(t)
+	clearEnv(t)
+	writeConfig(t, filepath.Join(xdg, "fanout", "config.json"), `{
+  "consoleKeybind": true
+}`)
+	writeConfig(t, RepoConfigPath(repo), `{
+  "consoleKeybind": false
+}`)
+
+	got := Resolve(repo, CLIOverrides{}, t.Fatalf)
+	if got.ConsoleKeybind {
+		t.Fatal("ConsoleKeybind = true, want repo config override false")
+	}
+
+	t.Setenv("FANOUT_CONSOLE_KEYBIND", "on")
+	got = Resolve(repo, CLIOverrides{}, t.Fatalf)
+	if !got.ConsoleKeybind {
+		t.Fatal("ConsoleKeybind = false, want env override true")
+	}
+}
+
 func TestResolveClampsWatcherIntervalSeconds(t *testing.T) {
 	repo := t.TempDir()
 	setEmptyUserConfig(t)
@@ -333,6 +357,7 @@ func clearEnv(t *testing.T) {
 		"FANOUT_AGENT_TEAMS_HINT",
 		"FANOUT_PR_VISUALIZATION",
 		"FANOUT_DASHBOARD_KEYBIND",
+		"FANOUT_CONSOLE_KEYBIND",
 		"FANOUT_WATCHER",
 		"FANOUT_WATCHER_TRIGGER_LABEL",
 		"FANOUT_WATCHER_RUNNING_LABEL",

--- a/internal/tmuxctl/tmuxctl.go
+++ b/internal/tmuxctl/tmuxctl.go
@@ -26,6 +26,26 @@ func DisplayMessage(target, msg string) error {
 	return nil
 }
 
+// DisplayMessageToClient shows msg on the status line of one client — for
+// keybinding-driven commands, the client that pressed the key (#{client_name}
+// expanded at keypress). An empty client falls back to tmux's current-client
+// resolution, which outside a client context is the most recently active one.
+func DisplayMessageToClient(client, msg string) error {
+	msg = strings.TrimSpace(msg)
+	if msg == "" {
+		return fmt.Errorf("message is required")
+	}
+	args := []string{"display-message"}
+	if strings.TrimSpace(client) != "" {
+		args = append(args, "-c", client)
+	}
+	args = append(args, tmuxLiteral(msg))
+	if err := exec.Command("tmux", args...).Run(); err != nil {
+		return fmt.Errorf("tmux display-message: %w", err)
+	}
+	return nil
+}
+
 func tmuxLiteral(msg string) string {
 	return strings.ReplaceAll(msg, "#", "##")
 }

--- a/internal/tmuxrun/tmuxrun.go
+++ b/internal/tmuxrun/tmuxrun.go
@@ -33,6 +33,8 @@ const (
 	livePaneShellKeyFormat     = "#{pane_id}\t#{" + shellKeyOption + "}"
 	livePaneProjectRootFormat  = "#{pane_id}\t#{" + projectRootOption + "}"
 	livePaneWorktreePathFormat = "#{pane_id}\t#{" + worktreePathOption + "}"
+	livePaneRoleFormat         = "#{pane_id}\t#{" + roleOption + "}"
+	livePaneSessionIDFormat    = "#{pane_id}\t#{session_id}"
 	paneAlternateFormat        = "#{alternate_on}"
 	// paneLabelOption is a tmux pane user option holding the border label fanout
 	// shows on the pane's top border (e.g. "#123 · fix-login-bug-123"). It is set
@@ -300,6 +302,18 @@ type LivePane struct {
 	// pane. It gives action keybindings a stable match that does not depend on
 	// pane_current_path.
 	WorktreePath string
+	// Role is @fanout_role, the auto-layout role fanout stamps on panes it
+	// manages (RoleConsole for the TUI console). Like every pane user option it
+	// is settable by the process inside the pane, so it is a display/UX signal,
+	// not a security boundary. It can also degrade to "": a failed role
+	// listing, or a forged duplicate row reusing this pane's id (see
+	// parseLivePaneField), blanks it — the console-return keys then report no
+	// console until the next keypress re-lists.
+	Role string
+	// SessionID is #{session_id}, the tmux-generated $N id of the session
+	// holding the pane. tmux produces it, so unlike the user options above a
+	// pane's process cannot forge its value.
+	SessionID string
 }
 
 // ListLivePanes returns every live tmux pane across all sessions with its
@@ -311,10 +325,10 @@ type LivePane struct {
 //
 // It issues separate list-panes calls for each field (livePanePathFormat,
 // livePaneTitleFormat, livePaneAgentStateFormat, livePaneShellKeyFormat,
-// livePaneProjectRootFormat, then livePaneWorktreePathFormat) so each
-// variable-content field is last on its line and survives strings.Cut with
-// embedded tabs intact — both pane paths and pane titles may legally contain
-// tabs.
+// livePaneProjectRootFormat, livePaneWorktreePathFormat, livePaneRoleFormat,
+// then livePaneSessionIDFormat) so each variable-content field is last on its
+// line and survives strings.Cut with embedded tabs intact — both pane paths
+// and pane titles may legally contain tabs.
 //
 // Injection defense: pane_current_path is just a directory name, so a crafted
 // path containing a newline can forge whole extra lines in the path listing.
@@ -365,6 +379,14 @@ func ListLivePanes() ([]LivePane, error) {
 	if worktreePathOut, err := exec.Command("tmux", "list-panes", "-a", "-F", livePaneWorktreePathFormat).Output(); err == nil {
 		worktreePaths = parseLivePaneField(string(worktreePathOut))
 	}
+	roles := map[string]string{}
+	if roleOut, err := exec.Command("tmux", "list-panes", "-a", "-F", livePaneRoleFormat).Output(); err == nil {
+		roles = parseLivePaneField(string(roleOut))
+	}
+	sessionIDs := map[string]string{}
+	if sessionIDOut, err := exec.Command("tmux", "list-panes", "-a", "-F", livePaneSessionIDFormat).Output(); err == nil {
+		sessionIDs = parseLivePaneField(string(sessionIDOut))
+	}
 	// A real tmux listing emits each pane id exactly once; a duplicate means a
 	// newline-bearing pane_current_path forged an extra row reusing a REAL id
 	// (which would pass the title-listing check below). Conservatively drop
@@ -389,6 +411,8 @@ func ListLivePanes() ([]LivePane, error) {
 		pane.ShellKey = shellKeys[pane.ID]
 		pane.ProjectRoot = projectRoots[pane.ID]
 		pane.WorktreePath = worktreePaths[pane.ID]
+		pane.Role = roles[pane.ID]
+		pane.SessionID = sessionIDs[pane.ID]
 		joined = append(joined, pane)
 	}
 	return joined, nil
@@ -429,7 +453,12 @@ func parseLivePanePaths(out string) []LivePane {
 // dropped entirely — the genuine line cannot be told apart from the forgery,
 // so the field conservatively degrades to absent ("" at the join) instead of
 // letting a later forged line overwrite another pane's entry. The residual
-// impact is the attacker mis-reporting its own pane's display-only field.
+// impact is the attacker mis-reporting its own pane's display-only field —
+// or, by forging a duplicate that reuses ANOTHER pane's real id, blanking
+// that pane's field. For @fanout_role that blanks the console's Role and the
+// console-return keys report "no live console": an accepted nuisance in the
+// same trust bucket as role stamping itself (focus-console is a UX primitive,
+// not a security boundary; the sweep re-reads on every keypress).
 func parseLivePaneField(out string) map[string]string {
 	fields := make(map[string]string)
 	dropped := map[string]bool{}
@@ -495,6 +524,49 @@ func BindDashboardKeys(prefixKey, directKey, fanoutBin string) error {
 		"-c", startDir, launch,
 	}
 	if err := exec.Command("tmux", directArgs...).Run(); err != nil {
+		return fmt.Errorf("tmux bind-key -n %s: %w", directKey, err)
+	}
+	return nil
+}
+
+// BindConsoleKeys registers tmux key bindings that return focus to the fanout
+// TUI console from any pane. The prefix key is bound under the prefix table;
+// the direct key is bound in the root table so it works without tmux's prefix.
+//
+// Unlike BindDashboardKeys the launch command runs through `run-shell`, not
+// `new-window`: returning to the console must not create a window. run-shell
+// is still exactly one shell level, and the binding itself is registered via
+// argv, so the binary path needs a single shellQuote for the shell layer —
+// plus '#' doubling, because run-shell format-expands its argument at
+// keypress time (that is what resolves #{pane_id} / #{client_name}), and
+// format expansion pierces shell quotes, so an unescaped '#' in an install
+// path would be mangled (or a '#(' even command-substituted) before the shell
+// runs. `#{pane_id}` / `#{client_name}` expand to the pressing pane and
+// client, letting `fanout focus-console` prefer the console recorded for that
+// pane's repo and pin the switch to the client that pressed the key. Baking a
+// console pane id into the binding instead would go stale on every console
+// restart and turn multi-repo registrations into an overwrite war; resolving
+// the target at keypress time keeps one global binding correct.
+//
+// Any failure of the spawned command (the recorded binary was rebuilt or
+// deleted, the console died mid-switch) degrades to a status-line notice: the
+// `|| tmux display-message` tail keeps run-shell's exit status zero, because
+// a non-zero exit would pop tmux's copy-mode error view over whatever pane
+// the user was working in.
+//
+// fanoutBin should be an absolute path (os.Executable) so the bindings do not
+// depend on PATH.
+func BindConsoleKeys(prefixKey, directKey, fanoutBin string) error {
+	if strings.TrimSpace(prefixKey) == "" || strings.TrimSpace(directKey) == "" || strings.TrimSpace(fanoutBin) == "" {
+		return fmt.Errorf("tmux bind-key: prefix key, direct key, and fanout binary path are required")
+	}
+	launch := strings.ReplaceAll(shellQuote(fanoutBin), "#", "##") +
+		` focus-console --from "#{pane_id}" --client "#{client_name}" >/dev/null 2>&1` +
+		` || tmux display-message "fanout: focus-console failed; restart fanout to refresh this key"`
+	if err := exec.Command("tmux", "bind-key", prefixKey, "run-shell", launch).Run(); err != nil {
+		return fmt.Errorf("tmux bind-key %s: %w", prefixKey, err)
+	}
+	if err := exec.Command("tmux", "bind-key", "-n", directKey, "run-shell", launch).Run(); err != nil {
 		return fmt.Errorf("tmux bind-key -n %s: %w", directKey, err)
 	}
 	return nil
@@ -876,6 +948,27 @@ func ZoomPane(paneID string) error {
 	}
 	if err := exec.Command("tmux", "resize-pane", "-Z", "-t", paneID).Run(); err != nil {
 		return fmt.Errorf("tmux resize-pane -Z: %w", err)
+	}
+	return nil
+}
+
+// SelectPaneForClient is SelectPane pinned to one client. Keybinding-driven
+// commands run through run-shell with no client context, where a bare
+// switch-client falls back to the most recently active client — with two
+// clients attached to the server that can yank the wrong terminal. clientName
+// comes from #{client_name} expanded at keypress; when empty, this falls back
+// to SelectPane's current-client resolution.
+func SelectPaneForClient(clientName, paneID string) error {
+	clientName = strings.TrimSpace(clientName)
+	if clientName == "" {
+		return SelectPane(paneID)
+	}
+	paneID = strings.TrimSpace(paneID)
+	if paneID == "" {
+		return fmt.Errorf("pane id is required")
+	}
+	if err := exec.Command("tmux", "switch-client", "-c", clientName, "-t", paneID).Run(); err != nil {
+		return fmt.Errorf("tmux switch-client: %w", err)
 	}
 	return nil
 }

--- a/internal/tmuxrun/tmuxrun_test.go
+++ b/internal/tmuxrun/tmuxrun_test.go
@@ -171,8 +171,8 @@ printf '%%43\n'
 // `list-panes -a -F <format>` calls ListLivePanes makes, dispatching on the
 // format argument ($4): pathBody for livePanePathFormat, titleBody for
 // livePaneTitleFormat, agentStateBody for livePaneAgentStateFormat, and
-// optional shell/project/worktree user-option bodies. Each argv is appended to
-// the args file separated by "---" lines.
+// optional shell/project/worktree/role/session bodies. Each argv is appended
+// to the args file separated by "---" lines.
 func installLivePanesShim(t *testing.T, pathBody, titleBody, agentStateBody string, optionBodies ...string) string {
 	t.Helper()
 	shellBody := `printf ''`
@@ -186,6 +186,14 @@ func installLivePanesShim(t *testing.T, pathBody, titleBody, agentStateBody stri
 	worktreePathBody := `printf ''`
 	if len(optionBodies) > 2 {
 		worktreePathBody = optionBodies[2]
+	}
+	roleBody := `printf ''`
+	if len(optionBodies) > 3 {
+		roleBody = optionBodies[3]
+	}
+	sessionIDBody := `printf ''`
+	if len(optionBodies) > 4 {
+		sessionIDBody = optionBodies[4]
 	}
 	script := `printf '%s\n' "$@" >> "$TMUXRUN_ARGS"
 printf '%s\n' '---' >> "$TMUXRUN_ARGS"
@@ -204,6 +212,12 @@ case "$4" in
 	;;
 *fanout_worktree_path*)
 	` + worktreePathBody + `
+	;;
+*fanout_role*)
+	` + roleBody + `
+	;;
+*session_id*)
+	` + sessionIDBody + `
 	;;
 *pane_title*)
 	` + titleBody + `
@@ -224,16 +238,18 @@ func TestListLivePanesJoinsPathTitleAndAgentStateOutputsByID(t *testing.T) {
 		`printf '%%9\trunning\n%%10\tdone\n'`,
 		`printf '%%9\tshell-nine\n'`,
 		`printf '%%9\t/repo\n%%10\t/repo\n'`,
-		`printf '%%9\t/wt/nine\n%%10\t/wt/ten\twith\ttabs\n'`)
+		`printf '%%9\t/wt/nine\n%%10\t/wt/ten\twith\ttabs\n'`,
+		`printf '%%9\tconsole\n'`,
+		`printf '%%9\t$1\n%%10\t$1\n%%11\t$2\n'`)
 
 	panes, err := ListLivePanes()
 	if err != nil {
 		t.Fatalf("ListLivePanes() failed: %v", err)
 	}
 	want := []LivePane{
-		{ID: "%9", CurrentPath: "/wt/nine", Title: "nine: child", AgentState: "running", ShellKey: "shell-nine", ProjectRoot: "/repo", WorktreePath: "/wt/nine"},
-		{ID: "%10", CurrentPath: "/wt/ten\twith\ttabs", Title: "title\twith\ttabs", AgentState: "done", ProjectRoot: "/repo", WorktreePath: "/wt/ten\twith\ttabs"},
-		{ID: "%11", CurrentPath: "/wt/eleven", Title: "", AgentState: ""},
+		{ID: "%9", CurrentPath: "/wt/nine", Title: "nine: child", AgentState: "running", ShellKey: "shell-nine", ProjectRoot: "/repo", WorktreePath: "/wt/nine", Role: "console", SessionID: "$1"},
+		{ID: "%10", CurrentPath: "/wt/ten\twith\ttabs", Title: "title\twith\ttabs", AgentState: "done", ProjectRoot: "/repo", WorktreePath: "/wt/ten\twith\ttabs", SessionID: "$1"},
+		{ID: "%11", CurrentPath: "/wt/eleven", Title: "", AgentState: "", SessionID: "$2"},
 	}
 	if !reflect.DeepEqual(panes, want) {
 		t.Fatalf("ListLivePanes() = %#v, want %#v", panes, want)
@@ -246,6 +262,8 @@ func TestListLivePanesJoinsPathTitleAndAgentStateOutputsByID(t *testing.T) {
 		"list-panes", "-a", "-F", "#{pane_id}\t#{@fanout_shell_key}", "---",
 		"list-panes", "-a", "-F", "#{pane_id}\t#{@fanout_project_root}", "---",
 		"list-panes", "-a", "-F", "#{pane_id}\t#{@fanout_worktree_path}", "---",
+		"list-panes", "-a", "-F", "#{pane_id}\t#{@fanout_role}", "---",
+		"list-panes", "-a", "-F", "#{pane_id}\t#{session_id}", "---",
 	})
 }
 
@@ -517,6 +535,120 @@ func TestBindDashboardKeysRejectsEmptyArgs(t *testing.T) {
 	}
 	if err := BindDashboardKeys("D", "F12", ""); err == nil {
 		t.Fatal("BindDashboardKeys(empty bin) should error")
+	}
+}
+
+func TestBindConsoleKeysRegistersRunShellBindings(t *testing.T) {
+	dir := t.TempDir()
+	argsPath := filepath.Join(dir, "args.txt")
+	tmuxPath := filepath.Join(dir, "tmux")
+	script := `#!/bin/sh
+printf '%s\n' "$@" >> "$TMUXRUN_ARGS"
+printf '%s\n' '---' >> "$TMUXRUN_ARGS"
+`
+	if err := os.WriteFile(tmuxPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TMUXRUN_ARGS", argsPath)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if err := BindConsoleKeys("T", "F11", "/abs/path/fanout"); err != nil {
+		t.Fatalf("BindConsoleKeys() failed: %v", err)
+	}
+	body, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	commands := strings.Split(strings.TrimSuffix(string(body), "\n---\n"), "\n---\n")
+	if len(commands) != 2 {
+		t.Fatalf("tmux command count = %d, want 2\n%s", len(commands), body)
+	}
+	gotPrefix := strings.Split(commands[0], "\n")
+	gotDirect := strings.Split(commands[1], "\n")
+	// Each tmux argv on its own line: bind-key T run-shell <launch>, with
+	// #{pane_id} / #{client_name} left for tmux to expand at keypress time and
+	// a display-message tail that keeps a failed keypress out of tmux's error
+	// view.
+	launch := `/abs/path/fanout focus-console --from "#{pane_id}" --client "#{client_name}" >/dev/null 2>&1` +
+		` || tmux display-message "fanout: focus-console failed; restart fanout to refresh this key"`
+	wantPrefix := []string{"bind-key", "T", "run-shell", launch}
+	wantDirect := []string{"bind-key", "-n", "F11", "run-shell", launch}
+	if strings.Join(gotPrefix, "\x00") != strings.Join(wantPrefix, "\x00") {
+		t.Fatalf("prefix tmux args = %#v, want %#v", gotPrefix, wantPrefix)
+	}
+	if strings.Join(gotDirect, "\x00") != strings.Join(wantDirect, "\x00") {
+		t.Fatalf("direct tmux args = %#v, want %#v", gotDirect, wantDirect)
+	}
+}
+
+func TestBindConsoleKeysQuotesBinaryPathWithSpaces(t *testing.T) {
+	dir := t.TempDir()
+	argsPath := filepath.Join(dir, "args.txt")
+	tmuxPath := filepath.Join(dir, "tmux")
+	script := `#!/bin/sh
+printf '%s\n' "$@" > "$TMUXRUN_ARGS"
+`
+	if err := os.WriteFile(tmuxPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TMUXRUN_ARGS", argsPath)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if err := BindConsoleKeys("T", "F11", "/opt/My Tools/fanout"); err != nil {
+		t.Fatalf("BindConsoleKeys() failed: %v", err)
+	}
+	body, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := strings.Split(strings.TrimRight(string(body), "\n"), "\n")
+	// run-shell runs the launch arg through one shell, so the binary path is
+	// single-quoted to survive word-splitting on "My Tools".
+	launch := got[len(got)-1]
+	if !strings.HasPrefix(launch, `'/opt/My Tools/fanout' focus-console --from "#{pane_id}"`) {
+		t.Fatalf("launch arg = %q, want the binary path single-quoted", launch)
+	}
+}
+
+func TestBindConsoleKeysEscapesHashForTmuxFormatLayer(t *testing.T) {
+	// run-shell format-expands the launch string at keypress time; shell
+	// quotes do not stop that layer, so a '#' in the install path must be
+	// doubled or tmux mangles the path before the shell ever runs.
+	dir := t.TempDir()
+	argsPath := filepath.Join(dir, "args.txt")
+	tmuxPath := filepath.Join(dir, "tmux")
+	script := `#!/bin/sh
+printf '%s\n' "$@" > "$TMUXRUN_ARGS"
+`
+	if err := os.WriteFile(tmuxPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TMUXRUN_ARGS", argsPath)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if err := BindConsoleKeys("T", "F11", "/opt/proj#2/fanout"); err != nil {
+		t.Fatalf("BindConsoleKeys() failed: %v", err)
+	}
+	body, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := strings.Split(strings.TrimRight(string(body), "\n"), "\n")
+	launch := got[len(got)-1]
+	if !strings.HasPrefix(launch, `'/opt/proj##2/fanout' focus-console`) {
+		t.Fatalf("launch arg = %q, want '#' doubled for the format layer", launch)
+	}
+}
+
+func TestBindConsoleKeysRejectsEmptyArgs(t *testing.T) {
+	if err := BindConsoleKeys("", "F11", "/abs/fanout"); err == nil {
+		t.Fatal("BindConsoleKeys(empty prefix key) should error")
+	}
+	if err := BindConsoleKeys("T", "", "/abs/fanout"); err == nil {
+		t.Fatal("BindConsoleKeys(empty direct key) should error")
+	}
+	if err := BindConsoleKeys("T", "F11", ""); err == nil {
+		t.Fatal("BindConsoleKeys(empty bin) should error")
 	}
 }
 

--- a/site/content/docs/cli.ja.md
+++ b/site/content/docs/cli.ja.md
@@ -318,6 +318,19 @@ fanout dashboard --web [--port N] [--open] [--no-token] [--no-keybind]
 
 全フラグは `fanout dashboard --help` を参照してください。
 
+### `fanout focus-console`
+
+```text
+fanout focus-console [--from <pane-id>] [--client <client-name>]
+```
+
+live な [TUI コンソール]({{< relref "/docs/monitoring" >}})ペインに切り替えます。コンソール起動時に登録される `F11` / `prefix + T` キーが実行するコマンドです。live なコンソールが無いときはステータスラインに通知して正常終了します。
+
+| flag | 引数 | 説明 |
+|---|---|---|
+| `--from` | `pane-id` | 記録済み project root で複数コンソールから選ぶ基準ペイン。既定: `$TMUX_PANE`。 |
+| `--client` | `client-name` | 切り替える tmux クライアント。既定: 現在のクライアント。 |
+
 ### `fanout msg`
 
 ```text
@@ -380,6 +393,7 @@ fanout check-update
 | `FANOUT_AGENT_TEAMS_HINT` | Claude Agent Teams ヒント（`agentTeamsHint`）の環境変数レイヤ。 |
 | `FANOUT_PR_VISUALIZATION` | 構造化 PR 本文とゲート付き Mermaid 指示（`prVisualization`）の環境変数レイヤ。 |
 | `FANOUT_DASHBOARD_KEYBIND` | tmux ダッシュボード / 同一 worktree 操作キーバインド（`dashboardKeybind`）の環境変数レイヤ。 |
+| `FANOUT_CONSOLE_KEYBIND` | tmux コンソール復帰キーバインド（`consoleKeybind`）の環境変数レイヤ。 |
 | `FANOUT_WATCHER` | watcher opt-in（`watcher`）の環境変数レイヤ。 |
 | `FANOUT_WATCHER_TRIGGER_LABEL` | watcher trigger label（`watcherTriggerLabel`）の環境変数レイヤ。 |
 | `FANOUT_WATCHER_RUNNING_LABEL` | watcher running label（`watcherRunningLabel`）の環境変数レイヤ。 |

--- a/site/content/docs/cli.md
+++ b/site/content/docs/cli.md
@@ -319,6 +319,19 @@ Starts the read-only localhost web dashboard: bound to `127.0.0.1`, GET-only, to
 
 Run `fanout dashboard --help` for the full flag list.
 
+### `fanout focus-console`
+
+```text
+fanout focus-console [--from <pane-id>] [--client <client-name>]
+```
+
+Switches to the live [TUI console]({{< relref "/docs/monitoring" >}}) pane — the command behind the `F11` / `prefix + T` keys registered at console start. With no live console it shows a status-line notice and exits zero.
+
+| Flag | Argument | Description |
+|---|---|---|
+| `--from` | `pane-id` | Pane whose recorded project root picks among multiple consoles. Default: `$TMUX_PANE`. |
+| `--client` | `client-name` | tmux client to switch. Default: the current client. |
+
 ### `fanout msg`
 
 ```text
@@ -381,6 +394,7 @@ Read-only: fetches the latest release tag from `butaosuinu/fanout`, compares it 
 | `FANOUT_AGENT_TEAMS_HINT` | Environment layer for the Claude Agent Teams hint (`agentTeamsHint`). |
 | `FANOUT_PR_VISUALIZATION` | Environment layer for the structured PR-body and gated Mermaid guidance (`prVisualization`). |
 | `FANOUT_DASHBOARD_KEYBIND` | Environment layer for the dashboard/action tmux keybindings (`dashboardKeybind`). |
+| `FANOUT_CONSOLE_KEYBIND` | Environment layer for the console-return tmux keybindings (`consoleKeybind`). |
 | `FANOUT_WATCHER` | Environment layer for watcher opt-in (`watcher`). |
 | `FANOUT_WATCHER_TRIGGER_LABEL` | Environment layer for the watcher trigger label (`watcherTriggerLabel`). |
 | `FANOUT_WATCHER_RUNNING_LABEL` | Environment layer for the watcher running label (`watcherRunningLabel`). |

--- a/site/content/docs/monitoring.ja.md
+++ b/site/content/docs/monitoring.ja.md
@@ -47,6 +47,12 @@ footer は短く保ちます。通常画面で `?` を押すと、全ショー�
 
 > worktree 行が `stale!` になるのは、worktree が無い、agent command が無いなど fanout が復元できない場合です。shell terminal は resume できないため、対応する tmux ペインが無ければ TUI が state 行を削除します。
 
+### F11 / prefix + T
+
+コンソール起動時に fanout が tmux キーバインドを登録するので、どのペインからでも **`F11`** または **`prefix + T`** でコンソールに戻れます。ダッシュボードの `F12` / `prefix + D` と対になる復帰キーです。どちらのキーも `fanout focus-console` を実行します。押したペインのリポジトリに記録された live コンソールを優先し（1 つの tmux サーバに複数リポジトリのコンソールが同居しても正しく着地します）、無ければ同一セッションのコンソールに切り替えます。live なコンソールが無いときはステータスラインに通知して終わります。
+
+登録は設定キー `consoleKeybind` または `FANOUT_CONSOLE_KEYBIND=0` で無効化できます（[Settings]({{< relref "/docs/settings" >}}) を参照してください）。
+
 ### 新規 Session のモード
 
 `n` は Mode 行つきの tmux popup を開きます。Mode 行で `Left` / `Right` を押すとモードが切り替わり、`Tab` でフィールドを移動し、`Esc` でキャンセルします（agent 割り当て画面では 1 つ前に戻る）。

--- a/site/content/docs/monitoring.md
+++ b/site/content/docs/monitoring.md
@@ -47,6 +47,12 @@ The footer stays short; press `?` in the monitor to open the full shortcut help.
 
 > Worktree rows become `stale!` only when fanout cannot restore them, such as a missing worktree or unavailable agent command. Recorded shell terminals are not resumable; if their tmux pane is gone, the TUI removes the state row.
 
+### F11 / prefix + T
+
+When the console starts, fanout registers tmux keybindings so that **`F11`** or **`prefix + T`** returns to the console from any pane — the counterpart of the dashboard's `F12` / `prefix + D`. Both keys run `fanout focus-console`, which prefers the live console recorded for the pressing pane's repository (several repositories can keep consoles in one tmux server), falls back to a console in the same session, and switches the client there. With no live console, a status-line message points at `fanout` instead.
+
+Disable the registration with the `consoleKeybind` config key or `FANOUT_CONSOLE_KEYBIND=0` — see [Settings]({{< relref "/docs/settings" >}}).
+
 ### New session modes
 
 `n` opens a tmux popup with a Mode row. `Left` / `Right` on that row switches the mode, `Tab` moves between fields, and `Esc` cancels (or steps back from the assignment screen).

--- a/site/content/docs/settings.ja.md
+++ b/site/content/docs/settings.ja.md
@@ -26,6 +26,7 @@ fanout の挙動はチームの好みで変えたくなる箇所がいくつか�
 - `agentTeamsHint`: Claude の子に Claude Code Agent Teams を使う余地があると伝えます。Claude 以外の子には影響しません。
 - `prVisualization`: 子が開く PR の本文を構造化し、条件付きで Mermaid 図を入れる指示を加えます（後述）。
 - `dashboardKeybind`: tmux に `F12` / `prefix + D` のダッシュボードキーと `prefix + M` の同一 worktree 操作キーを登録します。
+- `consoleKeybind`: TUI コンソール起動時に、tmux へ `F11` / `prefix + T` のコンソール復帰キーを登録します。
 
 watcher と通知 channel は別系統の設定です。watcher はラベル巡回による自動起動の opt-in 制御、通知 channel は TUI の状態遷移をどこへ知らせるかの選択です。
 
@@ -39,6 +40,7 @@ watcher と通知 channel は別系統の設定です。watcher はラベル巡�
 | Claude Agent Teams ヒント | `agentTeamsHint` | `FANOUT_AGENT_TEAMS_HINT` | `--agent-teams-hint` / `--no-agent-teams-hint` | `true` |
 | 構造化 PR 本文とゲート付き Mermaid の briefing 指示 | `prVisualization` | `FANOUT_PR_VISUALIZATION` | `--pr-visualization` / `--no-pr-visualization` | `true` |
 | ダッシュボード / 同一 worktree 操作 tmux キーバインド | `dashboardKeybind` | `FANOUT_DASHBOARD_KEYBIND` | `--dashboard-keybind` / `--no-dashboard-keybind` | `true` |
+| コンソール復帰 tmux キーバインド | `consoleKeybind` | `FANOUT_CONSOLE_KEYBIND` | n/a | `true` |
 | watcher opt-in | `watcher` | `FANOUT_WATCHER` | n/a | `false` |
 | watcher trigger label | `watcherTriggerLabel` | `FANOUT_WATCHER_TRIGGER_LABEL` | n/a | `fanout:auto` |
 | watcher running label | `watcherRunningLabel` | `FANOUT_WATCHER_RUNNING_LABEL` | n/a | `fanout:running` |
@@ -63,6 +65,7 @@ watcher と通知 channel は別系統の設定です。watcher はラベル巡�
   "agentTeamsHint": false,
   "prVisualization": true,
   "dashboardKeybind": true,
+  "consoleKeybind": true,
   "watcher": false,
   "watcherTriggerLabel": "fanout:auto",
   "watcherRunningLabel": "fanout:running",

--- a/site/content/docs/settings.md
+++ b/site/content/docs/settings.md
@@ -26,6 +26,7 @@ The behavior toggles are instructions that ship on by default but a team may wan
 - `agentTeamsHint`: tells Claude children that Claude Code Agent Teams is available. It has no effect on non-Claude children.
 - `prVisualization`: asks children to structure the PR body they open and, conditionally, include a Mermaid diagram (see below).
 - `dashboardKeybind`: registers the `F12` / `prefix + D` dashboard keys and `prefix + M` same-worktree action key in tmux.
+- `consoleKeybind`: registers the `F11` / `prefix + T` console-return keys in tmux when the TUI console starts.
 
 The watcher and notification channels are a separate track: the watcher gates opt-in label-driven launches, and notification channels pick where TUI state transitions go.
 
@@ -39,6 +40,7 @@ The watcher and notification channels are a separate track: the watcher gates op
 | Claude Agent Teams hint | `agentTeamsHint` | `FANOUT_AGENT_TEAMS_HINT` | `--agent-teams-hint` / `--no-agent-teams-hint` | `true` |
 | Structured PR body and gated Mermaid briefing guidance | `prVisualization` | `FANOUT_PR_VISUALIZATION` | `--pr-visualization` / `--no-pr-visualization` | `true` |
 | Dashboard/action tmux keybindings | `dashboardKeybind` | `FANOUT_DASHBOARD_KEYBIND` | `--dashboard-keybind` / `--no-dashboard-keybind` | `true` |
+| Console-return tmux keybindings | `consoleKeybind` | `FANOUT_CONSOLE_KEYBIND` | n/a | `true` |
 | Watcher opt-in | `watcher` | `FANOUT_WATCHER` | n/a | `false` |
 | Watcher trigger label | `watcherTriggerLabel` | `FANOUT_WATCHER_TRIGGER_LABEL` | n/a | `fanout:auto` |
 | Watcher running label | `watcherRunningLabel` | `FANOUT_WATCHER_RUNNING_LABEL` | n/a | `fanout:running` |
@@ -63,6 +65,7 @@ Both config files share the same shape: a flat JSON object of booleans, strings,
   "agentTeamsHint": false,
   "prVisualization": true,
   "dashboardKeybind": true,
+  "consoleKeybind": true,
   "watcher": false,
   "watcherTriggerLabel": "fanout:auto",
   "watcherRunningLabel": "fanout:running",


### PR DESCRIPTION
## TL;DR

任意のペインから TUI コンソールへワンキー(root `F11` / `prefix + T`)で戻る復帰導線と、その実体の新サブコマンド `fanout focus-console` を追加。dashboard の `F12` / `prefix + D` と対になる。押下ペインの記録済み project root で multi-repo でも正しい console に着地し、console 不在・バイナリ消失時はステータスライン通知に縮退する。

Review effort: 3

## Why

親 #383(TUI compact switcher)の C2。コンソール→agent ペインは enter / o で飛べるが、戻りは手動 tmux 操作しかない片方向だった。issue #385 は `docs/tui-compact-switcher.ja.md`「コンソール復帰キー」「focus-console の対象探索と信頼境界」節を正典として、`BindConsoleKeys` + `focus-console` + settings `ConsoleKeybind` の追加を指定している。なお issue の「第 5〜第 7 の listing(role / projectRoot / session_id)」のうち `@fanout_project_root` は issue 作成後に実装済みだったため、本 PR で追加した listing は `@fanout_role` と `#{session_id}` の 2 本(internal/tmuxrun/tmuxrun.go:36-37)。

## Changes by file

<details><summary>Changed files</summary>

| File | What changed | Why |
|---|---|---|
| `internal/tmuxrun/tmuxrun.go` | `BindConsoleKeys`(run-shell 方式・shell 層 `shellQuote` + format 層 `#`→`##`・`\|\| tmux display-message` フォールバック)、`SelectPaneForClient`、`ListLivePanes` に role / session_id listing と `LivePane.Role` / `SessionID` | キー登録と console 探索の tmux 層。偽造行対策済みの既存 parse 経路(`parseLivePaneField`)を共有し、並行実装 `ListConsolePanes` は作らない(issue 指定) |
| `internal/tmuxrun/tmuxrun_test.go` | `BindConsoleKeys` の登録 argv・スペース入りパスのクォート・`#` エスケープ・空引数を pin、join テストへ Role / SessionID 追加 | 受け入れ条件「スペース入りバイナリパスのクォートを pin」ほか |
| `cmd/fanout/focusconsole.go`(新規) | `focus-console` dispatch・`--from` / `--client` / `--help`・純関数 `pickConsolePane`・`bindConsoleKey`・キー定数 `T` / `F11` | root 一致(同率は同一 session 優先)→ 同一 session → 先頭の優先順で console を選び、押下クライアントへピン留めした `switch-client` で復帰。console 不在は `display-message` + exit 0 |
| `cmd/fanout/focusconsole_test.go`(新規) | `pickConsolePane` の優先順と role + タイトル二重照合、flags 解析をテーブル駆動で pin | 受け入れ条件「優先順と二重照合を純関数テストで pin」 |
| `cmd/fanout/main.go` | `isFocusConsoleRequest` dispatch 追加 | 既存サブコマンド群と同じ pre-Parse dispatch |
| `cmd/fanout/tui.go` | `bindDashboardKey` の直後に `bindConsoleKey(lg, resolvedSettings.ConsoleKeybind)` | 登録は live TUI 起動時のみ(issue 指定。dry-run / executePlan 経路は不変) |
| `cmd/fanout/tui_test.go` | console キー登録の positive / negative、dashboard-off 単独・console-off 単独の両方向トグル独立を pin | 既存「dashboard off で bind-key ゼロ」テストが console キー追加で意味が変わったため両方向を明示 |
| `internal/settings/settings.go` / `settings_test.go` | `ConsoleKeybind`(default true、JSON `consoleKeybind` / env `FANOUT_CONSOLE_KEYBIND`)。CLI フラグは追加しない | issue は JSON / env のみ列挙。登録箇所の TUI 起動は cliflags を通らない |
| `internal/tmuxctl/tmuxctl.go` | `DisplayMessageToClient`(`-c` 付き、既存 `tmuxLiteral` の `#` エスケープ再利用) | 通知を押下クライアントへ届ける。既存 `DisplayMessage` と別関数(pane target と client target で flag が異なる) |
| `internal/cliflags/usage.go` | Subcommands に `focus-console` 追記 | `fanout --help` の網羅性 |
| `README.md` / `README.ja.md` | TUI console bullet に復帰キーを追記 | 受け入れ条件のドキュメント同期 |
| `site/content/docs/monitoring.md` / `.ja.md` | TUI 節に `### F11 / prefix + T` を追加 | 同上(キー表) |
| `site/content/docs/settings.md` / `.ja.md` | `consoleKeybind` の bullet・表・JSON 例 | settings 一覧の完全性 |
| `site/content/docs/cli.md` / `.ja.md` | `fanout focus-console` 節と `FANOUT_CONSOLE_KEYBIND` env 行 | CLI リファレンスの網羅性(レビュー指摘) |

</details>

## Risk

> [!WARNING]
> `@fanout_role` / pane title は pane 内プロセスが偽装・妨害できる(悪意ペインへの誘導、newline 偽装による "no live console" 化)。これは設計正典 `docs/tui-compact-switcher.ja.md` に記録済みの信頼境界で、focus-console はセキュリティ境界ではなく表示フォーカスを移すだけの UX プリミティブ(cmd/fanout/focusconsole.go:100-115 の doc comment に明記)。また root F11 バインドは dashboard F12 と同様 tmux server に残留し、`consoleKeybind=false` は次回登録を止めるだけで既存バインドは解除しない。TUI クラッシュ時の stale role も `findTUIPane` と同じ既知の限界として v1 で許容(いずれも設計の判断記録どおり)。

```mermaid
flowchart LR
    K["F11 / prefix + T\n(bind-key … run-shell)"] --> R["run-shell: fanout focus-console\n--from #{pane_id} --client #{client_name}"]
    R --> L["tmuxrun.ListLivePanes\n(+ @fanout_role / session_id listing)"]
    L --> P["pickConsolePane\nroot一致 > 同一session > 先頭"]
    P -->|console あり| S["tmuxrun.SelectPaneForClient\n(switch-client -c)"]
    P -->|console なし| D["tmuxctl.DisplayMessageToClient\n(status line 通知, exit 0)"]
    R -.失敗時.-> F["|| tmux display-message\n(エラービュー抑止)"]
```

## Test plan

- `make lint` — 0 issues
- `make test` — 全 suite green(Go unit + web vitest + bats Tier 1/2)。Tier 2 golden は無変更で通過 = dry-run 出力に変化なし(受け入れ条件)
- 隔離 tmux server(`tmux -L`)での live 検証:
  - バインド登録 → `send-keys -K F11` → console ペインへ切り替わる(押下時 `#{pane_id}` 展開込みの全ラウンドトリップ)
  - 複数リポジトリの console 同居時に押下ペインの root と一致する側へ着地
  - console 不在時: exit 0・ペイン切り替えなし・copy-mode ビューなし
  - バインド先バイナリ消失時: エラービューを出さず status line 通知へ縮退(`pane_in_mode`=0 を確認)
  - `tmux run-shell` 環境に `TMUX` が渡ること(非デフォルトソケットでも正しい server に届く)を実測
- `/code-review`(xhigh workflow)で 15 指摘 → 8 系統修正(format 層 `#` エスケープ、client ピン留め、失敗時フォールバック、両方向トグルテスト、cli.md 同期、tmuxctl 再利用、`--help`、信頼境界コメント正確化)。残り 7 件は設計正典の判断記録どおりスキップ
- codex review — 「既存動作を壊す明確な問題は見つかりませんでした」(指摘なし)

Closes #385
