### PR TITLE
feat(tui): compact switcher レンダラと v トグルを追加

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -139,7 +139,7 @@ watcher は repo 全体から label 付き issue を探し、one-shot session �
 | `fanout 123 --unblocked-only` | ブロッカーが closed の子だけをファンアウト — 次の wave |
 | `fanout 123 --dry-run` | git / tmux / state / briefing file を変更せず計画だけ表示 |
 | `fanout plan spec.json --agent claude` | GitHub の子 issue でなくローカル plan spec をファンアウト |
-| `fanout` | 常駐 TUI コンソールを起動(Session ジャンプ・数字ジャンプ 1-9・focus・zoom・peek・terminal・prompt / issue からの Session 起動・同一 worktree への追加・復元・lifecycle キー) |
+| `fanout` | 常駐 TUI コンソールを起動(Session ジャンプ・数字ジャンプ 1-9・focus・zoom・peek・幅 80 桁未満のコンパクト switcher(`v`)・terminal・prompt / issue からの Session 起動・同一 worktree への追加・復元・lifecycle キー) |
 | `fanout 123 --status` | ペイン・PR review・CI 状態を JSON または table で |
 | `fanout dashboard --web` | localhost で read-only Web ダッシュボードを配信 |
 | `fanout 123 --merge 4` | 子 branch を fast-forward merge(`--close` / `--cleanup` でペインを畳む) |

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ it discovers labeled issues across the repository and starts one-shot sessions.
 | `fanout 123 --unblocked-only` | Fan out only children whose blockers are closed — the next wave |
 | `fanout 123 --dry-run` | Print the plan without modifying git, tmux, state, or briefing files |
 | `fanout plan spec.json --agent claude` | Fan out a local plan spec instead of GitHub child issues |
-| `fanout` | Start the persistent TUI console (Session jump, numeric jump 1-9, focus, zoom, peek, terminal, prompt / issue session launch, same-worktree attach, restore, lifecycle keys) |
+| `fanout` | Start the persistent TUI console (Session jump, numeric jump 1-9, focus, zoom, peek, compact switcher below 80 columns (`v`), terminal, prompt / issue session launch, same-worktree attach, restore, lifecycle keys) |
 | `fanout 123 --status` | Pane, PR review, and CI state as JSON or a table |
 | `fanout dashboard --web` | Serve the read-only web dashboard on localhost |
 | `fanout 123 --merge 4` | Fast-forward merge a child branch (`--close` / `--cleanup` fold panes away) |

--- a/go.mod
+++ b/go.mod
@@ -5,15 +5,15 @@ go 1.26
 require (
 	github.com/charmbracelet/bubbles v0.20.0
 	github.com/charmbracelet/bubbletea v1.3.4
-	github.com/charmbracelet/x/term v0.2.1
 	github.com/charmbracelet/lipgloss v1.0.0
+	github.com/charmbracelet/x/ansi v0.8.0
+	github.com/charmbracelet/x/term v0.2.1
 	modernc.org/sqlite v1.52.0
 )
 
 require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
-	github.com/charmbracelet/x/ansi v0.8.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/MakeNowJust/heredoc v1.0.0 h1:cXCdzVdstXyiTqTvfqk9SDHpKNjxuom+DOlyEeQ4pzQ=
+github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
 github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
 github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52/v2 v2.0.1 h1:HwpRHbFMcZLEVr42D4p7XBqjyuxQH5SMiErDT4WkJ2k=

--- a/internal/tui/compact.go
+++ b/internal/tui/compact.go
@@ -1,0 +1,275 @@
+package tui
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/charmbracelet/x/ansi"
+)
+
+// compactEntry is one switcher unit: a session header line or a pane row.
+// The selected pane carries its expansion lines in the same entry so the
+// sliding window never splits them from the row.
+type compactEntry struct {
+	lines  []string
+	active bool
+}
+
+// cellWidth / truncateCells measure terminal display cells (CJK-aware),
+// unlike the package's rune-count helpers: a compact row that exceeds the
+// pane width wraps and breaks the fixed-height frame, while the bubbles
+// table clips cells display-width-aware.
+func cellWidth(s string) int {
+	return ansi.StringWidth(s)
+}
+
+func truncateCells(s string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	if ansi.StringWidth(s) <= width {
+		return s
+	}
+	if width <= 3 {
+		return ansi.Truncate(s, width, "")
+	}
+	return ansi.Truncate(s, width, "...")
+}
+
+// compactBody renders the vertical switcher list that replaces the table +
+// detail panel below compactWidthAt. It reads the same m.panes /
+// m.table.Cursor() state as the table, so selection and key handling are
+// unchanged. The output is padded to exactly layout.TableRows lines so the
+// footer stays anchored while the selection moves.
+func (m model) compactBody(layout monitorLayout) string {
+	if len(m.allPanes) == 0 {
+		return padCompactLines([]string{truncateCells(emptyStateNoPanes, layout.MainWidth)}, layout.TableRows)
+	}
+	if len(m.panes) == 0 {
+		return padCompactLines([]string{truncateCells(emptyStateNoFilter, layout.MainWidth)}, layout.TableRows)
+	}
+	entries, activeIdx := m.compactEntries(layout.MainWidth)
+	return padCompactLines(compactWindowLines(entries, activeIdx, layout.TableRows), layout.TableRows)
+}
+
+func padCompactLines(lines []string, height int) string {
+	for len(lines) < height {
+		lines = append(lines, "")
+	}
+	return strings.Join(lines, "\n")
+}
+
+// compactEntries walks m.panes in row order, inserting a session header
+// whenever the parent changes, and returns the entry index of the selected
+// pane. Ordinals are the 1-based visible-row index, matching jumpToOrdinal.
+func (m model) compactEntries(width int) ([]compactEntry, int) {
+	sessions := buildSessionSummaries(m.panes, m.table.Cursor())
+	summaryByParent := make(map[string]sessionSummary, len(sessions))
+	for _, session := range sessions {
+		summaryByParent[session.Parent] = session
+	}
+	cursor := m.table.Cursor()
+	if cursor < 0 || cursor >= len(m.panes) {
+		cursor = 0
+	}
+	entries := make([]compactEntry, 0, len(m.panes)+len(sessions))
+	activeIdx := 0
+	prevParent := ""
+	for i, pane := range m.panes {
+		parent := normalizeParent(pane.Parent)
+		if i == 0 || parent != prevParent {
+			header := compactSessionHeaderLine(summaryByParent[parent], width)
+			entries = append(entries, compactEntry{lines: []string{dimStyle.Render(header)}})
+			prevParent = parent
+		}
+		selected := i == cursor
+		line := compactPaneLine(pane, i+1, selected, width)
+		if selected {
+			activeIdx = len(entries)
+			lines := []string{compactSelectedStyle.Render(line)}
+			lines = append(lines, m.compactExpansionLines(pane, width)...)
+			entries = append(entries, compactEntry{lines: lines, active: true})
+			continue
+		}
+		entries = append(entries, compactEntry{lines: []string{line}})
+	}
+	return entries, activeIdx
+}
+
+// compactSessionHeaderLine has no ">" marker: that column marks the selected
+// pane row, and headers reuse the sidebar's counter text instead.
+func compactSessionHeaderLine(session sessionSummary, width int) string {
+	return truncateCells("▏"+sessionCountersText(session), width)
+}
+
+// compactPaneLine renders one switcher row: selection marker, ordinal
+// (digit-jump correspondence, blank past 9), agent-state glyph, item label,
+// name, and the pane ID right-aligned. Only Name shrinks when the width is
+// short; below that the trailing pane ID gets clipped.
+func compactPaneLine(p paneView, ordinal int, selected bool, width int) string {
+	marker := " "
+	if selected {
+		marker = ">"
+	}
+	ord := " "
+	if ordinal >= 1 && ordinal <= 9 {
+		ord = strconv.Itoa(ordinal)
+	}
+	prefix := marker + ord + agentStateGlyph(p) + " " + p.itemLabel() + " "
+	paneID := dash(p.PaneID)
+	name := truncateCells(strings.TrimSpace(p.Name), width-cellWidth(prefix)-cellWidth(paneID)-1)
+	line := prefix + name
+	pad := max(width-cellWidth(line)-cellWidth(paneID), 1)
+	line += strings.Repeat(" ", pad) + paneID
+	return truncateCells(line, width)
+}
+
+// compactExpansionLines are the detail lines under the selected row: branch +
+// PR, ci/wave/blockers/dirty, the recorded worktree error, and the last line
+// of the peek capture (or its loading/error state, which the detail panel
+// would otherwise be the only surface for). A line with no content is
+// dropped, so healthy panes expand by 2-3 lines.
+func (m model) compactExpansionLines(p paneView, width int) []string {
+	lines := make([]string, 0, 4)
+	branch := make([]string, 0, 2)
+	if b := strings.TrimSpace(p.BranchName); b != "" && b != "-" {
+		branch = append(branch, "⎇ "+b)
+	}
+	if pr := strings.TrimSpace(p.PRSummary); pr != "" && pr != "-" {
+		branch = append(branch, "PR"+pr)
+	}
+	if len(branch) > 0 {
+		lines = append(lines, truncateCells("   "+strings.Join(branch, " "), width))
+	}
+	status := make([]string, 0, 4)
+	if ci := p.paneCI(); ci != "" {
+		status = append(status, "ci:"+ci)
+	}
+	wave := strings.TrimSpace(p.WaveLabel)
+	if wave == "" && p.Wave > 0 {
+		wave = fmt.Sprintf("W%d", p.Wave)
+	}
+	if wave != "" && wave != "-" {
+		status = append(status, wave)
+	}
+	if blk := strings.TrimSpace(p.Blockers); blk != "" && blk != "-" {
+		status = append(status, "blk:"+blk)
+	}
+	if p.DirtyState == "dirty" {
+		status = append(status, "dirty")
+	}
+	if len(status) > 0 {
+		lines = append(lines, truncateCells("   "+strings.Join(status, " "), width))
+	}
+	if err := strings.TrimSpace(p.WorktreeErr); err != "" {
+		lines = append(lines, truncateCells("   worktree_error="+err, width))
+	}
+	if p.PaneID != "" && m.peek.PaneID == p.PaneID {
+		switch {
+		case m.peek.Loading:
+			lines = append(lines, truncateCells("   peek: loading...", width))
+		case m.peek.Err != "":
+			lines = append(lines, truncateCells("   peek: "+m.peek.Err, width))
+		default:
+			if out := strings.TrimRight(m.peek.Output, "\r\n"); out != "" {
+				if tail := tailLines(out, 1); len(tail) == 1 && strings.TrimSpace(tail[0]) != "" {
+					lines = append(lines, truncateCells("   "+strings.ReplaceAll(tail[0], "\t", " "), width))
+				}
+			}
+		}
+	}
+	return lines
+}
+
+// compactWindowLines flattens entries into at most budget lines, keeping the
+// active entry fully visible and roughly centered, with a "..." line marking
+// each truncated side — the sessionRows pattern, made height-aware because
+// the active entry spans multiple lines.
+func compactWindowLines(entries []compactEntry, activeIdx, budget int) []string {
+	if len(entries) == 0 || budget <= 0 {
+		return nil
+	}
+	total := 0
+	for _, entry := range entries {
+		total += len(entry.lines)
+	}
+	if total <= budget {
+		return flattenCompactEntries(entries)
+	}
+	activeIdx = clampInt(activeIdx, 0, len(entries)-1)
+	// Grow outward from the active entry, alternating sides. Each acceptance
+	// keeps used + current "..." markers within budget; markers only shrink
+	// afterwards (a side disappears once fully included), so the invariant
+	// holds through the loop.
+	start, end := activeIdx, activeIdx+1
+	used := len(entries[activeIdx].lines)
+	for start > 0 || end < len(entries) {
+		grew := false
+		if start > 0 {
+			cand := len(entries[start-1].lines)
+			if used+cand+markLines(start-1 > 0)+markLines(end < len(entries)) <= budget {
+				start--
+				used += cand
+				grew = true
+			}
+		}
+		if end < len(entries) {
+			cand := len(entries[end].lines)
+			if used+cand+markLines(start > 0)+markLines(end+1 < len(entries)) <= budget {
+				end++
+				used += cand
+				grew = true
+			}
+		}
+		if !grew {
+			break
+		}
+	}
+	head := markLines(start > 0)
+	tail := markLines(end < len(entries))
+	if used+head+tail > budget {
+		// Degenerate case: the active entry alone plus markers exceeds the
+		// budget. Trim the active entry's tail (its first line is the pane
+		// row) rather than the markers, so truncation stays visible; with no
+		// room for markers at all, spend the whole budget on the active rows.
+		avail := budget - head - tail
+		if avail < 1 {
+			return entries[activeIdx].lines[:min(budget, len(entries[activeIdx].lines))]
+		}
+		avail = min(avail, len(entries[activeIdx].lines))
+		lines := make([]string, 0, budget)
+		if head > 0 {
+			lines = append(lines, "...")
+		}
+		lines = append(lines, entries[activeIdx].lines[:avail]...)
+		if tail > 0 && len(lines) < budget {
+			lines = append(lines, "...")
+		}
+		return lines
+	}
+	lines := make([]string, 0, budget)
+	if head > 0 {
+		lines = append(lines, "...")
+	}
+	lines = append(lines, flattenCompactEntries(entries[start:end])...)
+	if tail > 0 {
+		lines = append(lines, "...")
+	}
+	return lines
+}
+
+func markLines(present bool) int {
+	if present {
+		return 1
+	}
+	return 0
+}
+
+func flattenCompactEntries(entries []compactEntry) []string {
+	lines := []string{}
+	for _, entry := range entries {
+		lines = append(lines, entry.lines...)
+	}
+	return lines
+}

--- a/internal/tui/compact.go
+++ b/internal/tui/compact.go
@@ -162,7 +162,10 @@ func (m model) compactExpansionLines(p paneView, width int) []string {
 	if len(status) > 0 {
 		lines = append(lines, truncateCells("   "+strings.Join(status, " "), width))
 	}
-	if err := strings.TrimSpace(p.WorktreeErr); err != "" {
+	// WorktreeErr carries raw git stderr, which can embed newlines; flatten
+	// it first so the entry stays one display line (the window and padding
+	// count slice elements as lines).
+	if err := strings.Join(strings.Fields(p.WorktreeErr), " "); err != "" {
 		lines = append(lines, truncateCells("   worktree_error="+err, width))
 	}
 	if p.PaneID != "" && m.peek.PaneID == p.PaneID {

--- a/internal/tui/compact_test.go
+++ b/internal/tui/compact_test.go
@@ -498,6 +498,25 @@ func TestCompactViewRendersSwitcher(t *testing.T) {
 	}
 }
 
+// Guards that a long repository basename cannot wrap the one-line compact
+// header monitorLayout budgets for.
+func TestCompactHeaderTruncatesLongRepoBasename(t *testing.T) {
+	m := newModel(Options{ProjectRoot: "/tmp/very-long-repository-basename-that-overflows-forty-columns"})
+	m.width = 40
+	m.height = 20
+	m.allPanes = []paneView{{Parent: "100", IssueNum: 101, Name: "one", PaneID: "%1", TmuxState: "live"}}
+	m.resize()
+
+	view := m.View()
+	headerLine, _, _ := strings.Cut(view, "\n")
+	if got := cellWidth(headerLine); got > 40 {
+		t.Fatalf("compact header width = %d cells, want <= 40:\n%q", got, headerLine)
+	}
+	if !strings.Contains(headerLine, "very-long-repository-basename-...") {
+		t.Fatalf("compact header did not truncate the basename:\n%q", headerLine)
+	}
+}
+
 // Guards that cycling to full restores the table even below compactWidthAt.
 func TestViewOverrideFullForcesTableWhenNarrow(t *testing.T) {
 	m := newModel(Options{})

--- a/internal/tui/compact_test.go
+++ b/internal/tui/compact_test.go
@@ -327,6 +327,11 @@ func TestCompactExpansionLines(t *testing.T) {
 			want: []string{"   worktree_error=worktree missing"},
 		},
 		{
+			name: "multi-line worktree error flattens to one line",
+			pane: paneView{PaneID: "%8", TmuxState: "stale", WorktreeErr: "fatal: bad\nhint: try\nhint: again"},
+			want: []string{"   worktree_error=fatal: bad hint: tr..."},
+		},
+		{
 			name: "loading peek shows its state",
 			pane: full,
 			peek: panePeek{PaneID: "%8", Loading: true, Output: "stale"},

--- a/internal/tui/compact_test.go
+++ b/internal/tui/compact_test.go
@@ -1,0 +1,646 @@
+package tui
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/butaosuinu/fanout/internal/state"
+)
+
+// Pins the compactWidthAt breakpoint (80) and both override directions of the
+// v cycle: compact below 80 in auto, table forced by full, switcher forced by
+// compact even on wide terminals.
+func TestCompactLayoutThreshold(t *testing.T) {
+	tests := []struct {
+		name        string
+		width       int
+		override    viewOverride
+		wantCompact bool
+		wantSidebar bool
+		wantStrip   bool
+	}{
+		{name: "width 79 auto switches to compact", width: 79, wantCompact: true},
+		{name: "width 80 auto keeps the top strip", width: 80, wantStrip: true},
+		{name: "width 119 auto keeps the top strip", width: 119, wantStrip: true},
+		{name: "width 120 auto uses the sidebar", width: 120, wantSidebar: true},
+		{name: "override compact wins on a wide terminal", width: 150, override: overrideCompact, wantCompact: true},
+		{name: "override full forces the table when narrow", width: 40, override: overrideFull, wantStrip: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newModel(Options{})
+			m.width = tt.width
+			m.height = 30
+			m.viewOverride = tt.override
+
+			layout := m.monitorLayout()
+
+			if layout.Compact != tt.wantCompact {
+				t.Fatalf("monitorLayout().Compact = %v, want %v", layout.Compact, tt.wantCompact)
+			}
+			if layout.Sidebar != tt.wantSidebar {
+				t.Fatalf("monitorLayout().Sidebar = %v, want %v", layout.Sidebar, tt.wantSidebar)
+			}
+			if got := layout.TopStripHeight > 0; got != tt.wantStrip {
+				t.Fatalf("monitorLayout().TopStripHeight = %d, want strip %v", layout.TopStripHeight, tt.wantStrip)
+			}
+			if tt.wantCompact {
+				if want := max(m.height-4, 4); layout.TableRows != want {
+					t.Fatalf("compact TableRows = %d, want %d", layout.TableRows, want)
+				}
+			}
+		})
+	}
+}
+
+// Pins the v key's three-state cycle auto → compact → full → auto and that it
+// returns no command.
+func TestViewOverrideCycleKey(t *testing.T) {
+	m := newModel(Options{})
+	m.width = 100
+	m.height = 30
+	m.resize()
+
+	// The steps are order-dependent (each press mutates the model), so they
+	// run in sequence with names instead of independent subtests.
+	steps := []struct {
+		name         string
+		wantOverride viewOverride
+		wantCompact  bool
+		wantNotice   string
+	}{
+		{name: "first press forces compact", wantOverride: overrideCompact, wantCompact: true, wantNotice: "view=compact"},
+		{name: "second press forces full", wantOverride: overrideFull, wantCompact: false, wantNotice: "view=full"},
+		{name: "third press wraps to auto", wantOverride: overrideAuto, wantCompact: false, wantNotice: "view=auto"},
+	}
+	for _, step := range steps {
+		updated, cmd := m.Update(keyRunes("v"))
+		m = updated.(model)
+		if cmd != nil {
+			t.Fatalf("%s: v returned a command, want nil", step.name)
+		}
+		if m.viewOverride != step.wantOverride {
+			t.Fatalf("%s: viewOverride = %v, want %v", step.name, m.viewOverride, step.wantOverride)
+		}
+		if got := m.monitorLayout().Compact; got != step.wantCompact {
+			t.Fatalf("%s: monitorLayout().Compact = %v, want %v", step.name, got, step.wantCompact)
+		}
+		if m.notice != step.wantNotice {
+			t.Fatalf("%s: notice = %q, want %q", step.name, m.notice, step.wantNotice)
+		}
+	}
+}
+
+// Guards that the view toggle never touches tmux: no relayout is scheduled
+// and the injected Relayout callback is never invoked.
+func TestViewOverrideKeySchedulesNoRelayout(t *testing.T) {
+	called := 0
+	m := newModel(Options{Relayout: func() error { called++; return nil }})
+	m.width = 40
+	m.height = 20
+
+	for range 3 {
+		updated, cmd := m.Update(keyRunes("v"))
+		m = updated.(model)
+		if cmd != nil {
+			t.Fatal("v returned a command, want nil")
+		}
+	}
+	if m.relayoutGen != 0 {
+		t.Fatalf("relayoutGen = %d, want 0", m.relayoutGen)
+	}
+	if called != 0 {
+		t.Fatalf("Relayout called %d times, want 0", called)
+	}
+}
+
+// Guards that the v toggle re-sizes the stored table for the new mode: a
+// stale compact-sized table would scroll the selection out of the visible
+// window in a v-forced full view on a narrow terminal.
+func TestViewOverrideResizesStoredTable(t *testing.T) {
+	m := newModel(Options{})
+	m.width = 40
+	m.height = 20
+	m.resize()
+
+	compactRows := m.monitorLayout().TableRows
+	before := m.table.Height()
+
+	for range 2 { // auto → compact → full
+		updated, _ := m.Update(keyRunes("v"))
+		m = updated.(model)
+	}
+
+	fullRows := m.monitorLayout().TableRows
+	if fullRows == compactRows {
+		t.Fatalf("full TableRows = compact TableRows = %d, want them to differ at 40x20", fullRows)
+	}
+	// table.Height() excludes the bubbles header row, so compare the delta
+	// instead of the absolute values.
+	if after := m.table.Height(); before-after != compactRows-fullRows {
+		t.Fatalf("table height %d -> %d after v to full, want a %d-row shrink", before, after, compactRows-fullRows)
+	}
+}
+
+// Pins the exact 40-column switcher row format: marker, ordinal, glyph, item
+// label, name, right-aligned pane ID; only Name shrinks when width is short.
+func TestCompactPaneLineFormat(t *testing.T) {
+	tests := []struct {
+		name     string
+		pane     paneView
+		ordinal  int
+		selected bool
+		width    int
+		want     string
+	}{
+		{
+			name:    "done pane fills 40 columns",
+			pane:    paneView{IssueNum: 101, Name: "rate-limiter-core", PaneID: "%5", TmuxState: "live", AgentState: "done"},
+			ordinal: 1,
+			width:   40,
+			want:    " 1✓ #101 rate-limiter-core            %5",
+		},
+		{
+			name:     "selected row carries the > marker",
+			pane:     paneView{IssueNum: 102, Name: "api-cache", PaneID: "%8", TmuxState: "live", AgentState: "running"},
+			ordinal:  2,
+			selected: true,
+			width:    40,
+			want:     ">2● #102 api-cache                    %8",
+		},
+		{
+			name:    "only the name shrinks on overflow",
+			pane:    paneView{IssueNum: 103, Name: "very-long-name-that-overflows-the-line-badly", PaneID: "%12", TmuxState: "live", AgentState: "running"},
+			ordinal: 3,
+			width:   40,
+			want:    " 3● #103 very-long-name-that-over... %12",
+		},
+		{
+			name:    "ordinal past 9 renders blank",
+			pane:    paneView{IssueNum: 110, Name: "ten", PaneID: "%10", TmuxState: "live"},
+			ordinal: 10,
+			width:   40,
+			want:    "  · #110 ten                         %10",
+		},
+		{
+			name:    "stale pane shows the stale glyph",
+			pane:    paneView{IssueNum: 104, Name: "gone", PaneID: "%9", TmuxState: "stale", AgentState: "running"},
+			ordinal: 4,
+			width:   40,
+			want:    " 4✗ #104 gone                         %9",
+		},
+		{
+			name:    "shell row uses the shell label and dashes a missing pane id",
+			pane:    paneView{Kind: state.PaneKindShell, Name: "scratch", TmuxState: "-"},
+			ordinal: 5,
+			width:   40,
+			want:    " 5- shell scratch                      -",
+		},
+		{
+			name:    "plan task row uses the task id label",
+			pane:    paneView{TaskID: "T1", Name: "fix-flaky-test", PaneID: "%21", TmuxState: "live", AgentState: "running"},
+			ordinal: 4,
+			width:   40,
+			want:    " 4● T1 fix-flaky-test                %21",
+		},
+		{
+			name:    "narrow width keeps label and pane id intact",
+			pane:    paneView{IssueNum: 101, Name: "rate-limiter-core", PaneID: "%5", TmuxState: "live", AgentState: "done"},
+			ordinal: 1,
+			width:   20,
+			want:    " 1✓ #101 rate-... %5",
+		},
+		{
+			name:    "double-width name is measured in display cells",
+			pane:    paneView{IssueNum: 105, Name: "認証キャッシュ改善", PaneID: "%7", TmuxState: "live", AgentState: "running"},
+			ordinal: 6,
+			width:   40,
+			want:    " 6● #105 認証キャッシュ改善           %7",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := compactPaneLine(tt.pane, tt.ordinal, tt.selected, tt.width)
+			if got != tt.want {
+				t.Fatalf("compactPaneLine() = %q, want %q", got, tt.want)
+			}
+			if cells := cellWidth(got); cells != tt.width {
+				t.Fatalf("compactPaneLine() width = %d cells, want %d", cells, tt.width)
+			}
+		})
+	}
+}
+
+// Pins the session header format: ▏ + the sidebar counter text, no > marker
+// even for the active session.
+func TestCompactSessionHeaderLine(t *testing.T) {
+	tests := []struct {
+		name    string
+		session sessionSummary
+		width   int
+		want    string
+	}{
+		{
+			name:    "issue parent with counters",
+			session: sessionSummary{Parent: "100", Total: 3, Merged: 1, Pending: 2, Blocked: 1, Live: 3},
+			width:   40,
+			want:    "▏100 t3 m1 p2 b1 l3",
+		},
+		{
+			name:    "project parent uses the proj short form",
+			session: sessionSummary{Parent: "https://github.com/o/r/projects/7", Total: 1, Pending: 1, Live: 1},
+			width:   40,
+			want:    "▏proj/7 t1 m0 p1 b0 l1",
+		},
+		{
+			name:    "active session gets no > marker",
+			session: sessionSummary{Parent: "100", Total: 1, Pending: 1, Active: true},
+			width:   40,
+			want:    "▏100 t1 m0 p1 b0 l0",
+		},
+		{
+			name:    "header truncates to width",
+			session: sessionSummary{Parent: "100", Total: 3, Merged: 1, Pending: 2, Blocked: 1, Live: 3},
+			width:   10,
+			want:    "▏100 t3...",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := compactSessionHeaderLine(tt.session, tt.width)
+			if got != tt.want {
+				t.Fatalf("compactSessionHeaderLine() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// Pins the selected row's expansion: branch + PR, ci/wave/blockers/dirty, and
+// the last peek line, with empty lines dropped.
+func TestCompactExpansionLines(t *testing.T) {
+	full := paneView{
+		PaneID:     "%8",
+		TmuxState:  "live",
+		BranchName: "fanout/issue-102",
+		PRSummary:  "#77 open",
+		CIStatus:   "fail",
+		Wave:       2,
+		Blockers:   "#99",
+		DirtyState: "dirty",
+	}
+	tests := []struct {
+		name string
+		pane paneView
+		peek panePeek
+		want []string
+	}{
+		{
+			name: "full data renders all three lines",
+			pane: full,
+			peek: panePeek{PaneID: "%8", Output: "first\n$ make test ok\n"},
+			want: []string{
+				"   ⎇ fanout/issue-102 PR#77 open",
+				"   ci:fail W2 blk:#99 dirty",
+				"   $ make test ok",
+			},
+		},
+		{
+			name: "no branch or PR drops the first line",
+			pane: paneView{PaneID: "%8", TmuxState: "live", CIStatus: "fail", Wave: 2},
+			want: []string{"   ci:fail W2"},
+		},
+		{
+			name: "clean pane drops the status line",
+			pane: paneView{PaneID: "%8", TmuxState: "live", BranchName: "fanout/x", CIStatus: "-", DirtyState: "clean"},
+			want: []string{"   ⎇ fanout/x"},
+		},
+		{
+			name: "wave label wins over the wave number",
+			pane: paneView{PaneID: "%8", TmuxState: "live", WaveLabel: "wave5"},
+			want: []string{"   wave5"},
+		},
+		{
+			name: "worktree error renders its own line",
+			pane: paneView{PaneID: "%8", TmuxState: "stale", WorktreeErr: "worktree missing"},
+			want: []string{"   worktree_error=worktree missing"},
+		},
+		{
+			name: "loading peek shows its state",
+			pane: full,
+			peek: panePeek{PaneID: "%8", Loading: true, Output: "stale"},
+			want: []string{
+				"   ⎇ fanout/issue-102 PR#77 open",
+				"   ci:fail W2 blk:#99 dirty",
+				"   peek: loading...",
+			},
+		},
+		{
+			name: "peek error shows its state",
+			pane: full,
+			peek: panePeek{PaneID: "%8", Err: "boom", Output: "stale"},
+			want: []string{
+				"   ⎇ fanout/issue-102 PR#77 open",
+				"   ci:fail W2 blk:#99 dirty",
+				"   peek: boom",
+			},
+		},
+		{
+			name: "peek for another pane is omitted",
+			pane: full,
+			peek: panePeek{PaneID: "%9", Output: "other"},
+			want: []string{
+				"   ⎇ fanout/issue-102 PR#77 open",
+				"   ci:fail W2 blk:#99 dirty",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newModel(Options{})
+			m.peek = tt.peek
+			got := m.compactExpansionLines(tt.pane, 40)
+			if len(got) != len(tt.want) {
+				t.Fatalf("compactExpansionLines() = %q, want %q", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Fatalf("compactExpansionLines()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+// Pins the active-centered sliding window with ... markers, height-aware for
+// the multi-line selected entry.
+func TestCompactWindowCentersActive(t *testing.T) {
+	entry := func(text string, extra ...string) compactEntry {
+		return compactEntry{lines: append([]string{text}, extra...)}
+	}
+	tenRows := func() []compactEntry {
+		entries := make([]compactEntry, 0, 10)
+		for _, id := range []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"} {
+			entries = append(entries, entry(id))
+		}
+		return entries
+	}
+
+	tests := []struct {
+		name      string
+		entries   []compactEntry
+		activeIdx int
+		budget    int
+		want      []string
+	}{
+		{
+			name:      "everything fits without markers",
+			entries:   tenRows()[:4],
+			activeIdx: 2,
+			budget:    10,
+			want:      []string{"a", "b", "c", "d"},
+		},
+		{
+			name:      "active centered with markers on both sides",
+			entries:   tenRows(),
+			activeIdx: 5,
+			budget:    5,
+			want:      []string{"...", "e", "f", "g", "..."},
+		},
+		{
+			name:      "active first keeps only the trailing marker",
+			entries:   tenRows(),
+			activeIdx: 0,
+			budget:    4,
+			want:      []string{"a", "b", "c", "..."},
+		},
+		{
+			name:      "active last keeps only the leading marker",
+			entries:   tenRows(),
+			activeIdx: 9,
+			budget:    4,
+			want:      []string{"...", "h", "i", "j"},
+		},
+		{
+			name:      "multi-line active entry stays whole",
+			entries:   []compactEntry{entry("a"), entry("b"), {lines: []string{"c", "c1", "c2"}, active: true}, entry("d"), entry("e")},
+			activeIdx: 2,
+			budget:    5,
+			want:      []string{"...", "c", "c1", "c2", "..."},
+		},
+		{
+			name:      "active entry alone over budget is clipped",
+			entries:   []compactEntry{{lines: []string{"c", "c1", "c2", "c3", "c4", "c5"}, active: true}},
+			activeIdx: 0,
+			budget:    4,
+			want:      []string{"c", "c1", "c2", "c3"},
+		},
+		{
+			name:      "over-budget active keeps both markers and trims its tail",
+			entries:   []compactEntry{entry("a"), {lines: []string{"c", "c1", "c2", "c3"}, active: true}, entry("d")},
+			activeIdx: 1,
+			budget:    5,
+			want:      []string{"...", "c", "c1", "c2", "..."},
+		},
+		{
+			name:      "tiny budget favors the active row over markers",
+			entries:   []compactEntry{entry("a"), {lines: []string{"c", "c1"}, active: true}, entry("d")},
+			activeIdx: 1,
+			budget:    1,
+			want:      []string{"c"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := compactWindowLines(tt.entries, tt.activeIdx, tt.budget)
+			if len(got) > tt.budget {
+				t.Fatalf("compactWindowLines() = %d lines, want <= %d", len(got), tt.budget)
+			}
+			if strings.Join(got, "|") != strings.Join(tt.want, "|") {
+				t.Fatalf("compactWindowLines() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// Guards that the compact view replaces the table + detail panel: session
+// headers and switcher rows render, the table header and detail fields do not.
+func TestCompactViewRendersSwitcher(t *testing.T) {
+	m := newModel(Options{ProjectRoot: "/repo", Session: "fanout-demo"})
+	m.width = 40
+	m.height = 20
+	m.allPanes = []paneView{
+		{Parent: "100", IssueNum: 101, Name: "one", PaneID: "%1", TmuxState: "live", AgentState: "running", BranchName: "fanout/one"},
+		{Parent: "100", IssueNum: 102, Name: "two", PaneID: "%2", TmuxState: "live", AgentState: "done"},
+		{Parent: "200", IssueNum: 201, Name: "three", PaneID: "%3", TmuxState: "live"},
+	}
+	m.resize()
+
+	view := m.View()
+	for _, want := range []string{
+		"fanout repo", // title + project-root basename, not the full header
+		"▏100 t2 m0 p2 b0 l2",
+		"▏200 t1 m0 p1 b0 l1",
+		">1● #101 one",
+		"   ⎇ fanout/one",
+		" 2✓ #102 two",
+		" 3· #201 three",
+	} {
+		if !strings.Contains(view, want) {
+			t.Fatalf("compact view missing %q:\n%s", want, view)
+		}
+	}
+	for _, banned := range []string{"PARENT", "pane=", "session=", "/repo"} {
+		if strings.Contains(view, banned) {
+			t.Fatalf("compact view unexpectedly contains %q:\n%s", banned, view)
+		}
+	}
+}
+
+// Guards that cycling to full restores the table even below compactWidthAt.
+func TestViewOverrideFullForcesTableWhenNarrow(t *testing.T) {
+	m := newModel(Options{})
+	m.width = 40
+	m.height = 20
+	m.allPanes = []paneView{{Parent: "100", IssueNum: 101, Name: "one", PaneID: "%1", TmuxState: "live"}}
+	m.resize()
+
+	for range 2 { // auto → compact → full
+		updated, _ := m.Update(keyRunes("v"))
+		m = updated.(model)
+	}
+
+	if view := m.View(); !strings.Contains(view, "PARENT") {
+		t.Fatalf("full-override view missing table header:\n%s", view)
+	}
+}
+
+// Guards acceptance criterion 2: while compact renders, every selection-based
+// key still acts on selectedPane() via the table cursor.
+func TestCompactKeysUseSelectedPane(t *testing.T) {
+	newCompactModel := func(focused *string) model {
+		opts := Options{
+			PaneAlive:         func(string) bool { return true },
+			CapturePaneOutput: func(string, int) (string, error) { return "", nil },
+		}
+		if focused != nil {
+			opts.FocusPane = func(paneID string) error {
+				*focused = paneID
+				return nil
+			}
+		}
+		m := newModel(opts)
+		m.width = 40
+		m.height = 20
+		m.allPanes = []paneView{
+			{Parent: "100", IssueNum: 101, Name: "one", PaneID: "%1", TmuxState: "live"},
+			{Parent: "100", IssueNum: 102, Name: "two", PaneID: "%2", TmuxState: "live"},
+			{Parent: "200", IssueNum: 201, Name: "three", PaneID: "%3", TmuxState: "live"},
+		}
+		m.resize()
+		if !m.monitorLayout().Compact {
+			t.Fatal("test harness expected the compact layout at width 40")
+		}
+		return m
+	}
+
+	t.Run("enter focuses the cursor pane", func(t *testing.T) {
+		var focused string
+		m := newCompactModel(&focused)
+		m.moveTableCursorTo(1)
+
+		_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+		if cmd == nil {
+			t.Fatal("enter returned nil command, want focus command")
+		}
+		if msg := findPaneFocusedMsg(t, runCmd(cmd)); msg.err != nil {
+			t.Fatalf("focus msg err = %v, want nil", msg.err)
+		}
+		if focused != "%2" {
+			t.Fatalf("focused pane = %q, want %%2", focused)
+		}
+	})
+
+	t.Run("numeric jump moves the cursor and focuses", func(t *testing.T) {
+		var focused string
+		m := newCompactModel(&focused)
+
+		updated, cmd := m.Update(keyRunes("3"))
+		m = updated.(model)
+		if got := m.table.Cursor(); got != 2 {
+			t.Fatalf("cursor after 3 = %d, want 2", got)
+		}
+		if msg := findPaneFocusedMsg(t, runCmd(cmd)); msg.err != nil {
+			t.Fatalf("focus msg err = %v, want nil", msg.err)
+		}
+		if focused != "%3" {
+			t.Fatalf("focused pane = %q, want %%3", focused)
+		}
+	})
+
+	t.Run("session jump brackets move between parents", func(t *testing.T) {
+		m := newCompactModel(nil)
+
+		updated, _ := m.Update(keyRunes("]"))
+		m = updated.(model)
+		if got := m.table.Cursor(); got != 2 {
+			t.Fatalf("cursor after ] = %d, want 2 (parent 200 start)", got)
+		}
+		updated, _ = m.Update(keyRunes("["))
+		m = updated.(model)
+		if got := m.table.Cursor(); got != 0 {
+			t.Fatalf("cursor after [ = %d, want 0 (parent 100 start)", got)
+		}
+	})
+
+	lifecycleKeys := []struct {
+		key  string
+		want lifecycleAction
+	}{
+		{"c", actionClose},
+		{"x", actionClose},
+		{"m", actionMerge},
+		{"X", actionCleanup},
+	}
+	for _, tt := range lifecycleKeys {
+		t.Run(tt.key+" targets the cursor pane", func(t *testing.T) {
+			m := newCompactModel(nil)
+			m.moveTableCursorTo(1)
+
+			updated, _ := m.Update(keyRunes(tt.key))
+			m = updated.(model)
+			if m.pendingAction == nil {
+				t.Fatalf("%s did not open a pending action", tt.key)
+			}
+			if m.pendingAction.action != tt.want {
+				t.Fatalf("pending action = %v, want %v", m.pendingAction.action, tt.want)
+			}
+			if got := m.pendingAction.pane.PaneID; got != "%2" {
+				t.Fatalf("pending action pane = %q, want %%2", got)
+			}
+		})
+	}
+
+	t.Run("filter narrows the visible list", func(t *testing.T) {
+		m := newCompactModel(nil)
+
+		updated, _ := m.Update(keyRunes("/"))
+		m = updated.(model)
+		updated, _ = m.Update(keyRunes("two"))
+		m = updated.(model)
+		updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+		m = updated.(model)
+
+		if len(m.panes) != 1 {
+			t.Fatalf("filtered panes = %d, want 1", len(m.panes))
+		}
+		pane, ok := m.selectedPane()
+		if !ok || pane.Name != "two" {
+			t.Fatalf("selectedPane() = %#v ok=%v, want the filtered pane", pane, ok)
+		}
+		if view := m.View(); !strings.Contains(view, "#102") || strings.Contains(view, "#101") {
+			t.Fatalf("compact view after filter should show only #102:\n%s", view)
+		}
+	})
+}

--- a/internal/tui/focus.go
+++ b/internal/tui/focus.go
@@ -36,6 +36,13 @@ type panePeek struct {
 
 var errPaneNotAlive = errors.New("pane is no longer live")
 
+// Shared by the detail panel and the compact switcher so both views report
+// the same empty states.
+const (
+	emptyStateNoPanes  = "No recorded fanout panes in .fanout/state.json."
+	emptyStateNoFilter = "No panes match the current filter."
+)
+
 func (m *model) refreshRows() {
 	m.allPanes = applyIssueStatuses(m.opts.ProjectRoot, m.allPanes, m.issues)
 	m.panes = filterPaneViews(m.allPanes, m.filterQuery)
@@ -54,14 +61,14 @@ func (m *model) refreshDetail() {
 
 func (m model) detailContent() string {
 	if len(m.allPanes) == 0 {
-		return "No recorded fanout panes in .fanout/state.json."
+		return emptyStateNoPanes
 	}
 	if len(m.panes) == 0 {
-		return "No panes match the current filter."
+		return emptyStateNoFilter
 	}
 	pane, ok := m.selectedPane()
 	if !ok {
-		return "No panes match the current filter."
+		return emptyStateNoFilter
 	}
 	lines := []string{
 		fmt.Sprintf("%s %s  %s", pane.Parent, pane.itemLabel(), pane.Name),

--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -70,6 +70,7 @@ func (m model) helpView() string {
 		{"Enter/o", "Focus pane"},
 		{"Z", "Focus + zoom pane"},
 		{"p", "Peek output"},
+		{"v", "Auto/compact/full view"},
 		{"c/x", "Close pane"},
 		{"m", "Merge branch"},
 		{"X", "Cleanup parent"},

--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -60,7 +60,7 @@ func (m *model) openHelpPopupCmd() tea.Cmd {
 func (m model) helpView() string {
 	monitor := []helpEntry{
 		{"n", "New agent pane"},
-		{"a", "Attach agent to worktree"},
+		{"a", "Attach to worktree"},
 		{"A", "Worktree terminal"},
 		{"t", "Project root terminal"},
 		{"j/k", "Move selection"},
@@ -87,6 +87,9 @@ func (m model) helpView() string {
 		{"Esc", "Cancel / back"},
 	}
 	columnWidth := m.helpColumnWidth()
+	// No blank line above the close hint: with the v entry the monitor column
+	// is 16 rows, and the in-TUI modal fallback must stay within a standard
+	// 24-row terminal (content 20 + border/padding 4).
 	lines := make([]string, 0, 5)
 	if !m.helpOnly {
 		lines = append(lines, titleStyle.Render("Keyboard shortcuts"), "")
@@ -98,7 +101,6 @@ func (m model) helpView() string {
 			"  ",
 			m.helpColumn("New pane popup", newPane, columnWidth),
 		),
-		"",
 		dimStyle.Render("Esc / q / ? close"),
 	)
 	content := strings.Join(lines, "\n")

--- a/internal/tui/help.go
+++ b/internal/tui/help.go
@@ -60,7 +60,7 @@ func (m *model) openHelpPopupCmd() tea.Cmd {
 func (m model) helpView() string {
 	monitor := []helpEntry{
 		{"n", "New agent pane"},
-		{"a", "Attach to worktree"},
+		{"a", "Attach agent to worktree"},
 		{"A", "Worktree terminal"},
 		{"t", "Project root terminal"},
 		{"j/k", "Move selection"},
@@ -87,12 +87,13 @@ func (m model) helpView() string {
 		{"Esc", "Cancel / back"},
 	}
 	columnWidth := m.helpColumnWidth()
-	// No blank line above the close hint: with the v entry the monitor column
-	// is 16 rows, and the in-TUI modal fallback must stay within a standard
-	// 24-row terminal (content 20 + border/padding 4).
-	lines := make([]string, 0, 5)
+	// No blank lines around the columns: with the v entry the monitor column
+	// is 18 rows (16 entries + title + one wrapped description), and the
+	// in-TUI modal fallback must stay within a standard 24-row terminal
+	// (content 20 + border/padding 4).
+	lines := make([]string, 0, 4)
 	if !m.helpOnly {
-		lines = append(lines, titleStyle.Render("Keyboard shortcuts"), "")
+		lines = append(lines, titleStyle.Render("Keyboard shortcuts"))
 	}
 	lines = append(lines,
 		lipgloss.JoinHorizontal(

--- a/internal/tui/session.go
+++ b/internal/tui/session.go
@@ -188,9 +188,12 @@ func sessionSummaryText(session sessionSummary) string {
 	if session.Active {
 		marker = ">"
 	}
+	return marker + " " + sessionCountersText(session)
+}
+
+func sessionCountersText(session sessionSummary) string {
 	return fmt.Sprintf(
-		"%s %s t%d m%d p%d b%d l%d",
-		marker,
+		"%s t%d m%d p%d b%d l%d",
 		compactParent(session.Parent),
 		session.Total,
 		session.Merged,
@@ -200,6 +203,16 @@ func sessionSummaryText(session sessionSummary) string {
 	)
 }
 
+// normalizeParent is the session grouping key. compactEntries relies on the
+// same normalization to look session summaries back up by parent.
+func normalizeParent(parent string) string {
+	parent = strings.TrimSpace(parent)
+	if parent == "" {
+		return "-"
+	}
+	return parent
+}
+
 func buildSessionSummaries(panes []paneView, cursor int) []sessionSummary {
 	if len(panes) == 0 {
 		return nil
@@ -207,17 +220,11 @@ func buildSessionSummaries(panes []paneView, cursor int) []sessionSummary {
 	if cursor < 0 || cursor >= len(panes) {
 		cursor = 0
 	}
-	activeParent := strings.TrimSpace(panes[cursor].Parent)
-	if activeParent == "" {
-		activeParent = "-"
-	}
+	activeParent := normalizeParent(panes[cursor].Parent)
 	indexByParent := map[string]int{}
 	sessions := []sessionSummary{}
 	for i, pane := range panes {
-		parent := strings.TrimSpace(pane.Parent)
-		if parent == "" {
-			parent = "-"
-		}
+		parent := normalizeParent(pane.Parent)
 		idx, ok := indexByParent[parent]
 		if !ok {
 			idx = len(sessions)

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -20,10 +20,13 @@ var (
 var (
 	titleStyle = lipgloss.NewStyle().Bold(true).Foreground(colorAi)
 	dimStyle   = lipgloss.NewStyle().Foreground(colorInk)
-	warnStyle  = lipgloss.NewStyle().Foreground(colorTsuchi)
-	errStyle   = lipgloss.NewStyle().Foreground(colorBeni)
-	panelStyle = lipgloss.NewStyle().Border(lipgloss.NormalBorder(), true, false, false, false).BorderForeground(colorSuna)
-	modalStyle = lipgloss.NewStyle().Border(lipgloss.NormalBorder()).Padding(1, 2).BorderForeground(colorAsagi)
+	// compactSelectedStyle mirrors the table's selected-row look (tui.go
+	// styles.Selected) for the compact switcher's selected pane block.
+	compactSelectedStyle = lipgloss.NewStyle().Bold(true).Foreground(colorAsagi)
+	warnStyle            = lipgloss.NewStyle().Foreground(colorTsuchi)
+	errStyle             = lipgloss.NewStyle().Foreground(colorBeni)
+	panelStyle           = lipgloss.NewStyle().Border(lipgloss.NormalBorder(), true, false, false, false).BorderForeground(colorSuna)
+	modalStyle           = lipgloss.NewStyle().Border(lipgloss.NormalBorder()).Padding(1, 2).BorderForeground(colorAsagi)
 	// popupContentStyle drops the modal border when the popup runs inside a tmux
 	// display-popup: the popup frame is the only border, so the content only
 	// keeps a 1-column left/right gutter.

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -27,6 +27,7 @@ const (
 	sessionSidebarAt     = 120
 	sessionSidebarWidth  = 26
 	sessionTopHeight     = 3
+	compactWidthAt       = 80
 	// relayoutDebounce coalesces the burst of resize events tmux emits while a
 	// terminal window is being dragged into a single relayout.
 	relayoutDebounce = 150 * time.Millisecond
@@ -89,6 +90,7 @@ type model struct {
 	panes            []paneView
 	filterQuery      string
 	filterEditing    bool
+	viewOverride     viewOverride
 	issues           map[issueKey]issueStatus
 	lastState        time.Time
 	lastGH           time.Time

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -3035,6 +3035,9 @@ func TestHelpModalFitsStandardTerminalHeight(t *testing.T) {
 			t.Fatalf("80x24 help view missing %q:\n%s", want, view)
 		}
 	}
+	if got := lipgloss.Height(m.helpView()); got > 24 {
+		t.Fatalf("help modal height = %d lines, want <= 24 (bottom border clips otherwise)", got)
+	}
 }
 
 func TestHelpModalRendersCompactKeyLabels(t *testing.T) {

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -112,6 +112,15 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "p":
 			cmd := m.peekSelectedCmd(true)
 			return m, cmd
+		case "v":
+			// Rendering-only toggle: no command, no relayout, no tmux.
+			// resize() re-sizes the stored table/viewport for the new mode so
+			// cursor scrolling stays in sync; it only touches in-memory
+			// bubbles models.
+			m.viewOverride = m.viewOverride.next()
+			m.notice = "view=" + m.viewOverride.String()
+			m.resize()
+			return m, nil
 		case "c":
 			return m.startPendingAction(actionClose)
 		case "m":

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -81,7 +81,11 @@ func (m model) View() string {
 		// session header lines (a t/m/p/b HUD here would contradict them —
 		// summarizeHUD skips shell/attached rows, session counters do not).
 		if root := strings.TrimSpace(m.opts.ProjectRoot); root != "" {
-			header += " " + dimStyle.Render(filepath.Base(root))
+			// Truncate by display cells so a long basename cannot wrap the
+			// one-line header monitorLayout budgets for. 7 = "fanout" + space.
+			if base := truncateCells(filepath.Base(root), max(m.width-7, 0)); base != "" {
+				header += " " + dimStyle.Render(base)
+			}
 		}
 	} else {
 		if m.opts.Session != "" {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -1,15 +1,62 @@
 package tui
 
 import (
+	"path/filepath"
+	"strings"
+
 	"github.com/charmbracelet/lipgloss"
 )
 
 type monitorLayout struct {
 	Sidebar        bool
+	Compact        bool
 	MainWidth      int
 	TableRows      int
 	PanelWidth     int
 	TopStripHeight int
+}
+
+// viewOverride is the manual view toggle cycled by the v key. It is
+// session-local and never persisted.
+type viewOverride int
+
+const (
+	overrideAuto viewOverride = iota
+	overrideCompact
+	overrideFull
+)
+
+func (v viewOverride) next() viewOverride {
+	switch v {
+	case overrideAuto:
+		return overrideCompact
+	case overrideCompact:
+		return overrideFull
+	default:
+		return overrideAuto
+	}
+}
+
+func (v viewOverride) String() string {
+	switch v {
+	case overrideCompact:
+		return "compact"
+	case overrideFull:
+		return "full"
+	default:
+		return "auto"
+	}
+}
+
+func (m model) compactActive() bool {
+	switch m.viewOverride {
+	case overrideCompact:
+		return true
+	case overrideFull:
+		return false
+	default:
+		return m.width < compactWidthAt
+	}
 }
 
 func (m model) View() string {
@@ -25,14 +72,26 @@ func (m model) View() string {
 	if m.promptOnly {
 		return m.newPaneView()
 	}
+	layout := m.monitorLayout()
 	header := titleStyle.Render("fanout")
-	if m.opts.Session != "" {
-		header += " " + dimStyle.Render("session="+m.opts.Session)
+	if layout.Compact {
+		// The full header (session= + project root + HUD) wraps at 40 columns
+		// and eats list rows. Keep the title plus the repo basename so
+		// multi-repo consoles stay tellable apart; counters live on the ▏
+		// session header lines (a t/m/p/b HUD here would contradict them —
+		// summarizeHUD skips shell/attached rows, session counters do not).
+		if root := strings.TrimSpace(m.opts.ProjectRoot); root != "" {
+			header += " " + dimStyle.Render(filepath.Base(root))
+		}
+	} else {
+		if m.opts.Session != "" {
+			header += " " + dimStyle.Render("session="+m.opts.Session)
+		}
+		if m.opts.ProjectRoot != "" {
+			header += " " + dimStyle.Render(m.opts.ProjectRoot)
+		}
+		header += " " + dimStyle.Render(formatHUD(summarizeHUD(m.panes)))
 	}
-	if m.opts.ProjectRoot != "" {
-		header += " " + dimStyle.Render(m.opts.ProjectRoot)
-	}
-	header += " " + dimStyle.Render(formatHUD(summarizeHUD(m.panes)))
 
 	footer := dimStyle.Render(m.footerText())
 	if m.notice != "" {
@@ -51,13 +110,17 @@ func (m model) View() string {
 		footer += "\n" + warnStyle.Render("notify: "+m.notifyErr)
 	}
 
-	layout := m.monitorLayout()
-	body := m.monitorBody(layout)
-	if layout.Sidebar {
-		sessions := m.sessionSidebar(layout.PanelWidth, lipgloss.Height(body))
-		body = lipgloss.JoinHorizontal(lipgloss.Top, sessions, " ", body)
-	} else if layout.TopStripHeight > 0 {
-		body = lipgloss.JoinVertical(lipgloss.Left, m.sessionTopStrip(layout.PanelWidth, layout.TopStripHeight), body)
+	var body string
+	if layout.Compact {
+		body = m.compactBody(layout)
+	} else {
+		body = m.monitorBody(layout)
+		if layout.Sidebar {
+			sessions := m.sessionSidebar(layout.PanelWidth, lipgloss.Height(body))
+			body = lipgloss.JoinHorizontal(lipgloss.Top, sessions, " ", body)
+		} else if layout.TopStripHeight > 0 {
+			body = lipgloss.JoinVertical(lipgloss.Left, m.sessionTopStrip(layout.PanelWidth, layout.TopStripHeight), body)
+		}
 	}
 	base := lipgloss.JoinVertical(lipgloss.Left, header, body, footer)
 	if m.mode == modeNewPane {
@@ -87,6 +150,17 @@ func (m *model) resize() {
 
 func (m model) monitorLayout() monitorLayout {
 	width := max(1, m.width)
+	if m.compactActive() {
+		return monitorLayout{
+			Compact:    true,
+			MainWidth:  width,
+			PanelWidth: width,
+			// header (1) + footer base line (1) + 2 slack lines so a notice
+			// or error footer line does not push the header off-screen
+			// (table mode keeps the same slack via its rowBudget margin).
+			TableRows: max(m.height-4, 4),
+		}
+	}
 	rowBudget := m.height - detailHeight - 5
 	layout := monitorLayout{
 		MainWidth:  width,

--- a/site/content/docs/monitoring.ja.md
+++ b/site/content/docs/monitoring.ja.md
@@ -40,12 +40,17 @@ footer は短く保ちます。通常画面で `?` を押すと、全ショー�
 | `1`-`9` | 表示リストの N 行目へジャンプして、そのペインにフォーカスする。範囲外の数字は notice を表示する。 |
 | `Z` | 選択中のペインにフォーカスして zoom する（`resize-pane -Z`）。次の relayout（ペインの作成・削除、tmux window のリサイズ）で zoom は解除されるので、必要ならもう一度 `Z` を押す。 |
 | `p` | detail panel の read-only 出力スナップショットを更新する。 |
+| `v` | 表示の手動切替を auto → compact → full でサイクルする。auto は幅 80 桁未満で[コンパクト表示](#コンパクト表示)を選ぶ。compact は広い画面でも switcher を強制し、full は狭くてもテーブルを強制する。永続化はしない。 |
 | `c` / `x` | 選択中のペインの close option を開く。ペインだけを閉じる、ペインと worktree を閉じる、local branch も削除する、から選ぶ。 |
 | `m` | 選択中のペインの branch を fast-forward merge する（確認を挟み、`--merge` と同じコア処理を使う）。 |
 | `X` | 同じ親の merged/closed な子をまとめて cleanup する（確認を挟み、`--cleanup` と同じコア処理を使う）。 |
 | `q` | コンソールを離脱する。tmux session と子ペインはそのまま残る。 |
 
 > worktree 行が `stale!` になるのは、worktree が無い、agent command が無いなど fanout が復元できない場合です。shell terminal は resume できないため、対応する tmux ペインが無ければ TUI が state 行を削除します。
+
+### コンパクト表示
+
+幅 80 桁未満 — auto-layout がコンソールに割り当てる 40 桁サイドバーがこの帯です — では、テーブル + detail panel が 1 ペイン 1 行の switcher に切り替わります。各行は `1`-`9` ジャンプに対応する序数、agent 状態グリフ、issue / task ラベル、名前、右寄せのペイン ID を表示し、幅が足りないときは名前だけを削ります。Session ヘッダ行には Session リストと同じ `t`/`m`/`p`/`b`/`l` カウントが付きます。選択中の行だけが branch + PR、ci / wave / blockers / dirty、peek の末尾 1 行に展開されます。キー操作はすべてそのまま効きます。`v` は自動判定の手動上書きで、現在のコンソール限りです。
 
 ### F11 / prefix + T
 

--- a/site/content/docs/monitoring.md
+++ b/site/content/docs/monitoring.md
@@ -40,12 +40,17 @@ The footer stays short; press `?` in the monitor to open the full shortcut help 
 | `1`-`9` | Jump to the Nth row of the current list and focus its pane. Out-of-range numbers show a notice. |
 | `Z` | Focus the selected pane and zoom it (`resize-pane -Z`). The next relayout — a pane created or closed, or the tmux window resized — unzooms it; press `Z` again to re-zoom. |
 | `p` | Refresh the read-only output snapshot shown in the detail panel. |
+| `v` | Cycle the view override: auto → compact → full. Auto picks the [compact switcher](#compact-view) below 80 columns; compact forces it on a wide terminal, full forces the table when narrow. Not persisted. |
 | `c` / `x` | Open close options for the selected pane: close only the pane, close the pane and remove the worktree, or also delete the local branch. |
 | `m` | Fast-forward merge the selected pane's branch — confirmation prompt, then the same core path as `--merge`. |
 | `X` | Clean up merged/closed children of the same parent — confirmation prompt, then the same core path as `--cleanup`. |
 | `q` | Leave the console. The tmux session and child panes are left running. |
 
 > Worktree rows become `stale!` only when fanout cannot restore them, such as a missing worktree or unavailable agent command. Recorded shell terminals are not resumable; if their tmux pane is gone, the TUI removes the state row.
+
+### Compact view
+
+Below 80 columns — the 40-column sidebar the auto-layout gives the console — the table and detail panel become a one-line-per-pane switcher. Each row shows the ordinal matching the `1`-`9` jump, the agent-state glyph, the issue / task label, the name, and the pane ID right-aligned; when space runs out only the name shrinks. Session header rows carry the same `t`/`m`/`p`/`b`/`l` counts as the Session list. The selected row alone expands with branch + PR, ci / wave / blockers / dirty, and the last line of the output peek. Every key works unchanged. `v` overrides the automatic choice for the current console only.
 
 ### F11 / prefix + T
 


### PR DESCRIPTION
## TL;DR

幅 80 桁未満(auto-layout の 40 桁サイドバー)で TUI monitor をテーブル + 固定 13 行詳細から 1 ペイン 1 行の縦リスト(switcher)に切り替え、`v` キーで auto → compact → full の手動サイクルを追加する。行フォーマットは display cell 幅で計測し、CJK 名でも桁が崩れない。

Review effort: 3

## Why

fanout の主運用形態(コンソール + agent グリッド)では auto-layout がコンソールを幅 40 桁に固定するが、monitor のテーブルは 15 列・最小約 129 桁あり一覧がほぼ読めない(#387 / 設計正典 `docs/tui-compact-switcher.ja.md` 設計 1)。herdr の switcher に倣い、狭幅では圧縮表示を諦めて縦リストから選ぶ形に切り替える。前提の C1 `agentStateGlyph`(#384)と C3 数字ジャンプ(#386)はマージ済み。

## Changes by file

<details><summary>Changed files</summary>

| File | What changed | Why |
|---|---|---|
| `internal/tui/compact.go` | 新規: switcher レンダラ。cell 幅計測(`cellWidth` / `truncateCells`)、序数 + 状態グリフ + itemLabel + Name + 右寄せ pane ID の 1 行フォーマット(Name のみ縮む)、`▏` Session ヘッダ(t/m/p/b/l)、選択行の展開(branch+PR / ci・wave・blockers・dirty / worktree_error / peek 末尾 1 行 or loading・error)、アクティブ中心スライド窓 + `...`、TableRows までの padding | 設計 1 の実装本体 |
| `internal/tui/view.go` | `monitorLayout` に `Compact` を追加し `compactWidthAt = 80` 未満(または `v` 強制)で short-circuit(notice/error 用 slack 2 行込み予算)。`View()` に compact ヘッダ(title + repo basename、セル幅切り詰め)と `compactBody` 分岐 | 閾値 80 とレイアウト分岐。80〜119 帯は現行挙動を維持 |
| `internal/tui/update.go` | `v` キー: `viewOverride.next()` + notice + `resize()`。cmd を返さず relayout/tmux に触れない | 手動オーバーライドと stored table のジオメトリ同期 |
| `internal/tui/tui.go` | `compactWidthAt` 定数、model に `viewOverride`(永続化なし) | モデル状態 |
| `internal/tui/session.go` | `normalizeParent` / `sessionCountersText` を抽出(`sessionSummaryText` の出力は不変) | compact との重複排除 |
| `internal/tui/focus.go` | 空状態文言を定数化し detail panel と共有 | 文言の一元化 |
| `internal/tui/help.go` | `v` エントリ追加。close ヒント前の空行削減 + `a` 行の説明短縮で modal を 80x24 の 24 行に収める | 80x24 での下罫線切れ防止(codex 指摘) |
| `internal/tui/styles.go` | `compactSelectedStyle`(テーブル選択行と同系) | 選択行の強調 |
| `internal/tui/compact_test.go` | 新規: 40 桁行フォーマット(CJK 含む)・閾値 79/80 境界・`v` 3 状態サイクル・relayout 非発火・compact 中の enter/1-9/[ ]/c/x/m/X/フィルタ・窓境界・ヘッダ切り詰めを pin | 受け入れ基準の固定 |
| `internal/tui/tui_test.go` | help modal 高さ ≤ 24 の assert を追加 | 回帰 pin |
| `go.mod` / `go.sum` | `charmbracelet/x/ansi` を直接依存へ(bubbles/lipgloss と同系の幅計算) | CJK の display cell 幅計測 |
| `README.md` / `README.ja.md` | daily-commands の `fanout` 行に compact switcher (`v`) を追記 | ドキュメント同期 |
| `site/content/docs/monitoring.md` / `.ja.md` | キー表に `v` 行、`### Compact view` / `### コンパクト表示` 節を新設 | ドキュメント同期 |

</details>

## Risk

> [!WARNING]
> compact は detail panel の全フィールドを表示しない(選択行の展開に限定。詳細が必要なら `v` で full へ)。幅計測は `x/ansi` の `StringWidth` 依存で、端末が East Asian ambiguous 幅を 2 セル扱いする設定ではグリフ列が 1 セルずれる(bubbles table と同じ前提)。

```mermaid
flowchart TD
    V["View()"] --> L{"monitorLayout()"}
    L -->|"viewOverride=compact<br/>or auto & width < compactWidthAt (80)"| C["compactBody()"]
    L -->|else| B["monitorBody()<br/>table + 13 行 detail(現行)"]
    C --> E["compactEntries()<br/>Session ヘッダ + 序数行 + 選択行展開"]
    E --> W["compactWindowLines()<br/>アクティブ中心窓 + ..."]
    K["v キー(update.go)"] -->|"next() + resize()<br/>cmd なし・tmux 非接触"| L
```

## Test plan

- `make lint` — 0 issues(golangci-lint v2 + shellcheck)
- `make test` — Go unit + web vitest + bats Tier1/Tier2 全て pass(Tier 2 golden への影響なし)
- `go test ./internal/tui/` — 新規 `compact_test.go` 11 テスト + 既存全テスト pass。`TestNarrowShortLayoutCollapsesTopStrip` は無変更で pass
- 40x16 / 40x7 での `View()` 出力を目視確認(CJK 名の桁揃え・選択行展開・`...` 窓・footer 固定)
- code-review(xhigh workflow)+ codex review 3 反復(最終 approve)

Closes #387