### PR TITLE
docs(site): エンドユーザー向けドキュメントを改善

### DIFF
--- a/site/assets/css/main.css
+++ b/site/assets/css/main.css
@@ -894,3 +894,28 @@ html.search-open{ overflow:hidden; }
     transition:none !important;
   }
 }
+
+/* ============================================================
+   docs 図版(.dg)— quickstart / workflow / monitoring の SVG
+   ============================================================ */
+.dg-holder{ margin:2.4rem 0; }
+.dg{ display:block; width:100%; height:auto; overflow:visible; }
+.dg .box{ fill:var(--paper); stroke:var(--suna); stroke-width:1.5; }
+.dg .box-dash{ fill:var(--washi); stroke:var(--suna); stroke-width:1.5; stroke-dasharray:5 4; }
+.dg .hd{ fill:rgba(201,232,236,.62); }
+.dg .frame{ fill:none; stroke:var(--ai); stroke-width:1.5; opacity:.5; stroke-dasharray:2 4; }
+.dg .rule{ stroke:var(--suna); stroke-width:1; }
+.dg .chip{ fill:var(--washi); stroke:var(--suna); stroke-width:1; }
+.dg .sel{ fill:rgba(201,232,236,.45); }
+.dg .arrow{ stroke:var(--ai); stroke-width:1.8; fill:none; }
+.dg .bar{ fill:var(--suna); }
+.dg .bar.b2{ fill:rgba(22,94,131,.22); }
+.dg .dot-run{ fill:var(--asagi); }
+.dg .t-num{ font-family:var(--f-code); font-size:11px; font-weight:500; fill:var(--ai); }
+.dg .t-name{ font-family:var(--f-code); font-size:11.5px; fill:var(--sumi); }
+.dg .t-mut{ font-family:var(--f-code); font-size:10.5px; fill:var(--ink-60); }
+.dg .t-lbl{ font-family:var(--f-body); font-size:11px; fill:var(--ink-60); }
+.dg .t-cmd{ font-family:var(--f-code); font-size:12px; font-weight:500; fill:var(--ai-deep); }
+.dg .t-cap{ font-family:var(--f-head); font-size:14px; fill:var(--sumi); }
+.dg .run{ fill:var(--asagi); }
+.dg .ok{ fill:var(--asagi); }

--- a/site/assets/css/main.css
+++ b/site/assets/css/main.css
@@ -898,8 +898,10 @@ html.search-open{ overflow:hidden; }
 /* ============================================================
    docs 図版(.dg)— quickstart / workflow / monitoring の SVG
    ============================================================ */
-.dg-holder{ margin:2.4rem 0; }
-.dg{ display:block; width:100%; height:auto; overflow:visible; }
+/* 幅 800 の viewBox を縮小し続けるとラベルが読めなくなるので、
+   狭い画面では図の最小幅を保って横スクロールに逃がす */
+.dg-holder{ margin:2.4rem 0; overflow-x:auto; }
+.dg{ display:block; width:100%; min-width:640px; height:auto; overflow:visible; }
 .dg .box{ fill:var(--paper); stroke:var(--suna); stroke-width:1.5; }
 .dg .box-dash{ fill:var(--washi); stroke:var(--suna); stroke-width:1.5; stroke-dasharray:5 4; }
 .dg .hd{ fill:rgba(201,232,236,.62); }
@@ -910,12 +912,10 @@ html.search-open{ overflow:hidden; }
 .dg .arrow{ stroke:var(--ai); stroke-width:1.8; fill:none; }
 .dg .bar{ fill:var(--suna); }
 .dg .bar.b2{ fill:rgba(22,94,131,.22); }
-.dg .dot-run{ fill:var(--asagi); }
 .dg .t-num{ font-family:var(--f-code); font-size:11px; font-weight:500; fill:var(--ai); }
 .dg .t-name{ font-family:var(--f-code); font-size:11.5px; fill:var(--sumi); }
 .dg .t-mut{ font-family:var(--f-code); font-size:10.5px; fill:var(--ink-60); }
 .dg .t-lbl{ font-family:var(--f-body); font-size:11px; fill:var(--ink-60); }
 .dg .t-cmd{ font-family:var(--f-code); font-size:12px; font-weight:500; fill:var(--ai-deep); }
 .dg .t-cap{ font-family:var(--f-head); font-size:14px; fill:var(--sumi); }
-.dg .run{ fill:var(--asagi); }
-.dg .ok{ fill:var(--asagi); }
+.dg .dot-run, .dg .run, .dg .ok{ fill:var(--asagi); }

--- a/site/content/_index.ja.md
+++ b/site/content/_index.ja.md
@@ -14,7 +14,7 @@ quickstart:
   caption: "もう一度実行しても、同じ子に二度目のペインは作られない —— <code class=\"in\">.fanout/state.json</code> が覚えている。"
 features:
   title: "並列を止めないための、六つの機能。"
-  lede: "issue でも、ローカルの plan でも —— どの機能も並列の手を止めないために働く。"
+  lede: "冪等な再実行から三つの監視面まで —— GitHub issue にもローカルの plan spec にも、同じ仕組みで効く。"
   items:
     - no: "i"
       icon: "seal"
@@ -48,7 +48,7 @@ features:
       link: "/docs/agents"
 workflow:
   title: "用意して、展開して、片づける。"
-  lede: "基本はこの三手。wave が終わるたび、繰り返すだけ。"
+  lede: "一度きりではなくループ。再実行のたび、blocker の外れた子だけが次に動き出す。"
   steps:
     - num: "一"
       title: "用意する"

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -14,7 +14,7 @@ quickstart:
   caption: "Run it again and no child gets a second pane &mdash; <code class=\"in\">.fanout/state.json</code> remembers."
 features:
   title: "Six features that keep parallel work moving."
-  lede: "Whether you fan out GitHub issues or a local plan, every feature keeps parallel work moving."
+  lede: "The same machinery serves GitHub issues and local plan specs &mdash; from idempotent reruns to three ways of watching progress."
   items:
     - no: "i"
       icon: "seal"
@@ -48,7 +48,7 @@ features:
       link: "/docs/agents"
 workflow:
   title: "Prepare, fan out, fold away."
-  lede: "Prepare the work, fan it out, fold finished panes away &mdash; then rerun for the next wave."
+  lede: "A loop, not a one-shot: each rerun picks up exactly the children whose blockers just cleared."
   steps:
     - num: "一"
       title: "Prepare the work"

--- a/site/content/docs/agents.ja.md
+++ b/site/content/docs/agents.ja.md
@@ -9,76 +9,72 @@ yomi: agents
 
 ## エージェントセッションの中から呼ぶ
 
-あるペインの中で Claude Code や Codex を動かしながら、その場で子へ fanout したいときがあります。fanout は tmux の中で動いている agent セッションから呼び出しても安全です。作るのは子用の新規ペインだけで、呼び出し元のペインには一切触れません。
+あるペインで Claude Code や Codex を動かしながら、その場で子へ fanout したいことがあります。
+fanout は tmux の中で動く agent セッションから呼び出しても安全です。
+作るのは子用の新規ペインだけで、呼び出し元のペインには触れません。
 
-子ペインがどの agent CLI を起動するかを fanout に伝えるには、`--agent` を渡すか `FANOUT_AGENT` を設定してください。1 回の run で agent を混在させたいときは、繰り返し可能な per-target 上書きを足します。issue や Project の子には `--agent NUM=name`、`fanout plan` では `--agent task-id=name` を使います。各ターゲットはまず一致する上書き、次に global の `--agent`、最後に `FANOUT_AGENT` の順で解決します。解決順の詳細は [CLI Reference]({{< relref "/docs/cli" >}}) を参照してください。
-
-CLI の前提条件はそのまま適用されます。tmux の中で実行すること、そして子を分岐させたいリポジトリの中で実行することです。以下の連携ファイルはリポジトリに同梱されており、[インストールスクリプト]({{< relref "/docs/installation" >}})が配置します。
+子ペインが起動する agent CLI を指定するには、`--agent` を渡すか `FANOUT_AGENT` を設定します。
+1 回の run で agent を混在させたいときは、issue や Project の子に `--agent NUM=name`、`fanout plan` の task に `--agent task-id=name` の per-target 上書きを繰り返し指定します。
+上書きの解決順は [CLI Reference]({{< relref "/docs/cli" >}}) にまとめています。
 
 ## Claude Code
 
 ### `/fanout` スラッシュコマンド
 
-会話の中から fanout を呼びたいが、本実行の前にターゲットを確認したいときがあります。`~/.claude/commands/fanout.md` が次のスラッシュコマンドをインストールします。
+会話の中から fanout を呼びたいが、本実行の前にターゲットを確認したいことがあります。
+`~/.claude/commands/fanout.md` が次のスラッシュコマンドをインストールします。
 
 ```text
 /fanout [parent-issue] [--go] [extra fanout flags]
 ```
 
-このコマンドはまず `fanout <N> --dry-run` を実行してターゲット一覧を表示し、ユーザーが確認したあとにのみ本物のコマンドを実行します。`--go` を渡したときは確認をスキップして即実行します。
+まず `fanout <N> --dry-run` でターゲット一覧を表示し、確認したあとにだけ本実行に進みます。
+`--go` を渡すと確認をスキップして即実行します。
 
 ### `fanout` skill
 
-親 issue の本文に子への参照が散らばっていて、手で番号を拾い集めるのが面倒なことがあります。`~/.claude/skills/fanout/` は、その拾い集めを agent に肩代わりさせる skill です。fanout が使える場面を agent が認識し、勝手に実行せず `/fanout` を提案します。
-
-それに加えてこの skill は、CLI 本体がパースしない**暗黙の子参照**を親本文から読み取ります。読み取るのは `Closes #N` などのクローズキーワード、`Depends on #N` のような依存表現、素の箇条書き、`#N に関連` のような日本語の慣用句です。skill は候補をユーザーに提示し、承認された番号を `--include` で fanout に渡します。
-
-skill は `--name` フラグ(slug、display name、branch)も issue のタイトルと本文から生成します。CLI 自体は LLM を呼ばない設計で、命名は skill 側が判断します。
+親 issue の本文に子への参照が散らばっていて、番号を手で拾い集めるのは面倒なことがあります。
+`~/.claude/skills/fanout/` はその参照を読み取って候補を提示し、承認された番号を `--include` に渡したうえで `/fanout` の実行を提案する skill です。
 
 ### `fanout-issues` skill
 
-計画を fanout にかけられる形の issue ツリーへ落とし込みたいときがあります。`~/.claude/skills/fanout-issues/` は、その変換で agent を導く skill です。同一 repo 内の子 issue を作成し、GitHub Sub-issues でリンクし、親本文のタスクリストにミラーします。さらに `fanout --unblocked-only` が読める `## Blocked by` や `(blocked by #N)` の形式で blocker wave も記録します。
+計画を fanout にかけられる issue ツリーに落とし込みたいことがあります。
+`~/.claude/skills/fanout-issues/` は、同一 repo での子 issue 作成と GitHub Sub-issues でのリンク、親本文のタスクリストへのミラー、`fanout --unblocked-only` 用の blocker wave 記録までを担う skill です。
 
 ### `fanout-plan` skill
 
-GitHub の子 issue を作らず、手元の実装計画をそのまま fanout にかけたいときがあります。`~/.claude/skills/fanout-plan/` は `/fanout plan` を支える skill です。承認済みまたはローカルの実装計画を `fanout plan` の JSON spec に変換し、dry-run preview を実行して task や wave、branch を要約し、確認後に issue-less な task ペインを起動します。
+GitHub の子 issue を作らず、手元の実装計画をそのまま fanout にかけたいことがあります。
+`~/.claude/skills/fanout-plan/` は計画を `fanout plan` の JSON spec に変換し、dry-run で確認したうえで issue-less な task ペインを起動する skill です。
 
 ### レビューと PR follow-up の skill
 
-実装が一段落し、コミット前や PR 作成前にもう一度見直したいときがあります。`~/.claude/skills/post-work-review/` はローカルの PR review gate を支え、最終レビュー loop を回して reviewed HEAD marker を記録します。
-
-PR を作ったあとの追従には別の skill を使います。`~/.claude/commands/pr-watch.md` と `~/.claude/skills/pr-watch/` は、PR 作成後のコンフリクトや CI、レビューコメントへの対応を安全に見張って処理します。
+実装が一段落し、コミットや PR 作成の前にもう一度見直したいことがあります。
+`~/.claude/skills/post-work-review/` はローカルの PR review gate を支え、最終レビュー loop を回します。
+PR を作ったあとの追従には `~/.claude/commands/pr-watch.md` と `~/.claude/skills/pr-watch/` を使い、コンフリクトや CI、レビューコメントへの対応を見張ります。
 
 ## Codex CLI
 
-Codex 版の skill は `~/.codex/skills/fanout/`、`~/.codex/skills/fanout-issues/`、`~/.codex/skills/fanout-plan/`、`~/.codex/skills/post-work-review/`、`~/.codex/skills/pr-watch/` に配置されます。native subagent の TOML は `~/.codex/agents/post-work-reviewer.toml` と `~/.codex/agents/post-work-verifier.toml` に配置され、対応する `.md` は読める契約文として同梱されます。skill や agent のインストール、更新のあと、実行中の Codex セッションがあれば再起動すると新しいファイルを認識します。
+Codex にも `~/.codex/skills/` 配下に同じ skill が用意されています([インストール]({{< relref "/docs/installation" >}}) を参照)。
 
-fanout skill は、Codex に「#123 を fan out して」のように依頼するか、明示的に `$fanout` を指定すると起動します。Claude のコマンドと同じ安全フローに従い、まず dry-run、次にターゲットの確認、それから本実行へ進みます。暗黙の子参照のスキャンと `--name` 生成も同様に行います。
-
-`fanout-issues` skill も Claude 版をミラーします。fanout にかけられる GitHub issue ツリーの作成、計画の親子 issue 化、`fanout --unblocked-only` 用の blocker wave の準備を Codex に依頼したときに使われ、同一 repo の子 issue、GitHub Sub-issues のリンク、親本文のタスクリスト、`## Blocked by` 注記を同じように揃えます。
-
-GitHub の子 issue を作らずローカルの実装計画を fan out したいときは、`$fanout-plan` または `fanout plan` の依頼を使います。spec を作成または選択し、`fanout plan ... --dry-run` を preview してから、確認後に live 実行します(確認スキップが明示された場合を除く)。
-
-`$post-work-review` は、Codex にコミット前や PR 作成前の最終レビュー loop を依頼するときに使います。git から review bundle を 1 つ作り、新しい `post-work-reviewer` native subagent へ 1 回だけ渡します。actionable な指摘を修正したあとは、最大 2 回の `post-work-verifier` で修正確認だけを行います。HEAD が clean なら Claude の PR gate と同じ marker も記録します。
-
-`$pr-watch` は、PR 作成後に mergeability や失敗 CI、レビューコメントを Codex に確認させて修正させたいときに使います。Codex は background scheduler を持たないため、green、reviewer 待ち、CI 待ち、blocked のどの状態かを報告して止まります。
+fanout skill は「#123 を fan out して」のように依頼するか、明示的に `$fanout` を指定すると起動します。
+Claude の `/fanout` と同じ安全フロー(dry-run → ターゲット確認 → 本実行)をたどります。
+`fanout-issues`、`fanout-plan`、`post-work-review`、`pr-watch` も Codex 版として同梱されており、`$fanout-issues` や `$pr-watch` のように呼び出すと Claude 版と同じ役割を果たします。
 
 ## Codex Plan Mode
 
-子を起動する前に、Codex に実装計画を提案させてから先へ進めたいときがあります。batch の子起動では `--codex-plan-mode` で Plan Mode を有効にします。これは(per-target の `--agent` 上書きを適用したあとに)`codex` へ解決される子向けの opt-in 起動モードです。選択した全ての子が `codex` へ解決される必要があり、`claude` の子が混ざっていると起動前に拒否されます。
+子を起動する前に、Codex に実装計画を提案させてから先に進めたいことがあります。
+batch の子起動では `--codex-plan-mode` でこの Plan Mode を有効にできます(既定は off)。
 
 ```bash
 fanout 123 --agent codex --codex-plan-mode
 ```
 
-通常の positional な `codex "<prompt>"` ではなく、fanout は子ごとに Codex app-server を起動し、collaboration mode `plan` の thread を作成し、fanout プロンプト付きで interactive な Codex TUI から resume します。
-
-子 briefing も Plan Mode 向けに差し替わります。関連する文脈を調査してから `<proposed_plan>` に包んだ実装計画を出すこと、その turn ではファイル編集や commit、push、PR 作成をしないことを明示します。TUI の manual ペイン popup で `codex` を起動する場合も、同じ Plan Mode 経路を自動で使いますが、popup の prompt と Plan Mode 指示は `/tmp` briefing file ではなく inline prompt として渡します。
-
-この経路では tmux 経由で `/plan` やプロンプトのテキストを送信しません。ペインは interactive な Codex TUI セッションのまま残るため、その Plan Mode の会話から続行できます。Plan Mode thread のセットアップまたは TUI attach に失敗した場合は、state 記録前に launch を失敗扱いにし、ペインと worktree を後始末するため、同じ子を再実行できます。
+Plan Mode の子は interactive な Codex TUI として起動し、関連する文脈を調査したうえで `<proposed_plan>` に包んだ実装計画を提示します。
+その turn ではファイル編集や commit、push、PR 作成をしません。
+ペインは Plan Mode の会話のまま残るので、そこから続行できます。
 
 ## briefing の仕組み
 
-issue または plan task の子ペインに送られるのは 1 行のプロンプトだけです。issue や task の完全な本文と短い Requirements チェックリストは `/tmp/fanout-<repo>-<NUM>.md` または task briefing path に書き出され、起動プロンプトは agent にその briefing ファイルを読むよう短く伝えます。
-
-briefing の内容は、解決済みの settings でフィルタされます。対象は `autoPullRequest`、`prReviewGate`、`briefingCodeReview`、`agentTeamsHint`、`prVisualization` です。CLI フラグや環境変数、config ファイルがどう解決されるかは [Settings]({{< relref "/docs/settings" >}}) を参照してください。
+issue や plan task の子ペインに送られるのは 1 行のプロンプトだけです。
+issue や task の本文と短い Requirements チェックリストは `/tmp/fanout-<repo>-<NUM>.md` または task 用の briefing path に書き出され、起動プロンプトはそのファイルを読むよう agent に伝えるだけです。
+どの指示を briefing に含めるかは [Settings]({{< relref "/docs/settings" >}}) のトグルで変わります。

--- a/site/content/docs/agents.ja.md
+++ b/site/content/docs/agents.ja.md
@@ -73,6 +73,9 @@ Plan Mode の子は interactive な Codex TUI として起動し、関連する�
 その turn ではファイル編集や commit、push、PR 作成をしません。
 ペインは Plan Mode の会話のまま残るので、そこから続行できます。
 
+選択された子はすべて `codex` に解決される必要があります。
+`claude` の子が混ざっているとペイン作成前に失敗します。
+
 ## briefing の仕組み
 
 issue や plan task の子ペインに送られるのは 1 行のプロンプトだけです。

--- a/site/content/docs/agents.md
+++ b/site/content/docs/agents.md
@@ -57,6 +57,8 @@ fanout 123 --agent codex --codex-plan-mode
 
 Plan Mode children launch as an interactive Codex TUI, investigate relevant context, and present the implementation plan wrapped in `<proposed_plan>`. That turn does not edit files, commit, push, or open a PR. The pane remains in the Plan Mode conversation, so you can continue from there.
 
+Every selected child must resolve to `codex`: mixing in a `claude` child fails before any pane is created.
+
 ## How the briefing works
 
 Each issue or plan-task child pane receives a one-line prompt only. The full issue or task body plus a short Requirements checklist is written to `/tmp/fanout-<repo>-<NUM>.md` or the task briefing path, and the launch prompt only tells the agent to read that file. Which instructions the briefing includes depends on the toggles in [Settings]({{< relref "/docs/settings" >}}).

--- a/site/content/docs/agents.md
+++ b/site/content/docs/agents.md
@@ -1,7 +1,7 @@
 ---
 title: Agent Integrations
 linkTitle: Agent Integrations
-description: "The /fanout slash command, bundled Claude Code and Codex skills, and Codex Plan Mode."
+description: "Bundled skills for Claude Code and Codex, the /fanout slash command, and Codex Plan Mode."
 weight: 70
 kanji: 連
 yomi: agents
@@ -9,11 +9,9 @@ yomi: agents
 
 ## From inside an agent session
 
-Say you are running Claude Code or Codex in one pane and want to fan out to children without leaving it. fanout is safe to call from an agent session (Claude Code, Codex, etc.) that is itself running inside tmux. It only creates NEW panes for children; the caller's pane is never touched.
+Say you are running Claude Code or Codex in one pane and want to fan out to children without leaving it. fanout is safe to call from an agent session (Claude Code, Codex, etc.) that is itself running inside tmux. It only creates new panes for children; the caller's pane is never touched.
 
-To tell fanout which agent CLI the child panes should launch, pass `--agent` or set `FANOUT_AGENT`. To mix agents in one run, add repeatable per-target overrides: `--agent NUM=name` for issue / Project children, or `--agent task-id=name` with `fanout plan`. Each target resolves a matching override first, then the global `--agent`, then `FANOUT_AGENT` — see the [CLI Reference]({{< relref "/docs/cli" >}}).
-
-The CLI prerequisites still apply: run from inside tmux, and run from the repository whose children should branch from the selected base. The integration files below are bundled in the repo and placed by the [install script]({{< relref "/docs/installation" >}}).
+To tell fanout which agent CLI the child panes should launch, pass `--agent` or set `FANOUT_AGENT`. To mix agents in one run, add repeatable per-target overrides: `--agent NUM=name` for issue / Project children, or `--agent task-id=name` with `fanout plan`. See the [CLI Reference]({{< relref "/docs/cli" >}}) for how the overrides resolve.
 
 ## Claude Code
 
@@ -29,63 +27,36 @@ It runs `fanout <N> --dry-run` first, shows the target list, and only fires the 
 
 ### The `fanout` skill
 
-Say the parent body scatters child references around and collecting the numbers by hand is tedious. `~/.claude/skills/fanout/` hands that collection to the agent. It lets the agent recognize when fanout is applicable and suggest `/fanout` rather than invoking it unprompted.
-
-Beyond gating invocation, the skill reads the parent body for **implicit** child references that the CLI itself does not parse — close keywords like `Closes #N`, dependency wording like `Depends on #N`, plain bullets, and Japanese idioms like `#N に関連` — lists the candidates back to you for approval, and forwards the accepted numbers via `--include`.
-
-The skill also generates the `--name` flags (slug / display name / branch) from the issue title and body. The CLI itself never calls an LLM by design; the skill makes the naming decisions.
+Say the parent issue body scatters child references around and collecting the numbers by hand is tedious. `~/.claude/skills/fanout/` reads those references, presents the candidates for approval, forwards the accepted numbers via `--include`, and suggests running `/fanout`.
 
 ### The `fanout-issues` skill
 
-Say you want to shape a plan into the issue tree fanout can run against. `~/.claude/skills/fanout-issues/` guides the agent through that conversion. It creates same-repo children, links them through GitHub Sub-issues, mirrors them in the parent task list, and records blocker waves in the `## Blocked by` / `(blocked by #N)` shapes that `fanout --unblocked-only` understands.
+Say you want to shape a plan into the issue tree fanout can run against. `~/.claude/skills/fanout-issues/` creates same-repo children, links them through GitHub Sub-issues, mirrors them in the parent task list, and records blocker waves for `fanout --unblocked-only`.
 
 ### The `fanout-plan` skill
 
-Say you want to fan out a local implementation plan without creating GitHub
-child issues. `~/.claude/skills/fanout-plan/` backs `/fanout plan`. It turns an
-approved or local implementation plan into a `fanout plan` JSON spec, runs the
-dry-run preview, summarizes tasks/waves/branches, then launches issue-less task
-panes after confirmation.
+Say you want to fan out a local implementation plan without creating GitHub child issues. `~/.claude/skills/fanout-plan/` turns the plan into a `fanout plan` JSON spec, confirms it with a dry run, and launches issue-less task panes.
 
 ### Review and PR follow-up skills
 
-Say the implementation is done and you want one more look before committing or opening a PR. `~/.claude/skills/post-work-review/` backs the local PR review gate: it runs a final review loop and records the reviewed HEAD marker.
-
-For follow-up after a PR exists, use a separate skill. `~/.claude/commands/pr-watch.md` and `~/.claude/skills/pr-watch/` watch an existing PR after creation and handle safe conflict, CI, and review-comment follow-up.
+Say the implementation is done and you want one more look before committing or opening a PR. `~/.claude/skills/post-work-review/` backs the local PR review gate and runs a final review loop. For follow-up after a PR exists, use `~/.claude/commands/pr-watch.md` and `~/.claude/skills/pr-watch/`, which watch for conflicts, CI, and review comments.
 
 ## Codex CLI
 
-The Codex skills are installed to `~/.codex/skills/fanout/`, `~/.codex/skills/fanout-issues/`, `~/.codex/skills/fanout-plan/`, `~/.codex/skills/post-work-review/`, and `~/.codex/skills/pr-watch/`. The native subagent TOML files are installed to `~/.codex/agents/post-work-reviewer.toml` and `~/.codex/agents/post-work-verifier.toml`; matching `.md` files are installed as readable contracts. Restart any running Codex session after installing or updating the skills or agents so it picks up the new files.
+Codex has the same skills under `~/.codex/skills/` (see [Installation]({{< relref "/docs/installation" >}})).
 
-Invoke the fanout skill by asking Codex to fan out a parent issue (for example, "fan out #123") or explicitly with `$fanout`. It follows the same safety flow as the Claude command — dry-run first, confirm targets, then run the real command — and it also performs the implicit-child scan and `--name` generation.
-
-The `fanout-issues` skill mirrors the Claude version: ask Codex to create a fanout-ready GitHub issue tree, decompose a plan into parent/child issues, or prepare blocker waves for `fanout --unblocked-only`, and it produces the same same-repo children, GitHub Sub-issues links, parent task-list rows, and `## Blocked by` annotations.
-
-Use `$fanout-plan` or ask Codex for `fanout plan` when you want to fan out a
-local implementation plan without creating GitHub child issues. It writes or
-selects the plan spec, previews `fanout plan ... --dry-run`, and runs live
-after confirmation unless confirmation was explicitly skipped.
-
-Use `$post-work-review` when you want Codex to run a final pre-commit or pre-PR review loop. It prepares one git-derived review bundle, sends it to one fresh `post-work-reviewer` native subagent, fixes actionable findings, uses at most two `post-work-verifier` calls after fixes, and records the same marker used by the Claude PR gate when HEAD is clean.
-
-Use `$pr-watch` after opening a PR when you want Codex to inspect mergeability, failing CI, and review comments, then safely fix and push the items it can handle. Codex does not run a background scheduler, so the skill reports when it is green, reviewer-waiting, CI-waiting, or blocked.
+Invoke the fanout skill by asking Codex to fan out a parent issue (for example, "fan out #123") or explicitly with `$fanout`. It follows the same safety flow as Claude's `/fanout` — dry-run, confirm targets, then run. `fanout-issues`, `fanout-plan`, `post-work-review`, and `pr-watch` are also bundled as Codex versions; invoke them as `$fanout-issues` or `$pr-watch`, and they play the same role as the Claude versions.
 
 ## Codex Plan Mode
 
-Say you want Codex to propose an implementation plan before any child moves forward. Batch child launches enable Plan Mode with `--codex-plan-mode`, an opt-in mode for children that resolve to `codex` (after any per-target `--agent` overrides). It requires every selected child to resolve to `codex` — mixing in a `claude` child is rejected before launch:
+Say you want Codex to propose an implementation plan before any child moves forward. Batch child launches enable this Plan Mode with `--codex-plan-mode` (off by default).
 
 ```bash
 fanout 123 --agent codex --codex-plan-mode
 ```
 
-Instead of running positional `codex "<prompt>"`, fanout starts a Codex app-server for each child, creates a `plan` collaboration-mode thread, and resumes it with the fanout prompt through an interactive Codex TUI.
-
-The child briefing is also rewritten for Plan Mode: it tells Codex to inspect relevant context before presenting an implementation plan wrapped in `<proposed_plan>`, and explicitly forbids file edits, commits, pushes, and PR creation in that turn. The TUI manual pane popup uses the same Plan Mode path automatically when it launches `codex`, but sends the popup prompt and Plan Mode instructions inline instead of writing a `/tmp` briefing file.
-
-This path never sends `/plan` or prompt text through tmux. The pane remains an interactive Codex TUI session, so you can continue from the Plan Mode conversation. If Plan Mode thread setup or the TUI attach fails, the launch fails before state is recorded and fanout cleans up the pane/worktree so the child can be retried.
+Plan Mode children launch as an interactive Codex TUI, investigate relevant context, and present the implementation plan wrapped in `<proposed_plan>`. That turn does not edit files, commit, push, or open a PR. The pane remains in the Plan Mode conversation, so you can continue from there.
 
 ## How the briefing works
 
-Each issue or plan-task child pane receives a one-line prompt only. The full issue or task body plus a short Requirements checklist is written to `/tmp/fanout-<repo>-<NUM>.md` or the task briefing path, and the launch prompt stays short and points the agent at that briefing file.
-
-The briefing content is filtered through the resolved settings — `autoPullRequest`, `prReviewGate`, `briefingCodeReview`, `agentTeamsHint`, and `prVisualization`. See [Settings]({{< relref "/docs/settings" >}}) for how CLI flags, environment variables, and config files resolve into those switches.
+Each issue or plan-task child pane receives a one-line prompt only. The full issue or task body plus a short Requirements checklist is written to `/tmp/fanout-<repo>-<NUM>.md` or the task briefing path, and the launch prompt only tells the agent to read that file. Which instructions the briefing includes depends on the toggles in [Settings]({{< relref "/docs/settings" >}}).

--- a/site/content/docs/changelog.ja.md
+++ b/site/content/docs/changelog.ja.md
@@ -19,7 +19,7 @@ yomi: changelog
 
 ## v0.7.0 (2026-06-21)
 
-- **ライフサイクルフック。** worktree やペイン、merge のイベントの前後でユーザーの shell hook を実行するようになりました。`$XDG_CONFIG_HOME/fanout/hooks.json`（Codex 形式の `hooks` オブジェクト）で設定します。常時有効で、ファイルが無い場合やコマンドの無いイベントは no-op です。[CLI Reference]({{< relref "/docs/cli" >}}) を参照。
+- **ライフサイクルフック。** worktree やペイン、merge のイベントの前後でユーザーの shell hook を実行するようになりました。`$XDG_CONFIG_HOME/fanout/hooks.json`（Codex 形式の `hooks` オブジェクト）で設定します。常時有効で、ファイルが無い場合やコマンドの無いイベントは no-op です。[Lifecycle hooks]({{< relref "/docs/cli#lifecycle-hooks" >}}) を参照。
 - **TUI shell terminal。** 常駐コンソールで、選択行の worktree に `A`、project root に `t` で plain shell を開けます。shell 行は focus / peek 用に manual entry として記録され、close は tmux ペインと state 行だけを消します。[Monitoring]({{< relref "/docs/monitoring" >}}) を参照。
 - **コンパクトな Session ナビゲーター。** 常駐コンソールに、セッション間を移動するためのコンパクトな Session ナビゲーターが加わりました（既存の focus / peek / lifecycle キーはそのままです）。[Monitoring]({{< relref "/docs/monitoring" >}}) を参照。
 - **`origin` なしの `fanout plan`。** plan 実行に `origin` remote が不要になりました。base branch 解決は現在のローカルブランチや `HEAD` にフォールバックするため、ローカルだけのリポジトリでも plan をファンアウトできます。[CLI Reference]({{< relref "/docs/cli" >}}) を参照。

--- a/site/content/docs/changelog.md
+++ b/site/content/docs/changelog.md
@@ -19,7 +19,7 @@ Release highlights, newest first. Every tag also has a [GitHub release](https://
 
 ## v0.7.0 (2026-06-21)
 
-- **Lifecycle hooks.** fanout now runs user shell hooks around worktree, pane, and merge events. Configure them in `$XDG_CONFIG_HOME/fanout/hooks.json` (a Codex-style `hooks` object); they are always enabled, and a missing file or an event with no commands is a no-op. See [CLI Reference]({{< relref "/docs/cli" >}}).
+- **Lifecycle hooks.** fanout now runs user shell hooks around worktree, pane, and merge events. Configure them in `$XDG_CONFIG_HOME/fanout/hooks.json` (a Codex-style `hooks` object); they are always enabled, and a missing file or an event with no commands is a no-op. See [Lifecycle hooks]({{< relref "/docs/cli#lifecycle-hooks" >}}).
 - **TUI shell terminals.** The persistent console can now open a plain shell in the selected row's worktree with `A`, or at the project root with `t`. Shell rows are recorded as manual entries for focus / peek, and close removes only the tmux pane and state row. See [Monitoring]({{< relref "/docs/monitoring" >}}).
 - **Compact Session navigator.** The persistent console gained a compact Session navigator for jumping between sessions, alongside the existing focus / peek / lifecycle keys. See [Monitoring]({{< relref "/docs/monitoring" >}}).
 - **`fanout plan` without `origin`.** Plan runs no longer require an `origin` remote — base branch resolution falls back to the current local branch or `HEAD`, so a local-only repo can still fan out a plan. See [CLI Reference]({{< relref "/docs/cli" >}}).

--- a/site/content/docs/cli.ja.md
+++ b/site/content/docs/cli.ja.md
@@ -224,6 +224,8 @@ agent wrapper は同梱 skill 経由で plan fan-out へ routing します。Cla
 
 `fanout <parent> --status` は読み取り専用です。`.fanout/state.json`（または `FANOUT_STATE_PATH`）からその parent の記録済み子を列挙し、各子について `gh api graphql` で issue state と closed-by PR の merge/review/CI 状態を取得して、既定では JSON 1 ドキュメントを stdout に出力します。
 
+JSON ドキュメントは `parent`、`children[]`（各子は `num` / `state` / `prs[]`（`number` / `state` / `mergedAt` / `reviewDecision` / `ci`）/ `has_merged_pr`）、`summary`（`total` / `merged` / `pending` / `blocked` / `all_merged`）を持ちます。
+
 - `--format <json|table>`（出力形式。既定: `json`）。table 形式は正規化した PR 状態（`open`、`draft`、`review-required`、`approved`、`changes-requested`、`merged`、`closed`）、CI、差分バー、変更ファイル数、Conventional-Commit 種別、PR リンクを追加する。
 - `--post-dashboard`（親 issue に marker 付き rollup コメントを 1 つ upsert する）。各子の PR リンク、PR 状態、CI、差分規模、Conventional-Commit 種別、TL;DR、Review effort score を機械可読な PR データから集約する。`--status` 系で唯一 GitHub に書き込む option。
 
@@ -243,9 +245,10 @@ fanout 123 --status --post-dashboard
 Lifecycle コマンドは `.fanout/state.json` の記録済み entry だけを対象にします。任意の worktree を filesystem scan で探すことはしません。`--status` と同じく `FANOUT_STATE_PATH` を尊重します。
 
 `.fanout/state.json` には `schemaVersion` と、ペインごとに 1 行を保存します。
-各行は `parent` / `issueNum` / 任意の `taskId` / `kind` / `shellKey` / `slug` / `branchName` / `paneId` / `agent` / `displayName` / `worktreePath` / `prompt` / `createdAt` を持ちます。
-TUI の shell terminal は `kind: "shell"` で記録されるため、close は tmux ペインと state 行だけを消します。
-`shellKey` は行と live tmux ペインを結びつけます。
+各行は `parent` / `issueNum` / `slug` / `branchName` / `paneId` / `agent` / `displayName` / `worktreePath` / `prompt` / `createdAt` を必ず持ちます。
+空のとき省略されるキーは `taskId` / `kind` / `shellKey` / `baseBranch` / `wave` / `agentStatus`、Codex メタデータ(`codexPlanMode` / `codexThreadId` / `codexSessionId`)、attach 元(`sourceParent` / `sourceIssueNum` / `sourceTaskId`)です。
+TUI の shell terminal は `kind: "shell"` で記録されるため、close は tmux ペインと state 行だけを消します(`shellKey` が行と live tmux ペインを結びつけます)。
+既存 worktree に追加した agent は `kind: "attached-agent"` で記録されます。
 
 - `fanout <parent> --merge <NUM>` は、記録済み branch を `git -C <project-root> merge --ff-only <recorded-branch>` で取り込む。fast-forward できない場合は git エラーを報告するだけで、エディタや conflict 解決フローは起動しない。
 - `fanout <parent> --close <NUM>` は、記録済み worktree を `git worktree remove <path> --force` で削除し、記録済み tmux ペインが残っていれば kill し、state entry を削除して `git worktree prune` を実行する。
@@ -412,6 +415,7 @@ fanout check-update
 | `FANOUT_WATCHER_AGENT` | watcher child agent（`watcherAgent`）の環境変数レイヤ。 |
 | `FANOUT_WATCHER_MAX_SESSIONS` | watcher session 上限（`watcherMaxSessions`）の環境変数レイヤ。 |
 | `FANOUT_NOTIFICATIONS` | TUI 遷移通知チャネル（`notifications`）の環境変数レイヤ。[設定]({{< relref "/docs/settings" >}})を参照。 |
+| `FANOUT_TUI_ENHANCED_KEYS` | `0` で TUI prompt 欄の enhanced keyboard input を無効化する。既定は有効。`Shift+Enter` の改行は端末が区別して報告する必要があり（fanout が tmux `extended-keys` を有効化する）、`Ctrl+J` は常に使える。 |
 | `FANOUT_NTFY_URL` | ntfy POST URL（`ntfyURL`）の環境変数レイヤ。 |
 | `FANOUT_SLACK_WEBHOOK_URL` | Slack webhook POST URL（`slackWebhookURL`）の環境変数レイヤ。 |
 | `FANOUT_DB_PATH` | `--team` と `fanout msg` が使う parent ごとの peer messaging SQLite パスを上書きする。既定: `/tmp/fanout-<repo>-<parent>.db`。 |

--- a/site/content/docs/cli.ja.md
+++ b/site/content/docs/cli.ja.md
@@ -17,12 +17,13 @@ fanout <parent-issue|project-url>
        [--name <NUM>=<slug>[|<display>[|<branch>]]]
        [--base-branch <branch>] [--branch-prefix <prefix>] [--no-refresh]
        [--session <tmux-session>] [--sleep <seconds>]
-       [--popup-timeout <seconds>] [--dry-run] [--debug]
+       [--dry-run] [--debug]
        [--auto-pr|--no-auto-pr] [--pr-review-gate|--no-pr-review-gate]
        [--briefing-code-review|--no-briefing-code-review]
        [--agent-teams-hint|--no-agent-teams-hint]
        [--codex-plan-mode|--no-codex-plan-mode]
        [--pr-visualization|--no-pr-visualization]
+       [--dashboard-keybind|--no-dashboard-keybind]
        [--team]
 fanout plan <spec.json|plan-slug> [--agent <name|task-id=name>] [--dry-run]
        [--limit <N>] [--only <task-id[,id...]>] [--skip <task-id[,id...]>]
@@ -235,7 +236,7 @@ fanout 123 --status --format table
 fanout 123 --status --post-dashboard
 ```
 
-`--status` はすべての action 系フラグ（`--agent`、`--limit`、`--only`、`--skip`、`--include`、`--name`、`--base-branch`、`--branch-prefix`、`--no-refresh`、`--session`、`--sleep`、`--popup-timeout`、`--dry-run`、`--unblocked-only`、`--close`、`--merge`、`--cleanup`、`--auto-pr`、`--no-auto-pr`、`--pr-review-gate`、`--no-pr-review-gate`、`--briefing-code-review`、`--no-briefing-code-review`、`--agent-teams-hint`、`--no-agent-teams-hint`、`--codex-plan-mode`、`--no-codex-plan-mode`、`--pr-visualization`、`--no-pr-visualization`）と排他です。
+`--status` はすべての action 系フラグ（`--agent`、`--limit`、`--only`、`--skip`、`--include`、`--name`、`--base-branch`、`--branch-prefix`、`--no-refresh`、`--session`、`--sleep`、`--popup-timeout`、`--dry-run`、`--unblocked-only`、`--close`、`--merge`、`--cleanup`、`--team`、`--auto-pr`、`--no-auto-pr`、`--pr-review-gate`、`--no-pr-review-gate`、`--briefing-code-review`、`--no-briefing-code-review`、`--agent-teams-hint`、`--no-agent-teams-hint`、`--codex-plan-mode`、`--no-codex-plan-mode`、`--pr-visualization`、`--no-pr-visualization`、`--dashboard-keybind`、`--no-dashboard-keybind`）と排他です。
 
 ### `--merge` / `--close` / `--cleanup`
 
@@ -251,8 +252,13 @@ fanout 123 --close 4
 fanout 123 --cleanup
 ```
 
-Hook は常に有効です。user hook config が無い場合、または event に command が無い
-場合、その event は no-op です。fanout は `$XDG_CONFIG_HOME/fanout/hooks.json`、
+## Lifecycle hooks
+
+fanout は worktree・ペイン・merge の各 event で user shell hook を実行します —
+fan-out 中（`worktree_created`、`before_pane_create`）と上記の lifecycle
+コマンドの両方が対象です。Hook は常に有効です。user hook config が無い場合、
+または event に command が無い場合、その event は no-op です。fanout は
+`$XDG_CONFIG_HOME/fanout/hooks.json`、
 または `XDG_CONFIG_HOME` が無い場合は `~/.config/fanout/hooks.json` を読みます。
 ファイルは Codex 風の `hooks` object です:
 

--- a/site/content/docs/cli.ja.md
+++ b/site/content/docs/cli.ja.md
@@ -242,6 +242,11 @@ fanout 123 --status --post-dashboard
 
 Lifecycle コマンドは `.fanout/state.json` の記録済み entry だけを対象にします。任意の worktree を filesystem scan で探すことはしません。`--status` と同じく `FANOUT_STATE_PATH` を尊重します。
 
+`.fanout/state.json` には `schemaVersion` と、ペインごとに 1 行を保存します。
+各行は `parent` / `issueNum` / 任意の `taskId` / `kind` / `shellKey` / `slug` / `branchName` / `paneId` / `agent` / `displayName` / `worktreePath` / `prompt` / `createdAt` を持ちます。
+TUI の shell terminal は `kind: "shell"` で記録されるため、close は tmux ペインと state 行だけを消します。
+`shellKey` は行と live tmux ペインを結びつけます。
+
 - `fanout <parent> --merge <NUM>` は、記録済み branch を `git -C <project-root> merge --ff-only <recorded-branch>` で取り込む。fast-forward できない場合は git エラーを報告するだけで、エディタや conflict 解決フローは起動しない。
 - `fanout <parent> --close <NUM>` は、記録済み worktree を `git worktree remove <path> --force` で削除し、記録済み tmux ペインが残っていれば kill し、state entry を削除して `git worktree prune` を実行する。
 - `fanout <parent> --cleanup` は、issue が `CLOSED`、または closed-by PR に `MERGED` を含む記録済み子をまとめて後始末する。保留中の子は記録されたまま残る。

--- a/site/content/docs/cli.md
+++ b/site/content/docs/cli.md
@@ -243,6 +243,8 @@ fanout 123 --status --post-dashboard
 
 The lifecycle commands operate on entries recorded in `.fanout/state.json`; they do not discover arbitrary worktrees by scanning the filesystem. Like `--status`, they honor `FANOUT_STATE_PATH`.
 
+`.fanout/state.json` holds `schemaVersion` plus one row per pane: `parent`, `issueNum`, optional `taskId`, `kind`, `shellKey`, `slug`, `branchName`, `paneId`, `agent`, `displayName`, `worktreePath`, `prompt`, and `createdAt`. TUI shell terminals are recorded with `kind: "shell"`, so closing one removes only the tmux pane and the state row; `shellKey` ties the row to its live tmux pane.
+
 - `fanout <parent> --merge <NUM>` runs `git -C <project-root> merge --ff-only <recorded-branch>`. If the merge is not a fast-forward, fanout reports the git error and does not start an editor or conflict-resolution flow.
 - `fanout <parent> --close <NUM>` removes the recorded worktree with `git worktree remove <path> --force`, kills the recorded tmux pane when it is still present, removes the state entry, and runs `git worktree prune`.
 - `fanout <parent> --cleanup` closes every recorded child whose issue is `CLOSED` or whose closed-by PR list contains a `MERGED` PR. Pending children remain recorded.

--- a/site/content/docs/cli.md
+++ b/site/content/docs/cli.md
@@ -225,6 +225,8 @@ These paired switches toggle fanout's opinionated behaviors for one run — the 
 
 `fanout <parent> --status` is read-only: it enumerates the children recorded for that parent in `.fanout/state.json` (or `FANOUT_STATE_PATH`), queries each one through `gh api graphql` for issue state plus closed-by PR merge/review/CI status, and prints one JSON document on stdout by default.
 
+The JSON document carries `parent`, `children[]` — each child with `num`, `state`, `prs[]` (`number`, `state`, `mergedAt`, `reviewDecision`, `ci`), and `has_merged_pr` — and `summary` (`total`, `merged`, `pending`, `blocked`, `all_merged`).
+
 - `--format <json|table>` — output format, default `json`. The table format adds normalized PR state (`open`, `draft`, `review-required`, `approved`, `changes-requested`, `merged`, `closed`), CI, PR diff bars, changed-file counts, Conventional-Commit type and PR links.
 - `--post-dashboard` — upsert one marker-based rollup comment on the parent issue, aggregating child PR links, PR state, CI, diff size, Conventional-Commit type, TL;DR and Review effort score from machine-readable PR data. This is the only `--status` option that writes to GitHub.
 
@@ -243,7 +245,7 @@ fanout 123 --status --post-dashboard
 
 The lifecycle commands operate on entries recorded in `.fanout/state.json`; they do not discover arbitrary worktrees by scanning the filesystem. Like `--status`, they honor `FANOUT_STATE_PATH`.
 
-`.fanout/state.json` holds `schemaVersion` plus one row per pane: `parent`, `issueNum`, optional `taskId`, `kind`, `shellKey`, `slug`, `branchName`, `paneId`, `agent`, `displayName`, `worktreePath`, `prompt`, and `createdAt`. TUI shell terminals are recorded with `kind: "shell"`, so closing one removes only the tmux pane and the state row; `shellKey` ties the row to its live tmux pane.
+`.fanout/state.json` holds `schemaVersion` plus one row per pane. Every row carries `parent`, `issueNum`, `slug`, `branchName`, `paneId`, `agent`, `displayName`, `worktreePath`, `prompt`, and `createdAt`. Keys omitted when empty: `taskId`, `kind`, `shellKey`, `baseBranch`, `wave`, `agentStatus`, the Codex metadata (`codexPlanMode`, `codexThreadId`, `codexSessionId`), and the attach source (`sourceParent`, `sourceIssueNum`, `sourceTaskId`). TUI shell terminals are recorded with `kind: "shell"` (closing one removes only the tmux pane and the state row; `shellKey` ties the row to its live tmux pane), and agents attached to an existing worktree with `kind: "attached-agent"`.
 
 - `fanout <parent> --merge <NUM>` runs `git -C <project-root> merge --ff-only <recorded-branch>`. If the merge is not a fast-forward, fanout reports the git error and does not start an editor or conflict-resolution flow.
 - `fanout <parent> --close <NUM>` removes the recorded worktree with `git worktree remove <path> --force`, kills the recorded tmux pane when it is still present, removes the state entry, and runs `git worktree prune`.
@@ -409,6 +411,7 @@ Read-only: fetches the latest release tag from `butaosuinu/fanout`, compares it 
 | `FANOUT_WATCHER_AGENT` | Environment layer for the watcher child agent (`watcherAgent`). |
 | `FANOUT_WATCHER_MAX_SESSIONS` | Environment layer for the watcher session cap (`watcherMaxSessions`). |
 | `FANOUT_NOTIFICATIONS` | Environment layer for the TUI transition notification channels (`notifications`); see [Settings]({{< relref "/docs/settings" >}}). |
+| `FANOUT_TUI_ENHANCED_KEYS` | Set `0` to disable enhanced keyboard input in the TUI prompt fields. On by default; `Shift+Enter` newline needs a terminal that reports it distinctly (fanout turns on tmux `extended-keys` for it), and `Ctrl+J` always works. |
 | `FANOUT_NTFY_URL` | Environment layer for the ntfy POST URL (`ntfyURL`). |
 | `FANOUT_SLACK_WEBHOOK_URL` | Environment layer for the Slack webhook POST URL (`slackWebhookURL`). |
 | `FANOUT_DB_PATH` | Override the per-parent peer-messaging SQLite path used by `--team` and `fanout msg`. Default: `/tmp/fanout-<repo>-<parent>.db`. |

--- a/site/content/docs/cli.md
+++ b/site/content/docs/cli.md
@@ -17,12 +17,13 @@ fanout <parent-issue|project-url>
        [--name <NUM>=<slug>[|<display>[|<branch>]]]
        [--base-branch <branch>] [--branch-prefix <prefix>] [--no-refresh]
        [--session <tmux-session>] [--sleep <seconds>]
-       [--popup-timeout <seconds>] [--dry-run] [--debug]
+       [--dry-run] [--debug]
        [--auto-pr|--no-auto-pr] [--pr-review-gate|--no-pr-review-gate]
        [--briefing-code-review|--no-briefing-code-review]
        [--agent-teams-hint|--no-agent-teams-hint]
        [--codex-plan-mode|--no-codex-plan-mode]
        [--pr-visualization|--no-pr-visualization]
+       [--dashboard-keybind|--no-dashboard-keybind]
        [--team]
 fanout plan <spec.json|plan-slug> [--agent <name|task-id=name>] [--dry-run]
        [--limit <N>] [--only <task-id[,id...]>] [--skip <task-id[,id...]>]
@@ -236,7 +237,7 @@ fanout 123 --status --format table
 fanout 123 --status --post-dashboard
 ```
 
-`--status` is exclusive with all action-bearing flags (`--agent`, `--limit`, `--only`, `--skip`, `--include`, `--name`, `--base-branch`, `--branch-prefix`, `--no-refresh`, `--session`, `--sleep`, `--popup-timeout`, `--dry-run`, `--unblocked-only`, `--close`, `--merge`, `--cleanup`, `--auto-pr`, `--no-auto-pr`, `--pr-review-gate`, `--no-pr-review-gate`, `--briefing-code-review`, `--no-briefing-code-review`, `--agent-teams-hint`, `--no-agent-teams-hint`, `--codex-plan-mode`, `--no-codex-plan-mode`, `--pr-visualization`, `--no-pr-visualization`).
+`--status` is exclusive with all action-bearing flags (`--agent`, `--limit`, `--only`, `--skip`, `--include`, `--name`, `--base-branch`, `--branch-prefix`, `--no-refresh`, `--session`, `--sleep`, `--popup-timeout`, `--dry-run`, `--unblocked-only`, `--close`, `--merge`, `--cleanup`, `--team`, `--auto-pr`, `--no-auto-pr`, `--pr-review-gate`, `--no-pr-review-gate`, `--briefing-code-review`, `--no-briefing-code-review`, `--agent-teams-hint`, `--no-agent-teams-hint`, `--codex-plan-mode`, `--no-codex-plan-mode`, `--pr-visualization`, `--no-pr-visualization`, `--dashboard-keybind`, `--no-dashboard-keybind`).
 
 ### `--merge` / `--close` / `--cleanup`
 
@@ -252,8 +253,12 @@ fanout 123 --close 4
 fanout 123 --cleanup
 ```
 
-Hooks are always enabled. If the user hook config is missing, or an event has no
-commands, the event is a no-op. fanout reads hooks from
+## Lifecycle hooks
+
+fanout runs user shell hooks around worktree, pane, and merge events — both
+during fan-out (`worktree_created`, `before_pane_create`) and in the lifecycle
+commands above. Hooks are always enabled. If the user hook config is missing,
+or an event has no commands, the event is a no-op. fanout reads hooks from
 `$XDG_CONFIG_HOME/fanout/hooks.json`, or `~/.config/fanout/hooks.json` when
 `XDG_CONFIG_HOME` is unset. The file uses a Codex-style `hooks` object:
 

--- a/site/content/docs/installation.ja.md
+++ b/site/content/docs/installation.ja.md
@@ -1,7 +1,7 @@
 ---
 title: インストール
 linkTitle: インストール
-description: "curl 一行で Go バイナリと Claude Code、Codex の連携が入る。何が配置され、どう検証と上書きが起き、更新をどう保つかをまとめる。"
+description: "curl 一行で fanout 本体と Claude Code、Codex の連携を導入する手順。配置先の確認、アンインストール、macOS でブロックされた場合の対処、更新の保ち方をまとめる。"
 weight: 10
 kanji: 始
 yomi: install
@@ -9,7 +9,7 @@ yomi: install
 
 ## 前提ツール
 
-親 issue を子ごとのペインにファンアウトする既定のフローでは、役割の異なる次の 3 つのツールが `PATH` 上に必要です。
+親 issue を子ごとのペインにファンアウトする既定のフローでは、次の 3 つのツールが `PATH` 上に必要です。
 
 | ツール | 何のために要るか |
 |---|---|
@@ -17,14 +17,11 @@ yomi: install
 | `git` | worktree の作成、branch の分岐、merge に使う |
 | `tmux 3.3+` | 子ごとのペイン分割と TUI popup の表示に使う |
 
-fanout は選択したモードに必要な依存だけを起動時にチェックし、足りなければインストールのヒントを表示します。`--status` と `--cleanup` は `gh` と `git` を、`--merge` と `--close` は `git` を使います。
-ローカルの `fanout plan` 実行と、TUI から起動する手動ペインは、`git` と `tmux 3.3+`、選択した agent があれば動きます。`origin` remote や `gh` 認証が無い repository でも動作します。
-
 > **Project モード時のみ**: Project items を取得する GraphQL クエリのため、`gh` CLI に `read:project` スコープが必要です。`gh auth refresh -s read:project` で付与してください。issue モード(`fanout <N>`)では不要です。
 
-## 推奨: インストールスクリプト
+## インストール
 
-推奨インストール経路は Release 済みの Go バイナリです。安定コマンド名 `fanout` と、同梱の Claude/Codex 連携ファイルをまとめて配置します:
+推奨経路は Release 済みの Go バイナリです。
 
 ```bash
 # fanout + Claude/Codex 連携を ~/.local, ~/.claude, ~/.codex に配置
@@ -38,35 +35,23 @@ curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh |
 curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh | FANOUT_VERSION=v0.8.0 sh
 ```
 
-`install.sh` はまず macOS/Linux と amd64/arm64 を自動判定します。次に最新 GitHub Release(または `FANOUT_VERSION` で指定した tag)から `fanout_<os>_<arch>.tar.gz` を取得します。`sha256sum` または `shasum` があれば `SHA256SUMS` で検証します。再実行時は同じパスへ上書きします。シェル rc は自動編集しません。
+`install.sh` は OS/arch を自動判定し、最新 Release(または `FANOUT_VERSION` で指定した tag)から `fanout` バイナリと Claude/Codex 連携ファイルを取得して配置します。
 
-### 配置パス
+### 配置先
 
-- `$BIN_DIR/fanout`(既定は `~/.local/bin/fanout`)
-- `$CLAUDE_DIR/commands/fanout.md`(既定は `~/.claude/commands/fanout.md`)
-- `$CLAUDE_DIR/commands/pr-watch.md`(既定は `~/.claude/commands/pr-watch.md`)
-- `$CLAUDE_DIR/skills/fanout/`(既定は `~/.claude/skills/fanout/`)
-- `$CLAUDE_DIR/skills/fanout-issues/`(既定は `~/.claude/skills/fanout-issues/`)
-- `$CLAUDE_DIR/skills/fanout-plan/`(既定は `~/.claude/skills/fanout-plan/`)
-- `$CLAUDE_DIR/skills/post-work-review/`(既定は `~/.claude/skills/post-work-review/`。PR レビューゲートを支える skill です。同名 skill を上書きするので、自前のものがあればバックアップしてください)
-- `$CLAUDE_DIR/skills/pr-watch/`(既定は `~/.claude/skills/pr-watch/`)
-- `$CODEX_DIR/skills/fanout/`(既定は `~/.codex/skills/fanout/`)
-- `$CODEX_DIR/skills/fanout-issues/`(既定は `~/.codex/skills/fanout-issues/`)
-- `$CODEX_DIR/skills/fanout-plan/`(既定は `~/.codex/skills/fanout-plan/`)
-- `$CODEX_DIR/skills/post-work-review/`(既定は `~/.codex/skills/post-work-review/`)
-- `$CODEX_DIR/skills/pr-watch/`(既定は `~/.codex/skills/pr-watch/`)
-- `$CODEX_DIR/agents/post-work-reviewer.toml`(既定は `~/.codex/agents/post-work-reviewer.toml`)
-- `$CODEX_DIR/agents/post-work-verifier.toml`(既定は `~/.codex/agents/post-work-verifier.toml`)
-- `$CODEX_DIR/agents/post-work-reviewer.md`(既定は `~/.codex/agents/post-work-reviewer.md`)
-- `$CODEX_DIR/agents/post-work-verifier.md`(既定は `~/.codex/agents/post-work-verifier.md`)
+バイナリは `~/.local/bin/fanout` に、Claude Code 連携は `~/.claude` 配下、Codex CLI 連携は `~/.codex` 配下に配置されます。
 
-`~/.local/bin` が `PATH` に入っていることを確認してください:
+- `~/.local/bin/fanout`(バイナリ本体)
+- `~/.claude/commands/fanout.md`、`~/.claude/skills/fanout/`(Claude Code 連携)
+- `~/.codex/skills/fanout/`(Codex CLI 連携)
+
+`~/.local/bin` が `PATH` に入っていることを確認してください。
 
 ```bash
 echo $PATH | tr ':' '\n' | grep -F "$HOME/.local/bin"
 ```
 
-入っていない場合は、シェルの rc に `export PATH="$HOME/.local/bin:$PATH"` を追記してください。スキルをインストールまたは更新した後、実行中の Codex CLI セッションがある場合は再起動すると新しいファイルを認識します。
+入っていない場合は、シェルの rc に `export PATH="$HOME/.local/bin:$PATH"` を追記してください。
 
 ### アンインストール
 
@@ -74,64 +59,42 @@ echo $PATH | tr ':' '\n' | grep -F "$HOME/.local/bin"
 curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh | sh -s -- --uninstall
 ```
 
-## macOS セキュリティメモ
+## macOS でブロックされたら
 
-curl/wget 経由のインストールでは通常 `com.apple.quarantine` 拡張属性が付かないため、Gatekeeper の「開発元を検証できません」GUI ブロックは基本的に発生しません。ブラウザ経由でアーカイブを取得して quarantine が付いた場合は、展開後に次で属性を削除してください:
+curl/wget 経由のインストールでは通常 quarantine 属性が付かないため、Gatekeeper のブロックは基本的に起きません。
+ブラウザ経由で取得して quarantine が付いた場合は、次で属性を削除してください。
 
 ```bash
 xattr -d com.apple.quarantine /path/to/fanout
 ```
 
-Apple Silicon では、すべての実行ファイルに最低限 ad-hoc 署名が必要です。Release workflow は macOS 上で Go 1.26 の darwin バイナリをビルドするため、Go linker がビルド時に署名します。Release package 作成後に外部 `strip` をかけると署名が壊れることがあるので避けてください。ローカルコピーが壊れた場合は次で ad-hoc 再署名できます:
+ローカルコピーの署名が壊れた場合は、次で ad-hoc 再署名できます。
 
 ```bash
 codesign -s - /path/to/fanout
 ```
 
-Apple Developer ID 署名や notarization は curl 配布経路では当面スコープ外です。
-
 ## チェックアウトから使う場合
-
-ローカルの Makefile ターゲットは Go バイナリを安定コマンド名 `fanout` としてインストール / symlink し、同梱の連携ファイルも配置します:
 
 ```bash
 make install        # Go 版を $(BINDIR)/fanout としてビルド + 連携をコピー
 make link           # Go 版を $(BINDIR)/fanout として symlink + 連携を symlink
 make uninstall      # インストール済みのパスを削除
-
-PREFIX=/usr/local sudo make install      # システム全体に Go CLI を配置
-CLAUDE_DIR=/path/to/.claude make install # 既定以外の Claude データディレクトリを指定
-CODEX_DIR=/path/to/.codex make install   # 既定以外の Codex データディレクトリを指定
 ```
 
-チェックアウトからのビルドには **Go ツールチェイン**(Go 1.26+)に加えて **Node.js 24+ と pnpm 10+** が必要です。`make install`、`make link`、`make build-go` はまずダッシュボード Web UI をビルドし(`make build-web`、`web/` の Vite バンドル)、それを embed して `go build ./cmd/fanout` を実行します。上記の curl インストールは prebuilt バイナリを配置するので、Go も Node も要りません。
+ビルドには Go ツールチェイン(Go 1.26+)に加えて Node.js 24+ と pnpm 10+ が必要です(`make install` はダッシュボード Web UI を先にビルドして embed するため)。
+curl インストールは prebuilt バイナリを配置するので、Go も Node も要りません。
 
 ## 更新を保つ
 
-### `fanout --check-update`
+`fanout --check-update` は読み取り専用です。
+最新 release tag と埋め込み version を比較して更新の有無を表示するだけで、何も変更しません。
 
-`fanout --check-update` は読み取り専用です。`butaosuinu/fanout` の最新 release tag を取得し、バイナリ埋め込みの version と比較して、更新の有無を表示します。サブコマンド形の `fanout check-update` も使えます。ローカルの dev build(`version == "dev"`、素の `make build-go` を含む)は `gh` を呼ばず、dev build である旨を表示して exit 0 します。
+`fanout update` は上の curl インストールと同じ経路を呼び出し、本体と Claude/Codex 連携をまとめて更新します。
 
-| Exit code | 意味 |
-|---|---|
-| `0` | 比較が完了した、または dev build |
-| `2` | 現在の version か最新 tag が `MAJOR.MINOR.PATCH`(`v` prefix 可)でない |
-| `3` | `gh release view -R butaosuinu/fanout` が失敗した |
+- `--version <tag>`: 指定した tag をインストールする
+- `--no-skills`: バイナリのみ更新する
 
-### `fanout update`
-
-`fanout update` は、上で説明した `install.sh` の経路をそのまま呼び出して実行中の release バイナリを置き換えます。OS/arch 判定、release ダウンロード、checksum 検証、アーカイブ展開、Claude/Codex skill のインストールは、すべて 1 つのスクリプトに集約したままです。
-
-既定では最新 release を解決して埋め込み version と比較し、現在のバイナリパス(`EvalSymlinks` 解決後)を表示してから、すぐにインストーラを実行します。ローカルの dev build は置き換えを拒否します。
-
-- `--version <tag>`: `FANOUT_VERSION=<tag>` を `install.sh` に渡し、指定 tag をインストールする。
-- `--no-skills`: `--no-skills` を `install.sh` に渡し、バイナリのみ更新する。
-
-| Exit code | 意味 |
-|---|---|
-| `0` | 更新が完了した、または既に最新 |
-| `1` | 環境 / preflight の失敗: dev build、`curl`/`wget` 無し、書き込めない binary ディレクトリ、オプション値の欠落 |
-| `2` | 未知のオプション、想定外の引数、比較不能な version 文字列 |
-| `3` | 最新 release の取得に失敗した |
+exit code の一覧は[CLI リファレンス]({{< relref "/docs/cli" >}})を参照してください。
 
 次は[クイックスタート]({{< relref "/docs/quickstart" >}})で、最初の親 issue を開いてみてください。

--- a/site/content/docs/installation.ja.md
+++ b/site/content/docs/installation.ja.md
@@ -95,6 +95,10 @@ curl インストールは prebuilt バイナリを配置するので、Go も N
 - `--version <tag>`: 指定した tag をインストールする
 - `--no-skills`: バイナリのみ更新する
 
+> install と update は `~/.claude` と `~/.codex` 配下の同梱ファイル(`post-work-review` や `pr-watch` skill を含む)を上書きします。
+> カスタマイズした copy は先に退避してください。
+> Codex CLI は起動時に skill を読み込むため、更新後は実行中の Codex セッションを再起動してください。
+
 exit code の一覧は[CLI リファレンス]({{< relref "/docs/cli" >}})を参照してください。
 
 次は[クイックスタート]({{< relref "/docs/quickstart" >}})で、最初の親 issue を開いてみてください。

--- a/site/content/docs/installation.ja.md
+++ b/site/content/docs/installation.ja.md
@@ -39,11 +39,14 @@ curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh |
 
 ### 配置先
 
-バイナリは `~/.local/bin/fanout` に、Claude Code 連携は `~/.claude` 配下、Codex CLI 連携は `~/.codex` 配下に配置されます。
+各配置先はインストールコマンドの環境変数で上書きできます。`BIN_DIR`(既定 `~/.local/bin`)、`CLAUDE_DIR`(既定 `~/.claude`)、`CODEX_DIR`(既定 `~/.codex`)です。
 
-- `~/.local/bin/fanout`(バイナリ本体)
-- `~/.claude/commands/fanout.md`、`~/.claude/skills/fanout/`(Claude Code 連携)
-- `~/.codex/skills/fanout/`(Codex CLI 連携)
+- `$BIN_DIR/fanout`(バイナリ本体)
+- `$CLAUDE_DIR/commands/`(`fanout`、`pr-watch`、`session-retro` のスラッシュコマンド)
+- `$CLAUDE_DIR/skills/`(`fanout`、`fanout-issues`、`fanout-plan`、`post-work-review`、`pr-watch`、`session-retro` の skill)
+- `$CODEX_DIR/skills/`(`session-retro` を除く同じ skill 群)と `$CODEX_DIR/agents/`(post-work reviewer / verifier)、`$CODEX_DIR/tools/`
+
+install と update はこれらすべてを上書きします。
 
 `~/.local/bin` が `PATH` に入っていることを確認してください。
 

--- a/site/content/docs/installation.md
+++ b/site/content/docs/installation.md
@@ -1,7 +1,7 @@
 ---
 title: Installation
 linkTitle: Installation
-description: "One curl line installs the Go binary and the Claude Code / Codex integrations. Everything it places, verifies and overwrites — and how to keep it updated."
+description: "One curl line installs fanout and the Claude Code / Codex integrations. Covers where it installs to, uninstalling, macOS Gatekeeper blocks, and how to keep it updated."
 weight: 10
 kanji: 始
 yomi: install
@@ -9,7 +9,7 @@ yomi: install
 
 ## Prerequisites
 
-Fanning a parent issue out into one pane per child needs three tools on your `PATH`, each with a distinct role:
+Fanning a parent issue out into one pane per child needs three tools on your `PATH`.
 
 | Tool | What it's for |
 |---|---|
@@ -17,14 +17,11 @@ Fanning a parent issue out into one pane per child needs three tools on your `PA
 | `git` | creating worktrees, branching, merging |
 | `tmux 3.3+` | splitting one pane per child and showing TUI popups |
 
-fanout checks only the dependencies needed for the selected mode at startup and prints install hints when one is missing. `--status` and `--cleanup` use `gh` and `git`; `--merge` and `--close` use `git`.
-Local `fanout plan` runs and manual panes launched from the TUI need `git`, `tmux 3.3+`, and the selected agent. They run even in repositories without an `origin` remote or `gh` authentication.
-
 > **Project mode only:** the `gh` CLI must have the `read:project` scope so the GraphQL query that lists Project items can succeed. Add it with `gh auth refresh -s read:project`. Issue mode (`fanout <N>`) does not need this scope.
 
-## Recommended: the install script
+## Installation
 
-The recommended install path is the released Go binary. It installs the stable `fanout` command plus the bundled Claude / Codex integration files:
+The recommended path is the released Go binary.
 
 ```bash
 # fanout + Claude/Codex integrations into ~/.local, ~/.claude, ~/.codex
@@ -38,27 +35,15 @@ curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh |
 curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh | FANOUT_VERSION=v0.8.0 sh
 ```
 
-`install.sh` first detects macOS/Linux and amd64/arm64. It then downloads `fanout_<os>_<arch>.tar.gz` from the latest GitHub Release (or `FANOUT_VERSION`) and verifies it against `SHA256SUMS` when `sha256sum` or `shasum` exists. On rerun it overwrites the same paths. It never edits shell rc files.
+`install.sh` auto-detects your OS/arch, then fetches and installs the `fanout` binary and the Claude/Codex integration files from the latest Release (or the tag given via `FANOUT_VERSION`).
 
 ### Installed paths
 
-- `$BIN_DIR/fanout` (default `~/.local/bin/fanout`)
-- `$CLAUDE_DIR/commands/fanout.md` (default `~/.claude/commands/fanout.md`)
-- `$CLAUDE_DIR/commands/pr-watch.md` (default `~/.claude/commands/pr-watch.md`)
-- `$CLAUDE_DIR/skills/fanout/` (default `~/.claude/skills/fanout/`)
-- `$CLAUDE_DIR/skills/fanout-issues/` (default `~/.claude/skills/fanout-issues/`)
-- `$CLAUDE_DIR/skills/fanout-plan/` (default `~/.claude/skills/fanout-plan/`)
-- `$CLAUDE_DIR/skills/post-work-review/` (default `~/.claude/skills/post-work-review/` — backs the PR review gate; overwrites a same-named skill, so back yours up)
-- `$CLAUDE_DIR/skills/pr-watch/` (default `~/.claude/skills/pr-watch/`)
-- `$CODEX_DIR/skills/fanout/` (default `~/.codex/skills/fanout/`)
-- `$CODEX_DIR/skills/fanout-issues/` (default `~/.codex/skills/fanout-issues/`)
-- `$CODEX_DIR/skills/fanout-plan/` (default `~/.codex/skills/fanout-plan/`)
-- `$CODEX_DIR/skills/post-work-review/` (default `~/.codex/skills/post-work-review/`)
-- `$CODEX_DIR/skills/pr-watch/` (default `~/.codex/skills/pr-watch/`)
-- `$CODEX_DIR/agents/post-work-reviewer.toml` (default `~/.codex/agents/post-work-reviewer.toml`)
-- `$CODEX_DIR/agents/post-work-verifier.toml` (default `~/.codex/agents/post-work-verifier.toml`)
-- `$CODEX_DIR/agents/post-work-reviewer.md` (default `~/.codex/agents/post-work-reviewer.md`)
-- `$CODEX_DIR/agents/post-work-verifier.md` (default `~/.codex/agents/post-work-verifier.md`)
+The binary goes to `~/.local/bin/fanout`; the Claude Code integration goes under `~/.claude`; the Codex CLI integration goes under `~/.codex`.
+
+- `~/.local/bin/fanout` (the binary)
+- `~/.claude/commands/fanout.md`, `~/.claude/skills/fanout/` (Claude Code integration)
+- `~/.codex/skills/fanout/` (Codex CLI integration)
 
 Confirm `~/.local/bin` is on your `PATH`:
 
@@ -66,7 +51,7 @@ Confirm `~/.local/bin` is on your `PATH`:
 echo $PATH | tr ':' '\n' | grep -F "$HOME/.local/bin"
 ```
 
-If not, add `export PATH="$HOME/.local/bin:$PATH"` to your shell rc. Restart any running Codex CLI session after installing or updating skills so it picks up the new skill files.
+If not, add `export PATH="$HOME/.local/bin:$PATH"` to your shell rc.
 
 ### Uninstall
 
@@ -74,64 +59,39 @@ If not, add `export PATH="$HOME/.local/bin:$PATH"` to your shell rc. Restart any
 curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh | sh -s -- --uninstall
 ```
 
-## macOS security notes
+## If blocked on macOS
 
-The curl/wget install path normally does not attach the `com.apple.quarantine` extended attribute, so the Gatekeeper "cannot verify developer" GUI block should not appear for the installed binary. If you download the archive through a browser and macOS quarantines it, remove the attribute after extracting:
+The curl/wget install path normally does not attach the `com.apple.quarantine` extended attribute, so Gatekeeper blocks generally don't happen. If you download it through a browser and it gets quarantined, remove the attribute:
 
 ```bash
 xattr -d com.apple.quarantine /path/to/fanout
 ```
 
-Apple Silicon requires every executable to carry at least an ad-hoc signature. The release workflow builds darwin binaries on macOS with Go 1.26, so the Go linker signs the binary as part of the build. Do not run an external `strip` after release packaging; it can invalidate the signature. If a local copy is damaged, ad-hoc re-sign it with:
+If a local copy's signature is broken, ad-hoc re-sign it:
 
 ```bash
 codesign -s - /path/to/fanout
 ```
 
-Developer ID signing and notarization are intentionally out of scope for the curl distribution path.
-
 ## From a checkout
 
-Local Makefile targets install or symlink the Go binary as the stable `fanout` command plus the bundled integrations:
-
 ```bash
-make install            # builds Go as $(BINDIR)/fanout + installs integrations
-make link               # symlinks Go as $(BINDIR)/fanout + links integrations
-make uninstall          # removes installed paths
-
-PREFIX=/usr/local sudo make install      # system-wide Go CLI; overrides BINDIR
-CLAUDE_DIR=/path/to/.claude make install # non-default Claude data dir
-CODEX_DIR=/path/to/.codex make install   # non-default Codex data dir
+make install        # builds the Go binary as $(BINDIR)/fanout + copies integrations
+make link           # symlinks the Go binary as $(BINDIR)/fanout + symlinks integrations
+make uninstall      # removes installed paths
 ```
 
-Building from a checkout needs a **Go toolchain** (Go 1.26+) plus **Node.js 24+ and pnpm 10+**: `make install`, `make link`, and `make build-go` first build the dashboard web UI (`make build-web`, the Vite bundle under `web/`) and embed it into `go build ./cmd/fanout`. The curl install above ships a prebuilt binary and needs neither Go nor Node.
+Building it needs a Go toolchain (Go 1.26+) plus Node.js 24+ and pnpm 10+ (`make install` builds the dashboard web UI first and embeds it). The curl install ships a prebuilt binary, so it needs neither Go nor Node.
 
 ## Keeping it updated
 
-### `fanout --check-update`
+`fanout --check-update` is read-only. It only compares the latest release tag with the embedded version and reports whether an update is available — it changes nothing.
 
-`fanout --check-update` is read-only. It fetches the latest release tag from `butaosuinu/fanout`, compares it with the binary's embedded version, and prints whether an update is available. `fanout check-update` is accepted as the subcommand form. Local dev builds (`version == "dev"`, including plain `make build-go`) do not call `gh`; they print a dev-build message and exit 0.
+`fanout update` calls the same curl install path above, updating the binary and the Claude/Codex integrations together.
 
-| Exit code | Meaning |
-|---|---|
-| `0` | comparison completed, or this is a dev build |
-| `2` | the current version or latest tag is not `MAJOR.MINOR.PATCH` (optionally `v`-prefixed) |
-| `3` | `gh release view -R butaosuinu/fanout` failed |
+- `--version <tag>`: install the given tag
+- `--no-skills`: update only the binary
 
-### `fanout update`
+See the [CLI reference]({{< relref "/docs/cli" >}}) for the exit code list.
 
-`fanout update` replaces the running release binary by invoking the same `install.sh` path documented above, so OS/arch detection, release downloads, checksum verification, archive extraction, and Claude/Codex skill installation stay centralized in one script.
-
-By default it resolves the latest release, compares it with the embedded version, reports the current binary path (after `EvalSymlinks`), and then runs the installer immediately. Local dev builds refuse replacement.
-
-- `--version <tag>` — install a pinned release tag by passing `FANOUT_VERSION=<tag>` to `install.sh`.
-- `--no-skills` — pass `--no-skills` through to `install.sh`, updating only the binary.
-
-| Exit code | Meaning |
-|---|---|
-| `0` | update completed, or already up to date |
-| `1` | environment/preflight failure: dev build, no `curl`/`wget`, unwritable binary directory, missing option value |
-| `2` | unknown option, unexpected argument, or incomparable version strings |
-| `3` | latest release lookup failed |
-
-Next: fan out your first parent issue in the [Quickstart]({{< relref "/docs/quickstart" >}}).
+Next: open your first parent issue in the [Quickstart]({{< relref "/docs/quickstart" >}}).

--- a/site/content/docs/installation.md
+++ b/site/content/docs/installation.md
@@ -39,11 +39,14 @@ curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh |
 
 ### Installed paths
 
-The binary goes to `~/.local/bin/fanout`; the Claude Code integration goes under `~/.claude`; the Codex CLI integration goes under `~/.codex`.
+Each destination has an environment-variable override for the install command: `BIN_DIR` (default `~/.local/bin`), `CLAUDE_DIR` (default `~/.claude`), and `CODEX_DIR` (default `~/.codex`).
 
-- `~/.local/bin/fanout` (the binary)
-- `~/.claude/commands/fanout.md`, `~/.claude/skills/fanout/` (Claude Code integration)
-- `~/.codex/skills/fanout/` (Codex CLI integration)
+- `$BIN_DIR/fanout` — the binary
+- `$CLAUDE_DIR/commands/` — the `fanout`, `pr-watch`, and `session-retro` slash commands
+- `$CLAUDE_DIR/skills/` — the `fanout`, `fanout-issues`, `fanout-plan`, `post-work-review`, `pr-watch`, and `session-retro` skills
+- `$CODEX_DIR/skills/` — the same skills minus `session-retro`, plus `$CODEX_DIR/agents/` (the post-work reviewer / verifier) and `$CODEX_DIR/tools/`
+
+Install and update overwrite all of these.
 
 Confirm `~/.local/bin` is on your `PATH`:
 

--- a/site/content/docs/installation.md
+++ b/site/content/docs/installation.md
@@ -92,6 +92,8 @@ Building it needs a Go toolchain (Go 1.26+) plus Node.js 24+ and pnpm 10+ (`make
 - `--version <tag>`: install the given tag
 - `--no-skills`: update only the binary
 
+> Install and update overwrite the bundled files under `~/.claude` and `~/.codex` — including the `post-work-review` / `pr-watch` skills — so back up customized copies first. Codex CLI loads skills at startup; restart running Codex sessions after an update.
+
 See the [CLI reference]({{< relref "/docs/cli" >}}) for the exit code list.
 
 Next: open your first parent issue in the [Quickstart]({{< relref "/docs/quickstart" >}}).

--- a/site/content/docs/monitoring.ja.md
+++ b/site/content/docs/monitoring.ja.md
@@ -7,13 +7,18 @@ kanji: 見
 yomi: monitoring
 ---
 
-子 issue を 5 つファンアウトすると、tmux には 5 枚のペインが並び、それぞれ別のエージェントが別の worktree で動き出します。次に知りたいのは「どのペインが PR まで進んだか」「どこで止まっているか」「未 commit の作業を抱えたまま放置されているペインはないか」です。fanout はこれを 3 つの窓で見ます。手元で常時眺めるなら**常駐 TUI コンソール**、automation に食わせるなら `--status` の **JSON**、チームやブラウザで共有するなら読み取り専用の **Web ダッシュボード**。`--status` と Web ダッシュボードは読み取り専用で、`.fanout/state.json` と tmux と GitHub を読むだけです。TUI も同じように眺めるための窓ですが、キーバインドから merge、close、cleanup も実行できます（`--merge` / `--close` / `--cleanup` と同じ経路）。
+子 issue を 5 つファンアウトすると、tmux には 5 枚のペインが並び、それぞれ別のエージェントが別の worktree で動きます。
+知りたいのは、どのペインが PR まで進み、どこで止まっているかです。
+
+fanout はこれを 3 つの窓で見ます。
+手元で常時眺めるなら**常駐 TUI コンソール**、automation に食わせるなら `--status` の **JSON**、チームやブラウザで共有するなら読み取り専用の **Web ダッシュボード**です。
+`--status` と Web ダッシュボードは読み取り専用で `.fanout/state.json` と tmux と GitHub を読むだけですが、TUI はキー操作から merge、close、cleanup も実行できます(`--merge` / `--close` / `--cleanup` と同じ処理です)。
 
 ## ペイン枠線ラベル
 
-3 つの窓の前に、tmux 自体がペインを見分けさせてくれます。fanout は作成した各ペインの上枠に `<parent> · <name>` のラベルを付けます — issue の子なら `#123 · fix-login-bug-123`、plan タスクなら `plan:my-feature · task-slug` — さらに枠線を fanout のテーマ色（アクティブは浅葱、それ以外は藍）に染めます。タイル状に並んだ window を一瞥するだけで、どのペインがどの子か、フォーカスせずに分かります。
-
-tmux の枠線オプションは window 単位なので、fanout ペインを含む window では全ペインに上枠が付きます。fanout が作っていないペインは自身の `#{pane_title}` に fallback し、自分で設定した `pane-border-style` はその window では上書きされます。
+3 つの窓を見る前に、tmux 自体がペインを見分けさせてくれます。
+fanout は作成した各ペインの上枠に `<parent> · <name>` のラベルを付け(issue の子なら `#123 · fix-login-bug-123`、plan タスクなら `plan:my-feature · task-slug`)、枠線を fanout のテーマ色に染めます(アクティブは浅葱、それ以外は藍)。
+タイル状に並んだ window を一瞥するだけで、どのペインがどの子か、フォーカスせずに分かります。
 
 ## 常駐 TUI コンソール
 
@@ -23,166 +28,95 @@ tmux の枠線オプションは window 単位なので、fanout ペインを含
 fanout   # start the persistent tmux console
 ```
 
-素のシェルから起動したときは、現在のリポジトリ用の deterministic な fanout 管理 tmux session を作成または attach し、その session 内でコンソールを開始します。tmux 内から起動したときは、現在のペインをそのままコンソール画面にします。起動時と state 更新ごとに、コンソールは tmux 上に残っている記録済み worktree ペインへ再バインドし、消えた worktree ペインは agent CLI の resume で作り直します。使うのは `claude --continue`、`codex resume --last`、または Plan ペインに保存した Codex Plan Mode thread です。
-
-コンソールは `<git-root>/.fanout/state.json` を読み、記録済みペイン ID が tmux 上にまだ存在するかを確認し、`fanout <parent> --status` と同じ GitHub CLI 経路で issue と closed-by PR の状態を定期更新します。エージェント側に計測の仕込みは要りません。各行にはペインの worktree の総作業量を `+X/-Y` で示します。これは記録した base ブランチとの merge-base に対する `git diff --shortstat` で、コミット済みと未 commit の合計です（base 未記録の旧行は `origin/HEAD` から `HEAD` に fallback します）。あわせて `git status --porcelain` 由来の `dirty` / `clean` を出すので、未 commit の作業を抱えたペインをその場で見分けられます。`RUN` 列には各ペインの agent 状態がグリフで出ます — `●` が running、`✓` が done（agent 起動ラッパーが報告）— ので、まだ作業中のペインが分かります。detail panel には同じ値が `run=` として文字で出ます。
+素のシェルから起動すると fanout 管理の tmux session を作成または attach し、tmux 内から起動すると現在のペインをそのままコンソールにします。
+コンソールは `.fanout/state.json` を読み、記録済みペインの issue と PR の状態を定期更新し、各行の worktree には変更量を `+X/-Y`、未 commit の作業の有無を `dirty` / `clean` で示します。
+`RUN` 列には agent の実行状態がグリフで出て(`●` が running、`✓` が done)、detail panel には同じ値が `run=` として出ます。
 
 {{< diagram "console" >}}
 
-行が増えてきたら `/` で絞り込みます。ロード済みの行をメモリ内でフィルタでき、フリーテキストのほか `state:open`、`agent:codex`、`wave:wave5` のような述語も使えます。フィルタは追加の fetch を起こさず、絞り込み中も state と GitHub の自動更新は続きます。
-
-記録済みの issue 親については、親の子一覧も再読込し、`--unblocked-only` と同じ `## Blocked by` と `(blocked by #N)` のソースから wave 列と blocker 列を出します。まだファンアウトしていない blocked な子は `deferred` 行として並び、CLOSED の blocker は resolved として区別されます。ヘッダーには `total` / `merged` / `pending` / `blocked` の集約 count が出ます。
-
 ### キー操作
-
-footer は短く保ちます。通常画面で `?` を押すと、全ショートカットのヘルプが tmux popup で開きます。
 
 | キー | 動作 |
 |---|---|
 | `?` | キーボードショートカットのヘルプを tmux popup で開く。`Esc`、`q`、もう一度 `?` のいずれかで閉じる。 |
-| `j` / `k` | 選択を下 / 上に移動する（矢印キーでも可）。 |
+| `j` / `k` | 選択を下 / 上に移動する(矢印キーでも可)。 |
 | `[` / `]` | 前 / 次の Session グループへジャンプする。 |
-| `/` | ロード済みの行を絞り込む — フリーテキストか `state:open` のような述語。`Esc` は入力を抜けるだけで、一覧からもう一度 `Esc` を押すとフィルタを解除する。 |
+| `/` | ロード済みの行を絞り込む(フリーテキストか `state:open` のような述語)。`Esc` は入力を抜けるだけで、一覧からもう一度 `Esc` を押すとフィルタを解除する。 |
 | `n` | 新規 Session の tmux popup を開く。Mode 行で Prompt / Issue を切り替える。詳細は[新規 Session のモード](#新規-session-のモード)を参照。 |
 | `a` | 選択中の行に記録された worktree に、agent ペインを 1 つ以上追加する。git worktree は作らない。追加行は選択元の worktree と branch を共有し、focus と peek はできるが merge 進捗には数えない。`codex` は Codex Plan Mode で起動する。 |
 | `A` | 選択中の行に記録された worktree で shell terminal を開く。shell 行は `@manual` entry として記録され、focus と peek はできるが merge 進捗には数えない。 |
 | `t` | project root で shell terminal を開く。close は tmux ペインと state 行だけを消し、git worktree は削除しない。 |
 | `Enter` / `o` | 選択中の live 行のペインにフォーカスする。 |
 | `1`-`9` | 表示リストの N 行目へジャンプして、そのペインにフォーカスする。範囲外の数字は notice を表示する。 |
-| `Z` | 選択中のペインにフォーカスして zoom する（`resize-pane -Z`）。次の relayout（ペインの作成・削除、tmux window のリサイズ）で zoom は解除されるので、必要ならもう一度 `Z` を押す。 |
+| `Z` | 選択中のペインにフォーカスして zoom する。ペインの作成や削除、tmux window のリサイズで解除されるので、必要ならもう一度 `Z` を押す。 |
 | `p` | detail panel の read-only 出力スナップショットを更新する。 |
 | `v` | 表示の手動切替を auto → compact → full でサイクルする。auto は幅 80 桁未満で[コンパクト表示](#コンパクト表示)を選ぶ。compact は広い画面でも switcher を強制し、full は狭くてもテーブルを強制する。永続化はしない。 |
 | `c` / `x` | 選択中のペインの close option を開く。ペインだけを閉じる、ペインと worktree を閉じる、local branch も削除する、から選ぶ。 |
-| `m` | 選択中のペインの branch を fast-forward merge する（確認を挟み、`--merge` と同じコア処理を使う）。 |
-| `X` | 同じ親の merged/closed な子をまとめて cleanup する（確認を挟み、`--cleanup` と同じコア処理を使う）。 |
+| `m` | 選択中のペインの branch を fast-forward merge する(確認あり)。 |
+| `X` | 同じ親の merged/closed な子をまとめて cleanup する(確認あり)。 |
 | `q` | コンソールを離脱する。tmux session と子ペインはそのまま残る。 |
-
-> worktree 行が `stale!` になるのは、worktree が無い、agent command が無いなど fanout が復元できない場合です。shell terminal は resume できないため、対応する tmux ペインが無ければ TUI が state 行を削除します。
 
 ### コンパクト表示
 
-幅 80 桁未満 — auto-layout がコンソールに割り当てる 40 桁サイドバーがこの帯です — では、テーブル + detail panel が 1 ペイン 1 行の switcher に切り替わります。各行は `1`-`9` ジャンプに対応する序数、agent 状態グリフ、issue / task ラベル、名前、右寄せのペイン ID を表示し、幅が足りないときは名前だけを削ります。Session ヘッダ行には Session リストと同じ `t`/`m`/`p`/`b`/`l` カウントが付きます。選択中の行だけが branch + PR、ci / wave / blockers / dirty、peek の末尾 1 行に展開されます。キー操作はすべてそのまま効きます。`v` は自動判定の手動上書きで、現在のコンソール限りです。
+幅 80 桁未満では、テーブル + detail panel が 1 ペイン 1 行の switcher に切り替わり、選択中の行だけが branch や PR、ci / wave / blockers / dirty などの詳細に展開されます。
 
 ### F11 / prefix + T
 
-コンソール起動時に fanout が tmux キーバインドを登録するので、どのペインからでも **`F11`** または **`prefix + T`** でコンソールに戻れます。ダッシュボードの `F12` / `prefix + D` と対になる復帰キーです。どちらのキーも `fanout focus-console` を実行します。押したペインのリポジトリに記録された live コンソールを優先し（1 つの tmux サーバに複数リポジトリのコンソールが同居しても正しく着地します）、無ければ同一セッションのコンソールに切り替えます。live なコンソールが無いときはステータスラインに通知して終わります。
+どのペインからでも **`F11`** または **`prefix + T`** でコンソールに戻れます(`F12` / `prefix + D` の対)が、live なコンソールが無いときはステータスラインに通知して終わります。
 
-登録は設定キー `consoleKeybind` または `FANOUT_CONSOLE_KEYBIND=0` で無効化できます（[Settings]({{< relref "/docs/settings" >}}) を参照してください）。
+設定キー `consoleKeybind` または `FANOUT_CONSOLE_KEYBIND=0` で無効化できます([Settings]({{< relref "/docs/settings" >}}) を参照してください)。
 
 ### 新規 Session のモード
 
-`n` は Mode 行つきの tmux popup を開きます。Mode 行で `Left` / `Right` を押すとモードが切り替わり、`Tab` でフィールドを移動し、`Esc` でキャンセルします（agent 割り当て画面では 1 つ前に戻る）。
+`n` は Mode 行つきの tmux popup を開き、Prompt / Issue を切り替えます。
 
-**Prompt** は従来の manual ペインです。複数行の必須 prompt と `claude` / `codex` の起動数を指定します。
+**Prompt** は従来の manual ペインです。
+複数行の prompt を書いて `claude` / `codex` の起動数を指定し、prompt 欄では `Shift+Enter` で改行、`@` でリポジトリのファイルパス補完を使えます。
+下の plan fan-out チェックボックスを有効にすると、プロンプトを `fanout plan` で並列タスクに分解する起動に切り替わります。
 
-- `Up` / `Down` で agent 行を選び、`Space` で 0 / 1 を切り替え、`Left` / `Right` で起動数を変える。`codex` は Codex Plan Mode で起動し popup の prompt を inline で受け取る。`claude` は通常起動する。
-- prompt 欄では `Shift+Enter` または `Ctrl+J` で改行し、`@` を打つとリポジトリのファイルパス補完が開き、`Enter` でペインを作成する。enhanced keyboard input は既定で有効（`FANOUT_TUI_ENHANCED_KEYS=0` で無効化）で、`Shift+Enter` を区別して送る terminal が必要なため fanout が tmux の `extended-keys` を有効化する。
-- prompt の下の **plan fan-out** チェックボックスを入れると起動内容が変わる。agent をちょうど 1 本選んで有効にすると、project root にコーディネータ pane を 1 つ起動し、そのプロンプトに対して `/fanout plan`（claude）または `$fanout-plan`（codex）を実行して並列タスクに分解する。コーディネータは自身で `fanout plan` を走らせるため、常に通常 agent として起動する — plan fan-out では `codex` でも Codex Plan Mode にはならない。
-- manual ペインは synthetic な `@manual` state entry として記録され、起動後に一覧へ表示される。
+**Issue** はリポジトリの OPEN issue を一覧し、番号やタイトル、ラベルで絞り込んで、選んだ issue ごとに `claude` / `codex` の既定 agent と割り当てを指定できます。
+OPEN な子を持つ issue は `--unblocked-only` 相当でファンアウトし、blocked な子は deferred のまま残ります。
+子のない issue は `@watch` 配下の単独ペインとして起動します。
 
-**Issue** はリポジトリの OPEN issue を全件一覧します（cursor ページングで取得）。
+## --status（JSON / table / --post-dashboard）
 
-- 文字入力で番号・タイトル・ラベルで絞り込み、`Up` / `Down` で一覧をスクロールする。すでにペインが記録されている行は `(has session)` と表示されるが選択はできる。
-- 各行の先頭には GitHub Sub-issues グラフ上の位置を示すマーカーが付く: `▸` は OPEN な子を持つファンアウト親、`└` は子、`·` は単独。マーカーは Sub-issues リンクだけを見るので、子を本文のタスクリスト行（`- [ ] #N`）で管理している親は `·` と表示されても起動時にはファンアウトする。
-- 一覧の下の **Agent** 行でファンアウトの既定 agent を `claude` / `codex` の起動数として選ぶ — Prompt モードと同じカウント式表示だが、常にちょうど 1 つが `[1]`。`Up` / `Down` で行を移動し、`Space` / `Left` / `Right` で選択する。
-- `Enter` で子 issue ごとの agent 割り当て画面が開き、`Left` / `Right` で行の agent を切り替え — 繰り返し指定の `--agent NUM=name` と同じ — もう一度 `Enter` で起動する。
-- OPEN な子を持つ issue は `fanout <issue> --unblocked-only` 相当でファンアウトする。blocked な子は deferred のまま残るので、ブロッカーが閉じたら同じ issue を選び直す（全子を一度に起動したい場合は CLI を使う）。子のない issue は `@watch` 配下に記録される単独ペインを起動する。
-
-## --status（JSON）
-
-進捗を CI や jq に食わせて判定したいなら、`fanout <parent> --status` を使います。これは読み取り専用です。`.fanout/state.json` から指定 parent ですでにファンアウト済みの子 issue を列挙し、各子について `gh api graphql` で `repository.issue.closedByPullRequestsReferences(first: 100)` を照会して（子を close する PR が 100 件を超える場合は cursor でページング）、`state`、`mergedAt`、`reviewDecision`、最新 commit の CI rollup を取得します。既定では JSON ドキュメントを 1 つ stdout に出力します。
+進捗を CI や jq に食わせて判定したいなら `fanout <parent> --status` を使い、`.fanout/state.json` から指定 parent の子 issue を列挙して各子の状態と紐づく PR を JSON で出します(読み取り専用)。
 
 ```json
-{
-  "parent": 123,
-  "children": [
-    { "num": 4, "state": "CLOSED",
-      "prs": [ { "number": 250, "state": "MERGED",
-                 "mergedAt": "2026-05-04T10:00:00Z",
-                 "reviewDecision": "APPROVED", "ci": "pass" } ],
-      "has_merged_pr": true },
-    { "num": 7, "state": "OPEN",
-      "prs": [],
-      "has_merged_pr": false }
-  ],
-  "summary": {
-    "total":      2,
-    "merged":     1,
-    "pending":    1,
-    "blocked":    0,
-    "all_merged": false
-  }
-}
+{ "parent": 123,
+  "children": [{ "num": 4, "state": "CLOSED", "has_merged_pr": true }],
+  "summary": { "total": 2, "merged": 1, "all_merged": false } }
 ```
-
-この JSON は automation 向けです。
 
 ```bash
 fanout 123 --status | jq '.summary.all_merged'
+fanout 123 --status --format table       # 人が読みやすい表形式
+fanout 123 --status --post-dashboard     # 親 issue に集約コメントを upsert
 ```
 
-複数の親をファンアウトした state file では、他の親の子はフィルタされ、`summary.all_merged` は指定した親だけを反映します。リポジトリのチェックアウト外から読むなら `FANOUT_STATE_PATH` で state file を直接指定できます。指定が無ければ fanout は `<git-root>/.fanout/state.json` を読みます。
-
-`--status` の exit code は通常フローとは別レーンです。
-
-| Exit code | 意味 |
-|---|---|
-| `0` | status を出力した（JSON mode では実際の状態を `summary.all_merged` で確認する） |
-| `2` | 列挙できない: 不正な呼び出し、読めない / 壊れた state file、使えない project root、Projects v2 URL を parent に指定。state file が無い場合は空 state として扱う |
-| `3` | `gh` API 呼び出しが失敗した（認証、ネットワーク、存在しない issue など） |
-
-> **issue parent 専用:** 現在の JSON schema は issue parent 用なので、Projects v2 URL を parent にした `--status` は最初に拒否されます。
-
-## --status --format table
-
-同じデータを人が一覧で読みたいときは `--format table` を付けます。
-
-```bash
-fanout 123 --status --format table
-```
-
-JSON に加えて、正規化した PR 状態（`open`、`draft`、`review-required`、`approved`、`changes-requested`、`merged`、`closed`）、CI、PR の差分バー、変更ファイル数、Conventional-Commit 種別、PR リンクが並びます。
-
-## --status --post-dashboard
-
-進捗を親 issue 上で共有したいときは `--post-dashboard` を使います。
-
-```bash
-fanout 123 --status --post-dashboard
-```
-
-このオプションは親 issue に marker 付きコメントを 1 つ upsert し、各子 PR の sub-issue 番号、PR リンク、PR 状態、CI、差分規模、Conventional-Commit 種別、TL;DR、`Review effort` score を集約します。集約は GitHub の機械可読データと PR 本文だけから作り、LLM は呼びません。
-
-コメント本文の先頭に `<!-- fanout:dashboard parent=N -->` を置き、paginated な GitHub REST comments endpoint で既存の marker コメントを探して、そのコメントだけを更新します。marker コメントが無い場合は `gh issue comment --body-file -` で新規作成します。
-
-> `--post-dashboard` は `--status` 系で唯一 GitHub に書き込むオプションです。
+JSON の全 field と exit code は [CLI リファレンス]({{< relref "/docs/cli" >}}) を参照してください。
+`--format table` は PR 状態、CI、差分規模、変更ファイル数などを一覧にします。
+`--status` 系で GitHub に書き込むのは `--post-dashboard` だけで、親 issue に集約コメントを 1 つ upsert して更新し続けます。
 
 ## Web ダッシュボード（fanout dashboard --web）
 
-チームやブラウザで全 Session を共有しながら見たいときは、`fanout dashboard --web` で**読み取り専用**の Web ダッシュボードを起動します。fanout の **Session**（`.fanout/state.json` に記録されたペインを親 issue 単位でまとめたもの）をブラウザに出し、SSE でライブ更新します。各行ではペインの生存（`tmux list-panes`）、ライブの tmux ペインのタイトル、`running` / `done` の agent 実行状態バッジ、wave 列と未解決 blocker 列（親 issue グラフ由来）、issue 状態、PR マージ状態、CI 状態、diff/dirty を見られます。データ源は `--status` と同じで、リポジトリ内の全親について一度に再利用します。まだファンアウトしていない子 issue は synthetic な未開始行として並びます。GitHub の状態は一切変更せず、tmux も*読み取る*だけです。便宜は 2 つです。起動中サーバを `.fanout/dashboard.json` に記録して 2 回目の起動で再利用すること、そして後述の tmux キーバインドを登録すること（`--no-keybind` でオプトアウト可）です。
+チームやブラウザで全 Session を共有しながら見たいときは、`fanout dashboard --web` で読み取り専用の Web ダッシュボードを起動します。
 
 ```bash
 fanout dashboard --web [--port N] [--open] [--no-token] [--no-keybind]
 ```
 
-- **localhost 限定。** サーバは `127.0.0.1` にのみバインドし、GET 専用の endpoint を公開します。内訳は `/api/snapshot`、SSE の `/api/stream`、`/api/peek`（記録ペイン 1 つの `tmux capture-pane` スナップショット）、`/api/plan`（`--codex-plan-mode` ペインの最後の完全な `<proposed_plan>` ブロック）、埋め込み UI です。`--port` は既定 `0`（OS 割り当ての ephemeral port）で、確定した URL が表示されます。
-- **トークン既定 ON。** 起動毎にランダムトークンを生成し、表示 / オープンされる URL に埋め込んで `/api/*` をゲートします。同一ホストの他ユーザや他プロセスがループバックポート経由で issue/PR データを読むのを防ぎます。単一ユーザ端末では `--no-token` で外せます。
-- **`--open`** は既定ブラウザで URL を開きます。すでに起動中のサーバ（`.fanout/dashboard.json` に記録）があればそれを再利用し、二重起動しません。
-- **SPA。** 埋め込みの React+Vite SPA は、API 単体よりも多くの情報をライブ Session 一覧に重ねます。まず構造化フィルタ欄があり、自由語と `state:` / `run:` / `agent:` / `wave:` / `ci:` / `dirty:` / `live:` / `issue:` / `task:` / `pr:` の各 term を AND で絞り込めて、ドロップダウンと外せるチップが付きます。行をクリックすると詳細ドロワーが開き、ペインのメタ情報、wave と blocker、worktree、CI 付き PR、元プロンプト、5 秒ごとに更新される直近出力のライブ *peek* を見られます。`--codex-plan-mode` ペインには *plan* セクションが付きます。上部の HUD は repo 全体の running 数と blocked 数を出します。テーマは PAPER BREEZE のライト/ダークです。
-
-全フラグは `fanout dashboard --help` を参照してください。
+サーバは `127.0.0.1` にのみバインドして GET 専用の endpoint だけを公開し、起動毎にランダムトークンを生成して URL に埋め込みます(単一ユーザ端末では `--no-token` で外せます)。
+埋め込みの SPA は、フィルタと詳細ドロワー、直近出力の live peek でライブの Session 一覧を見せます。
 
 ### F12 / prefix + D
 
-TUI 起動時、ライブ fan-out 後、ダッシュボード自体の起動時に fanout が tmux キーバインドを自動登録するので、どのペインからでも **`F12`** または **`prefix + D`** でダッシュボードを開けます。どちらのキーも detached な `fanout-dashboard` ウィンドウでサーバを起動するため、キー押下後も生き続け、2 回目以降は既存 URL を開き直すだけです。**`prefix + M`** では記録済みペインから同一 worktree 操作を開けます。
-
-ブラウザ opener が失敗した場合、fanout は tmux status line に dashboard URL を表示します。
-
-自動登録は `--no-dashboard-keybind`（fan-out 側）、`--no-keybind`（dashboard 側）、設定キー `dashboardKeybind`、`FANOUT_DASHBOARD_KEYBIND=0` でまとめて無効化できます（[Settings]({{< relref "/docs/settings" >}}) を参照してください）。
+どのペインからでも **`F12`** または **`prefix + D`** でダッシュボードを開けます。
+`--no-dashboard-keybind`(fan-out 側)、`--no-keybind`(dashboard 側)、設定キー `dashboardKeybind`、`FANOUT_DASHBOARD_KEYBIND=0` で無効化できます([Settings]({{< relref "/docs/settings" >}}) を参照してください)。
 
 ### prefix + M
 
-同じ登録処理で **`prefix + M`** も登録します。記録済みの fanout ペインから押すと、そのペインの worktree 用 popup が開きます。同じ worktree に別 agent を追加するか、その worktree で shell を開けます。未記録ペインや worktree path がないペインは拒否します。
+同じ登録処理で **`prefix + M`** も登録し、記録済みの fanout ペインから押すとその worktree に agent を追加するか shell を開ける popup が開きます。
 
 ### 縮退動作
 

--- a/site/content/docs/monitoring.ja.md
+++ b/site/content/docs/monitoring.ja.md
@@ -9,6 +9,12 @@ yomi: monitoring
 
 子 issue を 5 つファンアウトすると、tmux には 5 枚のペインが並び、それぞれ別のエージェントが別の worktree で動き出します。次に知りたいのは「どのペインが PR まで進んだか」「どこで止まっているか」「未 commit の作業を抱えたまま放置されているペインはないか」です。fanout はこれを 3 つの窓で見ます。手元で常時眺めるなら**常駐 TUI コンソール**、automation に食わせるなら `--status` の **JSON**、チームやブラウザで共有するなら読み取り専用の **Web ダッシュボード**。`--status` と Web ダッシュボードは読み取り専用で、`.fanout/state.json` と tmux と GitHub を読むだけです。TUI も同じように眺めるための窓ですが、キーバインドから merge、close、cleanup も実行できます（`--merge` / `--close` / `--cleanup` と同じ経路）。
 
+## ペイン枠線ラベル
+
+3 つの窓の前に、tmux 自体がペインを見分けさせてくれます。fanout は作成した各ペインの上枠に `<parent> · <name>` のラベルを付けます — issue の子なら `#123 · fix-login-bug-123`、plan タスクなら `plan:my-feature · task-slug` — さらに枠線を fanout のテーマ色（アクティブは浅葱、それ以外は藍）に染めます。タイル状に並んだ window を一瞥するだけで、どのペインがどの子か、フォーカスせずに分かります。
+
+tmux の枠線オプションは window 単位なので、fanout ペインを含む window では全ペインに上枠が付きます。fanout が作っていないペインは自身の `#{pane_title}` に fallback し、自分で設定した `pane-border-style` はその window では上書きされます。
+
 ## 常駐 TUI コンソール
 
 手元で全ペインを眺め続けるなら、引数なしの `fanout` で常駐コンソールを起動します。
@@ -19,7 +25,9 @@ fanout   # start the persistent tmux console
 
 素のシェルから起動したときは、現在のリポジトリ用の deterministic な fanout 管理 tmux session を作成または attach し、その session 内でコンソールを開始します。tmux 内から起動したときは、現在のペインをそのままコンソール画面にします。起動時と state 更新ごとに、コンソールは tmux 上に残っている記録済み worktree ペインへ再バインドし、消えた worktree ペインは agent CLI の resume で作り直します。使うのは `claude --continue`、`codex resume --last`、または Plan ペインに保存した Codex Plan Mode thread です。
 
-コンソールは `<git-root>/.fanout/state.json` を読み、記録済みペイン ID が tmux 上にまだ存在するかを確認し、`fanout <parent> --status` と同じ GitHub CLI 経路で issue と closed-by PR の状態を定期更新します。エージェント側に計測の仕込みは要りません。各行にはペインの worktree の総作業量を `+X/-Y` で示します。これは記録した base ブランチとの merge-base に対する `git diff --shortstat` で、コミット済みと未 commit の合計です（base 未記録の旧行は `origin/HEAD` から `HEAD` に fallback します）。あわせて `git status --porcelain` 由来の `dirty` / `clean` を出すので、未 commit の作業を抱えたペインをその場で見分けられます。
+コンソールは `<git-root>/.fanout/state.json` を読み、記録済みペイン ID が tmux 上にまだ存在するかを確認し、`fanout <parent> --status` と同じ GitHub CLI 経路で issue と closed-by PR の状態を定期更新します。エージェント側に計測の仕込みは要りません。各行にはペインの worktree の総作業量を `+X/-Y` で示します。これは記録した base ブランチとの merge-base に対する `git diff --shortstat` で、コミット済みと未 commit の合計です（base 未記録の旧行は `origin/HEAD` から `HEAD` に fallback します）。あわせて `git status --porcelain` 由来の `dirty` / `clean` を出すので、未 commit の作業を抱えたペインをその場で見分けられます。`RUN` 列には各ペインの agent 状態（agent 起動ラッパーが報告する `running` / `done`）が出るので、まだ作業中のペインが分かります。detail panel には同じ値が `run=` として出ます。
+
+{{< diagram "console" >}}
 
 行が増えてきたら `/` で絞り込みます。ロード済みの行をメモリ内でフィルタでき、フリーテキストのほか `state:open`、`agent:codex`、`wave:wave5` のような述語も使えます。フィルタは追加の fetch を起こさず、絞り込み中も state と GitHub の自動更新は続きます。
 
@@ -32,6 +40,9 @@ footer は短く保ちます。通常画面で `?` を押すと、全ショー�
 | キー | 動作 |
 |---|---|
 | `?` | キーボードショートカットのヘルプを tmux popup で開く。`Esc`、`q`、もう一度 `?` のいずれかで閉じる。 |
+| `j` / `k` | 選択を下 / 上に移動する（矢印キーでも可）。 |
+| `[` / `]` | 前 / 次の Session グループへジャンプする。 |
+| `/` | ロード済みの行を絞り込む — フリーテキストか `state:open` のような述語。`Esc` でフィルタを解除する。 |
 | `n` | 新規 Session の tmux popup を開く。Mode 行で Prompt / Issue を切り替える。詳細は[新規 Session のモード](#新規-session-のモード)を参照。 |
 | `a` | 選択中の行に記録された worktree に、agent ペインを 1 つ以上追加する。git worktree は作らない。追加行は選択元の worktree と branch を共有し、focus と peek はできるが merge 進捗には数えない。`codex` は Codex Plan Mode で起動する。 |
 | `A` | 選択中の行に記録された worktree で shell terminal を開く。shell 行は `@manual` entry として記録され、focus と peek はできるが merge 進捗には数えない。 |
@@ -62,8 +73,20 @@ footer は短く保ちます。通常画面で `?` を押すと、全ショー�
 
 `n` は Mode 行つきの tmux popup を開きます。Mode 行で `Left` / `Right` を押すとモードが切り替わり、`Tab` でフィールドを移動し、`Esc` でキャンセルします（agent 割り当て画面では 1 つ前に戻る）。
 
-- **Prompt** — 従来の manual ペイン。複数行の必須 prompt と `claude` / `codex` の起動数を指定する。`Up` / `Down` で agent 行を選び、`Space` で 0 / 1 を切り替え、`Left` / `Right` で起動数を変える。`codex` は Codex Plan Mode で起動し popup の prompt を inline で受け取る。`claude` は通常起動する。prompt の下の **plan fan-out** チェックボックスを入れると起動内容が変わる。agent をちょうど 1 本選んで有効にすると、project root にコーディネータ pane を 1 つ起動し、そのプロンプトに対して `/fanout plan`（claude）または `$fanout-plan`（codex）を実行して並列タスクに分解する。コーディネータは自身で `fanout plan` を走らせるため、常に通常 agent として起動する — plan fan-out では `codex` でも Codex Plan Mode にはならない。prompt 欄では `Shift+Enter` または `Ctrl+J` で改行し、`Enter` でペインを作成する。enhanced keyboard input は既定で有効（`FANOUT_TUI_ENHANCED_KEYS=0` で無効化）で、`Shift+Enter` を区別して送る terminal が必要なため fanout が tmux の `extended-keys` を有効化する。manual ペインは synthetic な `@manual` state entry として記録され、起動後に一覧へ表示される。
-- **Issue** — リポジトリの OPEN issue を全件一覧する（cursor ページングで取得）。文字入力で番号・タイトル・ラベルで絞り込み、`Up` / `Down` で一覧をスクロールする。すでにペインが記録されている行は `(has session)` と表示されるが選択はできる。各行の先頭には GitHub Sub-issues グラフ上の位置を示すマーカーが付く — `▸` は OPEN な子を持つファンアウト親、`└` は子、`·` は単独。マーカーは Sub-issues リンクだけを見るので、子を本文のタスクリスト行（`- [ ] #N`）で管理している親は `·` と表示されても起動時にはファンアウトする。一覧の下の **Agent** 行でファンアウトの既定 agent を `claude` / `codex` の起動数として選ぶ — Prompt モードと同じカウント式表示だが、常にちょうど 1 つが `[1]`。`Up` / `Down` で行を移動し、`Space` / `Left` / `Right` で選択する。`Enter` で子 issue ごとの agent 割り当て画面が開き、`Left` / `Right` で行の agent を切り替え — 繰り返し指定の `--agent NUM=name` と同じ — もう一度 `Enter` で起動する。OPEN な子を持つ issue は `fanout <issue> --unblocked-only` 相当でファンアウトする。blocked な子は deferred のまま残るので、ブロッカーが閉じたら同じ issue を選び直す（全子を一度に起動したい場合は CLI を使う）。子のない issue は `@watch` 配下に記録される単独ペインを起動する。
+**Prompt** は従来の manual ペインです。複数行の必須 prompt と `claude` / `codex` の起動数を指定します。
+
+- `Up` / `Down` で agent 行を選び、`Space` で 0 / 1 を切り替え、`Left` / `Right` で起動数を変える。`codex` は Codex Plan Mode で起動し popup の prompt を inline で受け取る。`claude` は通常起動する。
+- prompt 欄では `Shift+Enter` または `Ctrl+J` で改行し、`@` を打つとリポジトリのファイルパス補完が開き、`Enter` でペインを作成する。enhanced keyboard input は既定で有効（`FANOUT_TUI_ENHANCED_KEYS=0` で無効化）で、`Shift+Enter` を区別して送る terminal が必要なため fanout が tmux の `extended-keys` を有効化する。
+- prompt の下の **plan fan-out** チェックボックスを入れると起動内容が変わる。agent をちょうど 1 本選んで有効にすると、project root にコーディネータ pane を 1 つ起動し、そのプロンプトに対して `/fanout plan`（claude）または `$fanout-plan`（codex）を実行して並列タスクに分解する。コーディネータは自身で `fanout plan` を走らせるため、常に通常 agent として起動する — plan fan-out では `codex` でも Codex Plan Mode にはならない。
+- manual ペインは synthetic な `@manual` state entry として記録され、起動後に一覧へ表示される。
+
+**Issue** はリポジトリの OPEN issue を全件一覧します（cursor ページングで取得）。
+
+- 文字入力で番号・タイトル・ラベルで絞り込み、`Up` / `Down` で一覧をスクロールする。すでにペインが記録されている行は `(has session)` と表示されるが選択はできる。
+- 各行の先頭には GitHub Sub-issues グラフ上の位置を示すマーカーが付く: `▸` は OPEN な子を持つファンアウト親、`└` は子、`·` は単独。マーカーは Sub-issues リンクだけを見るので、子を本文のタスクリスト行（`- [ ] #N`）で管理している親は `·` と表示されても起動時にはファンアウトする。
+- 一覧の下の **Agent** 行でファンアウトの既定 agent を `claude` / `codex` の起動数として選ぶ — Prompt モードと同じカウント式表示だが、常にちょうど 1 つが `[1]`。`Up` / `Down` で行を移動し、`Space` / `Left` / `Right` で選択する。
+- `Enter` で子 issue ごとの agent 割り当て画面が開き、`Left` / `Right` で行の agent を切り替え — 繰り返し指定の `--agent NUM=name` と同じ — もう一度 `Enter` で起動する。
+- OPEN な子を持つ issue は `fanout <issue> --unblocked-only` 相当でファンアウトする。blocked な子は deferred のまま残るので、ブロッカーが閉じたら同じ issue を選び直す（全子を一度に起動したい場合は CLI を使う）。子のない issue は `@watch` 配下に記録される単独ペインを起動する。
 
 ## --status（JSON）
 

--- a/site/content/docs/monitoring.ja.md
+++ b/site/content/docs/monitoring.ja.md
@@ -71,10 +71,12 @@ fanout   # start the persistent tmux console
 `n` は Mode 行つきの tmux popup を開き、Prompt / Issue を切り替えます。
 
 **Prompt** は従来の manual ペインです。
-複数行の prompt を書いて `claude` / `codex` の起動数を指定し、prompt 欄では `Shift+Enter` で改行、`@` でリポジトリのファイルパス補完を使えます。
-下の plan fan-out チェックボックスを有効にすると、プロンプトを `fanout plan` で並列タスクに分解する起動に切り替わります。
+複数行の prompt を書いて `claude` / `codex` の起動数を指定し、prompt 欄では `Shift+Enter` または `Ctrl+J` で改行、`@` でリポジトリのファイルパス補完を使えます。
+manual の `codex` ペインは Codex Plan Mode で起動し、prompt を inline で受け取ります(`claude` は通常起動)。
+下の plan fan-out チェックボックスを有効にすると、agent をちょうど 1 本選んだうえで、プロンプトを `fanout plan` で並列タスクに分解するコーディネータ 1 つの起動に切り替わります(コーディネータは `codex` でも常に通常 agent として起動します)。
 
-**Issue** はリポジトリの OPEN issue を一覧し、番号やタイトル、ラベルで絞り込んで、選んだ issue ごとに `claude` / `codex` の既定 agent と割り当てを指定できます。
+**Issue** はリポジトリの OPEN issue を一覧し、番号やタイトル、ラベルで絞り込めます。
+issue を選んで既定の `claude` / `codex` を決めると、`Enter` で子ごとに agent を切り替える割り当て画面が開きます(繰り返し指定の `--agent NUM=name` 相当)。
 OPEN な子を持つ issue は `--unblocked-only` 相当でファンアウトし、blocked な子は deferred のまま残ります。
 子のない issue は `@watch` 配下の単独ペインとして起動します。
 
@@ -84,8 +86,16 @@ OPEN な子を持つ issue は `--unblocked-only` 相当でファンアウトし
 
 ```json
 { "parent": 123,
-  "children": [{ "num": 4, "state": "CLOSED", "has_merged_pr": true }],
-  "summary": { "total": 2, "merged": 1, "all_merged": false } }
+  "children": [
+    { "num": 4, "state": "CLOSED",
+      "prs": [ { "number": 250, "state": "MERGED",
+                 "mergedAt": "2026-05-04T10:00:00Z",
+                 "reviewDecision": "APPROVED", "ci": "pass" } ],
+      "has_merged_pr": true },
+    { "num": 7, "state": "OPEN", "prs": [], "has_merged_pr": false }
+  ],
+  "summary": { "total": 2, "merged": 1, "pending": 1,
+               "blocked": 0, "all_merged": false } }
 ```
 
 ```bash

--- a/site/content/docs/monitoring.ja.md
+++ b/site/content/docs/monitoring.ja.md
@@ -25,7 +25,7 @@ fanout   # start the persistent tmux console
 
 素のシェルから起動したときは、現在のリポジトリ用の deterministic な fanout 管理 tmux session を作成または attach し、その session 内でコンソールを開始します。tmux 内から起動したときは、現在のペインをそのままコンソール画面にします。起動時と state 更新ごとに、コンソールは tmux 上に残っている記録済み worktree ペインへ再バインドし、消えた worktree ペインは agent CLI の resume で作り直します。使うのは `claude --continue`、`codex resume --last`、または Plan ペインに保存した Codex Plan Mode thread です。
 
-コンソールは `<git-root>/.fanout/state.json` を読み、記録済みペイン ID が tmux 上にまだ存在するかを確認し、`fanout <parent> --status` と同じ GitHub CLI 経路で issue と closed-by PR の状態を定期更新します。エージェント側に計測の仕込みは要りません。各行にはペインの worktree の総作業量を `+X/-Y` で示します。これは記録した base ブランチとの merge-base に対する `git diff --shortstat` で、コミット済みと未 commit の合計です（base 未記録の旧行は `origin/HEAD` から `HEAD` に fallback します）。あわせて `git status --porcelain` 由来の `dirty` / `clean` を出すので、未 commit の作業を抱えたペインをその場で見分けられます。`RUN` 列には各ペインの agent 状態（agent 起動ラッパーが報告する `running` / `done`）が出るので、まだ作業中のペインが分かります。detail panel には同じ値が `run=` として出ます。
+コンソールは `<git-root>/.fanout/state.json` を読み、記録済みペイン ID が tmux 上にまだ存在するかを確認し、`fanout <parent> --status` と同じ GitHub CLI 経路で issue と closed-by PR の状態を定期更新します。エージェント側に計測の仕込みは要りません。各行にはペインの worktree の総作業量を `+X/-Y` で示します。これは記録した base ブランチとの merge-base に対する `git diff --shortstat` で、コミット済みと未 commit の合計です（base 未記録の旧行は `origin/HEAD` から `HEAD` に fallback します）。あわせて `git status --porcelain` 由来の `dirty` / `clean` を出すので、未 commit の作業を抱えたペインをその場で見分けられます。`RUN` 列には各ペインの agent 状態がグリフで出ます — `●` が running、`✓` が done（agent 起動ラッパーが報告）— ので、まだ作業中のペインが分かります。detail panel には同じ値が `run=` として文字で出ます。
 
 {{< diagram "console" >}}
 
@@ -42,7 +42,7 @@ footer は短く保ちます。通常画面で `?` を押すと、全ショー�
 | `?` | キーボードショートカットのヘルプを tmux popup で開く。`Esc`、`q`、もう一度 `?` のいずれかで閉じる。 |
 | `j` / `k` | 選択を下 / 上に移動する（矢印キーでも可）。 |
 | `[` / `]` | 前 / 次の Session グループへジャンプする。 |
-| `/` | ロード済みの行を絞り込む — フリーテキストか `state:open` のような述語。`Esc` でフィルタを解除する。 |
+| `/` | ロード済みの行を絞り込む — フリーテキストか `state:open` のような述語。`Esc` は入力を抜けるだけで、一覧からもう一度 `Esc` を押すとフィルタを解除する。 |
 | `n` | 新規 Session の tmux popup を開く。Mode 行で Prompt / Issue を切り替える。詳細は[新規 Session のモード](#新規-session-のモード)を参照。 |
 | `a` | 選択中の行に記録された worktree に、agent ペインを 1 つ以上追加する。git worktree は作らない。追加行は選択元の worktree と branch を共有し、focus と peek はできるが merge 進捗には数えない。`codex` は Codex Plan Mode で起動する。 |
 | `A` | 選択中の行に記録された worktree で shell terminal を開く。shell 行は `@manual` entry として記録され、focus と peek はできるが merge 進捗には数えない。 |

--- a/site/content/docs/monitoring.md
+++ b/site/content/docs/monitoring.md
@@ -25,7 +25,7 @@ fanout   # start the persistent tmux console
 
 From a plain shell it creates a deterministic fanout-managed tmux session for the current repository, starts the console in that session, and attaches to it. From inside tmux it turns the current pane into the console. On startup and each state refresh, the console rebinds recorded worktree panes that still exist in tmux and recreates missing worktree panes by resuming their agent CLI: `claude --continue`, `codex resume --last`, or the saved Codex Plan Mode thread for Plan panes.
 
-The console reads `<git-root>/.fanout/state.json`, checks whether recorded pane IDs still exist in tmux, and periodically refreshes issue / closed-by PR state through the same GitHub CLI source used by `fanout <parent> --status` — no agent instrumentation required. Each row shows the pane worktree's total work size as `+X/-Y`: `git diff --shortstat` against the merge-base with the recorded base branch, so committed and uncommitted changes both count (rows recorded before the base branch was tracked fall back to `origin/HEAD`, then `HEAD`). It also shows `dirty`/`clean` from `git status --porcelain`, so you can spot a pane holding uncommitted work at a glance. A `RUN` column carries each pane's agent state (`running` / `done`, reported by the agent launch wrapper), so you can see which panes are still working; the detail panel repeats the value as `run=`.
+The console reads `<git-root>/.fanout/state.json`, checks whether recorded pane IDs still exist in tmux, and periodically refreshes issue / closed-by PR state through the same GitHub CLI source used by `fanout <parent> --status` — no agent instrumentation required. Each row shows the pane worktree's total work size as `+X/-Y`: `git diff --shortstat` against the merge-base with the recorded base branch, so committed and uncommitted changes both count (rows recorded before the base branch was tracked fall back to `origin/HEAD`, then `HEAD`). It also shows `dirty`/`clean` from `git status --porcelain`, so you can spot a pane holding uncommitted work at a glance. A `RUN` column carries each pane's agent state as a glyph — `●` running, `✓` done, as reported by the agent launch wrapper — so you can see which panes are still working; the detail panel spells the value out as `run=`.
 
 {{< diagram "console" >}}
 
@@ -42,7 +42,7 @@ The footer stays short; press `?` in the monitor to open the full shortcut help 
 | `?` | Open the keyboard shortcut help in a tmux popup. Press `Esc`, `q`, or `?` again to close it. |
 | `j` / `k` | Move the selection down / up (arrow keys work too). |
 | `[` / `]` | Jump to the previous / next Session group. |
-| `/` | Filter the loaded rows — free text or predicates like `state:open`. `Esc` clears the active filter. |
+| `/` | Filter the loaded rows — free text or predicates like `state:open`. `Esc` leaves filter editing; pressed again from the list, it clears the active filter. |
 | `n` | Open the new-session tmux popup. Its Mode row switches between Prompt and Issue; see [New session modes](#new-session-modes). |
 | `a` | Attach one or more agent panes to the selected row's recorded worktree. No git worktree is created. The attached rows share the selected worktree and branch, can be focused and peeked, and do not count toward merge progress. `codex` starts in Codex Plan Mode. |
 | `A` | Open a shell terminal in the selected row's recorded worktree. Shell rows are recorded as `@manual` entries, can be focused and peeked, and do not count toward merge progress. |

--- a/site/content/docs/monitoring.md
+++ b/site/content/docs/monitoring.md
@@ -7,186 +7,105 @@ kanji: 見
 yomi: monitoring
 ---
 
-Fan out five children and tmux fills with five panes, each running a different agent in a different worktree. The next thing you want to know is which pane reached a PR, where one is stuck, and whether any pane is sitting on uncommitted work. fanout answers that through three windows: the **persistent TUI console** for watching from your terminal, `--status` **JSON** for feeding automation, and the read-only **web dashboard** for sharing with a team or a browser. `--status` and the web dashboard are strictly read-only — they only read `.fanout/state.json`, tmux, and GitHub. The TUI watches the same way, but its key bindings can also merge, close, and clean up panes (the same paths as `--merge` / `--close` / `--cleanup`).
+Fan out five child issues and tmux fills with five panes, each running a different agent in a different worktree. The next thing you want to know is which pane reached a PR, and where one is stuck.
+
+fanout answers that through three windows: the **persistent TUI console** if you want to watch from your terminal, `--status` **JSON** if you want to feed automation, and the read-only **web dashboard** if you want to share with a team or a browser. `--status` and the web dashboard are read-only — they only read `.fanout/state.json`, tmux, and GitHub — but the TUI's key bindings can also merge, close, and clean up panes (the same operations as `--merge` / `--close` / `--cleanup`).
 
 ## Pane border labels
 
 Before any of the three windows, tmux itself tells the panes apart: fanout labels each pane it creates on its top border with `<parent> · <name>` — `#123 · fix-login-bug-123` for issue children, `plan:my-feature · task-slug` for plan tasks — and themes the borders with fanout's colors (asagi teal for the active pane, ai indigo for the rest). A glance at a tiled window shows which pane belongs to which child without focusing anything.
 
-tmux scopes border options to the window, so every pane in a window holding fanout panes shows a top border: panes fanout did not create fall back to their own `#{pane_title}`, and a `pane-border-style` you configured yourself is overridden for that window.
-
 ## Persistent TUI console
 
-To watch every pane from your terminal, run `fanout` with no arguments to start the persistent console:
+To watch every pane from your terminal, run `fanout` with no arguments to start the persistent console.
 
 ```bash
 fanout   # start the persistent tmux console
 ```
 
-From a plain shell it creates a deterministic fanout-managed tmux session for the current repository, starts the console in that session, and attaches to it. From inside tmux it turns the current pane into the console. On startup and each state refresh, the console rebinds recorded worktree panes that still exist in tmux and recreates missing worktree panes by resuming their agent CLI: `claude --continue`, `codex resume --last`, or the saved Codex Plan Mode thread for Plan panes.
-
-The console reads `<git-root>/.fanout/state.json`, checks whether recorded pane IDs still exist in tmux, and periodically refreshes issue / closed-by PR state through the same GitHub CLI source used by `fanout <parent> --status` — no agent instrumentation required. Each row shows the pane worktree's total work size as `+X/-Y`: `git diff --shortstat` against the merge-base with the recorded base branch, so committed and uncommitted changes both count (rows recorded before the base branch was tracked fall back to `origin/HEAD`, then `HEAD`). It also shows `dirty`/`clean` from `git status --porcelain`, so you can spot a pane holding uncommitted work at a glance. A `RUN` column carries each pane's agent state as a glyph — `●` running, `✓` done, as reported by the agent launch wrapper — so you can see which panes are still working; the detail panel spells the value out as `run=`.
+From a plain shell it creates or attaches to fanout's managed tmux session; from inside tmux it turns the current pane into the console. The console reads `.fanout/state.json`, periodically refreshes the issue and PR state of recorded panes, and shows each row's worktree change size as `+X/-Y` and whether it holds uncommitted work as `dirty` / `clean`. The `RUN` column shows the agent's execution state as a glyph — `●` for running, `✓` for done — and the detail panel shows the same value as `run=`.
 
 {{< diagram "console" >}}
 
-When the list grows, press `/` to filter the loaded rows in memory, with free-text terms or predicates such as `state:open`, `agent:codex`, and `wave:wave5`. Filtering never triggers extra data fetches, and the automatic state / GitHub refresh continues while a filter is active.
-
-For recorded issue parents the console also reloads the parent's child set and shows wave / blocker columns, using the same `## Blocked by` and `(blocked by #N)` sources as `--unblocked-only`. Blocked children that have not been fanned out yet appear as `deferred` rows, and CLOSED blockers are shown as resolved. The header shows `total` / `merged` / `pending` / `blocked` rollup counts.
-
 ### Key bindings
-
-The footer stays short; press `?` in the monitor to open the full shortcut help in a tmux popup.
 
 | Key | Action |
 |---|---|
 | `?` | Open the keyboard shortcut help in a tmux popup. Press `Esc`, `q`, or `?` again to close it. |
 | `j` / `k` | Move the selection down / up (arrow keys work too). |
 | `[` / `]` | Jump to the previous / next Session group. |
-| `/` | Filter the loaded rows — free text or predicates like `state:open`. `Esc` leaves filter editing; pressed again from the list, it clears the active filter. |
+| `/` | Filter the loaded rows (free text or a predicate such as `state:open`). `Esc` only leaves the input; pressing `Esc` again from the list clears the filter. |
 | `n` | Open the new-session tmux popup. Its Mode row switches between Prompt and Issue; see [New session modes](#new-session-modes). |
 | `a` | Attach one or more agent panes to the selected row's recorded worktree. No git worktree is created. The attached rows share the selected worktree and branch, can be focused and peeked, and do not count toward merge progress. `codex` starts in Codex Plan Mode. |
 | `A` | Open a shell terminal in the selected row's recorded worktree. Shell rows are recorded as `@manual` entries, can be focused and peeked, and do not count toward merge progress. |
-| `t` | Open a shell terminal at the project root. Closing it kills the tmux pane and removes the state row; it never removes a git worktree. |
+| `t` | Open a shell terminal at the project root. Closing it removes only the tmux pane and the state row; it never deletes the git worktree. |
 | `Enter` / `o` | Focus the selected live row's pane. |
-| `1`-`9` | Jump to the Nth row of the current list and focus its pane. Out-of-range numbers show a notice. |
-| `Z` | Focus the selected pane and zoom it (`resize-pane -Z`). The next relayout — a pane created or closed, or the tmux window resized — unzooms it; press `Z` again to re-zoom. |
-| `p` | Refresh the read-only output snapshot shown in the detail panel. |
-| `v` | Cycle the view override: auto → compact → full. Auto picks the [compact switcher](#compact-view) below 80 columns; compact forces it on a wide terminal, full forces the table when narrow. Not persisted. |
-| `c` / `x` | Open close options for the selected pane: close only the pane, close the pane and remove the worktree, or also delete the local branch. |
-| `m` | Fast-forward merge the selected pane's branch — confirmation prompt, then the same core path as `--merge`. |
-| `X` | Clean up merged/closed children of the same parent — confirmation prompt, then the same core path as `--cleanup`. |
+| `1`-`9` | Jump to the Nth row of the displayed list and focus its pane. Out-of-range numbers show a notice. |
+| `Z` | Focus the selected pane and zoom it. Creating or closing a pane, or resizing the tmux window, unzooms it — press `Z` again if you need to. |
+| `p` | Refresh the read-only output snapshot in the detail panel. |
+| `v` | Cycle the view override: auto → compact → full. Auto picks the [compact view](#compact-view) below 80 columns; compact forces the switcher even on a wide screen, full forces the table even on a narrow one. Not persisted. |
+| `c` / `x` | Open close options for the selected pane: close only the pane, close the pane and the worktree, or also delete the local branch. |
+| `m` | Fast-forward merge the selected pane's branch (with a confirmation prompt). |
+| `X` | Clean up merged/closed children of the same parent together (with a confirmation prompt). |
 | `q` | Leave the console. The tmux session and child panes are left running. |
-
-> Worktree rows become `stale!` only when fanout cannot restore them, such as a missing worktree or unavailable agent command. Recorded shell terminals are not resumable; if their tmux pane is gone, the TUI removes the state row.
 
 ### Compact view
 
-Below 80 columns — the 40-column sidebar the auto-layout gives the console — the table and detail panel become a one-line-per-pane switcher. Each row shows the ordinal matching the `1`-`9` jump, the agent-state glyph, the issue / task label, the name, and the pane ID right-aligned; when space runs out only the name shrinks. Session header rows carry the same `t`/`m`/`p`/`b`/`l` counts as the Session list. The selected row alone expands with branch + PR, ci / wave / blockers / dirty, and the last line of the output peek. Every key works unchanged. `v` overrides the automatic choice for the current console only.
+Below 80 columns, the table and detail panel become a one-line-per-pane switcher, and only the selected row expands into details such as branch, PR, and ci / wave / blockers / dirty.
 
 ### F11 / prefix + T
 
-When the console starts, fanout registers tmux keybindings so that **`F11`** or **`prefix + T`** returns to the console from any pane — the counterpart of the dashboard's `F12` / `prefix + D`. Both keys run `fanout focus-console`, which prefers the live console recorded for the pressing pane's repository (several repositories can keep consoles in one tmux server), falls back to a console in the same session, and switches the client there. With no live console, a status-line message points at `fanout` instead.
+From any pane, **`F11`** or **`prefix + T`** returns to the console — the counterpart of `F12` / `prefix + D` — but with no live console it just prints a notice on the status line.
 
-Disable the registration with the `consoleKeybind` config key or `FANOUT_CONSOLE_KEYBIND=0` — see [Settings]({{< relref "/docs/settings" >}}).
+Disable it with the `consoleKeybind` config key or `FANOUT_CONSOLE_KEYBIND=0` (see [Settings]({{< relref "/docs/settings" >}})).
 
 ### New session modes
 
-`n` opens a tmux popup with a Mode row. `Left` / `Right` on that row switches the mode, `Tab` moves between fields, and `Esc` cancels (or steps back from the assignment screen).
+`n` opens a tmux popup with a Mode row that switches between Prompt and Issue.
 
-**Prompt** is the classic manual pane: a required **multi-line** prompt plus `claude` / `codex` launch counts.
+**Prompt** is the classic manual pane. Write a multi-line prompt and set the `claude` / `codex` launch counts; in the prompt field, `Shift+Enter` inserts a newline and `@` completes repository file paths. Enabling the plan fan-out checkbox below switches the launch to decompose the prompt into parallel tasks with `fanout plan`.
 
-- Pick an agent row with `Up` / `Down`, toggle it with `Space`, and change the count with `Left` / `Right`. `codex` starts in Codex Plan Mode and receives the popup prompt inline; `claude` starts normally.
-- In the prompt field, `Shift+Enter` or `Ctrl+J` inserts a newline, typing `@` completes repository file paths into the prompt, and `Enter` creates the selected panes. Enhanced keyboard input is on by default (set `FANOUT_TUI_ENHANCED_KEYS=0` to opt out); `Shift+Enter` needs a terminal that reports it distinctly, for which fanout turns on tmux `extended-keys`.
-- A **plan fan-out** checkbox below the prompt changes what launches: tick it, select exactly one agent, and fanout starts a single coordinator pane at the project root that runs `/fanout plan` (claude) or `$fanout-plan` (codex) on the prompt to decompose it into parallel tasks. The coordinator always launches as a normal agent — `codex` is not in Codex Plan Mode here — because it runs `fanout plan` itself.
-- Manual panes are recorded as synthetic `@manual` state entries and appear in the list after launch.
+**Issue** lists the repository's OPEN issues, lets you narrow them by number, title, or label, and sets the default `claude` / `codex` agent and assignment for each issue you pick. An issue with OPEN children fans out the equivalent of `--unblocked-only`, leaving blocked children deferred. An issue without children starts as a single pane under `@watch`.
 
-**Issue** lists every OPEN issue in the repository, fetched with cursor pagination.
+## --status (JSON / table / --post-dashboard)
 
-- Typing narrows by number, title, or label; `Up` / `Down` scroll the list. Rows that already have a recorded pane show `(has session)` but stay selectable.
-- Each row leads with a marker for its place in the GitHub Sub-issues graph: `▸` a fan-out parent with OPEN children, `└` a child, `·` standalone. The marker reads Sub-issues links only — a parent that tracks its children as body task-list rows (`- [ ] #N`) shows `·` yet still fans out on launch.
-- An **Agent** row below the list picks the fan-out's default agent as `claude` / `codex` launch counts — the same count-style selector as Prompt mode, but exactly one is always `[1]`. `Up` / `Down` move between rows, `Space` / `Left` / `Right` select.
-- `Enter` opens a per-child agent assignment screen where `Left` / `Right` flips one row's agent — the equivalent of repeatable `--agent NUM=name` flags — and `Enter` launches.
-- An issue with OPEN children fans out like `fanout <issue> --unblocked-only`: blocked children stay deferred, so re-select the issue after their blockers close (or use the CLI to launch every child at once). An issue without children starts a single pane recorded under `@watch`.
-
-## --status (JSON)
-
-To judge progress from CI or jq, use `fanout <parent> --status`. It is read-only. It reads `.fanout/state.json` to enumerate the children already fanned out under that specific parent, queries each child through `gh api graphql` against `repository.issue.closedByPullRequestsReferences(first: 100)` — cursor-paginated when a child is closed by more than 100 PRs — so the response carries `state`, `mergedAt`, `reviewDecision`, and the latest commit's CI rollup when present, and prints one JSON document on stdout by default:
+Use `fanout <parent> --status` when you want to feed progress to CI or jq — it enumerates the specified parent's child issues from `.fanout/state.json` and prints each child's state and linked PR as JSON (read-only).
 
 ```json
-{
-  "parent": 123,
-  "children": [
-    { "num": 4, "state": "CLOSED",
-      "prs": [ { "number": 250, "state": "MERGED",
-                 "mergedAt": "2026-05-04T10:00:00Z",
-                 "reviewDecision": "APPROVED", "ci": "pass" } ],
-      "has_merged_pr": true },
-    { "num": 7, "state": "OPEN",
-      "prs": [],
-      "has_merged_pr": false }
-  ],
-  "summary": {
-    "total":      2,
-    "merged":     1,
-    "pending":    1,
-    "blocked":    0,
-    "all_merged": false
-  }
-}
+{ "parent": 123,
+  "children": [{ "num": 4, "state": "CLOSED", "has_merged_pr": true }],
+  "summary": { "total": 2, "merged": 1, "all_merged": false } }
 ```
-
-The JSON is meant for automation:
 
 ```bash
 fanout 123 --status | jq '.summary.all_merged'
+fanout 123 --status --format table       # human-readable table format
+fanout 123 --status --post-dashboard     # upsert a rollup comment on the parent issue
 ```
 
-In a state file that has fanned multiple parents, children of other parents are filtered out so `summary.all_merged` reflects only the requested parent. Set `FANOUT_STATE_PATH` to point directly at a state file when reading from outside the repository checkout; otherwise fanout reads `<git-root>/.fanout/state.json`.
-
-`--status` exit codes are a separate lane from the default flow:
-
-| Exit code | Meaning |
-|---|---|
-| `0` | status emitted — check `summary.all_merged` in JSON mode for the actual state |
-| `2` | cannot enumerate: bad invocation, unreadable or malformed state file, unusable project root, or a Projects v2 URL as parent. A missing state file is treated as an empty state |
-| `3` | `gh` API call failed (auth, network, non-existent issue, etc.) |
-
-> **Issue-mode parents only:** a Projects v2 URL as the parent is rejected up-front, because the current JSON schema is built around issue parents.
-
-## --status --format table
-
-When you want the same data as a human-readable list, add `--format table`:
-
-```bash
-fanout 123 --status --format table
-```
-
-On top of the JSON it adds a normalized PR state (`open`, `draft`, `review-required`, `approved`, `changes-requested`, `merged`, or `closed`), CI, PR diff bars, changed-file counts, the Conventional-Commit type, and PR links.
-
-## --status --post-dashboard
-
-When you want to share progress on the parent issue itself, use `--post-dashboard`:
-
-```bash
-fanout 123 --status --post-dashboard
-```
-
-It upserts one marker-based comment on the parent issue, listing for each child PR the sub-issue number, PR link, PR state, CI, diff size, Conventional-Commit type, TL;DR, and a `Review effort` score. The comment is built from machine-readable GitHub data and PR bodies; it does not call an LLM.
-
-It puts `<!-- fanout:dashboard parent=N -->` at the start of the comment body, finds an existing marker comment with the paginated GitHub REST comments endpoint, and updates that exact comment. If no marker comment exists, it creates one with `gh issue comment --body-file -`.
-
-> `--post-dashboard` is the only `--status` option that writes to GitHub.
+See the [CLI Reference]({{< relref "/docs/cli" >}}) for every JSON field and exit code. `--format table` lists PR state, CI, diff size, and changed-file count. `--post-dashboard` is the only `--status` variant that writes to GitHub — it upserts one rollup comment on the parent issue and keeps updating it.
 
 ## Web dashboard (fanout dashboard --web)
 
-When you want to share every Session in a browser or with a team, `fanout dashboard --web` starts a **read-only** web dashboard. It visualizes fanout **Sessions** — the panes recorded in `.fanout/state.json`, grouped by parent issue — and keeps them live in the browser over SSE. Each row shows pane liveness (from `tmux list-panes`), the live tmux pane title, a `running` / `done` agent-state badge, wave / open-blocker columns (from the parent issue graph), issue state, PR merge status, CI status, and diff/dirty. The data source is the same as `--status`, reused across every parent in the repo at once. Children that have not been fanned out yet appear as synthetic not-started rows. It never mutates GitHub state and only ever *reads* tmux, with two deliberate conveniences: it records the running server in `.fanout/dashboard.json` so a second launch reuses it, and it registers the tmux keybindings described below (opt out with `--no-keybind`).
+When you want to share every Session with a team or in a browser, `fanout dashboard --web` starts a read-only web dashboard.
 
 ```bash
 fanout dashboard --web [--port N] [--open] [--no-token] [--no-keybind]
 ```
 
-- **localhost only.** The server binds `127.0.0.1` and exposes GET-only endpoints: `/api/snapshot`, an SSE `/api/stream`, `/api/peek` (a `tmux capture-pane` snapshot of one recorded pane), `/api/plan` (the last complete `<proposed_plan>` block of a `--codex-plan-mode` pane), and the embedded UI. `--port` defaults to `0` (an OS-assigned ephemeral port); the chosen URL is printed.
-- **Token by default.** A random token is generated each start and embedded in the printed/opened URL, gating `/api/*` so other local users or processes cannot read your issue/PR data off the loopback port. Pass `--no-token` on a single-user machine to drop it.
-- **`--open`** opens the URL in your default browser. The dashboard reuses a server that is already running (recorded in `.fanout/dashboard.json`) instead of starting a second one.
-- **Single-page UI.** The embedded React + Vite SPA layers more onto the live Session list than the API alone. A structured filter box ANDs free words with `state:` / `run:` / `agent:` / `wave:` / `ci:` / `dirty:` / `live:` / `issue:` / `task:` / `pr:` terms, with dropdowns and removable chips. Click a row to open a detail drawer showing pane metadata, wave / blockers, the worktree, PRs with CI, the original prompt, and a live *peek* of recent output refreshed every 5 s. `--codex-plan-mode` panes get a *plan* section. A top HUD shows repo-wide running / blocked counts. The theme is PAPER BREEZE light/dark.
-
-Run `fanout dashboard --help` for the full flag list.
+The server binds only to `127.0.0.1` and exposes GET-only endpoints, generating a random token each start and embedding it in the URL (drop it with `--no-token` on a single-user machine). The embedded SPA shows the live Session list with a filter, a detail drawer, and a live peek of recent output.
 
 ### F12 / prefix + D
 
-When the TUI starts, after a live fan-out, and whenever the dashboard itself starts, fanout registers tmux keybindings so that **`F12`** or **`prefix + D`** pops the dashboard from any pane. Both keys launch the server in a detached `fanout-dashboard` window, so it outlives the keypress; a second press just reopens the existing URL. It also registers **`prefix + M`** for same-worktree actions from the focused recorded pane.
-
-If the browser opener fails, fanout prints the dashboard URL in the tmux status line.
-
-Disable the auto-bindings with `--no-dashboard-keybind` (fan-out side), `--no-keybind` (dashboard side), the `dashboardKeybind` config key, or `FANOUT_DASHBOARD_KEYBIND=0` — see [Settings]({{< relref "/docs/settings" >}}).
+From any pane, **`F12`** or **`prefix + D`** opens the dashboard. Disable it with `--no-dashboard-keybind` (fan-out side), `--no-keybind` (dashboard side), the `dashboardKeybind` config key, or `FANOUT_DASHBOARD_KEYBIND=0` (see [Settings]({{< relref "/docs/settings" >}})).
 
 ### prefix + M
 
-The same binding pass also registers **`prefix + M`**. Press it from a recorded fanout pane to open a popup for that pane's worktree: attach another agent to the same worktree, or open a shell there. The popup refuses unrecorded panes and panes without a stored worktree path.
+The same registration also binds **`prefix + M`**: press it from a recorded fanout pane to open a popup that attaches an agent to that worktree or opens a shell there.
 
 ### Graceful degradation
 
-- With `gh` logged out, the dashboard shows a banner and a state-only view.
-- Outside tmux it still serves, marking pane liveness as unknown.
+- With `gh` logged out, it shows a banner and a state-only view.
+- Outside tmux it keeps serving, with pane liveness left as unknown.
 
 Every flag on this page is listed in the [CLI Reference]({{< relref "/docs/cli" >}}).

--- a/site/content/docs/monitoring.md
+++ b/site/content/docs/monitoring.md
@@ -9,6 +9,12 @@ yomi: monitoring
 
 Fan out five children and tmux fills with five panes, each running a different agent in a different worktree. The next thing you want to know is which pane reached a PR, where one is stuck, and whether any pane is sitting on uncommitted work. fanout answers that through three windows: the **persistent TUI console** for watching from your terminal, `--status` **JSON** for feeding automation, and the read-only **web dashboard** for sharing with a team or a browser. `--status` and the web dashboard are strictly read-only — they only read `.fanout/state.json`, tmux, and GitHub. The TUI watches the same way, but its key bindings can also merge, close, and clean up panes (the same paths as `--merge` / `--close` / `--cleanup`).
 
+## Pane border labels
+
+Before any of the three windows, tmux itself tells the panes apart: fanout labels each pane it creates on its top border with `<parent> · <name>` — `#123 · fix-login-bug-123` for issue children, `plan:my-feature · task-slug` for plan tasks — and themes the borders with fanout's colors (asagi teal for the active pane, ai indigo for the rest). A glance at a tiled window shows which pane belongs to which child without focusing anything.
+
+tmux scopes border options to the window, so every pane in a window holding fanout panes shows a top border: panes fanout did not create fall back to their own `#{pane_title}`, and a `pane-border-style` you configured yourself is overridden for that window.
+
 ## Persistent TUI console
 
 To watch every pane from your terminal, run `fanout` with no arguments to start the persistent console:
@@ -19,7 +25,9 @@ fanout   # start the persistent tmux console
 
 From a plain shell it creates a deterministic fanout-managed tmux session for the current repository, starts the console in that session, and attaches to it. From inside tmux it turns the current pane into the console. On startup and each state refresh, the console rebinds recorded worktree panes that still exist in tmux and recreates missing worktree panes by resuming their agent CLI: `claude --continue`, `codex resume --last`, or the saved Codex Plan Mode thread for Plan panes.
 
-The console reads `<git-root>/.fanout/state.json`, checks whether recorded pane IDs still exist in tmux, and periodically refreshes issue / closed-by PR state through the same GitHub CLI source used by `fanout <parent> --status` — no agent instrumentation required. Each row shows the pane worktree's total work size as `+X/-Y`: `git diff --shortstat` against the merge-base with the recorded base branch, so committed and uncommitted changes both count (rows recorded before the base branch was tracked fall back to `origin/HEAD`, then `HEAD`). It also shows `dirty`/`clean` from `git status --porcelain`, so you can spot a pane holding uncommitted work at a glance.
+The console reads `<git-root>/.fanout/state.json`, checks whether recorded pane IDs still exist in tmux, and periodically refreshes issue / closed-by PR state through the same GitHub CLI source used by `fanout <parent> --status` — no agent instrumentation required. Each row shows the pane worktree's total work size as `+X/-Y`: `git diff --shortstat` against the merge-base with the recorded base branch, so committed and uncommitted changes both count (rows recorded before the base branch was tracked fall back to `origin/HEAD`, then `HEAD`). It also shows `dirty`/`clean` from `git status --porcelain`, so you can spot a pane holding uncommitted work at a glance. A `RUN` column carries each pane's agent state (`running` / `done`, reported by the agent launch wrapper), so you can see which panes are still working; the detail panel repeats the value as `run=`.
+
+{{< diagram "console" >}}
 
 When the list grows, press `/` to filter the loaded rows in memory, with free-text terms or predicates such as `state:open`, `agent:codex`, and `wave:wave5`. Filtering never triggers extra data fetches, and the automatic state / GitHub refresh continues while a filter is active.
 
@@ -32,6 +40,9 @@ The footer stays short; press `?` in the monitor to open the full shortcut help 
 | Key | Action |
 |---|---|
 | `?` | Open the keyboard shortcut help in a tmux popup. Press `Esc`, `q`, or `?` again to close it. |
+| `j` / `k` | Move the selection down / up (arrow keys work too). |
+| `[` / `]` | Jump to the previous / next Session group. |
+| `/` | Filter the loaded rows — free text or predicates like `state:open`. `Esc` clears the active filter. |
 | `n` | Open the new-session tmux popup. Its Mode row switches between Prompt and Issue; see [New session modes](#new-session-modes). |
 | `a` | Attach one or more agent panes to the selected row's recorded worktree. No git worktree is created. The attached rows share the selected worktree and branch, can be focused and peeked, and do not count toward merge progress. `codex` starts in Codex Plan Mode. |
 | `A` | Open a shell terminal in the selected row's recorded worktree. Shell rows are recorded as `@manual` entries, can be focused and peeked, and do not count toward merge progress. |
@@ -62,8 +73,20 @@ Disable the registration with the `consoleKeybind` config key or `FANOUT_CONSOLE
 
 `n` opens a tmux popup with a Mode row. `Left` / `Right` on that row switches the mode, `Tab` moves between fields, and `Esc` cancels (or steps back from the assignment screen).
 
-- **Prompt** — the classic manual pane: a required **multi-line** prompt plus `claude` / `codex` launch counts. Use `Up` / `Down` to pick an agent row, `Space` to toggle it, and `Left` / `Right` to change the count. `codex` starts in Codex Plan Mode and receives the popup prompt inline; `claude` starts normally. A **plan fan-out** checkbox below the prompt changes what launches: tick it, select exactly one agent, and fanout starts a single coordinator pane at the project root that runs `/fanout plan` (claude) or `$fanout-plan` (codex) on the prompt to decompose it into parallel tasks. The coordinator always launches as a normal agent — `codex` is not in Codex Plan Mode for a plan fan-out — because it runs `fanout plan` itself. In the prompt field, `Shift+Enter` or `Ctrl+J` inserts a newline and `Enter` creates the selected panes. Enhanced keyboard input is on by default (set `FANOUT_TUI_ENHANCED_KEYS=0` to opt out); `Shift+Enter` needs a terminal that reports it distinctly, for which fanout turns on tmux `extended-keys`. Manual panes are recorded as synthetic `@manual` state entries and appear in the list after launch.
-- **Issue** — lists every OPEN issue in the repository, fetched with cursor pagination. Typing narrows by number, title, or label, and `Up` / `Down` scroll the list; rows that already have a recorded pane show `(has session)` but stay selectable. Each row leads with a marker for its place in the GitHub Sub-issues graph — `▸` a fan-out parent with OPEN children, `└` a child, `·` standalone. The marker reads Sub-issues links only: a parent that tracks its children as body task-list rows (`- [ ] #N`) shows `·` yet still fans out on launchAn **Agent** row below the list picks the fan-out's default agent as `claude` / `codex` launch counts — the same count-style selector as Prompt mode, but exactly one is always `[1]`; `Up` / `Down` move between rows and `Space` / `Left` / `Right` select. `Enter` opens a per-child agent assignment screen where `Left` / `Right` flips one row's agent — the equivalent of repeatable `--agent NUM=name` flags — and `Enter` launches. An issue with OPEN children fans out like `fanout <issue> --unblocked-only`: blocked children stay deferred, so re-select the issue after their blockers close (or use the CLI to launch every child at once). An issue without children starts a single pane recorded under `@watch`.
+**Prompt** is the classic manual pane: a required **multi-line** prompt plus `claude` / `codex` launch counts.
+
+- Pick an agent row with `Up` / `Down`, toggle it with `Space`, and change the count with `Left` / `Right`. `codex` starts in Codex Plan Mode and receives the popup prompt inline; `claude` starts normally.
+- In the prompt field, `Shift+Enter` or `Ctrl+J` inserts a newline, typing `@` completes repository file paths into the prompt, and `Enter` creates the selected panes. Enhanced keyboard input is on by default (set `FANOUT_TUI_ENHANCED_KEYS=0` to opt out); `Shift+Enter` needs a terminal that reports it distinctly, for which fanout turns on tmux `extended-keys`.
+- A **plan fan-out** checkbox below the prompt changes what launches: tick it, select exactly one agent, and fanout starts a single coordinator pane at the project root that runs `/fanout plan` (claude) or `$fanout-plan` (codex) on the prompt to decompose it into parallel tasks. The coordinator always launches as a normal agent — `codex` is not in Codex Plan Mode here — because it runs `fanout plan` itself.
+- Manual panes are recorded as synthetic `@manual` state entries and appear in the list after launch.
+
+**Issue** lists every OPEN issue in the repository, fetched with cursor pagination.
+
+- Typing narrows by number, title, or label; `Up` / `Down` scroll the list. Rows that already have a recorded pane show `(has session)` but stay selectable.
+- Each row leads with a marker for its place in the GitHub Sub-issues graph: `▸` a fan-out parent with OPEN children, `└` a child, `·` standalone. The marker reads Sub-issues links only — a parent that tracks its children as body task-list rows (`- [ ] #N`) shows `·` yet still fans out on launch.
+- An **Agent** row below the list picks the fan-out's default agent as `claude` / `codex` launch counts — the same count-style selector as Prompt mode, but exactly one is always `[1]`. `Up` / `Down` move between rows, `Space` / `Left` / `Right` select.
+- `Enter` opens a per-child agent assignment screen where `Left` / `Right` flips one row's agent — the equivalent of repeatable `--agent NUM=name` flags — and `Enter` launches.
+- An issue with OPEN children fans out like `fanout <issue> --unblocked-only`: blocked children stay deferred, so re-select the issue after their blockers close (or use the CLI to launch every child at once). An issue without children starts a single pane recorded under `@watch`.
 
 ## --status (JSON)
 

--- a/site/content/docs/monitoring.md
+++ b/site/content/docs/monitoring.md
@@ -63,9 +63,9 @@ Disable it with the `consoleKeybind` config key or `FANOUT_CONSOLE_KEYBIND=0` (s
 
 `n` opens a tmux popup with a Mode row that switches between Prompt and Issue.
 
-**Prompt** is the classic manual pane. Write a multi-line prompt and set the `claude` / `codex` launch counts; in the prompt field, `Shift+Enter` inserts a newline and `@` completes repository file paths. Enabling the plan fan-out checkbox below switches the launch to decompose the prompt into parallel tasks with `fanout plan`.
+**Prompt** is the classic manual pane. Write a multi-line prompt and set the `claude` / `codex` launch counts; in the prompt field, `Shift+Enter` or `Ctrl+J` inserts a newline and `@` completes repository file paths. Manual `codex` panes start in Codex Plan Mode with the prompt passed inline; `claude` starts normally. Enabling the plan fan-out checkbox below switches the launch to a single coordinator (select exactly one agent) that decomposes the prompt into parallel tasks with `fanout plan` — the coordinator always launches as a normal agent, even `codex`.
 
-**Issue** lists the repository's OPEN issues, lets you narrow them by number, title, or label, and sets the default `claude` / `codex` agent and assignment for each issue you pick. An issue with OPEN children fans out the equivalent of `--unblocked-only`, leaving blocked children deferred. An issue without children starts as a single pane under `@watch`.
+**Issue** lists the repository's OPEN issues and lets you narrow them by number, title, or label. Pick an issue, choose the default `claude` / `codex` agent, and `Enter` opens an assignment screen that flips the agent per child of that issue — the equivalent of repeatable `--agent NUM=name`. An issue with OPEN children fans out the equivalent of `--unblocked-only`, leaving blocked children deferred. An issue without children starts as a single pane under `@watch`.
 
 ## --status (JSON / table / --post-dashboard)
 
@@ -73,8 +73,16 @@ Use `fanout <parent> --status` when you want to feed progress to CI or jq — it
 
 ```json
 { "parent": 123,
-  "children": [{ "num": 4, "state": "CLOSED", "has_merged_pr": true }],
-  "summary": { "total": 2, "merged": 1, "all_merged": false } }
+  "children": [
+    { "num": 4, "state": "CLOSED",
+      "prs": [ { "number": 250, "state": "MERGED",
+                 "mergedAt": "2026-05-04T10:00:00Z",
+                 "reviewDecision": "APPROVED", "ci": "pass" } ],
+      "has_merged_pr": true },
+    { "num": 7, "state": "OPEN", "prs": [], "has_merged_pr": false }
+  ],
+  "summary": { "total": 2, "merged": 1, "pending": 1,
+               "blocked": 0, "all_merged": false } }
 ```
 
 ```bash

--- a/site/content/docs/quickstart.ja.md
+++ b/site/content/docs/quickstart.ja.md
@@ -1,21 +1,23 @@
 ---
 title: クイックスタート
 linkTitle: クイックスタート
-description: "5 分で最初のファンアウト。親 issue から並列ペインを立ち上げ、その間に何が起きるかも示します。"
+description: "5 分で最初のファンアウト。親 issue から並列ペインを立ち上げるまでの手順を示します。"
 weight: 20
 kanji: 開
 yomi: quickstart
 ---
 
-## 最初のファンアウト（5 分）
+## 最初のファンアウト(5 分)
 
-親 issue に OPEN なサブ issue が 3 つあるとします。1 つずつ着手して順番待ちさせる代わりに、fanout は全部を同時に動かします。子ごとに tmux のペインを 1 枚開き、それぞれが独立した git worktree を持つので、3 つのエージェントが互いの編集と衝突せずに並行して進みます。
+親 issue に OPEN なサブ issue が 3 つあるとします。
+1 つずつ着手して順番待ちさせる代わりに、fanout は全部を同時に動かします。
+子ごとに tmux のペインを 1 枚開き、それぞれが独立した git worktree を持つので、3 つのエージェントが互いの編集と衝突せずに並行して進みます。
 
 {{< diagram "overview" >}}
 
-issue ツリーがまだ無い場合は、同梱の `fanout-issues` skill が計画を親 issue + リンク済みの子 issue に変換します（[エージェント連携]({{< relref "/docs/agents" >}}) を参照）。fanout が期待する形は[後述](#子-issue-の宣言方法)します。
+issue ツリーがまだ無い場合は、同梱の `fanout-issues` skill が計画を親 issue とリンク済みの子 issue に変換します([エージェント連携]({{< relref "/docs/agents" >}})を参照)。
 
-tmux セッションを開始（または attach）します。
+tmux セッションを開始(または attach)します。
 
 ```bash
 tmux new -A -s work
@@ -29,7 +31,8 @@ export FANOUT_AGENT=claude
 cd path/to/repo
 ```
 
-まず計画をプレビューします。`--dry-run` は git worktree と tmux のコマンド列を実行せずに表示するだけで、worktree もペインも state 行も briefing ファイルも作りません。
+まず計画をプレビューします。
+`--dry-run` は git worktree と tmux のコマンド列を実行せずに表示するだけで、worktree もペインも state 行も briefing ファイルも作りません。
 
 ```bash
 # Preview commands without creating worktrees, panes, state, or briefings
@@ -45,55 +48,28 @@ fanout 123
 
 子 issue ごとに、現在の tmux セッション内のペイン、`.fanout/worktrees/<slug>/` 配下の独立した worktree、issue ごとの briefing を指す 1 行プロンプトで起動したエージェントが得られます。
 
-> ペイン作成には `gh`、`git`、`tmux 3.3+` が `PATH` 上に必要です。fanout は起動時に依存を確認し、欠けていればインストールのヒントを表示します（[インストール]({{< relref "/docs/installation" >}})を参照）。
+> ペイン作成には `gh`、`git`、`tmux 3.3+` が `PATH` 上に必要です。
+> fanout は起動時に依存を確認し、欠けていればインストールのヒントを表示します([インストール]({{< relref "/docs/installation" >}})を参照)。
 
 ## 子 issue の宣言方法
 
-自分の issue ツリーをどう書けば fanout が拾うかを示します。fanout は 2 つのソースの和集合で子を列挙します。
+fanout は子を GitHub の Sub-issues と、親本文のタスクリスト行 `- [ ] #NUM ...` の和集合で列挙し、処理するのは `state == "OPEN"` の子だけです。
+タスクリスト参照は同一 repo 内のみ有効で、`owner/repo#NUM` はスキップされます。
+書き方の詳細は[ワークフロー]({{< relref "/docs/workflow" >}})を参照してください。
 
-- **Sub-issues** として親に正式リンクされた issue
-- **親本文のタスクリスト参照**。`- [ ] #NUM ...` にマッチする行の `#NUM`
+## 再実行しても安全(冪等性)
 
-```text
-- [ ] #124 Extract the parser
-- [ ] #125 Add the --format flag
-- [ ] other/repo#126 Upstream fix   <- skipped: same-repo references only
-```
-
-タスクリスト参照は同一 repo 内のみで、`owner/repo#NUM` 形式はスキップされます。子はどちらか一方のソースでも両方でも宣言でき、和集合なので重複は除かれます。処理されるのは `state == "OPEN"` の子だけで、CLOSED の子にペインは作られません。
-
-つまり、親 issue にサブ issue を 3 つぶら下げてもよいし、親本文に 3 行のタスクリストを書いてもよいし、両方を混ぜてもかまいません。どう書いても、OPEN な子がそのまま並列ペインになります。
-
-## 実行時に起きること
-
-live 実行は次のステップで進みます。
-
-1. `gh`、`git`、`tmux 3.3+` がインストールされているかを確認する。
-2. リポジトリルート、現在の tmux セッションと起動元ペイン、`--agent` または `FANOUT_AGENT` から使うエージェントを解決する。
-3. Sub-issues と親タスクリスト行の和集合で子を列挙する（OPEN の子のみ処理）。
-4. `.fanout/state.json` を読み、`(parent, issueNum)` ペアが記録済みの子はスキップする。
-5. 対象 issue ごとに、issue 本文と短い Requirements チェックリストからなる briefing を書き出す。
-6. fresh 化した base branch から `.fanout/worktrees/<slug>/` を作り、`tmux split-window` で子ペインを選択せずに開き、ペインタイトルを設定してウィンドウを快適幅グリッドに組み直し（失敗時は `main-vertical` → `tiled` にフォールバック）、次の子に進む前に `--sleep` 秒（既定 4）スリープする。
-7. created / skipped / deferred / failed の件数サマリを表示する。
-
-> ペイン起動プロンプトが短いのは意図的です。完全な issue 本文は briefing ファイルにあり、エージェントはそれを読むよう指示されます。`deferred` は `--unblocked-only` 指定時のみ現れ、OPEN な blocker が残る子を保留します。
-
-> `--dry-run` では確認用に将来の briefing path と size を表示するだけで、ファイルを書くのは live 実行時だけです。
-
-## 再実行しても安全（冪等性）
-
-冪等とは、同じ操作を複数回行っても 1 回行ったのと同じ結果になることです。`.fanout/state.json` が起動済みのペインを `(parent, issueNum)` キーで記録するため、同じ親で再実行しても記録済みの子はスキップされ、足りない分だけが作られます。
+`.fanout/state.json` が起動済みの子を記録するため、同じ親で再実行しても記録済みの子はスキップされ、足りない分だけが作られます。
 
 ```bash
 # Rerun after the first batch — already-recorded children are skipped
 fanout 123
 ```
 
-state 行の無い既存の `.fanout/worktrees/<slug>/` ディレクトリも、ファンアウト済みとして扱われます。pre-state run や中断された launch のための移行用 fallback です。
-
 ## エージェントの指定
 
-エージェント名が解決できることが必須です。`--agent claude` か `--agent codex` を渡すか、`FANOUT_AGENT` を設定してください。
+エージェント名が解決できることが必須です。
+`--agent claude` か `--agent codex` を渡すか、`FANOUT_AGENT` を設定してください。
 
 ```bash
 fanout 123 --agent claude
@@ -101,6 +77,9 @@ fanout 123 --agent codex
 export FANOUT_AGENT=claude   # applies to every following run in this shell
 ```
 
-未知のエージェントはペイン作成前に失敗し、live 実行では選択したエージェント CLI がインストール済みかも確認します。fanout は tmux セッション内から実行してください。子ペインは `tmux split-window` で直接作られ、`--session` で別セッションを指定しない限り起動元ペインが target になります。唯一の例外は引数なしの `fanout`（TUI コンソール）で、素のシェルからも起動できます（[モニタリング]({{< relref "/docs/monitoring" >}})を参照）。
+未知のエージェントはペイン作成前に失敗し、live 実行では選択したエージェント CLI がインストール済みかも確認します。
+fanout は tmux セッション内から実行してください。
+子ペインは `tmux split-window` で直接作られ、`--session` で別セッションを指定しない限り起動元ペインが target になります。
+唯一の例外は引数なしの `fanout`(TUI コンソール)で、素のシェルからも起動できます([モニタリング]({{< relref "/docs/monitoring" >}})を参照)。
 
 次は[ワークフロー]({{< relref "/docs/workflow" >}})で、run を形作る flag を見ていきます。

--- a/site/content/docs/quickstart.ja.md
+++ b/site/content/docs/quickstart.ja.md
@@ -9,21 +9,21 @@ yomi: quickstart
 
 ## 最初のファンアウト（5 分）
 
-親 issue に OPEN なサブ issue が 5 つあるとします。1 つずつ着手して順番待ちさせる代わりに、fanout は全部を同時に動かします。子ごとに tmux のペインを 1 枚開き、それぞれが独立した git worktree を持つので、5 つのエージェントが互いの編集と衝突せずに並行して進みます。
+親 issue に OPEN なサブ issue が 3 つあるとします。1 つずつ着手して順番待ちさせる代わりに、fanout は全部を同時に動かします。子ごとに tmux のペインを 1 枚開き、それぞれが独立した git worktree を持つので、3 つのエージェントが互いの編集と衝突せずに並行して進みます。
 
 {{< diagram "overview" >}}
 
 issue ツリーがまだ無い場合は、同梱の `fanout-issues` skill が計画を親 issue + リンク済みの子 issue に変換します（[エージェント連携]({{< relref "/docs/agents" >}}) を参照）。fanout が期待する形は[後述](#子-issue-の宣言方法)します。
 
-子ごとのペインで使うエージェントを決め、対象リポジトリで tmux セッションを開始（または attach）します。
+tmux セッションを開始（または attach）し、セッションの中でエージェントを決めて対象リポジトリへ移動します。
 
 ```bash
-# Use Claude for child panes
-export FANOUT_AGENT=claude
-
-# Start (or attach) a tmux session in the repository
-cd path/to/repo
+# Start (or attach) a tmux session
 tmux new -A -s work
+
+# Inside the session: use Claude for child panes, from the repository root
+export FANOUT_AGENT=claude
+cd path/to/repo
 ```
 
 まず計画をプレビューします。`--dry-run` は git worktree と tmux のコマンド列を実行せずに表示するだけで、worktree もペインも state 行も briefing ファイルも作りません。
@@ -59,7 +59,7 @@ fanout 123
 
 タスクリスト参照は同一 repo 内のみで、`owner/repo#NUM` 形式はスキップされます。子はどちらか一方のソースでも両方でも宣言でき、和集合なので重複は除かれます。処理されるのは `state == "OPEN"` の子だけで、CLOSED の子にペインは作られません。
 
-つまり、親 issue にサブ issue を 5 つぶら下げてもよいし、親本文に 5 行のタスクリストを書いてもよいし、両方を混ぜてもかまいません。どう書いても、OPEN な子がそのまま並列ペインになります。
+つまり、親 issue にサブ issue を 3 つぶら下げてもよいし、親本文に 3 行のタスクリストを書いてもよいし、両方を混ぜてもかまいません。どう書いても、OPEN な子がそのまま並列ペインになります。
 
 ## 実行時に起きること
 

--- a/site/content/docs/quickstart.ja.md
+++ b/site/content/docs/quickstart.ja.md
@@ -11,11 +11,19 @@ yomi: quickstart
 
 親 issue に OPEN なサブ issue が 5 つあるとします。1 つずつ着手して順番待ちさせる代わりに、fanout は全部を同時に動かします。子ごとに tmux のペインを 1 枚開き、それぞれが独立した git worktree を持つので、5 つのエージェントが互いの編集と衝突せずに並行して進みます。
 
+{{< diagram "overview" >}}
+
+issue ツリーがまだ無い場合は、同梱の `fanout-issues` skill が計画を親 issue + リンク済みの子 issue に変換します（[エージェント連携]({{< relref "/docs/agents" >}}) を参照）。fanout が期待する形は[後述](#子-issue-の宣言方法)します。
+
 子ごとのペインで使うエージェントを決め、対象リポジトリで tmux セッションを開始（または attach）します。
 
 ```bash
 # Use Claude for child panes
 export FANOUT_AGENT=claude
+
+# Start (or attach) a tmux session in the repository
+cd path/to/repo
+tmux new -A -s work
 ```
 
 まず計画をプレビューします。`--dry-run` は git worktree と tmux のコマンド列を実行せずに表示するだけで、worktree もペインも state 行も briefing ファイルも作りません。

--- a/site/content/docs/quickstart.ja.md
+++ b/site/content/docs/quickstart.ja.md
@@ -15,13 +15,16 @@ yomi: quickstart
 
 issue ツリーがまだ無い場合は、同梱の `fanout-issues` skill が計画を親 issue + リンク済みの子 issue に変換します（[エージェント連携]({{< relref "/docs/agents" >}}) を参照）。fanout が期待する形は[後述](#子-issue-の宣言方法)します。
 
-tmux セッションを開始（または attach）し、セッションの中でエージェントを決めて対象リポジトリへ移動します。
+tmux セッションを開始（または attach）します。
 
 ```bash
-# Start (or attach) a tmux session
 tmux new -A -s work
+```
 
-# Inside the session: use Claude for child panes, from the repository root
+次に、セッションの中でエージェントを決めて対象リポジトリへ移動します。
+
+```bash
+# Use Claude for child panes, from the repository root
 export FANOUT_AGENT=claude
 cd path/to/repo
 ```

--- a/site/content/docs/quickstart.md
+++ b/site/content/docs/quickstart.md
@@ -1,7 +1,7 @@
 ---
 title: Quickstart
 linkTitle: Quickstart
-description: "Your first fan-out in five minutes — bring up parallel panes from a parent issue, and see what happens in between."
+description: "Your first fan-out in five minutes — the steps to bring up parallel panes from a parent issue."
 weight: 20
 kanji: 開
 yomi: quickstart
@@ -13,7 +13,7 @@ Suppose your parent issue has three OPEN sub-issues. Instead of picking them off
 
 {{< diagram "overview" >}}
 
-No issue tree yet? The bundled `fanout-issues` skill turns a plan into a parent issue with linked children — see [Agent Integrations]({{< relref "/docs/agents" >}}). The shape fanout expects is described [below](#how-child-issues-are-declared).
+No issue tree yet? The bundled `fanout-issues` skill turns a plan into a parent issue with linked children — see [Agent Integrations]({{< relref "/docs/agents" >}}).
 
 Start (or attach) a tmux session:
 
@@ -29,7 +29,7 @@ export FANOUT_AGENT=claude
 cd path/to/repo
 ```
 
-Preview the plan first. `--dry-run` prints the git worktree + tmux commands without executing them. It creates no worktrees, panes, state rows, or briefing files:
+Preview the plan first. `--dry-run` prints the git worktree and tmux commands without executing them. It creates no worktrees, panes, state rows, or briefing files:
 
 ```bash
 # Preview commands without creating worktrees, panes, state, or briefings
@@ -49,47 +49,16 @@ Each child gets a pane in the current tmux session, an isolated worktree under `
 
 ## How child issues are declared
 
-Here is how to write your issue tree so fanout picks it up. fanout enumerates children by taking the union of two sources:
-
-- issues formally linked to the parent as **Sub-issues**, and
-- **task-list references in the parent body** — any line matching `- [ ] #NUM ...` contributes `#NUM`.
-
-```text
-- [ ] #124 Extract the parser
-- [ ] #125 Add the --format flag
-- [ ] other/repo#126 Upstream fix   <- skipped: same-repo references only
-```
-
-Task-list references are same-repo only; `owner/repo#NUM` is skipped. Children may be declared via either source or both — the union deduplicates them. Only children whose state is OPEN are processed; closed children never get a pane.
-
-So you can hang three sub-issues off the parent, write a three-line task list in the parent body, or mix both. Either way, every OPEN child becomes a parallel pane.
-
-## What happens during a run
-
-A live run walks these steps:
-
-1. Verifies `gh`, `git`, and `tmux 3.3+` are installed.
-2. Resolves the repository root, the current tmux session and invoking pane, and the agent from `--agent` or `FANOUT_AGENT`.
-3. Enumerates children as the union of Sub-issues and parent task-list rows; only OPEN children are processed.
-4. Reads `.fanout/state.json` and skips children whose `(parent, issueNum)` pair is already recorded.
-5. Writes a briefing for each target with the issue body and a short Requirements checklist.
-6. Creates `.fanout/worktrees/<slug>/` from the refreshed base branch, creates the child pane with `tmux split-window` without selecting it, sets the pane title, re-lays out the window into a comfortable-width grid (falling back to `main-vertical` then `tiled`), then sleeps `--sleep` seconds (default 4) before the next child.
-7. Prints a summary of created / skipped / deferred / failed counts.
-
-> The pane launch prompt stays short on purpose: the full issue body lives in the briefing file, and the agent is told to read it from there. `deferred` only appears with `--unblocked-only`, which holds back children that still have an OPEN blocker.
-
-> In `--dry-run`, fanout prints the future briefing path and size for review, but writes the file only during the live run.
+fanout enumerates children as the union of GitHub Sub-issues and task-list rows in the parent body (`- [ ] #NUM ...`), and only children with `state == "OPEN"` are processed. Task-list references are same-repo only — `owner/repo#NUM` is skipped. See [Workflow]({{< relref "/docs/workflow" >}}) for details on how to write it.
 
 ## Safe to rerun (idempotency)
 
-Idempotent means running the same operation many times leaves the same result as running it once. `.fanout/state.json` records every launched pane keyed by `(parent, issueNum)`, so rerunning the same parent skips children that already have a recorded fanout pane and only creates what is missing:
+`.fanout/state.json` records every launched child, so rerunning the same parent skips children that are already recorded and only creates what is missing:
 
 ```bash
 # Rerun after the first batch — already-recorded children are skipped
 fanout 123
 ```
-
-An existing `.fanout/worktrees/<slug>/` directory without a state row is also treated as already fanned — a migration fallback for pre-state runs or interrupted launches.
 
 ## Choosing the agent
 

--- a/site/content/docs/quickstart.md
+++ b/site/content/docs/quickstart.md
@@ -11,11 +11,19 @@ yomi: quickstart
 
 Suppose your parent issue has five OPEN sub-issues. Instead of picking them off one at a time and queueing the rest, fanout starts them all at once: one tmux pane per child, each with its own git worktree, so five agents work in parallel without colliding on each other's edits.
 
+{{< diagram "overview" >}}
+
+No issue tree yet? The bundled `fanout-issues` skill turns a plan into a parent issue with linked children — see [Agent Integrations]({{< relref "/docs/agents" >}}). The shape fanout expects is described [below](#how-child-issues-are-declared).
+
 Pick the agent used for child panes, then start (or attach) a tmux session in the target repository:
 
 ```bash
 # Use Claude for child panes
 export FANOUT_AGENT=claude
+
+# Start (or attach) a tmux session in the repository
+cd path/to/repo
+tmux new -A -s work
 ```
 
 Preview the plan first. `--dry-run` prints the git worktree + tmux commands without executing them. It creates no worktrees, panes, state rows, or briefing files:

--- a/site/content/docs/quickstart.md
+++ b/site/content/docs/quickstart.md
@@ -15,13 +15,16 @@ Suppose your parent issue has three OPEN sub-issues. Instead of picking them off
 
 No issue tree yet? The bundled `fanout-issues` skill turns a plan into a parent issue with linked children — see [Agent Integrations]({{< relref "/docs/agents" >}}). The shape fanout expects is described [below](#how-child-issues-are-declared).
 
-Start (or attach) a tmux session, then — inside the session — pick the agent and move to the target repository:
+Start (or attach) a tmux session:
 
 ```bash
-# Start (or attach) a tmux session
 tmux new -A -s work
+```
 
-# Inside the session: use Claude for child panes, from the repository root
+Then, inside the session, pick the agent and move to the target repository:
+
+```bash
+# Use Claude for child panes, from the repository root
 export FANOUT_AGENT=claude
 cd path/to/repo
 ```

--- a/site/content/docs/quickstart.md
+++ b/site/content/docs/quickstart.md
@@ -9,21 +9,21 @@ yomi: quickstart
 
 ## Your first fan-out (five minutes)
 
-Suppose your parent issue has five OPEN sub-issues. Instead of picking them off one at a time and queueing the rest, fanout starts them all at once: one tmux pane per child, each with its own git worktree, so five agents work in parallel without colliding on each other's edits.
+Suppose your parent issue has three OPEN sub-issues. Instead of picking them off one at a time and queueing the rest, fanout starts them all at once: one tmux pane per child, each with its own git worktree, so three agents work in parallel without colliding on each other's edits.
 
 {{< diagram "overview" >}}
 
 No issue tree yet? The bundled `fanout-issues` skill turns a plan into a parent issue with linked children — see [Agent Integrations]({{< relref "/docs/agents" >}}). The shape fanout expects is described [below](#how-child-issues-are-declared).
 
-Pick the agent used for child panes, then start (or attach) a tmux session in the target repository:
+Start (or attach) a tmux session, then — inside the session — pick the agent and move to the target repository:
 
 ```bash
-# Use Claude for child panes
-export FANOUT_AGENT=claude
-
-# Start (or attach) a tmux session in the repository
-cd path/to/repo
+# Start (or attach) a tmux session
 tmux new -A -s work
+
+# Inside the session: use Claude for child panes, from the repository root
+export FANOUT_AGENT=claude
+cd path/to/repo
 ```
 
 Preview the plan first. `--dry-run` prints the git worktree + tmux commands without executing them. It creates no worktrees, panes, state rows, or briefing files:
@@ -59,7 +59,7 @@ Here is how to write your issue tree so fanout picks it up. fanout enumerates ch
 
 Task-list references are same-repo only; `owner/repo#NUM` is skipped. Children may be declared via either source or both — the union deduplicates them. Only children whose state is OPEN are processed; closed children never get a pane.
 
-So you can hang five sub-issues off the parent, write a five-line task list in the parent body, or mix both. Either way, every OPEN child becomes a parallel pane.
+So you can hang three sub-issues off the parent, write a three-line task list in the parent body, or mix both. Either way, every OPEN child becomes a parallel pane.
 
 ## What happens during a run
 

--- a/site/content/docs/settings.ja.md
+++ b/site/content/docs/settings.ja.md
@@ -97,7 +97,7 @@ trigger label は、label を付けた issue と、それが parent fan-out な�
 
 不正な bool / integer env 値、設定ファイル内の未知キー、JSON type が合わない値は warn して無視します。将来の設定追加で古い fanout バイナリが壊れないようにするためです。
 
-Lifecycle hook は常に有効で、別の `hooks.json` で設定します。詳細は [CLI リファレンス]({{< relref "/docs/cli" >}})を参照してください。
+Lifecycle hook は常に有効で、別の `hooks.json` で設定します。詳細は CLI リファレンスの [Lifecycle hooks]({{< relref "/docs/cli#lifecycle-hooks" >}}) を参照してください。
 
 ## prVisualization の詳細
 

--- a/site/content/docs/settings.ja.md
+++ b/site/content/docs/settings.ja.md
@@ -106,9 +106,11 @@ fanout
 
 `fanout:auto` を付けた issue は、次の cycle で watcher がラベルを `fanout:running` に付け替えてから起動します。
 OPEN な子を持つ issue は `--unblocked-only` 相当の親ファンアウトになります。
-子を持たない issue は単独ペインとして起動します。
+OPEN な子を持たない issue は、子が全部 CLOSED の場合も含めて、単独ペインとして起動します。
 
-watcher からの起動は、親ファンアウトも単独ペインもすべて `watcherMaxSessions` を消費します。
+`watcherMaxSessions` は起動回数ではなく live ペイン数の上限です。
+watcher は cycle ごとに、起動元を問わずリポジトリの live な(shell 以外の)fanout ペインを数え、その数が上限を下回る間だけ起動します。
+親ファンアウトは起動した子 1 つにつき 1 枠を使い、ペインが閉じれば枠は空きます。
 blocked な子や session 上限で積み残しが出た場合、fanout はラベルを `fanout:running` から `fanout:auto` に戻します。
 その親は後続の cycle で自動的に再試行されます。
 
@@ -116,7 +118,7 @@ blocked な子や session 上限で積み残しが出た場合、fanout はラ�
 単独 watcher ペインは TUI の lifecycle key(`m`、`c`、`x`)で処理してください。
 公開 CLI の parent 引数には、予約 parent `@watch` の row を指定できません。
 
-再投入するときは、対象の issue に `fanout:auto` を付け直してください。
+再投入するときは、まず記録済みペインを畳んでから(`--close` / `--cleanup` か TUI のキー。state 行が残っている issue を watcher はスキップします)、対象の issue に `fanout:auto` を付け直してください。
 
 ## 前方互換
 

--- a/site/content/docs/settings.ja.md
+++ b/site/content/docs/settings.ja.md
@@ -93,6 +93,31 @@ watcher は誰かが checkout しただけで自動起動してほしくない�
 
 trigger label は、label を付けた issue と、それが parent fan-out なら起動される OPEN child から agent 作業を始める合図です。それらの本文はそのまま agent briefing になります。label は実行依頼として扱い、その issue と起動対象の child を信頼できるときだけ付けてください。
 
+## watcher の運用
+
+watcher は、TUI コンソールを起動している間だけ動きます。
+
+```bash
+# One shell
+export FANOUT_WATCHER=1
+export FANOUT_WATCHER_AGENT=codex
+fanout
+```
+
+`fanout:auto` を付けた issue は、次の cycle で watcher がラベルを `fanout:running` に付け替えてから起動します。
+OPEN な子を持つ issue は `--unblocked-only` 相当の親ファンアウトになります。
+子を持たない issue は単独ペインとして起動します。
+
+watcher からの起動は、親ファンアウトも単独ペインもすべて `watcherMaxSessions` を消費します。
+blocked な子や session 上限で積み残しが出た場合、fanout はラベルを `fanout:running` から `fanout:auto` に戻します。
+その親は後続の cycle で自動的に再試行されます。
+
+親ファンアウトでは、`fanout <parent> --merge <child>`、`--close`、`--cleanup` が `fanout:running` を best-effort で外します。
+単独 watcher ペインは TUI の lifecycle key(`m`、`c`、`x`)で処理してください。
+公開 CLI の parent 引数には、予約 parent `@watch` の row を指定できません。
+
+再投入するときは、対象の issue に `fanout:auto` を付け直してください。
+
 ## 前方互換
 
 不正な bool / integer env 値、設定ファイル内の未知キー、JSON type が合わない値は warn して無視します。将来の設定追加で古い fanout バイナリが壊れないようにするためです。

--- a/site/content/docs/settings.md
+++ b/site/content/docs/settings.md
@@ -104,13 +104,13 @@ export FANOUT_WATCHER_AGENT=codex
 fanout
 ```
 
-Issues labeled `fanout:auto` launch on the next cycle, once the watcher swaps the label to `fanout:running`. Issues with OPEN children become parent fan-outs equivalent to `--unblocked-only`; issues without children launch as a standalone pane.
+Issues labeled `fanout:auto` launch on the next cycle, once the watcher swaps the label to `fanout:running`. Issues with OPEN children become parent fan-outs equivalent to `--unblocked-only`; issues with no OPEN children — including ones whose children are all CLOSED — launch as a standalone pane.
 
-Every watcher launch — parent fan-out or standalone pane — counts against `watcherMaxSessions`. When blocked children or the session limit leave work outstanding, fanout reverts the label from `fanout:running` back to `fanout:auto`, and that parent is retried automatically on a later cycle.
+`watcherMaxSessions` caps live panes, not launches: each cycle the watcher counts the repository's live (non-shell) fanout panes — whoever launched them — and launches only while that count stays below the cap. A parent fan-out takes one slot per launched child, and slots free up as panes close. When blocked children or the session limit leave work outstanding, fanout reverts the label from `fanout:running` back to `fanout:auto`, and that parent is retried automatically on a later cycle.
 
 For parent fan-outs, `fanout <parent> --merge <child>`, `--close`, and `--cleanup` remove `fanout:running` on a best-effort basis. Handle standalone watcher panes with the TUI lifecycle keys (`m`, `c`, `x`) instead. The public CLI's parent argument does not accept rows for the reserved `@watch` parent.
 
-To requeue an issue, add the `fanout:auto` label back to it.
+To requeue an issue, first fold away its recorded panes (`--close` / `--cleanup`, or the TUI keys) — the watcher skips an issue whose state rows still exist — then add the `fanout:auto` label back to it.
 
 ## Forward compatibility
 

--- a/site/content/docs/settings.md
+++ b/site/content/docs/settings.md
@@ -100,7 +100,7 @@ issue and its launchable children.
 
 Invalid boolean or integer env values, unknown file keys, and file values with the wrong JSON type are warned and ignored, so future settings additions do not break older fanout binaries.
 
-Lifecycle hooks are always enabled and configured separately in `hooks.json`; see [CLI Reference]({{< relref "/docs/cli" >}}).
+Lifecycle hooks are always enabled and configured separately in `hooks.json`; see [Lifecycle hooks]({{< relref "/docs/cli#lifecycle-hooks" >}}) in the CLI Reference.
 
 ## prVisualization in detail
 

--- a/site/content/docs/settings.md
+++ b/site/content/docs/settings.md
@@ -91,10 +91,26 @@ Both HTTP channels only send outbound POST requests and never open inbound socke
 
 The watcher should never start just because someone checked out the repo, so repo config cannot opt into it. If `<project_root>/.fanout/config.json` sets `watcher`, fanout warns and ignores that key; enable it from user config or `FANOUT_WATCHER` instead. Repo config may still set `watcherTriggerLabel`, `watcherRunningLabel`, `watcherIntervalSeconds`, `watcherAgent`, and `watcherMaxSessions`.
 
-The trigger label starts agent work from the labeled issue and, for parent
-fan-outs, any OPEN children it launches. Their bodies become agent briefings, so
-treat the label as an execution request and apply it only when you trust that
-issue and its launchable children.
+The trigger label starts agent work from the labeled issue and, for parent fan-outs, any OPEN children it launches. Their bodies become agent briefings, so treat the label as an execution request and apply it only when you trust that issue and its launchable children.
+
+## Watcher operation
+
+The watcher only runs while a TUI console is running.
+
+```bash
+# One shell
+export FANOUT_WATCHER=1
+export FANOUT_WATCHER_AGENT=codex
+fanout
+```
+
+Issues labeled `fanout:auto` launch on the next cycle, once the watcher swaps the label to `fanout:running`. Issues with OPEN children become parent fan-outs equivalent to `--unblocked-only`; issues without children launch as a standalone pane.
+
+Every watcher launch — parent fan-out or standalone pane — counts against `watcherMaxSessions`. When blocked children or the session limit leave work outstanding, fanout reverts the label from `fanout:running` back to `fanout:auto`, and that parent is retried automatically on a later cycle.
+
+For parent fan-outs, `fanout <parent> --merge <child>`, `--close`, and `--cleanup` remove `fanout:running` on a best-effort basis. Handle standalone watcher panes with the TUI lifecycle keys (`m`, `c`, `x`) instead. The public CLI's parent argument does not accept rows for the reserved `@watch` parent.
+
+To requeue an issue, add the `fanout:auto` label back to it.
 
 ## Forward compatibility
 

--- a/site/content/docs/troubleshooting.ja.md
+++ b/site/content/docs/troubleshooting.ja.md
@@ -1,7 +1,7 @@
 ---
 title: トラブルシューティング
 linkTitle: トラブルシューティング
-description: "よくある失敗とその直し方。あわせて state やロック、ペイン作成の背後にある設計メモを置く。"
+description: "fanout のよくあるエラーメッセージと直し方。"
 weight: 80
 kanji: 直
 yomi: troubleshoot
@@ -9,36 +9,39 @@ yomi: troubleshoot
 
 ## "fanout must be run inside tmux"
 
-action mode は `tmux split-window` で子ペインを直接作成するため、fanout は tmux セッション内から実行してください。対象リポジトリの worktree で tmux セッションを開始または attach してから再実行します。唯一の例外は TUI モード(引数なしの `fanout`)です。fanout 管理の tmux session を自分で作成または attach するため、素のシェルから起動できます。[モニタリング]({{< relref "/docs/monitoring" >}})を参照してください。
+action mode は `tmux split-window` で子ペインを直接作成するため、対象リポジトリの worktree で tmux セッションを開始または attach してから fanout を実行してください。
+唯一の例外は TUI モード(引数なしの `fanout`)で、fanout 管理の tmux session を自分で作成または attach するため素のシェルから起動できます。
+詳しくは[モニタリング]({{< relref "/docs/monitoring" >}})を参照してください。
 
 ## "agent is required"
 
-`--agent claude` または `--agent codex` を渡すか、環境変数 `FANOUT_AGENT` を設定してください:
+`--agent claude` または `--agent codex` を渡すか、環境変数 `FANOUT_AGENT` を設定してください。
 
 ```bash
 fanout 123 --agent claude
 FANOUT_AGENT=codex fanout 123
 ```
 
-未知の agent はペイン作成前に失敗します。live 実行では、選択された agent CLI が `PATH` 上に無い場合も失敗します。
+未知の agent はペイン作成前に失敗し、live 実行では選択された agent CLI が `PATH` 上に無い場合も失敗します。
 
 ## "prepare worktree"
 
-git worktree の準備に失敗しています。出力に含まれる内側の git エラーを確認してください。よくある原因:
+git worktree の準備に失敗しているので、出力に含まれる内側の git エラーを確認してください。
+よくある原因は次のとおりです。
 
 - fast-forward できない dirty な checked-out base branch
 - diverge した local base branch
 - 既存の branch 名
 - stale または missing な remote branch
 
-base を変えるには `--base-branch <branch>` を使います。remote-tracking ref から直接切りたい場合は `origin/<branch>` を指定できます:
+base を変えるには `--base-branch <branch>` を使い、remote-tracking ref から直接切りたい場合は `origin/<branch>` を指定します。
 
 ```bash
 fanout 123 --base-branch release/v2
 fanout 123 --base-branch origin/main
 ```
 
-`--no-refresh` は、意図的に現在の local base/ref から切りたいときにだけ使ってください。fanout は base branch を force で整えることはしません。安全に refresh できない場合は、ユーザーのローカル作業を壊す代わりに失敗します。
+`--no-refresh` は、意図的に現在の local base/ref から切りたいときにだけ使ってください(fanout は base branch を force で整えることはせず、安全に refresh できない場合はユーザーのローカル作業を壊す代わりに失敗します)。
 
 ## "sub-issues fetch failed"
 
@@ -57,7 +60,9 @@ no sub-issues on #<parent>
 
 ## slug や branch 名が意図と違う
 
-既定では slug に `slugify(title)-<issueNum>`、branch に `fanout/<slug>` を使います。特定 issue は `--name <NUM>=<slug>|<display>|<branch>` で個別に、run 全体の branch 名は `--branch-prefix <prefix>` で一括して上書きできます。[ワークフロー]({{< relref "/docs/workflow" >}})を参照してください:
+既定では slug に `slugify(title)-<issueNum>`、branch に `fanout/<slug>` を使います。
+特定 issue は `--name <NUM>=<slug>|<display>|<branch>` で個別に、run 全体の branch 名は `--branch-prefix <prefix>` で一括して上書きできます。
+詳しくは[ワークフロー]({{< relref "/docs/workflow" >}})を参照してください。
 
 ```bash
 fanout 123 --name 4=fix-login-timeout --name 7='update-docs|Docs update'
@@ -68,54 +73,26 @@ fanout 123 --branch-prefix fanout/release/
 
 ## `gh pr create` が deny される("post-work-review が未実施です")
 
-`PreToolUse(Bash)` hook(`.claude/hooks/pre-pr-review-gate.sh`、コミット済みの `.claude/settings.json` に登録)が、現在の HEAD が `/post-work-review` を通過するまで `gh pr create` をブロックします。`/post-work-review` を実行すると最終ステップでレビュー済みコミットが記録されるので、その後 `gh pr create` を再実行してください。一度だけバイパスしたいときは、コマンドの先頭に付けます:
+`PreToolUse(Bash)` hook(`.claude/hooks/pre-pr-review-gate.sh`、コミット済みの `.claude/settings.json` に登録)が、現在の HEAD が `/post-work-review` を通過するまで `gh pr create` をブロックします。
+`/post-work-review` を実行すると最終ステップでレビュー済みコミットが記録されるので、その後 `gh pr create` を再実行してください(一度だけバイパスしたいときは、コマンドの先頭に次を付けます)。
 
 ```bash
 FANOUT_SKIP_PR_REVIEW=1 gh pr create ...
 ```
 
-fanout settings で `prReviewGate=false` になっている場合、子 Claude briefing にもこの bypass 許可が入りますが、コミット済み hook 自体は変更されません。このスイッチの意味は [Settings]({{< relref "/docs/settings" >}}) を参照してください。
+fanout settings で `prReviewGate=false` になっている場合、子 Claude briefing にもこの bypass 許可が入りますが、コミット済み hook 自体は変更されません(スイッチの意味は[Settings]({{< relref "/docs/settings" >}})を参照)。
 
-メモ:
-
-- ゲートは HEAD に固定されます。新しいコミットを積むと再武装されるので、PR の前にもう一度レビューしてください。marker は worktree ローカルなので、fanout の並列ペイン同士が干渉することはありません。
-- 検出はシェルトークナイザ(Python 製のコンパニオンパーサ)を通します。コマンド語と引用された引数値を区別するので、コミットメッセージに `gh pr create` と書いただけでは引っかかりません。`eval` / `xargs` / `sh -c "<文字列>"` のような間接実行はすり抜けることがありますが、fanout の通常フローでは許容範囲としています。
-- `python3` が無い環境では fail-closed になり、PR 作成らしきコマンドを粗い判定で deny します。`python3` をインストールするか、`export FANOUT_SKIP_PR_REVIEW=1` してください。
-- `make install` は Claude と Codex 配下の同名グローバル `post-work-review` skill と `pr-watch` skill を上書きします。独自に管理しているコピーがある場合は事前にバックアップしてください。
+ゲートは HEAD に固定されるため新しいコミットを積むと再武装されるので、PR の前にもう一度レビューしてください(marker は worktree ローカルなので、fanout の並列ペイン同士が干渉することはありません)。
+`python3` が無い環境では fail-closed になって PR 作成らしきコマンドを粗い判定で deny するため、`python3` をインストールするか `FANOUT_SKIP_PR_REVIEW=1` を使ってください。
 
 ## Project モードで items が取れない
 
-Project モードは GraphQL クエリで Project items を取得するため、`gh` CLI に `read:project` スコープが必要です。無いとクエリが失敗します。スコープを付与して再実行してください:
+Project モードは GraphQL クエリで Project items を取得するため、`gh` CLI に `read:project` スコープが必要です(無いとクエリが失敗します)。
+スコープを付与して再実行してください。
 
 ```bash
 gh auth refresh -s read:project
 ```
 
-items が消えたように見えて意図どおりのケースが 2 つあります:
-
-- Project に Status フィールドが無い場合は、警告を出して `--project-status` を無視し、全 item を対象にフォールバックします。
-- repository が現在の git repository root と一致しない item は警告を出してスキップします。fanout は今でも 1 回 1 repo の前提です。
-
-## 設計メモ(FAQ)
-
-state やロック、ペイン作成について「なぜそうなっているのか」への答えです。
-
-### `state.json` のスキーマ
-
-`.fanout/state.json` には `schemaVersion` と、ペインごとに 1 行を保存します。各行は `parent` / `issueNum` / 任意の `taskId` / `kind` / `shellKey` / `slug` / `branchName` / `paneId` / `agent` / `displayName` / `worktreePath` / `prompt` / `createdAt` を持ちます。TUI の shell terminal は `kind: "shell"` を使うため、close は tmux ペインと state 行だけを消します。`shellKey` は、その行と live tmux ペインを結びつけます。`--status` と lifecycle コマンドはこの行を対象に動作します。
-
-### atomic 書き込みとロック
-
-書き込みは sibling temp file と rename で行うため、クラッシュしても書きかけの `state.json` が残ることはありません。live run は planning から launch までの間 `.fanout/state.json.lock` を保持するため、並列の fanout 実行が同じ `(parent, issueNum)` のペインを二重作成することはありません。state 行の無い既存 worktree directory は、移行用 fallback として引き続きファンアウト済み扱いでスキップされます。
-
-### 同じ子 issue が別親に記録済みのとき
-
-既定の slug/branch 生成は issue suffix の前に親トークンを足すため、2 回目の run は 1 回目と衝突せず独自の worktree を得ます。今回の run が作る slug に一致する既存 worktree がある場合だけは、中断復旧用に引き続きスキップされます。
-
-### ペイン作成にポーリングが不要な理由
-
-```bash
-tmux split-window -t <invoking-pane> -d -h -P -F '#{pane_id}' -c <worktree>
-```
-
-が子ペインを選択せずに新しいペイン id を同期的に返すため、popup の横取りも完了ポーリングも不要です。
+items が想定より少なく見えることがありますが、Status フィールドの無い Project は全 item にフォールバックし、現在の git repository root と異なる repository の item は警告付きでスキップする仕様どおりの挙動です。
+詳しくは[ワークフロー]({{< relref "/docs/workflow" >}})と[CLI リファレンス]({{< relref "/docs/cli" >}})を参照してください。

--- a/site/content/docs/troubleshooting.md
+++ b/site/content/docs/troubleshooting.md
@@ -76,7 +76,7 @@ FANOUT_SKIP_PR_REVIEW=1 gh pr create ...
 
 If fanout settings resolve `prReviewGate=false`, child Claude briefings also carry this bypass permission, but the committed hook itself remains unchanged (see [Settings]({{< relref "/docs/settings" >}}) for what that switch means).
 
-The gate is pinned to HEAD, so pushing a new commit re-arms it — review again before the PR (the marker is worktree-local, so fanout's parallel panes don't interfere with each other). Without `python3` the hook fails closed and denies anything that coarsely looks like PR creation, so install `python3` or use `FANOUT_SKIP_PR_REVIEW=1`.
+The gate is pinned to HEAD, so adding a new commit re-arms it — review again before the PR (the marker is worktree-local, so fanout's parallel panes don't interfere with each other). Without `python3` the hook fails closed and denies anything that coarsely looks like PR creation, so install `python3` or use `FANOUT_SKIP_PR_REVIEW=1`.
 
 ## Project mode returns no items
 

--- a/site/content/docs/troubleshooting.md
+++ b/site/content/docs/troubleshooting.md
@@ -1,7 +1,7 @@
 ---
 title: Troubleshooting
 linkTitle: Troubleshooting
-description: "Common failures and their fixes, plus the design notes behind state, locking and pane creation."
+description: "Common fanout error messages and their fixes."
 weight: 80
 kanji: 直
 yomi: troubleshoot
@@ -9,36 +9,36 @@ yomi: troubleshoot
 
 ## "fanout must be run inside tmux"
 
-Action mode creates child panes directly with `tmux split-window`, so fanout has to be invoked from inside a tmux session. Start or attach a tmux session in the repository worktree, then rerun fanout. The one exception is TUI mode (`fanout` with no arguments): it can start from a plain shell, because it creates or attaches a fanout-managed tmux session itself — see [Monitoring]({{< relref "/docs/monitoring" >}}).
+Action mode creates child panes directly with `tmux split-window`, so start or attach a tmux session in the repository worktree, then run fanout. The one exception is TUI mode (`fanout` with no arguments): it can start from a plain shell, because it creates or attaches a fanout-managed tmux session itself — see [Monitoring]({{< relref "/docs/monitoring" >}}) for details.
 
 ## "agent is required"
 
-Pass `--agent claude` or `--agent codex`, or set the `FANOUT_AGENT` environment variable:
+Pass `--agent claude` or `--agent codex`, or set the `FANOUT_AGENT` environment variable.
 
 ```bash
 fanout 123 --agent claude
 FANOUT_AGENT=codex fanout 123
 ```
 
-Unknown agents fail before any pane is created. In live mode, fanout also fails if the selected agent CLI is not on `PATH`.
+Unknown agents fail before any pane is created, and in live mode fanout also fails if the selected agent CLI is not on `PATH`.
 
 ## "prepare worktree"
 
-The git worktree setup failed. Check the nested git error in the output. Common causes:
+The git worktree setup failed, so check the nested git error in the output. Common causes:
 
 - a dirty checked-out base branch that cannot be fast-forwarded
 - a diverged local base branch
 - an existing branch name
 - a stale or missing remote branch
 
-Use `--base-branch <branch>` to choose another base branch, including `origin/<branch>` when you want to branch directly from the remote-tracking ref:
+To change the base, use `--base-branch <branch>`; specify `origin/<branch>` when you want to branch directly from the remote-tracking ref.
 
 ```bash
 fanout 123 --base-branch release/v2
 fanout 123 --base-branch origin/main
 ```
 
-Use `--no-refresh` only when you intentionally want to branch from the current local base/ref. fanout never forces the base branch into shape — if it cannot refresh it safely, it fails rather than destroying your local work.
+Use `--no-refresh` only when you intentionally want to branch from the current local base/ref (fanout never forces the base branch into shape, and fails rather than destroying your local work when it cannot refresh safely).
 
 ## "sub-issues fetch failed"
 
@@ -57,7 +57,7 @@ no sub-issues on #<parent>
 
 ## Slug or branch names are not what you want
 
-By default, fanout uses `slugify(title)-<issueNum>` for the slug and `fanout/<slug>` for the branch. Use `--name <NUM>=<slug>|<display>|<branch>` to override a specific issue, or `--branch-prefix <prefix>` to change generated branch names for the whole run — see [Workflow]({{< relref "/docs/workflow" >}}):
+By default, fanout uses `slugify(title)-<issueNum>` for the slug and `fanout/<slug>` for the branch. Use `--name <NUM>=<slug>|<display>|<branch>` to override a specific issue, or `--branch-prefix <prefix>` to override branch names for the whole run at once. See [Workflow]({{< relref "/docs/workflow" >}}) for details.
 
 ```bash
 fanout 123 --name 4=fix-login-timeout --name 7='update-docs|Docs update'
@@ -68,54 +68,22 @@ fanout 123 --branch-prefix fanout/release/
 
 ## `gh pr create` is denied ("post-work-review が未実施です")
 
-A `PreToolUse(Bash)` hook (`.claude/hooks/pre-pr-review-gate.sh`, registered in the committed `.claude/settings.json`) blocks `gh pr create` until the current HEAD has passed `/post-work-review`. Run `/post-work-review` — its final step records the reviewed commit — then rerun `gh pr create`. To bypass once, prefix the command:
+A `PreToolUse(Bash)` hook (`.claude/hooks/pre-pr-review-gate.sh`, registered in the committed `.claude/settings.json`) blocks `gh pr create` until the current HEAD has passed `/post-work-review`. Running `/post-work-review` records the reviewed commit at its final step, so rerun `gh pr create` afterward (to bypass once, prefix the command with the following).
 
 ```bash
 FANOUT_SKIP_PR_REVIEW=1 gh pr create ...
 ```
 
-If fanout settings resolve `prReviewGate=false`, child Claude briefings also carry this bypass permission, but the committed hook itself remains unchanged — see [Settings]({{< relref "/docs/settings" >}}) for what that switch means.
+If fanout settings resolve `prReviewGate=false`, child Claude briefings also carry this bypass permission, but the committed hook itself remains unchanged (see [Settings]({{< relref "/docs/settings" >}}) for what that switch means).
 
-Notes:
-
-- The gate is HEAD-pinned: any new commit re-arms it, so review again before the PR. The marker is worktree-local, so fanout's parallel panes don't interfere with each other.
-- Detection runs through a shell tokenizer (a Python companion parser), so command words are distinguished from quoted argument values — a commit message that merely mentions `gh pr create` does not trip it. Indirect forms (`eval`, `xargs`, `sh -c "<string>"`) can still slip through; that is accepted for fanout's normal flow.
-- Without `python3` the hook fails closed: it denies anything that coarsely looks like PR creation. Install `python3`, or `export FANOUT_SKIP_PR_REVIEW=1`.
-- `make install` overwrites same-named global `post-work-review` and `pr-watch` skills under Claude and Codex; back up any custom copies first.
+The gate is pinned to HEAD, so pushing a new commit re-arms it — review again before the PR (the marker is worktree-local, so fanout's parallel panes don't interfere with each other). Without `python3` the hook fails closed and denies anything that coarsely looks like PR creation, so install `python3` or use `FANOUT_SKIP_PR_REVIEW=1`.
 
 ## Project mode returns no items
 
-Project mode lists items through a GraphQL query that requires the `gh` CLI to carry the `read:project` scope. Without it the query fails — add the scope and rerun:
+Project mode lists items through a GraphQL query that requires the `gh` CLI to carry the `read:project` scope (without it the query fails). Add the scope and rerun.
 
 ```bash
 gh auth refresh -s read:project
 ```
 
-Two cases that look like missing items are deliberate:
-
-- If the Project has no Status field, fanout warns and falls back to every item regardless of `--project-status`.
-- Items whose repository differs from the current git repository root are warned and skipped — fanout still assumes one repo per run.
-
-## Design notes (FAQ)
-
-The "why does it work that way" answers behind state, locking and pane creation.
-
-### The `state.json` schema
-
-`.fanout/state.json` stores `schemaVersion` plus one row per pane, each carrying `parent`, `issueNum`, optional `taskId` / `kind` / `shellKey`, `slug`, `branchName`, `paneId`, `agent`, `displayName`, `worktreePath`, `prompt`, and `createdAt`. TUI shell terminals use `kind: "shell"` so close can kill only the tmux pane and state row; `shellKey` ties that row to its live tmux pane. `--status` and lifecycle commands operate on these rows.
-
-### Atomic writes and locking
-
-Writes use a sibling temp file plus rename, so a crash never leaves a half-written `state.json`. Live runs hold `.fanout/state.json.lock` from planning through launch, so parallel fanout invocations cannot both create the same `(parent, issueNum)` pane. Existing worktree directories without a state row are still treated as already fanned out — a migration fallback — and skipped.
-
-### The same child issue is already recorded for another parent
-
-Default slug/branch generation adds a parent token before the issue suffix, so the second run gets its own worktree instead of colliding with the first one. An existing worktree matching the slug this current run would create is still skipped, as interrupted-launch recovery.
-
-### Why pane creation needs no polling
-
-```bash
-tmux split-window -t <invoking-pane> -d -h -P -F '#{pane_id}' -c <worktree>
-```
-
-returns the new pane id synchronously, without selecting the child pane — so no popup interception and no completion polling is needed.
+Items can look fewer than expected, but that's expected behavior: a Project with no Status field falls back to every item, and an item whose repository differs from the current git repository root is skipped with a warning. See [Workflow]({{< relref "/docs/workflow" >}}) and the [CLI reference]({{< relref "/docs/cli" >}}) for details.

--- a/site/content/docs/workflow.ja.md
+++ b/site/content/docs/workflow.ja.md
@@ -1,7 +1,7 @@
 ---
 title: 並列開発ワークフロー
 linkTitle: ワークフロー
-description: "wave 駆動のループ。issue ツリーを育ててファンアウトし、子を選び、merge とペインの後始末を経て次の wave へ進みます。"
+description: "wave 駆動のループ。issue ツリーを育ててファンアウトし、blocker が解けた子から merge して次の wave へ進みます。"
 weight: 30
 kanji: 流
 yomi: workflow
@@ -9,7 +9,9 @@ yomi: workflow
 
 ## ループの全体像
 
-fanout の日常は 1 回きりのコマンドではなくループです。OPEN な子を持つ親 issue を育て、子を並列ペインにファンアウトし、ペインの作業を眺め、終わった子を畳んで、次のバッチへ再実行します。一度に全部を終わらせるのではなく、blocker が解けた子から次々と並列で進める流れです。
+fanout の日常は 1 回きりのコマンドではなくループです。
+OPEN な子を持つ親 issue を育て、子を並列ペインにファンアウトし、ペインの作業を眺め、終わった子を畳んで、次のバッチへ再実行します。
+一度に全部を終わらせるのではなく、blocker が解けた子から次々と並列で進める流れです。
 
 1. **issue ツリーを作る。** 親 issue と、それにリンクされた子 issue 群を用意します。同梱の `fanout-issues` skill が計画を fanout-ready な形に変換します([エージェント連携]({{< relref "/docs/agents" >}})を参照)。
 2. **ファンアウトする。** `fanout <parent>` が OPEN な子ごとに tmux ペインと git worktree を作り、それぞれで agent CLI を起動します。
@@ -18,11 +20,10 @@ fanout の日常は 1 回きりのコマンドではなくループです。OPEN
 5. **後始末する。** `--cleanup` が、issue が close 済みか PR が merge 済みの記録済み子をまとめて畳みます。
 6. **次の wave へ。** fanout を再実行します。通常は `--unblocked-only` を付け、blocker が閉じたばかりの子を次のバッチにします。
 
-このページでは、このループを順に追って説明します。
-
 ## fanout-ready な issue ツリーの書き方
 
-子 issue は GitHub の **Sub-issues** 経由でも、親本文の**タスクリスト**(`- [ ] #NUM ...`)経由でも、両方でも宣言できます。fanout は両ソースの和集合を取ります。
+子 issue は GitHub の **Sub-issues** 経由でも、親本文の**タスクリスト**(`- [ ] #NUM ...`)経由でも、両方でも宣言できます。
+fanout は両ソースの和集合を取ります。
 
 ```text
 - [ ] #4 Extract the parser
@@ -40,35 +41,27 @@ blocker(後述の wave 進行を駆動する依存関係)は 2 つの書式か�
 - #7
 ```
 
-> `blocked` ラベルは弱いシグナルです。fanout はログに出すだけで、ラベル単体から具体的な blocker 番号を推測することはありません。
+> `blocked` ラベルは弱いシグナルです。
+> fanout はログに出すだけで、ラベル単体から具体的な blocker 番号を推測することはありません。
 
 ## 子の選択
 
-その run が対象にする OPEN な子は、4 つの flag で絞り込めます:
-
-| Flag | 効果 |
-|---|---|
-| `--limit <N>` | 今回の呼び出しを N 件までに制限する。残り分の再実行コマンドが表示される。 |
-| `--only <list>` | 許可リスト: 指定した番号だけをファンアウトする。親の OPEN 子集合に無い番号は警告して無視する。 |
-| `--skip <list>` | 指定した子を除外して残りをファンアウトする。 |
-| `--include <list>` | 自動検出(Sub-issues API とタスクリスト)から漏れた子を強制追加する。CLOSED や存在しない番号は警告してスキップ。include で追加した後に `--only` と `--skip` のフィルタが適用される。 |
-
-```bash
-fanout 123 --limit 3
-fanout 123 --only 4,7,8,10
-fanout 123 --skip 6,9 --limit 3
-fanout 123 --include 4,7
-```
-
-> `--include` は、同梱の Claude と Codex の skill が自動で埋める口です。skill は親本文から暗黙の子参照を読み取り、承認された番号をこの flag で fanout に渡します。子参照とは `Closes #N` のようなクローズキーワード、`Depends on #N` のような依存表現、素の箇条書き、日本語の慣用句です。CLI を agent セッション外で直接使うときは自分で指定してください。
+その run が対象にする OPEN な子は `--limit`、`--only`、`--skip`、`--include` の 4 flag で絞り込めます。
+各 flag の効果は [CLI リファレンス]({{< relref "/docs/cli" >}}) にまとめてあります。
 
 ## wave 進行(`--unblocked-only`)
 
-依存のある複数の子を抱えていると、blocker が解けるまで全員を待たせたくはありません。先に進められる子だけを並列で動かし、blocker が閉じるたびに次の子を足したい。この段階実行が wave です。
+依存のある複数の子を抱えていると、blocker が解けるまで全員を待たせたくはありません。
+先に進められる子だけを並列で動かし、blocker が閉じるたびに次の子を足したい。
+この段階実行が wave です。
 
-`--unblocked-only` は、blocker がすべて CLOSED の子だけをファンアウトします。OPEN な blocker が 1 つでも残る子は `deferred (blocked)` として報告され、その run ではスキップされます。スキップされた子には何も作られないので、取り消すものもありません。
+`--unblocked-only` は、blocker がすべて CLOSED の子だけをファンアウトします。
+OPEN な blocker が 1 つでも残る子は `deferred (blocked)` として報告され、その run ではスキップされます。
+スキップされた子には何も作られないので、取り消すものもありません。
 
-再実行では `.fanout/state.json` に記録済みの子もスキップされます。そのため、blocker PR が merge されるたびに同じコマンドをもう一度実行するだけでプロジェクトが進みます。Wave 1 → Wave 2 → … が手動の管理なしで進みます。
+再実行では `.fanout/state.json` に記録済みの子もスキップされます。
+そのため、blocker PR が merge されるたびに同じコマンドをもう一度実行するだけでプロジェクトが進みます。
+Wave 1 → Wave 2 → … が手動の管理なしで進みます。
 
 {{< diagram "waves" >}}
 
@@ -82,54 +75,25 @@ fanout 123 --unblocked-only --limit 3
 
 ## ラベル watcher
 
-watcher は引数なしの TUI コンソールが開いている間だけ動きます。既定は off で、
-有効化できるのは user config か環境変数だけです。repo config で checkout を
-自動起動の対象にすることはできません。
-
-```bash
-# One shell
-export FANOUT_WATCHER=1
-export FANOUT_WATCHER_AGENT=codex
-fanout
-```
-
-信頼できる issue に `fanout:auto` を付けると投入予約されます。次の cycle で
-fanout はそのラベルを `fanout:running` に付け替え、OPEN 子が無い issue は standalone
-ペインとして、OPEN 子がある issue は通常の親ファンアウトとして起動します。親ファンアウトは
-`--unblocked-only` を使います。watcher からの起動はすべて
-`watcherMaxSessions` の対象になります。blocked child や session 上限により残りが
-ある場合、fanout は `fanout:running` を `fanout:auto` に戻し、後続 cycle でその
-親を自動再試行します。
-
-親ファンアウトでは、`fanout <parent> --merge <child>`、`--close`、`--cleanup` が
-`fanout:running` を best-effort で外します。standalone watcher のペインは TUI の
-lifecycle key(`m`、`c`、`x`)で処理してください。公開 CLI の parent 引数では
-予約 parent `@watch` の row を指定できません。standalone のペインまたは完全 cleanup
-済みの親を新しく投入するには、`fanout:auto` を付け直してください。label 付き
-issue と、起動される OPEN child の本文は agent briefing になります。信頼できない
-issue に trigger label を付けないでください。
-
-watcher の仕事は repo 全体が対象です。label 付き issue を探し、one-shot session を
-起動します。ファンアウト済みの親配下の子を再訪するのは上の wave ループの仕事です —
-blocker が閉じるたびに `fanout <parent> --unblocked-only` を再実行してください。
+watcher は引数なしの TUI コンソールを開いている間だけ動く opt-in のランチャで、信頼できる issue に付けた `fanout:auto` ラベルを one-shot session に変えます。
+既定は off で、有効化できるのは user config か環境変数だけです(repo config では checkout を自動起動の対象にできません)。
+有効化の手順とラベル運用の詳細は [Settings]({{< relref "/docs/settings" >}}) を参照してください。
 
 ## issue を介さない plan ファンアウト
 
-ローカルでブレストやメモから作業をすでに分解済みで、GitHub に child issue を立てる
-ほどではない、というときがあります。issue ツリーを作らずに、手元の分解をそのまま
-並列ペインに流したい。そのためのレーンが `fanout plan` です。ループ自体は同じですが、
-source of truth は issue tree ではなく JSON spec です。
+ローカルでブレストやメモから作業をすでに分解済みで、GitHub に child issue を立てるほどではない、というときがあります。
+issue ツリーを作らずに、手元の分解をそのまま並列ペインに流したい。
+そのためのレーンが `fanout plan` です。
+ループ自体は同じですが、source of truth は issue tree ではなく JSON spec です。
 
-1. `version: 1`、`plan.slug`、`plan.title`、`tasks[]` entry(`id`、`title`、
-   `briefing`、任意の `wave`、`blocked_by`、`branch`、`display_name`、`slug`)
-   を持つ plan spec を書く、または選択する。
+1. plan spec(JSON)を書く、または既存の spec を選ぶ。
 2. まず `fanout plan <spec> --dry-run --agent <agent>` で preview する。
-3. live run は `fanout plan <spec> --agent <agent>`。task に `blocked_by` がある
-   場合は通常 `--unblocked-only` も付ける。
+3. live run は `fanout plan <spec> --agent <agent>`。task に `blocked_by` がある場合は通常 `--unblocked-only` も付ける。
 4. TUI や dashboard、または `fanout plan <slug> --status [--format table]` で見る。
-5. task ID を指定して取り込みや後始末をする:
-   `fanout plan <slug> --merge <task-id>`、`--close <task-id>`、`--cleanup`。
+5. task ID を指定して取り込みや後始末をする: `fanout plan <slug> --merge <task-id>`、`--close <task-id>`、`--cleanup`。
 6. 次 wave は保存済み slug で再実行する。
+
+spec フォーマットと、live run が記録する state の詳細は [CLI リファレンス]({{< relref "/docs/cli" >}}) にあります。
 
 ```bash
 fanout plan /tmp/fanout-plan-launch-plan.json --agent claude --dry-run
@@ -139,43 +103,14 @@ fanout plan launch-plan --merge base-types
 fanout plan launch-plan --cleanup
 ```
 
-live run は spec を `.fanout/plans/<slug>.json` に保存します。row は
-`.fanout/state.json` に parent `plan:<slug>`、`taskId`、`issueNum: 0` として
-記録されます。`blocked_by` 依存は、依存 task の明示 branch または生成 branch に
-merge 済み PR ができたときだけ complete とみなされます。Plan task briefing は
-GitHub issue-closing footer を避け、PR body 末尾を
-`Plan: <slug> / Task: <id>` にするよう agent に伝えます。
-
-同梱の agent wrapper は spec 作成も支援できます。Claude Code では
-`/fanout plan <path-or-plan>` が `fanout-plan` skill へ routing されます。Codex では
-`$fanout-plan`、または `fanout plan` の依頼を使います。skill は live launch 前に
-dry-run を要約します(確認スキップが明示された場合を除く)。
-
 ## 兄弟協調(peer messaging)
 
-並列で動く兄弟ペインが同じ interface を触っていると、互いの進捗や決め事を伝え合いたく
-なります。ところが親を複数ペインにファンアウトすると、各子は自分のペインで動く独立した
-agent セッションになり、既定ではペイン同士は互いを認識できません。run ごとに
-`--team` で opt-in すると、fanout が(best-effort で)各子の通常 briefing に
-「Coordinating with your sibling panes」節を注入し、per-parent の peer
-レジストリに seed するので、兄弟がお互いを把握できます。なお `--codex-plan-mode`
-の子はレジストリには seed されますが最小限の Plan-Mode briefing を受け取るため、
-協調節は付きません。
+並列で動く兄弟ペインが同じ interface を触っていると、互いの進捗や決め事を伝え合いたくなります。
+ところが親を複数ペインにファンアウトすると、各子は自分のペインで動く独立した agent セッションになり、既定ではペイン同士は互いを認識できません。
+run ごとに `--team` で opt-in すると、fanout が(best-effort で)各子の通常 briefing に「Coordinating with your sibling panes」節を注入し、per-parent の peer レジストリに seed するので、兄弟がお互いを把握できます。
+`--codex-plan-mode` の子はレジストリには seed されますが最小限の Plan-Mode briefing を受け取るため、協調節は付きません。
 
-ファンアウトしたペイン内では、`fanout msg` が自分が今どの子(または親)かを自動
-検出し、per-parent の SQLite バス `/tmp/fanout-<repo>-<parent>.db`
-(`FANOUT_DB_PATH` で上書き可)上でやり取りします。バスは全員へ配る共有
-`board`(ブロードキャスト)に加え、`--to <issue>` 宛の `1:1` メッセージを
-運びます。協調は pull ベースです。自分から要求しない限り、何かがペインを
-つつくことはありません。
-
-plan レーンも `--team` に対応します(`fanout plan <spec> --team`)。動作は同じ
-ですが、issue-less な plan task には `#N` が無いため、peer は **task id** で
-指定します。`fanout msg send --to <task-id> "<body>"` で兄弟 task に送り、
-`fanout msg peers` が現在の task id 一覧を表示します。plan のバスは
-`/tmp/fanout-<repo>-plan-<slug>.db` に置かれ、`--team` は plan の
-read モードと lifecycle モード(`--status`、`--close`、`--merge`、`--cleanup`)とは
-併用できません。
+ファンアウトしたペイン内では、`fanout msg` が自分が今どの子(または親)かを自動検出し、per-parent のバス上でやり取りします。
 
 ```bash
 fanout msg peers                # 兄弟は誰か?
@@ -184,44 +119,30 @@ fanout msg send --to 7 "SessionStore を PaneStore にリネームした"
 fanout msg inbox --mark-read
 ```
 
-verb の全表(`peers`、`inbox`、`board`、`send`、`post`、`mark-read`、
-`register`、`nudge`)と共通オプションは
-[CLI リファレンス]({{< relref "/docs/cli#fanout-msg" >}}) にあります。
+verb の全表や plan task の指定方法など、詳しい仕組みは [CLI リファレンス]({{< relref "/docs/cli#fanout-msg" >}}) にあります。
 
-`claude` と `codex` どちらのペインでも同じく動きます。これは 1 セッション内の
-チームメイトを協調させる Claude Code Agent Teams とは別物で、peer messaging は
-別々の fanout ペイン同士を協調させます。
+`claude` と `codex` どちらのペインでも同じく動き、1 セッション内のチームメイトを協調させる Claude Code Agent Teams とは別物です。
 
-> **セキュリティ。** バスは `/tmp` 配下の**平文** SQLite ファイルです。fanout は
-> `0600`(所有者のみ)で作成し、group/world-readable や別ユーザー所有のファイルは
-> 開くのを拒否します。ただし `/tmp` は共有のスクラッチ領域です。**秘密情報やトークン、
-> 認証情報をメッセージに載せないでください。** DB は使い捨てなので、終わったら
-> `/tmp/fanout-<repo>-<parent>.db*` を削除してください。
+> **セキュリティ。** バスは `/tmp` 配下の**平文** SQLite ファイルです。
+> fanout は `0600`(所有者のみ)で作成し、group/world-readable や別ユーザー所有のファイルは開くのを拒否します。
+> ただし `/tmp` は共有のスクラッチ領域なので、**秘密情報やトークン、認証情報をメッセージに載せないでください。**
 
 ## 命名とブランチ
 
-既定では、各子の worktree slug は `slugify(title)-<issueNum>`、branch は `fanout/<slug>` です。これを 3 つの flag で上書きできます:
-
-- `--name <NUM>=<slug>[|<display>[|<branch>]]`。特定の子の worktree slug stem、ペインのタイトル、branch を直接指定する。pipe 区切りの 3 セグメントはそれぞれ空でよいが、最低 1 つは非空であること。slug stem に issue 番号 suffix が無ければ fanout が `-<NUM>` を付け、3 つ目のセグメントは生成 branch 名を上書きする。対象ごとに 1 つ、繰り返し指定できる。
-- `--branch-prefix <prefix>`。run 全体の生成 branch 名の prefix を変える。
-- `--base-branch <branch>`。子が分岐する base branch を上書きする。bare な local branch 名と `origin/<branch>` の両方に対応。
-- `--no-refresh`。base branch の refresh をスキップする。既定では、分岐前に `git fetch --quiet --no-tags` と fast-forward 更新で base を fresh 化する。ローカル plan や手動のペインでは `origin` remote が無い場合、自動的に refresh をスキップして現在の local branch か `HEAD` を使う。
+既定では、各子の worktree slug は `slugify(title)-<issueNum>`、branch は `fanout/<slug>` です。
+`--name`、`--branch-prefix`、`--base-branch`、`--no-refresh` で上書きできます。
 
 ```bash
 fanout 123 --name 4=fix-login-timeout --name 7='update-docs|Docs update'
-fanout 123 --name 8='feat-x|Feature X|feat/issue-8-x'   # all three segments
-fanout 123 --name 9='||release/v2.0'                    # branch override only
-
-fanout 123 --base-branch release/v2 --branch-prefix fanout/release/
-
-fanout 123 --no-refresh
 ```
 
-> 同梱の Claude と Codex の連携は、追加の API 呼び出しなしに issue のタイトルと本文から `--name` flag を生成して渡します。上書きしたい場合は自分で `--name` を渡してください。rerun の冪等性は名前ではなく `.fanout/state.json` が担います。
+詳細は [CLI リファレンス]({{< relref "/docs/cli" >}}) を参照してください。
 
 ## Project モード
 
-位置引数には、親 issue 番号の代わりに Projects v2 の URL も渡せます(`https://github.com/users/<owner>/projects/<n>` または `https://github.com/orgs/<org>/projects/<n>`)。正規形の `/views/<id>` suffix やトレイリングのクエリ文字列付き URL も受け付けるので、ブラウザのアドレスバーからそのままコピペできます。このモードでは、子は Sub-issues とタスクリストの和集合ではなく Project の item から取り出されます。
+位置引数には、親 issue 番号の代わりに Projects v2 の URL も渡せます(`https://github.com/users/<owner>/projects/<n>` または `https://github.com/orgs/<org>/projects/<n>`)。
+正規形の `/views/<id>` suffix やトレイリングのクエリ文字列付き URL も受け付けるので、ブラウザのアドレスバーからそのままコピペできます。
+このモードでは、子は Sub-issues とタスクリストの和集合ではなく Project の item から取り出されます。
 
 ```bash
 fanout https://github.com/users/<owner>/projects/<n>
@@ -231,21 +152,14 @@ fanout https://github.com/orgs/<org>/projects/<n> --project-status "In Progress"
 fanout https://github.com/users/<owner>/projects/<n> --project-status all
 ```
 
-- **既定フィルタは `Status == Todo`。** 別の single-select 値にするには `--project-status "<name>"` を、フィルタを無効化して全 item(Done や Status 未設定も含む)を対象にするには `--project-status all` を渡す。
-- **親 body が無いので暗黙の子参照サルベージは無い。** skill が通常拾う `Closes #N` や依存表現はここには存在せず、Project が source of truth になる。Project が取りこぼしている子は `--include` で強制追加する。
-- **単一 repo のみ。** 現在の git リポジトリと異なる repository の item は警告してスキップする。
-- **Project に Status フィールドが無い場合**は、警告を出して `--project-status` に関わらず全 item にフォールバックする。
-- **blocker** の情報源は子本文の `## Blocked by` セクションのみ。親 body が無いため `(blocked by #X)` のタスクリストトレイラは存在しない。`blocked` ラベルはここでも弱いシグナルのままで、ラベルしか無い子は警告の上 unblocked として扱われる。
+既定フィルタは `Status == Todo` の item です。
+フィルタの変え方や blocker の扱いなど issue モードとの違いは [CLI リファレンス]({{< relref "/docs/cli" >}}) にまとめてあります。
 
 > Project モードでは `gh` CLI に `read:project` スコープが必要です([インストール]({{< relref "/docs/installation" >}})を参照)。
 
 ## 取り込みと後始末(lifecycle)
 
-lifecycle コマンドは `.fanout/state.json` に記録された entry に対してのみ動作します。filesystem scan で任意の worktree を探すことはしません。
-
-- `fanout <parent> --merge <NUM>`。`git -C <project-root> merge --ff-only <recorded-branch>` を実行する。fast-forward できない場合は git のエラーを報告して終了し、エディタや conflict 解決フローは起動しない。
-- `fanout <parent> --close <NUM>`。記録済み worktree を `git worktree remove <path> --force` で削除し、記録済み tmux ペインが残っていれば kill し、state entry を削除して `git worktree prune` を実行する。
-- `fanout <parent> --cleanup`。記録済みの子を照会し、issue が `CLOSED`、または closed-by PR に `MERGED` がある子をまとめて close する。未完了の子は記録に残る。
+lifecycle コマンドは `.fanout/state.json` に記録された entry に対してのみ動作します。
 
 ```bash
 fanout 123 --merge 4
@@ -254,21 +168,4 @@ fanout 123 --close 4
 fanout 123 --cleanup
 ```
 
-> `--status` と同様、これらのコマンドは `FANOUT_STATE_PATH` を尊重します。未設定なら `<git-root>/.fanout/state.json` を使います。
-
-## 実行制御
-
-| Flag | 効果 |
-|---|---|
-| `--session <name>` | 起動元のペインではなく、名前付き tmux session を target にする。 |
-| `--sleep <seconds>` | 成功した子起動の間のレート制限(既定 4 秒)。retry/backoff の knob ではない。 |
-| `--dry-run` | git worktree と tmux のコマンド列を、worktree やペイン、state row、briefing file を作らずにプレビューする。 |
-| `--debug` | 追加の診断ログを出力する。 |
-
-```bash
-fanout 123 --session work-repo
-fanout 123 --sleep 8
-fanout 123 --dry-run
-```
-
-このページの flag を含む全サーフェスは [CLI リファレンス]({{< relref "/docs/cli" >}})にあります。
+このページの flag や lifecycle コマンドの正確な動作を含む全サーフェスは [CLI リファレンス]({{< relref "/docs/cli" >}}) にあります。

--- a/site/content/docs/workflow.ja.md
+++ b/site/content/docs/workflow.ja.md
@@ -70,6 +70,8 @@ fanout 123 --include 4,7
 
 再実行では `.fanout/state.json` に記録済みの子もスキップされます。そのため、blocker PR が merge されるたびに同じコマンドをもう一度実行するだけでプロジェクトが進みます。Wave 1 → Wave 2 → … が手動の管理なしで進みます。
 
+{{< diagram "waves" >}}
+
 ```bash
 fanout 123 --unblocked-only
 
@@ -107,9 +109,9 @@ lifecycle key(`m`、`c`、`x`)で処理してください。公開 CLI の paren
 issue と、起動される OPEN child の本文は agent briefing になります。信頼できない
 issue に trigger label を付けないでください。
 
-この watcher は [#107](https://github.com/butaosuinu/fanout/issues/107) とは別レーンです。
-watcher は repo 全体から label 付き issue を探し、one-shot session を起動します。
-#107 は既知の親 issue 配下の子を skill 主体で継続巡回するループです。
+watcher の仕事は repo 全体が対象です。label 付き issue を探し、one-shot session を
+起動します。ファンアウト済みの親配下の子を再訪するのは上の wave ループの仕事です —
+blocker が閉じるたびに `fanout <parent> --unblocked-only` を再実行してください。
 
 ## issue を介さない plan ファンアウト
 
@@ -175,22 +177,20 @@ plan レーンも `--team` に対応します(`fanout plan <spec> --team`)。動
 read モードと lifecycle モード(`--status`、`--close`、`--merge`、`--cleanup`)とは
 併用できません。
 
-| verb | 効果 |
-|---|---|
-| `peers` | この親で把握している兄弟ペインを一覧する。 |
-| `inbox [--mark-read]` | 自分宛の未読 1:1 メッセージを表示する(任意で既読化)。 |
-| `board [--all]` | 最近のブロードキャストを表示する(`--all` で全件)。 |
-| `send --to <N> <body>` | 兄弟 `#N` へ 1:1 メッセージを送る。 |
-| `post [--kind K] <body>` | 共有 board へブロードキャストを投稿する。 |
-| `mark-read [--all]` | メッセージを既読にする。 |
-| `register` | 自分を peer レジストリへ(再)seed する。 |
-| `nudge <N>` | peer `#N` のペインへ `send-keys` でヒントを送る best-effort 通知。agent が running のときだけ送り、DB は一切触らない。 |
+```bash
+fanout msg peers                # 兄弟は誰か?
+fanout msg post "auth interface merged — login を触る前に rebase して"
+fanout msg send --to 7 "SessionStore を PaneStore にリネームした"
+fanout msg inbox --mark-read
+```
+
+verb の全表(`peers`、`inbox`、`board`、`send`、`post`、`mark-read`、
+`register`、`nudge`)と共通オプションは
+[CLI リファレンス]({{< relref "/docs/cli#fanout-msg" >}}) にあります。
 
 `claude` と `codex` どちらのペインでも同じく動きます。これは 1 セッション内の
 チームメイトを協調させる Claude Code Agent Teams とは別物で、peer messaging は
-別々の fanout ペイン同士を協調させます。全サーフェスは
-[CLI リファレンス]({{< relref "/docs/cli" >}}) または `fanout msg --help` を
-参照してください。
+別々の fanout ペイン同士を協調させます。
 
 > **セキュリティ。** バスは `/tmp` 配下の**平文** SQLite ファイルです。fanout は
 > `0600`(所有者のみ)で作成し、group/world-readable や別ユーザー所有のファイルは

--- a/site/content/docs/workflow.ja.md
+++ b/site/content/docs/workflow.ja.md
@@ -130,7 +130,8 @@ verb の全表や plan task の指定方法など、詳しい仕組みは [CLI �
 ## 命名とブランチ
 
 既定では、各子の worktree slug は `slugify(title)-<issueNum>`、branch は `fanout/<slug>` です。
-`--name`、`--branch-prefix`、`--base-branch`、`--no-refresh` で上書きできます。
+名前は `--name` と `--branch-prefix` で上書きできます。
+`--base-branch` と `--no-refresh` は名前ではなく、子の分岐元 base を制御します。
 
 ```bash
 fanout 123 --name 4=fix-login-timeout --name 7='update-docs|Docs update'
@@ -152,8 +153,9 @@ fanout https://github.com/orgs/<org>/projects/<n> --project-status "In Progress"
 fanout https://github.com/users/<owner>/projects/<n> --project-status all
 ```
 
-既定フィルタは `Status == Todo` の item です。
-フィルタの変え方や blocker の扱いなど issue モードとの違いは [CLI リファレンス]({{< relref "/docs/cli" >}}) にまとめてあります。
+既定フィルタは `Status == Todo` の item で、`--project-status` で変更できます([CLI リファレンス]({{< relref "/docs/cli" >}}) を参照)。
+blocker は子本文の `## Blocked by` セクションからだけ読み取られます。
+親本文が無いためタスクリスト行の `(blocked by #X)` トレイラは存在せず、`blocked` ラベルだけの子は警告のうえ unblocked として扱われます。
 
 > Project モードでは `gh` CLI に `read:project` スコープが必要です([インストール]({{< relref "/docs/installation" >}})を参照)。
 

--- a/site/content/docs/workflow.md
+++ b/site/content/docs/workflow.md
@@ -70,6 +70,8 @@ When several children depend on one another, you don't want to hold everyone bac
 
 Because reruns also skip children already recorded in `.fanout/state.json`, advancing the project is just running the same command again each time a blocker PR merges: Wave 1 → Wave 2 → … with no manual bookkeeping.
 
+{{< diagram "waves" >}}
+
 ```bash
 fanout 123 --unblocked-only
 
@@ -107,9 +109,10 @@ or fully cleaned parent, add `fanout:auto` again. Do not apply the trigger label
 to untrusted issues: the labeled issue and any OPEN children it launches become
 agent briefings.
 
-This watcher is separate from [#107](https://github.com/butaosuinu/fanout/issues/107):
-it discovers labeled issues across the repository and starts one-shot sessions.
-#107 remains the skill-led loop for revisiting children under a known parent.
+The watcher's job is repository-wide: it discovers labeled issues and starts
+one-shot sessions. Revisiting the children under a parent you already fanned
+out stays with the wave loop above — rerun `fanout <parent> --unblocked-only`
+as blockers close.
 
 ## Issue-less plan fan-out
 
@@ -177,22 +180,20 @@ task and `fanout msg peers` lists the live task ids. The plan bus lives at
 `/tmp/fanout-<repo>-plan-<slug>.db`, and `--team` is not combinable with the
 plan read/lifecycle modes (`--status` / `--close` / `--merge` / `--cleanup`).
 
-| Verb | Effect |
-|---|---|
-| `peers` | List the sibling panes known for this parent. |
-| `inbox [--mark-read]` | Show your unread 1:1 messages (optionally mark them read). |
-| `board [--all]` | Show recent broadcasts (all of them with `--all`). |
-| `send --to <N> <body>` | Send a 1:1 message to sibling `#N`. |
-| `post [--kind K] <body>` | Post a broadcast to the shared board. |
-| `mark-read [--all]` | Mark messages read. |
-| `register` | (Re-)seed yourself into the peer registry. |
-| `nudge <N>` | Best-effort `send-keys` hint into peer `#N`'s pane — only when its agent is running, and it never touches the DB. |
+```bash
+fanout msg peers                # who are my siblings?
+fanout msg post "auth interface merged — rebase before touching login"
+fanout msg send --to 7 "renamed SessionStore to PaneStore"
+fanout msg inbox --mark-read
+```
+
+The full verb table (`peers`, `inbox`, `board`, `send`, `post`, `mark-read`,
+`register`, `nudge`) and the common options are in the
+[CLI Reference]({{< relref "/docs/cli#fanout-msg" >}}).
 
 This works the same for `claude` and `codex` panes. It is distinct from Claude
 Code Agent Teams, which coordinates teammates inside a single session; peer
-messaging coordinates separate fanout panes. See the
-[CLI Reference]({{< relref "/docs/cli" >}}) or `fanout msg --help` for the full
-surface.
+messaging coordinates separate fanout panes.
 
 > **Security.** The bus is a **plaintext** SQLite file under `/tmp`. fanout
 > creates it `0600` (owner-only) and refuses one that is group/world-readable or

--- a/site/content/docs/workflow.md
+++ b/site/content/docs/workflow.md
@@ -108,7 +108,7 @@ It works the same for `claude` and `codex` panes, and is distinct from Claude Co
 
 ## Naming and branches
 
-By default each child gets the worktree slug `slugify(title)-<issueNum>` and the branch `fanout/<slug>`. Override these with `--name`, `--branch-prefix`, `--base-branch`, and `--no-refresh`.
+By default each child gets the worktree slug `slugify(title)-<issueNum>` and the branch `fanout/<slug>`. Override the names with `--name` and `--branch-prefix`; `--base-branch` and `--no-refresh` control which base the children branch from instead.
 
 ```bash
 fanout 123 --name 4=fix-login-timeout --name 7='update-docs|Docs update'
@@ -128,7 +128,7 @@ fanout https://github.com/orgs/<org>/projects/<n> --project-status "In Progress"
 fanout https://github.com/users/<owner>/projects/<n> --project-status all
 ```
 
-The default filter is items with `Status == Todo`. For how to change the filter and how blockers differ from issue mode, see the [CLI Reference]({{< relref "/docs/cli" >}}).
+The default filter is items with `Status == Todo`; change it with `--project-status` (see the [CLI Reference]({{< relref "/docs/cli" >}})). Blockers come only from the child body's `## Blocked by` section — there is no parent body, so the `(blocked by #X)` task-list trailer does not exist here, and a child carrying only the `blocked` label is warned and treated as unblocked.
 
 > Project mode requires the `gh` CLI to carry the `read:project` scope — see [Installation]({{< relref "/docs/installation" >}}).
 

--- a/site/content/docs/workflow.md
+++ b/site/content/docs/workflow.md
@@ -1,7 +1,7 @@
 ---
 title: Workflow
 linkTitle: Workflow
-description: "The wave-driven loop — grow an issue tree, fan it out, select children, then merge and fold panes away."
+description: "The wave-driven loop — grow an issue tree, fan it out, and merge children as their blockers clear before moving to the next wave."
 weight: 30
 kanji: 流
 yomi: workflow
@@ -17,8 +17,6 @@ fanout's day-to-day shape is a loop, not a one-shot command. You grow a parent i
 4. **Merge.** Take a finished child branch in with `--merge <NUM>`.
 5. **Clean up.** `--cleanup` folds away every recorded child whose issue is closed or whose PR is merged.
 6. **Next wave.** Rerun fanout — typically with `--unblocked-only` — and the children whose blockers just closed become the next batch.
-
-The rest of this page walks the loop in order.
 
 ## Writing a fanout-ready issue tree
 
@@ -44,23 +42,7 @@ Blockers — the dependencies that drive wave progression below — are read fro
 
 ## Selecting children
 
-Four flags shape which OPEN children a run targets:
-
-| Flag | Effect |
-|---|---|
-| `--limit <N>` | Cap this invocation to N children. A rerun command is printed for the rest. |
-| `--only <list>` | Allow-list: fan out only these numbers. Numbers not in the parent's OPEN child set are warned and ignored. |
-| `--skip <list>` | Fan out everything except these children. |
-| `--include <list>` | Force-add children that auto-detection (Sub-issues API + task list) misses. CLOSED or nonexistent numbers are warned and skipped. Included numbers are added first, then `--only`/`--skip` filter the result. |
-
-```bash
-fanout 123 --limit 3
-fanout 123 --only 4,7,8,10
-fanout 123 --skip 6,9 --limit 3
-fanout 123 --include 4,7
-```
-
-> `--include` is the hole the bundled Claude/Codex skills fill automatically: they read the parent body for implicit references — close keywords like `Closes #N`, dependency wording like `Depends on #N`, plain bullets, Japanese idioms — and forward the approved numbers through this flag. Pass it yourself when running the CLI outside an agent session.
+Four flags narrow which OPEN children a run targets: `--limit`, `--only`, `--skip`, and `--include`. Each flag's effect is summarized in the [CLI Reference]({{< relref "/docs/cli" >}}).
 
 ## Wave progression with `--unblocked-only`
 
@@ -82,58 +64,20 @@ The second form caps each wave while letting fanout pick the next unblocked batc
 
 ## Label watcher
 
-The watcher runs only while the no-argument TUI console is open. It is off by
-default, and only user config or environment variables can enable it; repo
-config cannot opt a checkout into background launches.
-
-```bash
-# One shell
-export FANOUT_WATCHER=1
-export FANOUT_WATCHER_AGENT=codex
-fanout
-```
-
-Add `fanout:auto` to a trusted issue to queue it. On the next cycle fanout
-swaps that label to `fanout:running`, then launches either a standalone pane
-for an issue with no OPEN children or a normal parent fan-out for an issue with
-OPEN children. Parent fan-outs use `--unblocked-only`; every watcher launch
-counts against `watcherMaxSessions`. If blocked children or the session cap
-leaves work for later, fanout swaps `fanout:running` back to `fanout:auto` so a
-later cycle retries the parent automatically.
-
-For parent fan-outs, `fanout <parent> --merge <child>`, `--close`, and
-`--cleanup` remove `fanout:running` best-effort. For standalone watcher panes,
-use the TUI lifecycle keys (`m`, `c`, `x`); the public CLI parent argument does
-not target reserved `@watch` rows. To queue a fresh run after a standalone pane
-or fully cleaned parent, add `fanout:auto` again. Do not apply the trigger label
-to untrusted issues: the labeled issue and any OPEN children it launches become
-agent briefings.
-
-The watcher's job is repository-wide: it discovers labeled issues and starts
-one-shot sessions. Revisiting the children under a parent you already fanned
-out stays with the wave loop above — rerun `fanout <parent> --unblocked-only`
-as blockers close.
+The watcher is an opt-in launcher that runs only while the no-argument TUI console is open, turning a `fanout:auto` label on a trusted issue into a one-shot session. It is off by default, and only user config or environment variables can enable it (repo config cannot opt a checkout into automatic launches). See [Settings]({{< relref "/docs/settings" >}}) for the enablement steps and label conventions.
 
 ## Issue-less plan fan-out
 
-Sometimes the work is already broken down from a brainstorm or notes, and it
-isn't worth opening GitHub child issues for it. You want to feed that local
-breakdown straight into parallel panes without building an issue tree. That is
-what `fanout plan` is for. The workflow is the same loop, but the source of
-truth is a JSON spec instead of an issue tree:
+Sometimes the work is already broken down from a brainstorm or notes, and it isn't worth opening GitHub child issues for it. You want to feed that local breakdown straight into parallel panes without building an issue tree. That is what `fanout plan` is for. The workflow is the same loop, but the source of truth is a JSON spec instead of an issue tree:
 
-1. Write or select a plan spec with `version: 1`, `plan.slug`, `plan.title`, and
-   `tasks[]` entries (`id`, `title`, `briefing`, optional `wave`,
-   `blocked_by`, `branch`, `display_name`, and `slug`).
+1. Write a plan spec (JSON), or pick an existing one.
 2. Preview first with `fanout plan <spec> --dry-run --agent <agent>`.
-3. Run live with `fanout plan <spec> --agent <agent>`, usually adding
-   `--unblocked-only` when any task has `blocked_by`.
-4. Monitor with the TUI/dashboard or `fanout plan <slug> --status
-   [--format table]`.
-5. Merge or fold away tasks with task IDs:
-   `fanout plan <slug> --merge <task-id>`, `--close <task-id>`, or
-   `--cleanup`.
+3. Run live with `fanout plan <spec> --agent <agent>`; add `--unblocked-only` too when a task has `blocked_by`.
+4. Monitor via the TUI, the dashboard, or `fanout plan <slug> --status [--format table]`.
+5. Merge or fold away tasks by task ID: `fanout plan <slug> --merge <task-id>`, `--close <task-id>`, `--cleanup`.
 6. Rerun the saved slug for the next wave.
+
+The spec format and the state that a live run records are in the [CLI Reference]({{< relref "/docs/cli" >}}).
 
 ```bash
 fanout plan /tmp/fanout-plan-launch-plan.json --agent claude --dry-run
@@ -143,42 +87,11 @@ fanout plan launch-plan --merge base-types
 fanout plan launch-plan --cleanup
 ```
 
-Live runs save the spec to `.fanout/plans/<slug>.json`; rows are stored in
-`.fanout/state.json` under parent `plan:<slug>` with `taskId` and `issueNum: 0`.
-`blocked_by` dependencies are considered complete only after the dependency
-task's explicit or generated branch has a merged PR. Plan task briefings avoid
-GitHub issue-closing footers and tell agents to end PR bodies with
-`Plan: <slug> / Task: <id>`.
-
-The bundled agent wrappers can create the spec for you. In Claude Code,
-`/fanout plan <path-or-plan>` routes to the `fanout-plan` skill; in Codex, use
-`$fanout-plan` or ask for `fanout plan`. The skill summarizes the dry-run
-before live launch unless confirmation was explicitly skipped.
-
 ## Sibling coordination (peer messaging)
 
-When sibling panes touch the same interface in parallel, they often need to
-share progress and decisions. But when a parent is fanned out, each child is an
-independent agent session in its own pane — by default the panes cannot see each
-other. Opt in per run with `--team`: fanout (best-effort) injects a
-"Coordinating with your sibling panes" section into each child's standard
-briefing and seeds a per-parent peer registry so the siblings know about one
-another. (`--codex-plan-mode` children are seeded into the registry but receive
-the minimal Plan-Mode briefing, so the roster section is not added to them.)
+When sibling panes touch the same interface in parallel, they often need to share progress and decisions. But when a parent is fanned out, each child is an independent agent session in its own pane — by default the panes cannot see each other. Opt in per run with `--team`: fanout (best-effort) injects a "Coordinating with your sibling panes" section into each child's standard briefing and seeds a per-parent peer registry so the siblings know about one another. `--codex-plan-mode` children are seeded into the registry too, but they receive the minimal Plan-Mode briefing, so the coordination section is not added.
 
-Inside any fanned pane, `fanout msg` auto-detects which child (or parent) you
-are and talks over a per-parent SQLite bus at
-`/tmp/fanout-<repo>-<parent>.db` (override with `FANOUT_DB_PATH`). The bus
-carries a shared `board` (broadcast to everyone) plus `1:1` messages addressed
-with `--to <issue>`. Coordination is pull-based — nothing nudges a pane unless
-you ask it to.
-
-The plan lane supports `--team` too (`fanout plan <spec> --team`). It behaves
-identically, except issue-less plan tasks have no `#N`, so peers are addressed
-by **task id**: `fanout msg send --to <task-id> "<body>"` messages a sibling
-task and `fanout msg peers` lists the live task ids. The plan bus lives at
-`/tmp/fanout-<repo>-plan-<slug>.db`, and `--team` is not combinable with the
-plan read/lifecycle modes (`--status` / `--close` / `--merge` / `--cleanup`).
+Inside a fanned-out pane, `fanout msg` auto-detects which child (or parent) you are and talks over a per-parent bus.
 
 ```bash
 fanout msg peers                # who are my siblings?
@@ -187,44 +100,25 @@ fanout msg send --to 7 "renamed SessionStore to PaneStore"
 fanout msg inbox --mark-read
 ```
 
-The full verb table (`peers`, `inbox`, `board`, `send`, `post`, `mark-read`,
-`register`, `nudge`) and the common options are in the
-[CLI Reference]({{< relref "/docs/cli#fanout-msg" >}}).
+The full verb table and how to address plan tasks are covered in the [CLI Reference]({{< relref "/docs/cli#fanout-msg" >}}).
 
-This works the same for `claude` and `codex` panes. It is distinct from Claude
-Code Agent Teams, which coordinates teammates inside a single session; peer
-messaging coordinates separate fanout panes.
+It works the same for `claude` and `codex` panes, and is distinct from Claude Code Agent Teams, which coordinates teammates inside a single session.
 
-> **Security.** The bus is a **plaintext** SQLite file under `/tmp`. fanout
-> creates it `0600` (owner-only) and refuses one that is group/world-readable or
-> owned by another user, but `/tmp` is shared scratch space — **do not put
-> secrets, tokens, or credentials in messages.** The DB is throwaway; delete
-> `/tmp/fanout-<repo>-<parent>.db*` when you are done.
+> **Security.** The bus is a **plaintext** SQLite file under `/tmp`. fanout creates it `0600` (owner-only) and refuses one that is group/world-readable or owned by another user, but `/tmp` is shared scratch space — **do not put secrets, tokens, or credentials in messages.**
 
 ## Naming and branches
 
-By default each child gets the worktree slug `slugify(title)-<issueNum>` and the branch `fanout/<slug>`. Three flags override this:
-
-- `--name <NUM>=<slug>[|<display>[|<branch>]]` — name one child's worktree slug stem, pane title, and branch directly. The three pipe-separated segments may each be empty, but at least one must be non-empty. fanout appends `-<NUM>` to slug stems that do not already carry it; the third segment overrides the generated branch name. Repeatable — one per target.
-- `--branch-prefix <prefix>` — change generated branch names for the whole run.
-- `--base-branch <branch>` — override the base branch the children branch from. Bare local branch names and `origin/<branch>` are both supported.
-- `--no-refresh` — skip the base-branch refresh. By default fanout refreshes the base with `git fetch --quiet --no-tags` plus a fast-forward update before branching; local plan/manual panes automatically skip refresh and use the current local branch/`HEAD` when no `origin` remote exists.
+By default each child gets the worktree slug `slugify(title)-<issueNum>` and the branch `fanout/<slug>`. Override these with `--name`, `--branch-prefix`, `--base-branch`, and `--no-refresh`.
 
 ```bash
 fanout 123 --name 4=fix-login-timeout --name 7='update-docs|Docs update'
-fanout 123 --name 8='feat-x|Feature X|feat/issue-8-x'   # all three segments
-fanout 123 --name 9='||release/v2.0'                    # branch override only
-
-fanout 123 --base-branch release/v2 --branch-prefix fanout/release/
-
-fanout 123 --no-refresh
 ```
 
-> The bundled Claude/Codex integrations generate `--name` flags from the issue title and body without any extra API call; pass `--name` yourself to override. Rerun idempotency comes from `.fanout/state.json`, not from names.
+See the [CLI Reference]({{< relref "/docs/cli" >}}) for details.
 
 ## Project mode
 
-The positional argument accepts a Projects v2 URL in place of a parent issue number — `https://github.com/users/<owner>/projects/<n>` or `https://github.com/orgs/<org>/projects/<n>`. The canonical `/views/<id>` suffix and trailing query strings are also accepted, so copy/paste from the browser address bar works. In this mode children come from the Project's items instead of the Sub-issues + task-list union.
+The positional argument accepts a Projects v2 URL in place of a parent issue number (`https://github.com/users/<owner>/projects/<n>` or `https://github.com/orgs/<org>/projects/<n>`). The canonical `/views/<id>` suffix and trailing query strings are also accepted, so copy/paste from the browser address bar works. In this mode children come from the Project's items instead of the Sub-issues + task-list union.
 
 ```bash
 fanout https://github.com/users/<owner>/projects/<n>
@@ -234,21 +128,13 @@ fanout https://github.com/orgs/<org>/projects/<n> --project-status "In Progress"
 fanout https://github.com/users/<owner>/projects/<n> --project-status all
 ```
 
-- **Default filter is `Status == Todo`.** Pass `--project-status "<name>"` to pick a different single-select value, or `--project-status all` to disable the filter and include every item (Done, no status, etc.).
-- **No parent body means no implicit-children salvage.** The `Closes #N` / dependency phrases the skills normally surface don't exist here — the Project is the source of truth. Use `--include` to force-add anything the Project happens to omit.
-- **Single-repo only.** Items whose repository differs from the current git repository are warned and skipped.
-- **No Status field on the Project?** fanout warns and falls back to every item regardless of `--project-status`.
-- **Blockers** come only from the child body's `## Blocked by` section; the `(blocked by #X)` task-list trailer doesn't exist without a parent body. The `blocked` label stays a weak signal here too — a child carrying only the label is warned and treated as unblocked.
+The default filter is items with `Status == Todo`. For how to change the filter and how blockers differ from issue mode, see the [CLI Reference]({{< relref "/docs/cli" >}}).
 
 > Project mode requires the `gh` CLI to carry the `read:project` scope — see [Installation]({{< relref "/docs/installation" >}}).
 
-## Merging and folding panes away
+## Merging and folding panes away (lifecycle)
 
-The lifecycle commands operate only on entries recorded in `.fanout/state.json`. They do not discover arbitrary worktrees by scanning the filesystem.
-
-- `fanout <parent> --merge <NUM>` — runs `git -C <project-root> merge --ff-only <recorded-branch>`. If the merge is not a fast-forward, fanout reports the git error and stops; it never starts an editor or a conflict-resolution flow.
-- `fanout <parent> --close <NUM>` — removes the recorded worktree with `git worktree remove <path> --force`, kills the recorded tmux pane when it is still present, removes the state entry, and runs `git worktree prune`.
-- `fanout <parent> --cleanup` — queries the recorded children and closes any child whose issue is `CLOSED` or whose closed-by PR list contains a `MERGED` PR. Pending children remain recorded.
+Lifecycle commands operate only on entries recorded in `.fanout/state.json`.
 
 ```bash
 fanout 123 --merge 4
@@ -257,21 +143,4 @@ fanout 123 --close 4
 fanout 123 --cleanup
 ```
 
-> Like `--status`, these commands honor `FANOUT_STATE_PATH`; otherwise they use `<git-root>/.fanout/state.json`.
-
-## Run control
-
-| Flag | Effect |
-|---|---|
-| `--session <name>` | Target a named tmux session instead of the invoking pane. |
-| `--sleep <seconds>` | Rate limit between successful child launches (default 4 seconds). It is not a retry/backoff knob. |
-| `--dry-run` | Preview the git worktree + tmux commands without creating worktrees, panes, state rows, or briefing files. |
-| `--debug` | Print extra diagnostic logging. |
-
-```bash
-fanout 123 --session work-repo
-fanout 123 --sleep 8
-fanout 123 --dry-run
-```
-
-Every flag on this page — and the rest of the surface — is in the [CLI Reference]({{< relref "/docs/cli" >}}).
+The full surface — the flags on this page plus the exact behavior of the lifecycle commands — is in the [CLI Reference]({{< relref "/docs/cli" >}}).

--- a/site/hugo.toml
+++ b/site/hugo.toml
@@ -37,11 +37,13 @@ disableKinds = ["taxonomy", "term"]
     guessSyntax = false
   [markup.goldmark.renderer]
     unsafe = true
-  # 日本語ソースは一文一行で書くため、CJK 文字間の soft break を
-  # スペースにしない (eastAsianLineBreaks)。EN ページには影響しない。
+  # 日本語ソースは一文一行で書くため、CJK 前後の soft break をスペースに
+  # しない。css3draft は片側が ASCII (OPEN、fanout 等) の文境界も対象に
+  # する。EN ページには影響しない。
   [markup.goldmark.extensions.cjk]
-    enabled = true
+    enable = true
     eastAsianLineBreaks = true
+    eastAsianLineBreaksStyle = "css3draft"
   [markup.tableOfContents]
     startLevel = 2
     endLevel = 3

--- a/site/hugo.toml
+++ b/site/hugo.toml
@@ -37,6 +37,11 @@ disableKinds = ["taxonomy", "term"]
     guessSyntax = false
   [markup.goldmark.renderer]
     unsafe = true
+  # 日本語ソースは一文一行で書くため、CJK 文字間の soft break を
+  # スペースにしない (eastAsianLineBreaks)。EN ページには影響しない。
+  [markup.goldmark.extensions.cjk]
+    enabled = true
+    eastAsianLineBreaks = true
   [markup.tableOfContents]
     startLevel = 2
     endLevel = 3

--- a/site/layouts/_partials/diagram-console.html
+++ b/site/layouts/_partials/diagram-console.html
@@ -1,0 +1,64 @@
+<svg class="dg" viewBox="0 0 800 300" role="img"
+     aria-label="{{ if eq .Language.Lang "ja" }}図: 常駐 TUI コンソールの模式図。Session ヘッダの下に ISSUE / NAME / AGENT / RUN / STATE / PR / DIFF 列のテーブルが並び、選択行の詳細と peek、キー操作の footer が続く{{ else }}Diagram: mock of the persistent TUI console — a Session header over a table with ISSUE, NAME, AGENT, RUN, STATE, PR and DIFF columns, a detail line with an output peek, and the key-binding footer{{ end }}">
+
+  <!-- terminal card -->
+  <rect class="box" x="20" y="16" width="760" height="268" rx="10"/>
+  <rect class="hd" x="20" y="16" width="760" height="30" rx="10"/>
+  <rect class="hd" x="20" y="31" width="760" height="15"/>
+  <text class="t-mut" x="40" y="36">fanout — console</text>
+  <text class="t-mut" x="760" y="36" text-anchor="end">%12</text>
+
+  <!-- session header row -->
+  <text class="t-name" x="40" y="72"><tspan class="t-num">#123</tspan> parent issue</text>
+  <text class="t-mut" x="760" y="72" text-anchor="end">t4 · m1 · p2 · b1</text>
+  <line class="rule" x1="36" y1="84" x2="764" y2="84"/>
+
+  <!-- table header -->
+  <text class="t-mut" x="56" y="104">ISSUE</text>
+  <text class="t-mut" x="130" y="104">NAME</text>
+  <text class="t-mut" x="230" y="104">AGENT</text>
+  <text class="t-mut" x="310" y="104">RUN</text>
+  <text class="t-mut" x="400" y="104">STATE</text>
+  <text class="t-mut" x="490" y="104">PR</text>
+  <text class="t-mut" x="600" y="104">DIFF</text>
+  <text class="t-mut" x="690" y="104">DIRTY</text>
+
+  <!-- selected row -->
+  <rect class="sel" x="36" y="114" width="728" height="24" rx="4"/>
+  <text class="t-num" x="40" y="130">▌</text>
+  <text class="t-num" x="56" y="130">#124</text>
+  <text class="t-name" x="130" y="130">auth</text>
+  <text class="t-name" x="230" y="130">claude</text>
+  <text class="t-name" x="310" y="130"><tspan class="run">● running</tspan></text>
+  <text class="t-name" x="400" y="130">OPEN</text>
+  <text class="t-mut" x="490" y="130">—</text>
+  <text class="t-name" x="600" y="130">+182/-40</text>
+  <text class="t-name" x="690" y="130">dirty</text>
+
+  <!-- row 2 -->
+  <text class="t-num" x="56" y="158">#125</text>
+  <text class="t-name" x="130" y="158">docs</text>
+  <text class="t-name" x="230" y="158">codex</text>
+  <text class="t-mut" x="310" y="158">done</text>
+  <text class="t-name" x="400" y="158">OPEN</text>
+  <text class="t-name" x="490" y="158">#250 <tspan class="ok">ci✓</tspan></text>
+  <text class="t-name" x="600" y="158">+96/-12</text>
+  <text class="t-name" x="690" y="158">clean</text>
+
+  <!-- row 3 (deferred) -->
+  <text class="t-num" x="56" y="186">#126</text>
+  <text class="t-name" x="130" y="186">api</text>
+  <text class="t-mut" x="230" y="186">—</text>
+  <text class="t-mut" x="310" y="186">—</text>
+  <text class="t-mut" x="400" y="186">deferred · blocked by #124</text>
+
+  <line class="rule" x1="36" y1="202" x2="764" y2="202"/>
+
+  <!-- detail / peek -->
+  <text class="t-mut" x="40" y="224">#124 · fanout/auth-124 · wave 1 · run=running</text>
+  <text class="t-mut" x="40" y="246">peek: writing token refresh tests…<tspan class="t-num">▌</tspan></text>
+
+  <!-- footer -->
+  <line class="rule" x1="36" y1="258" x2="764" y2="258"/>
+  <text class="t-mut" x="40" y="276">? help   / filter   n new   Enter focus   p peek   m merge   X cleanup   q quit</text>
+</svg>

--- a/site/layouts/_partials/diagram-console.html
+++ b/site/layouts/_partials/diagram-console.html
@@ -1,5 +1,5 @@
 <svg class="dg" viewBox="0 0 800 300" role="img"
-     aria-label="{{ if eq .Language.Lang "ja" }}図: 常駐 TUI コンソールの模式図。Session ヘッダの下に ISSUE / NAME / AGENT / RUN / STATE / PR / DIFF 列のテーブルが並び、選択行の詳細と peek、キー操作の footer が続く{{ else }}Diagram: mock of the persistent TUI console — a Session header over a table with ISSUE, NAME, AGENT, RUN, STATE, PR and DIFF columns, a detail line with an output peek, and the key-binding footer{{ end }}">
+     aria-label="{{ if eq .Language.Lang "ja" }}図: 常駐 TUI コンソールの模式図。Session ヘッダの下に ISSUE / NAME / AGENT / RUN / STATE / PR / DIFF / DIRTY 列のテーブルが並び、選択行の詳細と peek、footer が続く{{ else }}Diagram: mock of the persistent TUI console — a Session header over a table with ISSUE, NAME, AGENT, RUN, STATE, PR, DIFF and DIRTY columns, a detail line with an output peek, and the footer{{ end }}">
 
   <!-- terminal card -->
   <rect class="box" x="20" y="16" width="760" height="268" rx="10"/>
@@ -10,7 +10,7 @@
 
   <!-- session header row -->
   <text class="t-name" x="40" y="72"><tspan class="t-num">#123</tspan> parent issue</text>
-  <text class="t-mut" x="760" y="72" text-anchor="end">t4 · m1 · p2 · b1</text>
+  <text class="t-mut" x="760" y="72" text-anchor="end">t3 m0 p2 b1 l2</text>
   <line class="rule" x1="36" y1="84" x2="764" y2="84"/>
 
   <!-- table header -->
@@ -29,7 +29,7 @@
   <text class="t-num" x="56" y="130">#124</text>
   <text class="t-name" x="130" y="130">auth</text>
   <text class="t-name" x="230" y="130">claude</text>
-  <text class="t-name" x="310" y="130"><tspan class="run">● running</tspan></text>
+  <text class="t-name" x="310" y="130"><tspan class="run">●</tspan></text>
   <text class="t-name" x="400" y="130">OPEN</text>
   <text class="t-mut" x="490" y="130">—</text>
   <text class="t-name" x="600" y="130">+182/-40</text>
@@ -39,7 +39,7 @@
   <text class="t-num" x="56" y="158">#125</text>
   <text class="t-name" x="130" y="158">docs</text>
   <text class="t-name" x="230" y="158">codex</text>
-  <text class="t-mut" x="310" y="158">done</text>
+  <text class="t-name" x="310" y="158">✓</text>
   <text class="t-name" x="400" y="158">OPEN</text>
   <text class="t-name" x="490" y="158">#250 <tspan class="ok">ci✓</tspan></text>
   <text class="t-name" x="600" y="158">+96/-12</text>
@@ -60,5 +60,7 @@
 
   <!-- footer -->
   <line class="rule" x1="36" y1="258" x2="764" y2="258"/>
-  <text class="t-mut" x="40" y="276">? help   / filter   n new   Enter focus   p peek   m merge   X cleanup   q quit</text>
+  <text class="t-mut" x="40" y="276">? help</text>
+  <text class="t-mut" x="110" y="276">state 12s</text>
+  <text class="t-mut" x="196" y="276">gh 45s</text>
 </svg>

--- a/site/layouts/_partials/diagram-overview.html
+++ b/site/layouts/_partials/diagram-overview.html
@@ -3,7 +3,7 @@
   <defs>
     <marker id="dg-ov-arrow" viewBox="0 0 10 10" refX="9" refY="5"
             markerWidth="7" markerHeight="7" orient="auto-start-reverse">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--ai)"/>
+      <path d="M 0 0 L 10 5 L 0 10 z" style="fill:var(--ai)"/>
     </marker>
   </defs>
 

--- a/site/layouts/_partials/diagram-overview.html
+++ b/site/layouts/_partials/diagram-overview.html
@@ -1,0 +1,61 @@
+<svg class="dg" viewBox="0 0 800 300" role="img"
+     aria-label="{{ if eq .Language.Lang "ja" }}図: 親 issue #123 の OPEN な子 3 つが、fanout 123 の 1 回で worktree と branch を持つ 3 枚の tmux ペインになる{{ else }}Diagram: one run of fanout 123 turns parent issue #123's three OPEN children into three tmux panes, each with its own worktree and branch{{ end }}">
+  <defs>
+    <marker id="dg-ov-arrow" viewBox="0 0 10 10" refX="9" refY="5"
+            markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--ai)"/>
+    </marker>
+  </defs>
+
+  <!-- parent issue card -->
+  <rect class="box" x="24" y="70" width="200" height="160" rx="10"/>
+  <rect class="hd" x="24" y="70" width="200" height="30" rx="10"/>
+  <rect class="hd" x="24" y="85" width="200" height="15"/>
+  <text class="t-num" x="40" y="90">#123</text>
+  <text class="t-mut" x="82" y="90">parent issue</text>
+  <text class="t-name" x="40" y="126">- [ ] <tspan class="t-num">#124</tspan> auth</text>
+  <text class="t-name" x="40" y="152">- [ ] <tspan class="t-num">#125</tspan> docs</text>
+  <text class="t-name" x="40" y="178">- [ ] <tspan class="t-num">#126</tspan> api</text>
+  <text class="t-mut" x="40" y="210">Sub-issues / task list</text>
+
+  <!-- command arrow -->
+  <line class="arrow" x1="236" y1="150" x2="312" y2="150" marker-end="url(#dg-ov-arrow)"/>
+  <text class="t-cmd" x="274" y="136" text-anchor="middle">fanout 123</text>
+
+  <!-- tmux window -->
+  <rect class="frame" x="330" y="34" width="446" height="236" rx="8"/>
+  <text class="t-mut" x="344" y="26">tmux window</text>
+
+  <!-- pane #124 (left, tall) -->
+  <rect class="box" x="344" y="52" width="200" height="200" rx="6"/>
+  <rect class="chip" x="366" y="45" width="128" height="14" rx="4"/>
+  <text class="t-num" x="374" y="56">#124<tspan class="t-mut"> · auth-124</tspan></text>
+  <circle class="dot-run" cx="530" cy="66" r="3"/>
+  <rect class="bar" x="360" y="84" width="120" height="4" rx="2"/>
+  <rect class="bar b2" x="360" y="98" width="150" height="4" rx="2"/>
+  <rect class="bar" x="360" y="112" width="96" height="4" rx="2"/>
+  <rect class="bar b2" x="360" y="126" width="132" height="4" rx="2"/>
+  <text class="t-mut" x="360" y="222">.fanout/worktrees/auth-124/</text>
+  <text class="t-mut" x="360" y="240">fanout/auth-124</text>
+
+  <!-- pane #125 (right top) -->
+  <rect class="box" x="556" y="52" width="206" height="96" rx="6"/>
+  <rect class="chip" x="578" y="45" width="128" height="14" rx="4"/>
+  <text class="t-num" x="586" y="56">#125<tspan class="t-mut"> · docs-125</tspan></text>
+  <circle class="dot-run" cx="748" cy="66" r="3"/>
+  <rect class="bar" x="572" y="84" width="120" height="4" rx="2"/>
+  <rect class="bar b2" x="572" y="98" width="150" height="4" rx="2"/>
+  <text class="t-mut" x="572" y="136">fanout/docs-125</text>
+
+  <!-- pane #126 (right bottom) -->
+  <rect class="box" x="556" y="156" width="206" height="96" rx="6"/>
+  <rect class="chip" x="578" y="149" width="120" height="14" rx="4"/>
+  <text class="t-num" x="586" y="160">#126<tspan class="t-mut"> · api-126</tspan></text>
+  <circle class="dot-run" cx="748" cy="170" r="3"/>
+  <rect class="bar b2" x="572" y="188" width="140" height="4" rx="2"/>
+  <rect class="bar" x="572" y="202" width="104" height="4" rx="2"/>
+  <text class="t-mut" x="572" y="240">fanout/api-126</text>
+
+  <!-- caption -->
+  <text class="t-lbl" x="400" y="290" text-anchor="middle">{{ if eq .Language.Lang "ja" }}1 子 = 1 worktree = 1 ペイン = 1 agent{{ else }}one child = one worktree = one pane = one agent{{ end }}</text>
+</svg>

--- a/site/layouts/_partials/diagram-waves.html
+++ b/site/layouts/_partials/diagram-waves.html
@@ -3,7 +3,7 @@
   <defs>
     <marker id="dg-wv-arrow" viewBox="0 0 10 10" refX="9" refY="5"
             markerWidth="7" markerHeight="7" orient="auto-start-reverse">
-      <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--ai)"/>
+      <path d="M 0 0 L 10 5 L 0 10 z" style="fill:var(--ai)"/>
     </marker>
   </defs>
 

--- a/site/layouts/_partials/diagram-waves.html
+++ b/site/layouts/_partials/diagram-waves.html
@@ -1,0 +1,57 @@
+<svg class="dg" viewBox="0 0 800 260" role="img"
+     aria-label="{{ if eq .Language.Lang "ja" }}図: Wave 1 では blocker の無い #124 と #125 だけが起動し、#126 と #127 は deferred。PR がマージされた後に同じコマンドを再実行すると Wave 2 として #126 と #127 が起動する{{ else }}Diagram: Wave 1 launches only unblocked children #124 and #125 while #126 and #127 stay deferred; rerunning the same command after the PRs merge launches #126 and #127 as Wave 2{{ end }}">
+  <defs>
+    <marker id="dg-wv-arrow" viewBox="0 0 10 10" refX="9" refY="5"
+            markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--ai)"/>
+    </marker>
+  </defs>
+
+  <!-- Wave 1 -->
+  <text class="t-cap" x="28" y="40">Wave 1</text>
+  <text class="t-cmd" x="110" y="40">fanout 123 --unblocked-only</text>
+
+  <rect class="box" x="28" y="58" width="150" height="64" rx="8"/>
+  <text class="t-num" x="44" y="84">#124<tspan class="t-mut"> auth</tspan></text>
+  <circle class="dot-run" cx="160" cy="80" r="3"/>
+  <text class="t-mut" x="44" y="106">running</text>
+
+  <rect class="box" x="192" y="58" width="150" height="64" rx="8"/>
+  <text class="t-num" x="208" y="84">#125<tspan class="t-mut"> docs</tspan></text>
+  <circle class="dot-run" cx="324" cy="80" r="3"/>
+  <text class="t-mut" x="208" y="106">running</text>
+
+  <rect class="box-dash" x="28" y="138" width="150" height="64" rx="8"/>
+  <text class="t-num" x="44" y="164">#126<tspan class="t-mut"> api</tspan></text>
+  <text class="t-mut" x="44" y="186">blocked by #124</text>
+
+  <rect class="box-dash" x="192" y="138" width="150" height="64" rx="8"/>
+  <text class="t-num" x="208" y="164">#127<tspan class="t-mut"> cli</tspan></text>
+  <text class="t-mut" x="208" y="186">blocked by #125</text>
+
+  <!-- rerun arrow -->
+  <line class="arrow" x1="360" y1="130" x2="436" y2="130" marker-end="url(#dg-wv-arrow)"/>
+  <text class="t-lbl" x="398" y="112" text-anchor="middle">{{ if eq .Language.Lang "ja" }}PR がマージ{{ else }}PRs merge{{ end }}</text>
+  <text class="t-lbl" x="398" y="152" text-anchor="middle">{{ if eq .Language.Lang "ja" }}再実行{{ else }}rerun{{ end }}</text>
+
+  <!-- Wave 2 -->
+  <text class="t-cap" x="456" y="40">Wave 2</text>
+  <text class="t-cmd" x="538" y="40">{{ if eq .Language.Lang "ja" }}同じコマンド{{ else }}same command{{ end }}</text>
+
+  <rect class="chip" x="456" y="66" width="150" height="24" rx="12"/>
+  <text class="t-mut" x="472" y="82"><tspan class="ok">✓</tspan> #124 merged</text>
+  <rect class="chip" x="620" y="66" width="150" height="24" rx="12"/>
+  <text class="t-mut" x="636" y="82"><tspan class="ok">✓</tspan> #125 merged</text>
+
+  <rect class="box" x="456" y="138" width="150" height="64" rx="8"/>
+  <text class="t-num" x="472" y="164">#126<tspan class="t-mut"> api</tspan></text>
+  <circle class="dot-run" cx="588" cy="160" r="3"/>
+  <text class="t-mut" x="472" y="186">running</text>
+
+  <rect class="box" x="620" y="138" width="150" height="64" rx="8"/>
+  <text class="t-num" x="636" y="164">#127<tspan class="t-mut"> cli</tspan></text>
+  <circle class="dot-run" cx="752" cy="160" r="3"/>
+  <text class="t-mut" x="636" y="186">running</text>
+
+  <text class="t-lbl" x="400" y="244" text-anchor="middle">{{ if eq .Language.Lang "ja" }}記録済みの子は skip されるので、同じコマンドの再実行が次の wave を開く{{ else }}already-recorded children are skipped, so rerunning the same command opens the next wave{{ end }}</text>
+</svg>

--- a/site/layouts/_shortcodes/diagram.html
+++ b/site/layouts/_shortcodes/diagram.html
@@ -1,0 +1,5 @@
+{{- /* {{< diagram "overview" >}} renders partial diagram-<name>.html inside a figure */ -}}
+{{- $name := .Get 0 -}}
+<figure class="dg-holder">
+  {{ partial (printf "diagram-%s.html" $name) .Page }}
+</figure>


### PR DESCRIPTION
## TL;DR

2 段構成の docs 改善。第 1 弾は監査に基づく誤り修正 + 構造改善 + SVG 図 3 点、第 2 弾は追加指示書によるエンドユーザー向け簡潔化リライト (日本語を japanese-tech-writing 規範で先に書き、英訳する構成に変更。JA 6 ページ 1004 → 660 行)。CLI リファレンスと Settings は詳細許可ページとして温存し、削った事実はリンク化・移設した。

Review effort: 3

## 第 1 弾: 誤り修正 + 構造改善 + 図版

- monitoring (EN) の文章破損復元、cli シノプシスの `--popup-timeout` 削除 / `--dashboard-keybind` 追加、`--status` 排他リスト補完 (cliflags.go と照合)、内部 issue 参照の除去
- hooks を `## Lifecycle hooks` に昇格しアンカーリンク化、`fanout msg` 表を cli に一本化、quickstart に fanout-issues 導線
- README の目玉機能「ペイン枠線ラベル」の節を新設、TUI キー表補完 (`j/k` `[/]` `/`、`@` 補完、RUN 列)
- インライン SVG 図 3 点 (overview / waves / console) + diagram shortcode。既存 fan.html と同じ CSS 変数方式で、実 TUI 表示 (グリフ・counters・footer) と照合済み

## 第 2 弾: エンドユーザー向け簡潔化リライト

ユーザーの行動が紐づかない実装詳細・仕様列挙を削除し、事実が cli/settings に既載ならリンクで置換:

- quickstart: 内部 7 ステップの節を削除、冪等性と子宣言を要点化
- workflow: cli と二重のフラグ表 3 つを削除、watcher 運用を Settings へ移設
- monitoring: JSON スキーマ・GraphQL クエリ名・exit-code 表・endpoint 列挙を削除
- agents / installation / troubleshooting: 機構説明・パス列挙・設計メモ FAQ を削除 (state.json スキーマは cli へ移設)
- 日本語は一文一行 + 地の文のダッシュ・中黒排除。hugo.toml に Goldmark cjk 拡張 (`enable` + `css3draft`) を追加し、ビルド HTML で CJK/ASCII 両文境界の結合を実証

## レビュー

- リライトは Workflow (sonnet ×21 agents: JA 書き→英訳→検証) で実施し、検証ステージの must-fix (watcherMaxSessions の誤り) を修正
- code-review workflow (xhigh) 2 周: 第 1 弾 13 件 / 第 2 弾 15 件の CONFIRMED 指摘をすべて修正 (圧縮による事実改変 — watcher 分類・budget 意味論・再投入前提・`--base-branch` 混同・cjk キー名 no-op — を含む)
- codex review: 各弾 2 反復で approve
- `hugo` ビルド green、EN/JA 見出し同期一致、doc-style banned words clean、`make lint` / `make test` green

## Follow-up

- 実スクリーンショット / GIF の追加は #410
- changelog ページは次リリース時更新のためスコープ外

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TKBWo7Xy41bhGKTjhT25g6