### PR TITLE
[codex] popup modal の枠線を強調

### DIFF
--- a/internal/tmuxrun/tmuxrun.go
+++ b/internal/tmuxrun/tmuxrun.go
@@ -60,6 +60,10 @@ const (
 	// falls back to the nearest 256-color when the terminal lacks RGB support.
 	paneActiveBorderStyle = "fg=#00A3AF"
 	paneBorderStyle       = "fg=#165E83"
+	// popupBorderLines / popupBorderStyle make display-popup frames read as a
+	// fanout-owned modal instead of blending into the surrounding terminal.
+	popupBorderLines = "double"
+	popupBorderStyle = paneActiveBorderStyle
 )
 
 // paneIDPattern matches a well-formed tmux pane id (%N). The live-pane parsers
@@ -212,7 +216,13 @@ func displayPopupArgs(opts PopupOptions) ([]string, error) {
 	if strings.TrimSpace(opts.Command) == "" {
 		return nil, fmt.Errorf("popup command is required")
 	}
-	args := []string{"display-popup", "-E", "-w", strconv.Itoa(opts.Width), "-h", strconv.Itoa(opts.Height)}
+	args := []string{
+		"display-popup", "-E",
+		"-b", popupBorderLines,
+		"-S", popupBorderStyle,
+		"-w", strconv.Itoa(opts.Width),
+		"-h", strconv.Itoa(opts.Height),
+	}
 	if strings.TrimSpace(opts.StartDir) != "" {
 		args = append(args, "-d", opts.StartDir)
 	}
@@ -595,7 +605,11 @@ func BindWorktreeActionKey(key, fanoutBin string) error {
 	launch := shellQuote(fanoutBin) + " __worktree-action --pane #{pane_id}"
 	startDir := "#{?@fanout_project_root,#{@fanout_project_root},#{pane_current_path}}"
 	args := []string{
-		"bind-key", key, "display-popup", "-E", "-d", startDir, launch,
+		"bind-key", key, "display-popup", "-E",
+		"-b", popupBorderLines,
+		"-S", popupBorderStyle,
+		"-d", startDir,
+		launch,
 	}
 	if err := exec.Command("tmux", args...).Run(); err != nil {
 		return fmt.Errorf("tmux bind-key %s: %w", key, err)

--- a/internal/tmuxrun/tmuxrun_test.go
+++ b/internal/tmuxrun/tmuxrun_test.go
@@ -95,7 +95,16 @@ func TestDisplayPopupBuildsCenteredArgs(t *testing.T) {
 		t.Fatalf("DisplayPopup() failed: %v", err)
 	}
 	assertTmuxArgs(t, argsPath, []string{
-		"display-popup", "-E", "-w", "90", "-h", "32", "-d", "/tmp/work tree", "-x", "C", "-y", "C", "-T", "New agent pane", "/tmp/fanout __tui-new-pane-popup",
+		"display-popup", "-E",
+		"-b", popupBorderLines,
+		"-S", popupBorderStyle,
+		"-w", "90",
+		"-h", "32",
+		"-d", "/tmp/work tree",
+		"-x", "C",
+		"-y", "C",
+		"-T", "New agent pane",
+		"/tmp/fanout __tui-new-pane-popup",
 	})
 }
 
@@ -702,6 +711,8 @@ printf '%s\n' "$@" > "$TMUXRUN_ARGS"
 	got := strings.Split(strings.TrimRight(string(body), "\n"), "\n")
 	want := []string{
 		"bind-key", "M", "display-popup", "-E",
+		"-b", popupBorderLines,
+		"-S", popupBorderStyle,
 		"-d", "#{?@fanout_project_root,#{@fanout_project_root},#{pane_current_path}}",
 		"/abs/path/fanout __worktree-action --pane #{pane_id}",
 	}

--- a/internal/tui/styles.go
+++ b/internal/tui/styles.go
@@ -26,7 +26,7 @@ var (
 	warnStyle            = lipgloss.NewStyle().Foreground(colorTsuchi)
 	errStyle             = lipgloss.NewStyle().Foreground(colorBeni)
 	panelStyle           = lipgloss.NewStyle().Border(lipgloss.NormalBorder(), true, false, false, false).BorderForeground(colorSuna)
-	modalStyle           = lipgloss.NewStyle().Border(lipgloss.NormalBorder()).Padding(1, 2).BorderForeground(colorAsagi)
+	modalStyle           = lipgloss.NewStyle().Border(lipgloss.DoubleBorder()).Padding(1, 2).BorderForeground(colorAsagi)
 	// popupContentStyle drops the modal border when the popup runs inside a tmux
 	// display-popup: the popup frame is the only border, so the content only
 	// keeps a 1-column left/right gutter.

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -3618,9 +3618,12 @@ func TestNewPaneViewRendersCJKPromptInsideFrame(t *testing.T) {
 	if !strings.Contains(view, "日本語入力テスト") {
 		t.Fatalf("modal view missing CJK prompt:\n%s", view)
 	}
-	// Modal outer frame + the single Prompt box; the Agent toggle is unframed.
-	if got := strings.Count(view, "┌"); got != 2 {
-		t.Fatalf("framed input boxes: got %d top-left corners, want 2:\n%s", got, view)
+	// Double modal outer frame + the single Prompt box; the Agent toggle is unframed.
+	if got := strings.Count(view, "╔"); got != 1 {
+		t.Fatalf("modal frame top-left corners: got %d, want 1:\n%s", got, view)
+	}
+	if got := strings.Count(view, "┌"); got != 1 {
+		t.Fatalf("input box top-left corners: got %d, want 1:\n%s", got, view)
 	}
 }
 
@@ -3631,25 +3634,33 @@ func TestNewPaneViewFramesTextInputs(t *testing.T) {
 	m.openNewPaneForm()
 
 	view := m.newPaneView()
-	// One border for the modal itself plus one around the Prompt textarea; the
-	// Agent toggle stays unframed, so exactly two top-left corners must appear.
-	if got := strings.Count(view, "┌"); got != 2 {
-		t.Fatalf("framed input boxes: got %d top-left corners, want 2:\n%s", got, view)
+	// One double border for the modal itself plus one single border around the
+	// Prompt textarea; the Agent toggle stays unframed.
+	if got := strings.Count(view, "╔"); got != 1 {
+		t.Fatalf("modal frame top-left corners: got %d, want 1:\n%s", got, view)
+	}
+	if got := strings.Count(view, "┌"); got != 1 {
+		t.Fatalf("input box top-left corners: got %d, want 1:\n%s", got, view)
 	}
 
-	// Collect each "┌...┐" top border. Order: modal outer frame, then the Prompt
-	// box. Both must be well-formed single-line borders.
-	var boxTops []string
+	// Collect each top border. Order: modal outer frame, then the Prompt box.
+	var modalTops, inputTops []string
 	for ln := range strings.SplitSeq(view, "\n") {
-		i := strings.Index(ln, "┌")
-		j := strings.Index(ln, "┐")
-		if i < 0 || j < 0 || j < i {
-			continue
+		if i := strings.Index(ln, "╔"); i >= 0 {
+			j := strings.Index(ln, "╗")
+			if j >= i {
+				modalTops = append(modalTops, ln[i:j+len("╗")])
+			}
 		}
-		boxTops = append(boxTops, ln[i:j+len("┐")])
+		if i := strings.Index(ln, "┌"); i >= 0 {
+			j := strings.Index(ln, "┐")
+			if j >= i {
+				inputTops = append(inputTops, ln[i:j+len("┐")])
+			}
+		}
 	}
-	if len(boxTops) != 2 {
-		t.Fatalf("box top borders: got %d, want 2:\n%s", len(boxTops), view)
+	if len(modalTops) != 1 || len(inputTops) != 1 {
+		t.Fatalf("top borders: modal=%d input=%d, want 1 each:\n%s", len(modalTops), len(inputTops), view)
 	}
 }
 


### PR DESCRIPTION
## TL;DR

popup modal の外枠を二重線にし、fanout のメインカラーで境界を見やすくしました。

## 変更内容

- `tmux display-popup` に `-b double` と `-S fg=#00A3AF` を追加
- same-worktree action popup も同じ枠線設定に統一
- TUI 内フォールバック modal を `lipgloss.DoubleBorder()` に変更
- 枠線仕様のテスト期待値を更新

## 確認

- `go test ./internal/tmuxrun ./internal/tui ./cmd/fanout`
- `make test`
- `make lint`
- post-work-review: `clean=true`, `broad_review_calls=1`, `verify_review_calls=0`, `marker_written=true`

Review effort: 1
