### PR TITLE
refactor: 横断重複を統合する DRY 土台を追加 (layered 5/10)

### DIFF
--- a/cmd/fanout/dashboard.go
+++ b/cmd/fanout/dashboard.go
@@ -7,16 +7,15 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"os/exec"
 	"os/signal"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"syscall"
 	"time"
 
 	"github.com/butaosuinu/fanout/internal/app/sessionview"
 	"github.com/butaosuinu/fanout/internal/core/exitcode"
+	"github.com/butaosuinu/fanout/internal/infra/browser"
 	"github.com/butaosuinu/fanout/internal/infra/log"
 	"github.com/butaosuinu/fanout/internal/infra/settings"
 	"github.com/butaosuinu/fanout/internal/infra/tmuxrun"
@@ -339,26 +338,7 @@ func showDashboardStatusBestEffort(msg string, lg *log.Logger) {
 }
 
 func openBrowser(url string) error {
-	var cmd *exec.Cmd
-	switch runtime.GOOS {
-	case "darwin":
-		cmd = exec.Command("open", url)
-	case "windows":
-		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
-	default:
-		cmd = exec.Command("xdg-open", url)
-	}
-	if err := cmd.Start(); err != nil {
-		return err
-	}
-	done := make(chan error, 1)
-	go func() { done <- cmd.Wait() }()
-	select {
-	case err := <-done:
-		return err
-	case <-time.After(openBrowserWaitPeriod):
-		return nil
-	}
+	return browser.Open(url, openBrowserWaitPeriod)
 }
 
 func randomToken() (string, error) {

--- a/cmd/fanout/deps.go
+++ b/cmd/fanout/deps.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"fmt"
+	"os/exec"
+
+	"github.com/butaosuinu/fanout/internal/infra/log"
+	"github.com/butaosuinu/fanout/internal/infra/tmuxrun"
+)
+
+// depNeeds selects which external dependencies a command path requires.
+// Callers own the per-mode conditions; missingDeps owns the probes and the
+// hint strings.
+type depNeeds struct {
+	git  bool
+	gh   bool
+	tmux bool
+}
+
+// missingDeps probes the selected dependencies and returns one hint line per
+// missing one, in the fixed git → gh → tmux order the CLI has always printed.
+func missingDeps(needs depNeeds) []string {
+	var missing []string
+	check := func(cmd, hint string) {
+		if _, err := exec.LookPath(cmd); err != nil {
+			missing = append(missing, hint)
+		}
+	}
+	if needs.git {
+		check("git", "git")
+	}
+	if needs.gh {
+		check("gh", "gh (brew install gh)")
+	}
+	if needs.tmux {
+		if err := tmuxrun.CheckMinimumVersion(); err != nil {
+			missing = append(missing, err.Error())
+		}
+	}
+	return missing
+}
+
+// exitOnMissingDeps prints the shared "missing dependencies:" block to stderr
+// and reports whether the caller should exit. An empty list prints nothing.
+func exitOnMissingDeps(missing []string, lg *log.Logger) bool {
+	if len(missing) == 0 {
+		return false
+	}
+	lg.Err("missing dependencies:")
+	for _, d := range missing {
+		fmt.Fprintf(lg.Stderr(), "  - %s\n", d)
+	}
+	return true
+}

--- a/cmd/fanout/deps_test.go
+++ b/cmd/fanout/deps_test.go
@@ -1,0 +1,117 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/butaosuinu/fanout/internal/infra/log"
+	"github.com/butaosuinu/fanout/internal/infra/tmuxrun"
+)
+
+// installDepShims populates a PATH-only dir with the named fake binaries.
+// tmux answers `tmux -V` with a modern version so CheckMinimumVersion passes.
+func installDepShims(t *testing.T, names ...string) {
+	t.Helper()
+	binDir := t.TempDir()
+	for _, name := range names {
+		body := "#!/bin/sh\nexit 0\n"
+		if name == "tmux" {
+			body = "#!/bin/sh\nprintf 'tmux 3.6a\\n'\n"
+		}
+		if err := os.WriteFile(filepath.Join(binDir, name), []byte(body), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("PATH", binDir)
+}
+
+// TestMissingDeps pins the hint strings and the fixed git → gh → tmux probe
+// order shared by the issue, plan, and TUI lanes.
+func TestMissingDeps(t *testing.T) {
+	tests := []struct {
+		name      string
+		installed []string
+		needs     depNeeds
+		want      []string
+	}{
+		{
+			name:      "all present yields nothing",
+			installed: []string{"git", "gh", "tmux"},
+			needs:     depNeeds{git: true, gh: true, tmux: true},
+			want:      nil,
+		},
+		{
+			name:      "missing gh yields the brew hint",
+			installed: []string{"git", "tmux"},
+			needs:     depNeeds{git: true, gh: true, tmux: true},
+			want:      []string{"gh (brew install gh)"},
+		},
+		{
+			name:      "unneeded gh is not probed",
+			installed: []string{"git", "tmux"},
+			needs:     depNeeds{git: true, tmux: true},
+			want:      nil,
+		},
+		{
+			name:      "missing git and gh keep the git-first order",
+			installed: []string{"tmux"},
+			needs:     depNeeds{git: true, gh: true},
+			want:      []string{"git", "gh (brew install gh)"},
+		},
+		{
+			name:      "missing tmux reports the version hint last",
+			installed: []string{},
+			needs:     depNeeds{git: true, tmux: true},
+			want:      []string{"git", "tmux " + tmuxrun.MinimumVersion + "+ (brew install tmux)"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			installDepShims(t, tt.installed...)
+			if got := missingDeps(tt.needs); !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("missingDeps(%+v) = %v, want %v", tt.needs, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestExitOnMissingDeps pins the exact "missing dependencies:" stderr block.
+func TestExitOnMissingDeps(t *testing.T) {
+	tests := []struct {
+		name       string
+		missing    []string
+		want       bool
+		wantStderr string
+	}{
+		{
+			name:       "empty list prints nothing and does not exit",
+			missing:    nil,
+			want:       false,
+			wantStderr: "",
+		},
+		{
+			name:       "each missing dep becomes an indented dash line",
+			missing:    []string{"git", "gh (brew install gh)"},
+			want:       true,
+			wantStderr: "[err ] missing dependencies:\n  - git\n  - gh (brew install gh)\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out, errBuf bytes.Buffer
+			lg := log.NewWith(&out, &errBuf, false)
+			if got := exitOnMissingDeps(tt.missing, lg); got != tt.want {
+				t.Fatalf("exitOnMissingDeps(%v) = %v, want %v", tt.missing, got, tt.want)
+			}
+			if errBuf.String() != tt.wantStderr {
+				t.Fatalf("exitOnMissingDeps(%v) stderr = %q, want %q", tt.missing, errBuf.String(), tt.wantStderr)
+			}
+			if out.Len() != 0 {
+				t.Fatalf("exitOnMissingDeps(%v) wrote to stdout: %q", tt.missing, out.String())
+			}
+		})
+	}
+}

--- a/cmd/fanout/main.go
+++ b/cmd/fanout/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -14,6 +13,7 @@ import (
 	"github.com/butaosuinu/fanout/internal/core/exitcode"
 	"github.com/butaosuinu/fanout/internal/core/naming"
 	"github.com/butaosuinu/fanout/internal/infra/ghissue"
+	"github.com/butaosuinu/fanout/internal/infra/gitroot"
 	"github.com/butaosuinu/fanout/internal/infra/hooks"
 	"github.com/butaosuinu/fanout/internal/infra/log"
 	fanoutruntime "github.com/butaosuinu/fanout/internal/infra/runtime"
@@ -85,11 +85,15 @@ func main() {
 		lg = log.New(true)
 	}
 
-	if missing := checkDeps(cfg); len(missing) > 0 {
-		lg.Err("missing dependencies:")
-		for _, d := range missing {
-			fmt.Fprintf(lg.Stderr(), "  - %s\n", d)
-		}
+	// Which deps each mode needs stays here; the probe and printing are shared
+	// (deps.go).
+	lifecycle := cfg.CloseNum > 0 || cfg.MergeNum > 0 || cfg.CleanupMode
+	needs := depNeeds{
+		git:  true,
+		gh:   cfg.StatusMode || cfg.CleanupMode || !lifecycle,
+		tmux: !cfg.StatusMode && !lifecycle,
+	}
+	if exitOnMissingDeps(missingDeps(needs), lg) {
 		os.Exit(int(exitcode.Env))
 	}
 
@@ -290,7 +294,7 @@ func resolveRuntime(cfg *cliflags.Config, lg *log.Logger) (*runtimeInfo, exitcod
 	lg.Info("tmux target:  %s", info.Target)
 	lg.Info("project root: %s", info.ProjectRoot)
 
-	if !isGitWorkTree(info.ProjectRoot) {
+	if !gitroot.IsWorkTree(info.ProjectRoot) {
 		lg.Err("project root %s is not a git work tree; cannot resolve GitHub repo", info.ProjectRoot)
 		return nil, exitcode.Env
 	}
@@ -543,35 +547,4 @@ func executePlan(cfg *cliflags.Config, lg *log.Logger, info *fanoutruntime.Info,
 		}
 	}
 	return result
-}
-
-func isGitWorkTree(path string) bool {
-	cmd := exec.Command("git", "rev-parse", "--is-inside-work-tree")
-	cmd.Dir = path
-	return cmd.Run() == nil
-}
-
-func checkDeps(cfg *cliflags.Config) []string {
-	var missing []string
-	check := func(cmd, hint string) {
-		if _, err := exec.LookPath(cmd); err != nil {
-			missing = append(missing, hint)
-		}
-	}
-	checkTmux := func() {
-		if err := tmuxrun.CheckMinimumVersion(); err != nil {
-			missing = append(missing, err.Error())
-		}
-	}
-	check("git", "git")
-
-	lifecycle := cfg.CloseNum > 0 || cfg.MergeNum > 0 || cfg.CleanupMode
-	if cfg.StatusMode || cfg.CleanupMode || !lifecycle {
-		check("gh", "gh (brew install gh)")
-	}
-
-	if !cfg.StatusMode && !lifecycle {
-		checkTmux()
-	}
-	return missing
 }

--- a/cmd/fanout/plancmd.go
+++ b/cmd/fanout/plancmd.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"slices"
@@ -27,7 +26,6 @@ import (
 	fanoutruntime "github.com/butaosuinu/fanout/internal/infra/runtime"
 	"github.com/butaosuinu/fanout/internal/infra/settings"
 	"github.com/butaosuinu/fanout/internal/infra/state"
-	"github.com/butaosuinu/fanout/internal/infra/tmuxrun"
 	"github.com/butaosuinu/fanout/internal/infra/worktree"
 )
 
@@ -118,21 +116,13 @@ func cmdPlan(args []string, lg *log.Logger, commandName string) exitcode.Code {
 		lg = log.New(true)
 	}
 	if cfg.actionMode() {
-		if missing := checkPlanActionDeps(cfg); len(missing) > 0 {
-			lg.Err("missing dependencies:")
-			for _, d := range missing {
-				fmt.Fprintf(lg.Stderr(), "  - %s\n", d)
-			}
+		if exitOnMissingDeps(missingDeps(depNeeds{git: true, gh: cfg.StatusMode || cfg.CleanupMode}), lg) {
 			return exitcode.Env
 		}
 		return cmdPlanLifecycle(cfg, lg)
 	}
 
-	if missing := checkPlanDeps(); len(missing) > 0 {
-		lg.Err("missing dependencies:")
-		for _, d := range missing {
-			fmt.Fprintf(lg.Stderr(), "  - %s\n", d)
-		}
+	if exitOnMissingDeps(missingDeps(depNeeds{git: true, tmux: true}), lg) {
 		return exitcode.Env
 	}
 
@@ -628,34 +618,6 @@ func parsePlanAgentArg(cfg *planCommandConfig, raw string) error {
 	}
 	cfg.AgentOverrides = cliflags.UpsertAgentOverride(cfg.AgentOverrides, target, name)
 	return nil
-}
-
-func checkPlanDeps() []string {
-	var missing []string
-	check := func(cmd, hint string) {
-		if _, err := exec.LookPath(cmd); err != nil {
-			missing = append(missing, hint)
-		}
-	}
-	check("git", "git")
-	if err := tmuxrun.CheckMinimumVersion(); err != nil {
-		missing = append(missing, err.Error())
-	}
-	return missing
-}
-
-func checkPlanActionDeps(cfg planCommandConfig) []string {
-	var missing []string
-	check := func(cmd, hint string) {
-		if _, err := exec.LookPath(cmd); err != nil {
-			missing = append(missing, hint)
-		}
-	}
-	check("git", "git")
-	if cfg.StatusMode || cfg.CleanupMode {
-		check("gh", "gh (brew install gh)")
-	}
-	return missing
 }
 
 func resolvePlanBaseBranch(cfg planCommandConfig, spec planspec.Spec, projectRoot string) (string, error) {

--- a/cmd/fanout/plancmd_test.go
+++ b/cmd/fanout/plancmd_test.go
@@ -115,8 +115,8 @@ func TestCheckPlanDepsDoesNotRequireGhForUnblockedOnly(t *testing.T) {
 	}
 	t.Setenv("PATH", binDir)
 
-	if missing := checkPlanDeps(); len(missing) != 0 {
-		t.Fatalf("checkPlanDeps() missing = %v, want no gh requirement", missing)
+	if missing := missingDeps(depNeeds{git: true, tmux: true}); len(missing) != 0 {
+		t.Fatalf("missingDeps(plan launch needs) = %v, want no gh requirement", missing)
 	}
 }
 

--- a/cmd/fanout/state_runtime.go
+++ b/cmd/fanout/state_runtime.go
@@ -3,13 +3,14 @@ package main
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
 	"github.com/butaosuinu/fanout/internal/core/exitcode"
+	"github.com/butaosuinu/fanout/internal/infra/gitroot"
 	"github.com/butaosuinu/fanout/internal/infra/log"
 	"github.com/butaosuinu/fanout/internal/infra/state"
+	"github.com/butaosuinu/fanout/internal/infra/tmuxrun"
 )
 
 const fanoutStatePathEnv = "FANOUT_STATE_PATH"
@@ -99,15 +100,11 @@ func tmuxPaneGitToplevel() (string, error) {
 	if pane == "" {
 		return "", fmt.Errorf("not inside a tmux pane")
 	}
-	out, err := exec.Command("tmux", "display-message", "-p", "-t", pane, "#{pane_current_path}").Output()
+	path, err := tmuxrun.PaneCurrentPath(pane)
 	if err != nil {
-		return "", fmt.Errorf("tmux display-message pane_current_path: %w", err)
+		return "", err
 	}
-	path := strings.TrimSpace(string(out))
-	if path == "" {
-		return "", fmt.Errorf("tmux pane current path is empty")
-	}
-	return gitToplevelAt(path)
+	return gitroot.Toplevel(path)
 }
 
 func inferProjectRootFromStatePath(path string) string {
@@ -122,23 +119,7 @@ func inferProjectRootFromStatePath(path string) string {
 }
 
 func gitToplevelFromCwd() (string, error) {
-	return gitToplevelAt("")
-}
-
-func gitToplevelAt(dir string) (string, error) {
-	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
-	if strings.TrimSpace(dir) != "" {
-		cmd.Dir = dir
-	}
-	out, err := cmd.Output()
-	if err != nil {
-		return "", fmt.Errorf("current directory is not inside a git work tree")
-	}
-	root := strings.TrimSpace(string(out))
-	if root == "" {
-		return "", fmt.Errorf("git rev-parse --show-toplevel returned an empty path")
-	}
-	return root, nil
+	return gitroot.Toplevel("")
 }
 
 func dirExists(path string) bool {

--- a/cmd/fanout/tui.go
+++ b/cmd/fanout/tui.go
@@ -34,9 +34,7 @@ func cmdTUI(commandName string, lg *log.Logger) exitcode.Code {
 		lg.Err("%s", err.Error())
 		return exitcode.Env
 	}
-	if versionErr := tmuxrun.CheckMinimumVersion(); versionErr != nil {
-		lg.Err("missing dependencies:")
-		fmt.Fprintf(lg.Stderr(), "  - %s\n", versionErr)
+	if exitOnMissingDeps(missingDeps(depNeeds{tmux: true}), lg) {
 		return exitcode.Env
 	}
 

--- a/internal/app/cliflags/usage.go
+++ b/internal/app/cliflags/usage.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"strconv"
 	"strings"
+
+	"github.com/butaosuinu/fanout/internal/core/parentref"
 )
 
 const usageText = `Usage: fanout
@@ -214,11 +216,12 @@ func Usage(w io.Writer) {
 func NormalizeParentRef(raw string) (ref string, ok bool) {
 	raw = strings.TrimSpace(raw)
 	if reAllDigits.MatchString(raw) {
-		n, err := strconv.Atoi(raw)
-		if err != nil {
+		// Atoi validity is checked first so out-of-range digit strings keep
+		// returning ("", false); parentref.Canon would pass them through.
+		if _, err := strconv.Atoi(raw); err != nil {
 			return "", false
 		}
-		return strconv.Itoa(n), true
+		return parentref.Canon(raw), true
 	}
 	if m := reProjectURL.FindStringSubmatch(raw); len(m) == 5 {
 		n, err := strconv.Atoi(m[3])

--- a/internal/app/sessionview/aggregate.go
+++ b/internal/app/sessionview/aggregate.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/butaosuinu/fanout/internal/core/blockers"
+	"github.com/butaosuinu/fanout/internal/core/parentref"
 	"github.com/butaosuinu/fanout/internal/infra/ghissue"
 	"github.com/butaosuinu/fanout/internal/infra/state"
 )
@@ -422,12 +423,9 @@ func sortedParents(grouped map[string][]state.Pane) []string {
 // NormalizeParent は数値親を Atoi 往復で正規化する("0100" と "100" を同一
 // 親として扱う)。state の parentMatches と同じ規則で、dashboard poller の
 // wave cache キーもこれを使う(規則が割れるとエイリアス親の synthetic 行が
-// 二重 emit / 消失する)。
+// 二重 emit / 消失する)。実体は core の parentref.Canon。
 func NormalizeParent(parent string) string {
-	if n, err := strconv.Atoi(parent); err == nil {
-		return strconv.Itoa(n)
-	}
-	return parent
+	return parentref.Canon(parent)
 }
 
 // localSourceKey returns a stable public token distinguishing a worktree-local

--- a/internal/core/parentref/parentref.go
+++ b/internal/core/parentref/parentref.go
@@ -1,0 +1,18 @@
+// Package parentref canonicalizes fanout parent references. Numeric parents
+// are normalized by an Atoi round-trip so "0100" and "100" identify the same
+// parent; every non-numeric parent (Projects URL, plan:<slug>, @manual) passes
+// through unchanged. state, sessionview, the TUI, and cliflags all key rows by
+// this rule — if it splits, alias parents produce duplicate or missing rows.
+package parentref
+
+import "strconv"
+
+// Canon returns the canonical form of parent: numeric strings lose leading
+// zeros via an Atoi round-trip, anything Atoi rejects (including out-of-range
+// digit strings) is returned unchanged.
+func Canon(parent string) string {
+	if n, err := strconv.Atoi(parent); err == nil {
+		return strconv.Itoa(n)
+	}
+	return parent
+}

--- a/internal/core/parentref/parentref_test.go
+++ b/internal/core/parentref/parentref_test.go
@@ -1,0 +1,34 @@
+package parentref
+
+import "testing"
+
+// TestCanon pins the Atoi round-trip rule shared by state parent matching,
+// sessionview aggregation, and the TUI issue keys.
+func TestCanon(t *testing.T) {
+	tests := []struct {
+		name   string
+		parent string
+		want   string
+	}{
+		{name: "strips leading zeros from numeric parent", parent: "0100", want: "100"},
+		{name: "plain numeric parent unchanged", parent: "100", want: "100"},
+		{name: "all-zero string collapses to single zero", parent: "000", want: "0"},
+		{name: "negative number round-trips", parent: "-5", want: "-5"},
+		{name: "plus sign is normalized away by Atoi", parent: "+7", want: "7"},
+		{name: "empty string passes through", parent: "", want: ""},
+		{name: "projects URL passes through", parent: "https://github.com/o/r/projects/3", want: "https://github.com/o/r/projects/3"},
+		{name: "plan slug passes through", parent: "plan:my-slug", want: "plan:my-slug"},
+		{name: "manual marker passes through", parent: "@manual", want: "@manual"},
+		{name: "whitespace-padded number is not trimmed", parent: " 100", want: " 100"},
+		// Out-of-range digit strings fail Atoi and pass through — same as the
+		// pre-extraction NormalizeParent behavior.
+		{name: "int-overflowing digits pass through", parent: "99999999999999999999", want: "99999999999999999999"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := Canon(tt.parent); got != tt.want {
+				t.Errorf("Canon(%q) = %q, want %q", tt.parent, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/infra/atomicfs/atomicfs.go
+++ b/internal/infra/atomicfs/atomicfs.go
@@ -4,6 +4,7 @@
 package atomicfs
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 )
@@ -39,4 +40,38 @@ func WriteFile(path string, data []byte, perm os.FileMode) error {
 		return err
 	}
 	return nil
+}
+
+// WriteJSON marshals v with two-space MarshalIndent, appends a trailing
+// newline, creates filepath.Dir(path) if needed, and writes the result
+// atomically via WriteFile. All errors are returned unwrapped so callers keep
+// their own message formats.
+func WriteJSON(path string, v any, perm os.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	out, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	return WriteFile(path, append(out, '\n'), perm)
+}
+
+// ReadJSON reads path and unmarshals it into v. A missing file returns
+// (false, nil) with v untouched. found reports whether the file was read:
+// (false, err) is a read error, (true, err) an unmarshal error, so callers
+// can wrap the two stages with distinct messages. Errors are returned
+// unwrapped.
+func ReadJSON(path string, v any) (found bool, err error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	if err := json.Unmarshal(data, v); err != nil {
+		return true, err
+	}
+	return true, nil
 }

--- a/internal/infra/atomicfs/atomicfs_test.go
+++ b/internal/infra/atomicfs/atomicfs_test.go
@@ -1,0 +1,164 @@
+package atomicfs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type payload struct {
+	Name string `json:"name"`
+	N    int    `json:"n"`
+}
+
+// TestWriteJSON pins the exact byte layout (two-space MarshalIndent plus a
+// trailing newline), the final file mode, and directory auto-creation.
+func TestWriteJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		relPath  string
+		v        any
+		perm     os.FileMode
+		want     string
+		wantPerm os.FileMode
+	}{
+		{
+			name:     "struct is indented with trailing newline",
+			relPath:  "out.json",
+			v:        payload{Name: "a", N: 7},
+			perm:     0o644,
+			want:     "{\n  \"name\": \"a\",\n  \"n\": 7\n}\n",
+			wantPerm: 0o644,
+		},
+		{
+			name:     "0600 perm is applied exactly",
+			relPath:  "secret.json",
+			v:        map[string]string{"token": "t"},
+			perm:     0o600,
+			want:     "{\n  \"token\": \"t\"\n}\n",
+			wantPerm: 0o600,
+		},
+		{
+			name:     "missing parent directories are created",
+			relPath:  filepath.Join("a", "b", "out.json"),
+			v:        payload{},
+			perm:     0o644,
+			want:     "{\n  \"name\": \"\",\n  \"n\": 0\n}\n",
+			wantPerm: 0o644,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), tt.relPath)
+			if err := WriteJSON(path, tt.v, tt.perm); err != nil {
+				t.Fatalf("WriteJSON(%q) = %v, want nil", path, err)
+			}
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("ReadFile(%q) = %v, want nil", path, err)
+			}
+			if got := string(data); got != tt.want {
+				t.Errorf("WriteJSON wrote %q, want %q", got, tt.want)
+			}
+			info, err := os.Stat(path)
+			if err != nil {
+				t.Fatalf("Stat(%q) = %v, want nil", path, err)
+			}
+			if got := info.Mode().Perm(); got != tt.wantPerm {
+				t.Errorf("WriteJSON perm = %v, want %v", got, tt.wantPerm)
+			}
+		})
+	}
+}
+
+// TestWriteJSONUnmarshalableValue guarantees the marshal error surfaces and no
+// file is left behind.
+func TestWriteJSONUnmarshalableValue(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "out.json")
+	if err := WriteJSON(path, func() {}, 0o644); err == nil {
+		t.Fatal("WriteJSON(func) = nil, want marshal error")
+	}
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Errorf("Stat(%q) after failed WriteJSON = %v, want IsNotExist", path, err)
+	}
+}
+
+// TestReadJSON pins the (found, err) contract: missing file (false, nil),
+// read failure (false, err), decode failure (true, err), success (true, nil).
+func TestReadJSON(t *testing.T) {
+	tests := []struct {
+		name      string
+		setup     func(t *testing.T, dir string) string // returns path
+		wantFound bool
+		wantErr   bool
+		want      payload
+	}{
+		{
+			name: "missing file is found=false with nil error",
+			setup: func(t *testing.T, dir string) string {
+				t.Helper()
+				return filepath.Join(dir, "absent.json")
+			},
+			wantFound: false,
+			wantErr:   false,
+		},
+		{
+			name: "valid file decodes into v",
+			setup: func(t *testing.T, dir string) string {
+				t.Helper()
+				path := filepath.Join(dir, "ok.json")
+				if err := os.WriteFile(path, []byte(`{"name":"a","n":7}`), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				return path
+			},
+			wantFound: true,
+			wantErr:   false,
+			want:      payload{Name: "a", N: 7},
+		},
+		{
+			name: "malformed JSON is found=true with error",
+			setup: func(t *testing.T, dir string) string {
+				t.Helper()
+				path := filepath.Join(dir, "bad.json")
+				if err := os.WriteFile(path, []byte("{not json"), 0o644); err != nil {
+					t.Fatal(err)
+				}
+				return path
+			},
+			wantFound: true,
+			wantErr:   true,
+		},
+		{
+			// A directory exists but cannot be read as a file: the read stage
+			// fails, so found must stay false (distinguishes wrap messages).
+			name: "unreadable path is found=false with error",
+			setup: func(t *testing.T, dir string) string {
+				t.Helper()
+				path := filepath.Join(dir, "isadir")
+				if err := os.Mkdir(path, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				return path
+			},
+			wantFound: false,
+			wantErr:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := tt.setup(t, t.TempDir())
+			var got payload
+			found, err := ReadJSON(path, &got)
+			if found != tt.wantFound {
+				t.Errorf("ReadJSON(%q) found = %t, want %t", path, found, tt.wantFound)
+			}
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ReadJSON(%q) err = %v, wantErr %t", path, err, tt.wantErr)
+			}
+			if err == nil && got != tt.want {
+				t.Errorf("ReadJSON(%q) decoded %+v, want %+v", path, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/infra/browser/browser.go
+++ b/internal/infra/browser/browser.go
@@ -1,0 +1,35 @@
+// Package browser opens URLs in the OS default browser.
+package browser
+
+import (
+	"os/exec"
+	"runtime"
+	"time"
+)
+
+// Open launches the platform opener (open / rundll32 / xdg-open) for url and
+// waits up to wait for it to exit. Openers that outlive the wait (some
+// xdg-open implementations block for the browser's lifetime) are treated as
+// success so the caller never hangs.
+func Open(url string, wait time.Duration) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	default:
+		cmd = exec.Command("xdg-open", url)
+	}
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	done := make(chan error, 1)
+	go func() { done <- cmd.Wait() }()
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(wait):
+		return nil
+	}
+}

--- a/internal/infra/codexapp/status.go
+++ b/internal/infra/codexapp/status.go
@@ -31,7 +31,9 @@ type Status struct {
 }
 
 // writeStatus atomically writes the status file (tmp + rename). An empty path
-// is a no-op.
+// is a no-op. Deliberately not atomicfs.WriteJSON: its exact chmod would widen
+// the file mode under a restrictive umask, while os.WriteFile keeps the
+// historical umask-masked 0644.
 func writeStatus(path string, status Status) error {
 	if strings.TrimSpace(path) == "" {
 		return nil

--- a/internal/infra/displayname/metadata.go
+++ b/internal/infra/displayname/metadata.go
@@ -1,7 +1,6 @@
 package displayname
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -32,15 +31,14 @@ func WriteFanoutMetadata(worktreePath string, meta FanoutMetadata) error {
 	}
 	path := filepath.Join(dir, "worktree-metadata.json")
 	m := map[string]any{}
-	if data, err := os.ReadFile(path); err == nil {
-		if err = json.Unmarshal(data, &m); err != nil {
+	if found, err := atomicfs.ReadJSON(path, &m); err != nil {
+		if found {
 			return fmt.Errorf("parse existing metadata %s: %w", path, err)
 		}
-		if m == nil {
-			m = map[string]any{}
-		}
-	} else if !os.IsNotExist(err) {
 		return err
+	}
+	if m == nil {
+		m = map[string]any{}
 	}
 	m["agent"] = meta.Agent
 	m["displayName"] = meta.DisplayName
@@ -53,9 +51,5 @@ func WriteFanoutMetadata(worktreePath string, meta FanoutMetadata) error {
 	if meta.CodexSessionID != "" {
 		m["codexSessionId"] = meta.CodexSessionID
 	}
-	out, err := json.MarshalIndent(m, "", "  ")
-	if err != nil {
-		return err
-	}
-	return atomicfs.WriteFile(path, append(out, '\n'), 0o644)
+	return atomicfs.WriteJSON(path, m, 0o644)
 }

--- a/internal/infra/execx/execx.go
+++ b/internal/infra/execx/execx.go
@@ -1,0 +1,69 @@
+// Package execx runs external commands with the two error formats the infra
+// layer shares: Output reformats an exec.ExitError as
+// "name args...: <trimmed stderr>", Combined appends the trimmed combined
+// output as "%w: <output>". Both formats are locked in by callers' user-visible
+// error strings; do not change them.
+package execx
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// Output runs the command and returns its stdout. dir, when non-empty, becomes
+// the process working directory. extraEnv entries, when present, are appended
+// to os.Environ() (later entries win). On exec.ExitError the error becomes
+// "name args...: <trimmed stderr>"; any other error passes through unchanged.
+func Output(dir string, extraEnv []string, name string, args ...string) ([]byte, error) {
+	cmd := exec.Command(name, args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	if len(extraEnv) > 0 {
+		cmd.Env = append(os.Environ(), extraEnv...)
+	}
+	return capture(cmd, name, args)
+}
+
+// OutputStdin is Output with stdin attached; it shares the same exec.ExitError
+// formatting.
+func OutputStdin(dir, stdin, name string, args ...string) ([]byte, error) {
+	cmd := exec.Command(name, args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	cmd.Stdin = strings.NewReader(stdin)
+	return capture(cmd, name, args)
+}
+
+func capture(cmd *exec.Cmd, name string, args []string) ([]byte, error) {
+	out, err := cmd.Output()
+	if err != nil {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
+			return out, fmt.Errorf("%s %s: %s", name, strings.Join(args, " "), strings.TrimSpace(string(ee.Stderr)))
+		}
+		return out, err
+	}
+	return out, nil
+}
+
+// Combined runs the command in dir and returns its combined stdout+stderr. On
+// failure the trimmed output is appended as "%w: <output>"; when the output is
+// empty the raw error is returned unchanged.
+func Combined(dir string, name string, args ...string) ([]byte, error) {
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		msg := strings.TrimSpace(string(out))
+		if msg == "" {
+			return out, err
+		}
+		return out, fmt.Errorf("%w: %s", err, msg)
+	}
+	return out, nil
+}

--- a/internal/infra/execx/execx_test.go
+++ b/internal/infra/execx/execx_test.go
@@ -1,0 +1,196 @@
+package execx
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// installShim writes an executable shell script named name into a fresh dir
+// prepended to PATH, so tests exercise real exec paths deterministically.
+func installShim(t *testing.T, name, script string) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+// TestOutputErrorFormatting pins the shared "name args...: stderr" exit-error
+// format previously copy-pasted across ghissue and gitstat.
+func TestOutputErrorFormatting(t *testing.T) {
+	tests := []struct {
+		name    string
+		script  string
+		args    []string
+		wantErr string
+		wantOut string
+	}{
+		{
+			name:    "success returns stdout untouched",
+			script:  "printf 'ok\\n'",
+			args:    []string{"view", "1"},
+			wantOut: "ok\n",
+		},
+		{
+			name:    "exit error becomes name args colon trimmed stderr",
+			script:  "printf '  boom  \\n' >&2; exit 1",
+			args:    []string{"do", "thing"},
+			wantErr: "fakebin do thing: boom",
+		},
+		{
+			name:    "multiline stderr keeps inner newlines and trims edges",
+			script:  "printf 'one\\ntwo\\n' >&2; exit 2",
+			args:    []string{"x"},
+			wantErr: "fakebin x: one\ntwo",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			installShim(t, "fakebin", tt.script)
+			out, err := Output("", nil, "fakebin", tt.args...)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Output() error = %v, want nil", err)
+				}
+				if string(out) != tt.wantOut {
+					t.Fatalf("Output() = %q, want %q", out, tt.wantOut)
+				}
+				return
+			}
+			if err == nil || err.Error() != tt.wantErr {
+				t.Fatalf("Output() error = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+// TestOutputNonExitErrorPassesThrough guarantees only ExitErrors are
+// reformatted; a missing binary keeps its exec.ErrNotFound identity.
+func TestOutputNonExitErrorPassesThrough(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	if _, err := Output("", nil, "no-such-fanout-binary"); !errors.Is(err, exec.ErrNotFound) {
+		t.Fatalf("Output() error = %v, want exec.ErrNotFound", err)
+	}
+}
+
+// TestOutputDirAndExtraEnv guarantees dir becomes the working directory and
+// extraEnv entries win over the inherited environment.
+func TestOutputDirAndExtraEnv(t *testing.T) {
+	installShim(t, "fakebin", `printf '%s %s' "$(pwd)" "$FANOUT_EXECX_TEST"`)
+	dir := t.TempDir()
+	t.Setenv("FANOUT_EXECX_TEST", "inherited")
+
+	out, err := Output(dir, []string{"FANOUT_EXECX_TEST=extra"}, "fakebin")
+	if err != nil {
+		t.Fatalf("Output() error = %v", err)
+	}
+	gotDir, gotEnv, _ := strings.Cut(string(out), " ")
+	wantDir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved, err := filepath.EvalSymlinks(gotDir); err != nil || resolved != wantDir {
+		t.Fatalf("Output() ran in %q, want %q", gotDir, wantDir)
+	}
+	if gotEnv != "extra" {
+		t.Fatalf("Output() env FANOUT_EXECX_TEST = %q, want extra (extraEnv wins)", gotEnv)
+	}
+}
+
+// TestCombinedErrorFormatting pins the "%w: <trimmed combined output>" format
+// previously private to internal/infra/worktree.
+func TestCombinedErrorFormatting(t *testing.T) {
+	tests := []struct {
+		name    string
+		script  string
+		wantErr string // "" = want success
+		wantOut string
+	}{
+		{
+			name:    "success returns combined stdout and stderr",
+			script:  "printf 'out\\n'; printf 'err\\n' >&2",
+			wantOut: "out\nerr\n",
+		},
+		{
+			name:    "failure appends trimmed output after the exit error",
+			script:  "printf '  warning: bad ref  \\n'; exit 3",
+			wantErr: "exit status 3: warning: bad ref",
+		},
+		{
+			name:    "failure with empty output returns the raw error",
+			script:  "exit 4",
+			wantErr: "exit status 4",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			installShim(t, "fakebin", tt.script)
+			out, err := Combined(t.TempDir(), "fakebin")
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("Combined() error = %v, want nil", err)
+				}
+				if string(out) != tt.wantOut {
+					t.Fatalf("Combined() = %q, want %q", out, tt.wantOut)
+				}
+				return
+			}
+			if err == nil || err.Error() != tt.wantErr {
+				t.Fatalf("Combined() error = %v, want %q", err, tt.wantErr)
+			}
+			var ee *exec.ExitError
+			if !errors.As(err, &ee) {
+				t.Fatalf("Combined() error = %v, want wrapped *exec.ExitError", err)
+			}
+		})
+	}
+}
+
+// TestOutputStdin pins that stdin reaches the child and errors share Output's
+// exec.ExitError format.
+func TestOutputStdin(t *testing.T) {
+	tests := []struct {
+		name    string
+		script  string
+		stdin   string
+		wantOut string
+		wantErr string
+	}{
+		{
+			name:    "stdin is forwarded to the command",
+			script:  "cat",
+			stdin:   "hello\n",
+			wantOut: "hello\n",
+		},
+		{
+			name:    "failure formats name, args, and trimmed stderr",
+			script:  "cat >/dev/null\necho ' broken ' >&2\nexit 3",
+			stdin:   "ignored",
+			wantErr: "fakebin issue comment: broken",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			installShim(t, "fakebin", tt.script)
+			out, err := OutputStdin(t.TempDir(), tt.stdin, "fakebin", "issue", "comment")
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("OutputStdin() error = %v, want nil", err)
+				}
+				if string(out) != tt.wantOut {
+					t.Fatalf("OutputStdin() = %q, want %q", out, tt.wantOut)
+				}
+				return
+			}
+			if err == nil || err.Error() != tt.wantErr {
+				t.Fatalf("OutputStdin() error = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/infra/ghissue/ghissue.go
+++ b/internal/infra/ghissue/ghissue.go
@@ -7,11 +7,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os/exec"
 	"regexp"
 	"slices"
 	"strconv"
 	"strings"
+
+	"github.com/butaosuinu/fanout/internal/infra/execx"
 )
 
 // Label is the slim shape fanout cares about (just the name; we treat the
@@ -124,35 +125,12 @@ type Runner struct {
 }
 
 func (r Runner) gh(args ...string) ([]byte, error) {
-	cmd := exec.Command("gh", args...)
-	if r.Cwd != "" {
-		cmd.Dir = r.Cwd
-	}
-	out, err := cmd.Output()
-	if err != nil {
-		var ee *exec.ExitError
-		if errors.As(err, &ee) {
-			return out, fmt.Errorf("gh %s: %s", strings.Join(args, " "), strings.TrimSpace(string(ee.Stderr)))
-		}
-		return out, err
-	}
-	return out, nil
+	return execx.Output(r.Cwd, nil, "gh", args...)
 }
 
 func (r Runner) ghWithInput(input string, args ...string) error {
-	cmd := exec.Command("gh", args...)
-	if r.Cwd != "" {
-		cmd.Dir = r.Cwd
-	}
-	cmd.Stdin = strings.NewReader(input)
-	if _, err := cmd.Output(); err != nil {
-		var ee *exec.ExitError
-		if errors.As(err, &ee) {
-			return fmt.Errorf("gh %s: %s", strings.Join(args, " "), strings.TrimSpace(string(ee.Stderr)))
-		}
-		return err
-	}
-	return nil
+	_, err := execx.OutputStdin(r.Cwd, input, "gh", args...)
+	return err
 }
 
 // RepoNameWithOwner runs `gh repo view --json nameWithOwner -q .nameWithOwner`.

--- a/internal/infra/gitroot/gitroot.go
+++ b/internal/infra/gitroot/gitroot.go
@@ -1,0 +1,36 @@
+// Package gitroot resolves git work-tree roots. The error strings are shared
+// user-visible output (previously copy-pasted across runtime, team, and
+// cmd/fanout); do not change them.
+package gitroot
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// Toplevel returns `git rev-parse --show-toplevel` resolved from dir; an empty
+// or whitespace-only dir resolves from the current working directory.
+func Toplevel(dir string) (string, error) {
+	cmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	if strings.TrimSpace(dir) != "" {
+		cmd.Dir = dir
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("current directory is not inside a git work tree")
+	}
+	root := strings.TrimSpace(string(out))
+	if root == "" {
+		return "", fmt.Errorf("git rev-parse --show-toplevel returned an empty path")
+	}
+	return root, nil
+}
+
+// IsWorkTree reports whether dir is inside a git work tree
+// (`git rev-parse --is-inside-work-tree` succeeds there).
+func IsWorkTree(dir string) bool {
+	cmd := exec.Command("git", "rev-parse", "--is-inside-work-tree")
+	cmd.Dir = dir
+	return cmd.Run() == nil
+}

--- a/internal/infra/gitroot/gitroot_test.go
+++ b/internal/infra/gitroot/gitroot_test.go
@@ -1,0 +1,126 @@
+package gitroot
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func requireGit(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+}
+
+func initRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	cmd := exec.Command("git", "init", "-q")
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, out)
+	}
+	return dir
+}
+
+// mustEvalSymlinks canonicalizes a path (macOS t.TempDir lives under the
+// /tmp -> /private/tmp symlink; git prints the resolved path).
+func mustEvalSymlinks(t *testing.T, path string) string {
+	t.Helper()
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return resolved
+}
+
+// TestToplevel pins the two shared user-visible error strings and the
+// dir/cwd resolution behavior.
+func TestToplevel(t *testing.T) {
+	requireGit(t)
+	repo := initRepo(t)
+	subDir := filepath.Join(repo, "sub")
+	if err := os.Mkdir(subDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	nonRepo := t.TempDir()
+
+	tests := []struct {
+		name    string
+		dir     string
+		chdir   string // non-empty: t.Chdir here first
+		want    string // non-empty: expected root
+		wantErr string // non-empty: expected exact error string
+	}{
+		{
+			name: "resolves the toplevel of dir",
+			dir:  repo,
+			want: repo,
+		},
+		{
+			name: "resolves the toplevel from a subdirectory",
+			dir:  subDir,
+			want: repo,
+		},
+		{
+			name:  "empty dir resolves from the current working directory",
+			dir:   "",
+			chdir: repo,
+			want:  repo,
+		},
+		{
+			name:  "whitespace-only dir also resolves from cwd",
+			dir:   "   ",
+			chdir: repo,
+			want:  repo,
+		},
+		{
+			name:    "outside a work tree reports the fixed error",
+			dir:     nonRepo,
+			wantErr: "current directory is not inside a git work tree",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.chdir != "" {
+				t.Chdir(tt.chdir)
+			}
+			got, err := Toplevel(tt.dir)
+			if tt.wantErr != "" {
+				if err == nil || err.Error() != tt.wantErr {
+					t.Fatalf("Toplevel(%q) error = %v, want %q", tt.dir, err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Toplevel(%q) error = %v", tt.dir, err)
+			}
+			if mustEvalSymlinks(t, got) != mustEvalSymlinks(t, tt.want) {
+				t.Fatalf("Toplevel(%q) = %q, want %q", tt.dir, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsWorkTree(t *testing.T) {
+	requireGit(t)
+	repo := initRepo(t)
+
+	tests := []struct {
+		name string
+		dir  string
+		want bool
+	}{
+		{name: "inside a work tree", dir: repo, want: true},
+		{name: "outside any work tree", dir: t.TempDir(), want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsWorkTree(tt.dir); got != tt.want {
+				t.Fatalf("IsWorkTree(%q) = %v, want %v", tt.dir, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/infra/gitstat/gitstat.go
+++ b/internal/infra/gitstat/gitstat.go
@@ -2,13 +2,12 @@
 package gitstat
 
 import (
-	"errors"
 	"fmt"
-	"os"
-	"os/exec"
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/butaosuinu/fanout/internal/infra/execx"
 )
 
 var (
@@ -84,24 +83,13 @@ func (r Runner) diffBase(path, baseRef string) string {
 }
 
 func (r Runner) git(args ...string) ([]byte, error) {
-	cmd := exec.Command("git", args...)
-	if r.Cwd != "" {
-		cmd.Dir = r.Cwd
-	}
-	cmd.Env = gitEnv()
-	out, err := cmd.Output()
-	if err != nil {
-		var ee *exec.ExitError
-		if errors.As(err, &ee) {
-			return out, fmt.Errorf("git %s: %s", strings.Join(args, " "), strings.TrimSpace(string(ee.Stderr)))
-		}
-		return out, err
-	}
-	return out, nil
+	return execx.Output(r.Cwd, gitEnv(), "git", args...)
 }
 
+// gitEnv returns the extra environment entries execx.Output appends to
+// os.Environ() for every git invocation.
 func gitEnv() []string {
-	return append(os.Environ(), "LC_ALL=C", "GIT_OPTIONAL_LOCKS=0")
+	return []string{"LC_ALL=C", "GIT_OPTIONAL_LOCKS=0"}
 }
 
 func parseShortStat(out string) Stat {

--- a/internal/infra/runtime/runtime.go
+++ b/internal/infra/runtime/runtime.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/butaosuinu/fanout/internal/infra/gitroot"
 )
 
 type Info struct {
@@ -16,7 +18,7 @@ type Info struct {
 
 // Resolve discovers the git repository root and tmux target fanout should split.
 func Resolve(sessionOverride string) (*Info, error) {
-	root, err := gitToplevel()
+	root, err := gitroot.Toplevel("")
 	if err != nil {
 		return nil, err
 	}
@@ -36,18 +38,6 @@ func Resolve(sessionOverride string) (*Info, error) {
 		return nil, err
 	}
 	return &Info{Session: session, Target: target, ProjectRoot: root}, nil
-}
-
-func gitToplevel() (string, error) {
-	out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
-	if err != nil {
-		return "", fmt.Errorf("current directory is not inside a git work tree")
-	}
-	root := strings.TrimSpace(string(out))
-	if root == "" {
-		return "", fmt.Errorf("git rev-parse --show-toplevel returned an empty path")
-	}
-	return root, nil
 }
 
 func tmuxSession() (string, error) {

--- a/internal/infra/state/state.go
+++ b/internal/infra/state/state.go
@@ -2,7 +2,6 @@
 package state
 
 import (
-	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -111,16 +110,16 @@ func LoadProject(projectRoot string) (Store, error) {
 }
 
 func Load(path string) (Store, error) {
-	data, err := os.ReadFile(path)
-	if os.IsNotExist(err) {
-		return emptyStore(), nil
-	}
+	var store Store
+	found, err := atomicfs.ReadJSON(path, &store)
 	if err != nil {
+		if found {
+			return Store{}, fmt.Errorf("parse fanout state %s: %w", path, err)
+		}
 		return Store{}, fmt.Errorf("read fanout state %s: %w", path, err)
 	}
-	var store Store
-	if err := json.Unmarshal(data, &store); err != nil {
-		return Store{}, fmt.Errorf("parse fanout state %s: %w", path, err)
+	if !found {
+		return emptyStore(), nil
 	}
 	store.normalize()
 	return store, nil
@@ -307,14 +306,12 @@ func (s *Store) removeTask(parent, taskID string) bool {
 
 func save(path string, store Store) error {
 	store.normalize()
+	// MkdirAll runs here (not just inside WriteJSON) so its failure keeps this
+	// wrapped message; WriteJSON's own MkdirAll is then a no-op.
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return fmt.Errorf("create fanout state directory: %w", err)
 	}
-	out, err := json.MarshalIndent(store, "", "  ")
-	if err != nil {
-		return err
-	}
-	return atomicfs.WriteFile(path, append(out, '\n'), 0o644)
+	return atomicfs.WriteJSON(path, store, 0o644)
 }
 
 func emptyStore() Store {

--- a/internal/infra/team/detect.go
+++ b/internal/infra/team/detect.go
@@ -4,13 +4,12 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"regexp"
 	"slices"
 	"strconv"
-	"strings"
 
+	"github.com/butaosuinu/fanout/internal/infra/gitroot"
 	"github.com/butaosuinu/fanout/internal/infra/state"
 )
 
@@ -120,7 +119,7 @@ func paneIdentity(pane state.Pane) Identity {
 func Detect() (Identity, error) {
 	paneID := os.Getenv("TMUX_PANE")
 	worktree := ""
-	if top, err := gitToplevel(); err == nil {
+	if top, err := gitroot.Toplevel(""); err == nil {
 		if _, ok := childWorktreeOwner(top); ok {
 			worktree = top
 		}
@@ -158,24 +157,12 @@ const fanoutStatePathEnv = "FANOUT_STATE_PATH"
 // points at the original checkout that holds no fanout state. Anywhere else
 // the toplevel itself is the owner.
 func OwnerProjectRoot() (string, error) {
-	top, err := gitToplevel()
+	top, err := gitroot.Toplevel("")
 	if err != nil {
 		return "", err
 	}
 	if owner, ok := childWorktreeOwner(top); ok {
 		return owner, nil
-	}
-	return top, nil
-}
-
-func gitToplevel() (string, error) {
-	out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
-	if err != nil {
-		return "", fmt.Errorf("current directory is not inside a git work tree")
-	}
-	top := strings.TrimSpace(string(out))
-	if top == "" {
-		return "", fmt.Errorf("git rev-parse --show-toplevel returned an empty path")
 	}
 	return top, nil
 }

--- a/internal/infra/tmuxrun/panepath.go
+++ b/internal/infra/tmuxrun/panepath.go
@@ -1,0 +1,21 @@
+package tmuxrun
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// PaneCurrentPath returns the pane's current working directory
+// (#{pane_current_path}) via `tmux display-message -p -t <paneID>`.
+func PaneCurrentPath(paneID string) (string, error) {
+	out, err := exec.Command("tmux", "display-message", "-p", "-t", paneID, "#{pane_current_path}").Output()
+	if err != nil {
+		return "", fmt.Errorf("tmux display-message pane_current_path: %w", err)
+	}
+	path := strings.TrimSpace(string(out))
+	if path == "" {
+		return "", fmt.Errorf("tmux pane current path is empty")
+	}
+	return path, nil
+}

--- a/internal/infra/tmuxrun/panepath_test.go
+++ b/internal/infra/tmuxrun/panepath_test.go
@@ -1,0 +1,52 @@
+package tmuxrun
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestPaneCurrentPath pins the display-message invocation and the two error
+// strings that moved verbatim from cmd/fanout's tmuxPaneGitToplevel.
+func TestPaneCurrentPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		script  string
+		want    string
+		wantErr string
+	}{
+		{
+			name:   "returns the trimmed pane path",
+			script: "printf '%s\\n' \"$@\" > \"$TMUXRUN_ARGS\"\nprintf '/tmp/work tree\\n'\n",
+			want:   "/tmp/work tree",
+		},
+		{
+			name:    "tmux failure is wrapped with the fixed prefix",
+			script:  "exit 1\n",
+			wantErr: "tmux display-message pane_current_path: ",
+		},
+		{
+			name:    "blank output reports the empty-path error",
+			script:  "printf '  \\n'\n",
+			wantErr: "tmux pane current path is empty",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			argsPath := installTmuxShim(t, tt.script)
+			got, err := PaneCurrentPath("%3")
+			if tt.wantErr != "" {
+				if err == nil || !strings.HasPrefix(err.Error(), tt.wantErr) {
+					t.Fatalf("PaneCurrentPath() error = %v, want prefix %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("PaneCurrentPath() failed: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("PaneCurrentPath() = %q, want %q", got, tt.want)
+			}
+			assertTmuxArgs(t, argsPath, []string{"display-message", "-p", "-t", "%3", "#{pane_current_path}"})
+		})
+	}
+}

--- a/internal/infra/worktree/worktree.go
+++ b/internal/infra/worktree/worktree.go
@@ -9,6 +9,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/butaosuinu/fanout/internal/infra/execx"
 )
 
 const localExcludePattern = ".fanout/worktrees/"
@@ -502,17 +504,7 @@ func gitTrim(dir string, args ...string) (string, error) {
 }
 
 func git(dir string, args ...string) ([]byte, error) {
-	cmd := exec.Command("git", args...)
-	cmd.Dir = dir
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		msg := strings.TrimSpace(string(out))
-		if msg == "" {
-			return out, err
-		}
-		return out, fmt.Errorf("%w: %s", err, msg)
-	}
-	return out, nil
+	return execx.Combined(dir, "git", args...)
 }
 
 func dirExists(path string) bool {

--- a/internal/ui/dashboard/runfile.go
+++ b/internal/ui/dashboard/runfile.go
@@ -1,7 +1,6 @@
 package dashboard
 
 import (
-	"encoding/json"
 	"net"
 	"net/http"
 	"net/url"
@@ -33,15 +32,9 @@ func RunFilePath(projectRoot string) string {
 
 // ReadRunFile loads the run file. A missing file returns (nil, nil).
 func ReadRunFile(projectRoot string) (*RunFile, error) {
-	data, err := os.ReadFile(RunFilePath(projectRoot))
-	if os.IsNotExist(err) {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, err
-	}
 	var rf RunFile
-	if err := json.Unmarshal(data, &rf); err != nil {
+	found, err := atomicfs.ReadJSON(RunFilePath(projectRoot), &rf)
+	if err != nil || !found {
 		return nil, err
 	}
 	return &rf, nil
@@ -51,17 +44,9 @@ func ReadRunFile(projectRoot string) (*RunFile, error) {
 // the file holds the access token, so it must not be readable by other local
 // users — otherwise they could lift the token and call /api/* despite the gate.
 func WriteRunFile(projectRoot string, rf RunFile) error {
-	out, err := json.MarshalIndent(rf, "", "  ")
-	if err != nil {
-		return err
-	}
-	path := RunFilePath(projectRoot)
-	// A repo that has never been fanned out has no .fanout/ dir yet; create it so
-	// the atomic write (and thus reuse-if-running) does not fail with ENOENT.
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return err
-	}
-	return atomicfs.WriteFile(path, append(out, '\n'), 0o600)
+	// WriteJSON's MkdirAll covers the repo that has never been fanned out and
+	// so has no .fanout/ dir yet (reuse-if-running must not fail with ENOENT).
+	return atomicfs.WriteJSON(RunFilePath(projectRoot), rf, 0o600)
 }
 
 // RemoveRunFile deletes the run file (best effort; missing is fine).

--- a/internal/ui/tui/issues.go
+++ b/internal/ui/tui/issues.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/butaosuinu/fanout/internal/app/sessionview"
 	"github.com/butaosuinu/fanout/internal/core/blockers"
+	"github.com/butaosuinu/fanout/internal/core/parentref"
 	"github.com/butaosuinu/fanout/internal/infra/ghissue"
 	"github.com/butaosuinu/fanout/internal/infra/state"
 	"github.com/butaosuinu/fanout/internal/infra/tmuxrun"
@@ -294,7 +295,7 @@ func recordedParents(panes []state.Pane) []string {
 		if pane.Parent == "" || pane.IssueNum <= 0 {
 			continue
 		}
-		seen[normalizedParent(pane.Parent)] = true
+		seen[parentref.Canon(pane.Parent)] = true
 	}
 	parents := make([]string, 0, len(seen))
 	for parent := range seen {
@@ -343,7 +344,7 @@ func recordedTaskRows(panes []state.Pane) []taskStatusRow {
 }
 
 func keyForIssue(parent string, num int) issueKey {
-	return issueKey{Parent: normalizedParent(parent), Num: num}
+	return issueKey{Parent: parentref.Canon(parent), Num: num}
 }
 
 func keyForPaneView(pane paneView) issueKey {
@@ -357,20 +358,12 @@ func keyForPaneView(pane paneView) issueKey {
 	default:
 		// Manual/synthetic (@manual, non-positive issueNum): worktree-local, so
 		// scope by source to keep two worktrees' rows distinct.
-		return issueKey{Parent: normalizedParent(pane.Parent), Num: pane.IssueNum, Source: pane.sourceProjectRoot}
+		return issueKey{Parent: parentref.Canon(pane.Parent), Num: pane.IssueNum, Source: pane.sourceProjectRoot}
 	}
 }
 
 func keyForTask(parent, taskID, source string) issueKey {
-	return issueKey{Parent: normalizedParent(parent), Num: 0, TaskID: strings.TrimSpace(taskID), Source: source}
-}
-
-func normalizedParent(parent string) string {
-	parentNum, err := strconv.Atoi(parent)
-	if err != nil {
-		return parent
-	}
-	return strconv.Itoa(parentNum)
+	return issueKey{Parent: parentref.Canon(parent), Num: 0, TaskID: strings.TrimSpace(taskID), Source: source}
 }
 
 func buildPaneViews(panes []state.Pane, tmuxPanes []tmuxrun.LivePane, tmuxKnown bool, issues map[issueKey]issueStatus, worktrees map[string]worktreeStatView) []paneView {


### PR DESCRIPTION
## 概要

4 層再配置(全 10 PR)の DRY 統合。8 実装に重複していた同型コードを共有パッケージへ統合する。**全置換箇所でエラー文言・出力バイト列は旧実装と同一**(レビュー Workflow が diff 全ハンクで突き合わせ確認)。

- `internal/infra/execx`: Output / OutputStdin / Combined(ExitError→stderr 整形の一本化)。置換は ghissue.gh / ghissue.ghWithInput / gitstat.git / worktree.git のみ。tmuxrun/hooks/selfupdate/lifecycle は契約が異なるため対象外
- `internal/infra/gitroot`: Toplevel / IsWorkTree(runtime・team/detect・cmd の 3 重複を置換、文言はコピペ済み同一を確認)
- `internal/core/parentref`: Canon(sessionview.NormalizeParent は委譲化、tui の完全同一コピーは置換。cliflags のオーバーフロー時 ("", false) は維持)
- `atomicfs.WriteJSON / ReadJSON`: state・displayname・dashboard runfile の JSON ダンス統合(エラーラップ文言は呼び出し側残置。settings/planspec/hooks は文言が変わるため見送り)
- `internal/infra/browser` + `cmd/fanout/deps.go` + `tmuxrun.PaneCurrentPath`: cmd の生 exec 排除、missing dependencies チェック 4 重複統合

### レビュー対応済み
- codexapp の status ファイル書き出しは WriteJSON 化を取りやめ旧機構を維持(atomicfs の明示 chmod は restrictive umask 下で 0600→0644 に広がる挙動変化のため)
- ghWithInput を execx.OutputStdin へ委譲(整形文字列の残存重複を解消)

## 検証
make lint 0 issues / make test 全 green(golden 不変)/ codex review approve

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVKpKSXDTZbZqMw8cu1MUg