### PR TITLE
refactor: 実行系を core/fanset + app/run へ移送し main ディスパッチを整理 (layered 9/10)

### DIFF
--- a/cmd/fanout/dispatch_test.go
+++ b/cmd/fanout/dispatch_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/butaosuinu/fanout/internal/infra/codexapp"
+)
+
+// TestSelfExecSubcommandNames pins the hidden self-exec subcommand tokens so a
+// rename can never silently desync the tmux command line that spawns a popup /
+// Plan Mode pane from the dispatch that recognizes it back. These strings are
+// baked into tmux `display-popup`/`send-keys` invocations, so drift is a
+// runtime break the type system cannot catch.
+func TestSelfExecSubcommandNames(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		got  string
+		want string
+	}{
+		{name: "new pane popup", got: tuiNewPanePopupCommand, want: "__tui-new-pane-popup"},
+		{name: "help popup", got: tuiHelpPopupCommand, want: "__tui-help-popup"},
+		{name: "codex plan tui", got: codexapp.PlanTUICommand, want: "__codex-plan-tui"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.got != tc.want {
+				t.Fatalf("subcommand token = %q, want %q", tc.got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/fanout/lifecycle_test.go
+++ b/cmd/fanout/lifecycle_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/butaosuinu/fanout/internal/app/cliflags"
 	"github.com/butaosuinu/fanout/internal/app/lifecycle"
+	"github.com/butaosuinu/fanout/internal/app/run"
 	"github.com/butaosuinu/fanout/internal/core/exitcode"
 	"github.com/butaosuinu/fanout/internal/infra/log"
 	"github.com/butaosuinu/fanout/internal/infra/state"
@@ -1099,7 +1100,7 @@ func TestCmdPlanLifecycleCloseUsesRecordedTaskWhenSpecNoLongerListsIt(t *testing
 	})
 	t.Setenv(fanoutStatePathEnv, state.Path(repo))
 
-	code := cmdPlanLifecycle(planCommandConfig{SpecArg: specPath, CloseTaskID: "api-client"}, discardLogger())
+	code := cmdPlanLifecycle(run.PlanCommandConfig{SpecArg: specPath, CloseTaskID: "api-client"}, discardLogger())
 
 	if code != exitcode.OK {
 		t.Fatalf("cmdPlanLifecycle close code = %d, want %d", code, exitcode.OK)
@@ -1136,7 +1137,7 @@ func TestCmdPlanLifecycleCloseSkipsResolvedBranchValidation(t *testing.T) {
 	})
 	t.Setenv(fanoutStatePathEnv, state.Path(repo))
 
-	code := cmdPlanLifecycle(planCommandConfig{SpecArg: specPath, CloseTaskID: "base-types"}, discardLogger())
+	code := cmdPlanLifecycle(run.PlanCommandConfig{SpecArg: specPath, CloseTaskID: "base-types"}, discardLogger())
 
 	if code != exitcode.OK {
 		t.Fatalf("cmdPlanLifecycle close code = %d, want %d", code, exitcode.OK)
@@ -1168,7 +1169,7 @@ func TestCmdPlanLifecycleMergeUsesRecordedTaskWhenSpecNoLongerListsIt(t *testing
 	writeLifecycleState(t, repo, state.Pane{Parent: "plan:launch-plan", IssueNum: 0, TaskID: "api-client", BranchName: "fanout/api-client"})
 	t.Setenv(fanoutStatePathEnv, state.Path(repo))
 
-	code := cmdPlanLifecycle(planCommandConfig{SpecArg: specPath, MergeTaskID: "api-client"}, discardLogger())
+	code := cmdPlanLifecycle(run.PlanCommandConfig{SpecArg: specPath, MergeTaskID: "api-client"}, discardLogger())
 
 	if code != exitcode.OK {
 		t.Fatalf("cmdPlanLifecycle merge code = %d, want %d", code, exitcode.OK)

--- a/cmd/fanout/main.go
+++ b/cmd/fanout/main.go
@@ -4,78 +4,56 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"slices"
-	"strings"
-	"time"
 
-	"github.com/butaosuinu/fanout/internal/app/briefing"
 	"github.com/butaosuinu/fanout/internal/app/cliflags"
-	"github.com/butaosuinu/fanout/internal/app/panelaunch"
+	"github.com/butaosuinu/fanout/internal/app/run"
 	"github.com/butaosuinu/fanout/internal/core/exitcode"
-	"github.com/butaosuinu/fanout/internal/core/naming"
 	"github.com/butaosuinu/fanout/internal/infra/ghissue"
-	"github.com/butaosuinu/fanout/internal/infra/gitroot"
 	"github.com/butaosuinu/fanout/internal/infra/hooks"
 	"github.com/butaosuinu/fanout/internal/infra/log"
-	fanoutruntime "github.com/butaosuinu/fanout/internal/infra/runtime"
-	"github.com/butaosuinu/fanout/internal/infra/settings"
-	"github.com/butaosuinu/fanout/internal/infra/state"
-	"github.com/butaosuinu/fanout/internal/infra/tmuxrun"
-	"github.com/butaosuinu/fanout/internal/infra/worktree"
 )
 
+// version and commit are injected at build time via -ldflags (see release.yml,
+// which names main.version). Keep them here in package main; do not move them.
 var (
-	version            = "dev"
-	commit             = "none"
-	sleepBetweenIssues = time.Sleep
+	version = "dev"
+	commit  = "none"
 )
 
 func main() {
 	lg := log.New(false)
 	commandName := invokedCommandName(os.Args)
+	args := os.Args[1:]
 
-	if hooks.IsBackgroundRunnerRequest(os.Args[1:]) {
-		os.Exit(hooks.RunBackgroundRunner(os.Args[2:], os.Stderr))
+	// Subcommand dispatch: an ordered, first-match-wins table. The order is
+	// load-bearing (e.g. update before check-update, TUI before the popups) —
+	// keep it identical to preserve behavior.
+	type dispatch struct {
+		match  func([]string) bool
+		handle func() exitcode.Code
 	}
-	if isVersionRequest(os.Args[1:]) {
-		fmt.Fprintln(os.Stdout, versionLine())
-		os.Exit(int(exitcode.OK))
+	table := []dispatch{
+		{hooks.IsBackgroundRunnerRequest, func() exitcode.Code { return exitcode.Code(hooks.RunBackgroundRunner(os.Args[2:], os.Stderr)) }},
+		{isVersionRequest, func() exitcode.Code { fmt.Fprintln(os.Stdout, versionLine()); return exitcode.OK }},
+		{isUpdateRequest, func() exitcode.Code { return cmdUpdate(os.Args[2:], version, ghissue.Runner{}, lg) }},
+		{isCheckUpdateRequest, func() exitcode.Code { return cmdCheckUpdate(version, ghissue.Runner{}, lg) }},
+		{isTUIRequest, func() exitcode.Code { return cmdTUI(commandName, lg) }},
+		{isTUINewPanePopupRequest, func() exitcode.Code { return cmdTUINewPanePopup(os.Args[2:], lg) }},
+		{isTUIHelpPopupRequest, func() exitcode.Code { return cmdTUIHelpPopup(os.Args[2:], lg) }},
+		{isCodexPlanTUIRequest, func() exitcode.Code { return cmdCodexPlanTUI(os.Args[2:], lg) }},
+		{isPlanRequest, func() exitcode.Code { return cmdPlan(os.Args[2:], lg, commandName) }},
+		{isDashboardRequest, func() exitcode.Code { return cmdDashboard(os.Args[2:], lg) }},
+		{isFocusConsoleRequest, func() exitcode.Code { return cmdFocusConsole(os.Args[2:], lg) }},
+		{isWorktreeActionRequest, func() exitcode.Code { return cmdWorktreeAction(os.Args[1:], lg, commandName) }},
+		{isMsgRequest, func() exitcode.Code { return cmdMsg(os.Args[2:], lg) }},
 	}
-	if isUpdateRequest(os.Args[1:]) {
-		os.Exit(int(cmdUpdate(os.Args[2:], version, ghissue.Runner{}, lg)))
-	}
-	if isCheckUpdateRequest(os.Args[1:]) {
-		os.Exit(int(cmdCheckUpdate(version, ghissue.Runner{}, lg)))
-	}
-	if isTUIRequest(os.Args[1:]) {
-		os.Exit(int(cmdTUI(commandName, lg)))
-	}
-	if isTUINewPanePopupRequest(os.Args[1:]) {
-		os.Exit(int(cmdTUINewPanePopup(os.Args[2:], lg)))
-	}
-	if isTUIHelpPopupRequest(os.Args[1:]) {
-		os.Exit(int(cmdTUIHelpPopup(os.Args[2:], lg)))
-	}
-	if isCodexPlanTUIRequest(os.Args[1:]) {
-		os.Exit(int(cmdCodexPlanTUI(os.Args[2:], lg)))
-	}
-	if isPlanRequest(os.Args[1:]) {
-		os.Exit(int(cmdPlan(os.Args[2:], lg, commandName)))
-	}
-	if isDashboardRequest(os.Args[1:]) {
-		os.Exit(int(cmdDashboard(os.Args[2:], lg)))
-	}
-	if isFocusConsoleRequest(os.Args[1:]) {
-		os.Exit(int(cmdFocusConsole(os.Args[2:], lg)))
-	}
-	if isWorktreeActionRequest(os.Args[1:]) {
-		os.Exit(int(cmdWorktreeAction(os.Args[1:], lg, commandName)))
-	}
-	if isMsgRequest(os.Args[1:]) {
-		os.Exit(int(cmdMsg(os.Args[2:], lg)))
+	for _, d := range table {
+		if d.match(args) {
+			os.Exit(int(d.handle()))
+		}
 	}
 
-	pr := cliflags.Parse(os.Args[1:], lg, os.Stdout)
+	pr := cliflags.Parse(args, lg, os.Stdout)
 	if pr.Code != exitcode.OK || pr.Config == nil {
 		os.Exit(int(pr.Code))
 	}
@@ -109,7 +87,11 @@ func main() {
 		os.Exit(int(cmdCleanup(cfg, lg)))
 	}
 
-	os.Exit(int(run(cfg, lg, commandName)))
+	rt, code := run.ResolveRuntime(cfg, lg)
+	if code != exitcode.OK {
+		os.Exit(int(code))
+	}
+	os.Exit(int(run.Issues(cfg, lg, rt, commandName, bindDashboardKey)))
 }
 
 func isVersionRequest(args []string) bool {
@@ -137,414 +119,4 @@ func invokedCommandName(args []string) string {
 		return "fanout"
 	}
 	return name
-}
-
-func run(cfg *cliflags.Config, lg *log.Logger, commandName string) exitcode.Code {
-	rt, code := resolveRuntime(cfg, lg)
-	if code != exitcode.OK {
-		return code
-	}
-	return runWithRuntime(cfg, lg, rt, commandName)
-}
-
-func runWithRuntime(cfg *cliflags.Config, lg *log.Logger, rt *runtimeInfo, commandName string) exitcode.Code {
-	resolvedSettings := settings.Resolve(rt.info.ProjectRoot, settings.CLIOverrides{
-		AutoPullRequest:    cfg.AutoPullRequest,
-		PRReviewGate:       cfg.PRReviewGate,
-		BriefingCodeReview: cfg.BriefingCodeReview,
-		AgentTeamsHint:     cfg.AgentTeamsHint,
-		PRVisualization:    cfg.PRVisualization,
-		DashboardKeybind:   cfg.DashboardKeybind,
-	}, lg.Warn)
-	hookConfig := hooks.LoadUserConfig(lg)
-
-	loaded, code := loadChildren(cfg, rt.gh, lg)
-	if code != exitcode.OK {
-		return code
-	}
-
-	totalChildren := len(loaded.Children)
-	if totalChildren == 0 {
-		if cfg.ParentMode == cliflags.ModeProject {
-			lg.Info("no items in Project (after status/repo filter). nothing to do.")
-		} else {
-			lg.Info("no sub-issues on #%d. nothing to do.", cfg.Parent)
-		}
-		return exitcode.OK
-	}
-
-	openCount := len(openIssues(loaded.Children))
-	lg.Info("%s: %d total, %d OPEN", loaded.ChildNoun, totalChildren, openCount)
-	if openCount == 0 {
-		lg.Info("no OPEN %s. nothing to do.", loaded.ChildNoun)
-		return exitcode.OK
-	}
-
-	store, recorder, code := loadRunState(cfg, rt.info.ProjectRoot, lg)
-	if code != exitcode.OK {
-		return code
-	}
-	if recorder != nil {
-		defer func() {
-			if err := recorder.Unlock(); err != nil {
-				lg.Warn("unlock fanout state: %v", err)
-			}
-		}()
-	}
-
-	sameParentFanned := store.FannedNumbersForParent(cfg.ParentRef)
-	otherParentFanned := store.FannedNumbersForOtherParents(cfg.ParentRef)
-	worktreeFallbackFanned := existingWorktreeFanned(cfg, rt.info.ProjectRoot, loaded.Children, otherParentFanned)
-
-	plan := buildPlan(
-		cfg,
-		loaded.Children,
-		mergeFanned(sameParentFanned, worktreeFallbackFanned),
-		loaded.ParentBody,
-		func(issue *ghissue.Issue) {
-			if err := rt.gh.HydrateBodyLabels(issue); err != nil {
-				lg.Warn("#%d: could not fetch body/labels for blocker check; treating as unblocked", issue.Number)
-			}
-		},
-		func(num int) string {
-			state, _ := rt.gh.IssueState(num)
-			return state
-		},
-	)
-	logPlanDetails(plan, lg)
-
-	if plan.OpenAfterFilter == 0 {
-		lg.Info("all OPEN sub-issues filtered out by --only/--skip. nothing to do.")
-		return exitcode.OK
-	}
-	if plan.UnfannedCount == 0 {
-		lg.Ok("all %d OPEN sub-issue(s) already have a fanout pane. nothing to do.", len(plan.AlreadyFanned))
-		return exitcode.OK
-	}
-	if err := validateIssueAgents(cfg, plan.Targets, plan.LimitDeferred); err != nil {
-		lg.Err("%s", err.Error())
-		return exitcode.Env
-	}
-
-	logAlreadyFanned(plan.AlreadyFanned, lg)
-	lg.Info("will create %d pane(s); deferred (blocked): %d; deferred (--limit): %d",
-		len(plan.Targets), len(plan.BlockedRows), len(plan.LimitDeferred))
-
-	c := lg.Colors()
-	if cfg.DryRun {
-		printDryRunPlan(plan, lg, c)
-	}
-
-	var teamCtx *briefing.TeamContext
-	if cfg.Team {
-		teamCtx = buildTeamContext(rt.info.ProjectRoot, cfg.ParentRef, plan.Targets)
-	}
-
-	result := executePlan(cfg, lg, rt.info, rt.gh, plan.Targets, resolvedSettings, hookConfig, recorder, otherParentFanned, c, commandName, teamCtx)
-	printSummary(plan, result, cfg, lg, c, commandName)
-
-	// Register tmux keybindings so the user can pop the read-only dashboard
-	// (F12 or prefix + D) and same-worktree action menu (prefix + M) from any
-	// fanout pane. The bindings resolve the repo from the pressing pane at
-	// keypress, so they work from child worktree panes and across repos.
-	// Best-effort, live runs only.
-	if !cfg.DryRun && result.Created > 0 {
-		bindDashboardKey(lg, resolvedSettings.DashboardKeybind)
-	}
-
-	// Seed the peers registry for --team runs, fail-fast partial successes
-	// included. Best-effort: this runs outside the executePlan loop and a
-	// failure only warns, never changes the exit code.
-	if cfg.Team && len(result.CreatedNums) > 0 {
-		if cfg.DryRun {
-			fmt.Fprintf(lg.Stdout(), "%s# would seed team registry: %d peer(s) -> %s%s\n", c.Dim, len(result.CreatedNums), teamCtx.DBPath, c.Reset)
-		} else {
-			seedTeamRegistry(lg, teamCtx.DBPath, recorder.Store, cfg.ParentRef, result.CreatedNums)
-		}
-	}
-
-	if result.Failed > 0 {
-		return exitcode.Env
-	}
-	return exitcode.OK
-}
-
-type runtimeInfo struct {
-	info *fanoutruntime.Info
-	gh   ghissue.Runner
-}
-
-func resolveRuntime(cfg *cliflags.Config, lg *log.Logger) (*runtimeInfo, exitcode.Code) {
-	info, err := fanoutruntime.Resolve(cfg.Session)
-	if err != nil {
-		lg.Err("%s", err.Error())
-		return nil, exitcode.Env
-	}
-
-	if cfg.Agent == "" {
-		cfg.Agent = os.Getenv("FANOUT_AGENT")
-	}
-	if cfg.Agent == "" && len(cfg.AgentOverrides) == 0 {
-		lg.Err("agent is required; pass --agent <name> or set FANOUT_AGENT")
-		return nil, exitcode.Env
-	}
-
-	lg.Info("tmux session: %s", info.Session)
-	lg.Info("tmux target:  %s", info.Target)
-	lg.Info("project root: %s", info.ProjectRoot)
-
-	if !gitroot.IsWorkTree(info.ProjectRoot) {
-		lg.Err("project root %s is not a git work tree; cannot resolve GitHub repo", info.ProjectRoot)
-		return nil, exitcode.Env
-	}
-	if !cfg.DryRun {
-		markCurrentPaneProjectRoot(info.ProjectRoot, lg)
-	}
-	return &runtimeInfo{
-		info: info,
-		gh:   ghissue.Runner{Cwd: info.ProjectRoot},
-	}, exitcode.OK
-}
-
-func markCurrentPaneProjectRoot(projectRoot string, lg *log.Logger) {
-	paneID := strings.TrimSpace(os.Getenv("TMUX_PANE"))
-	if paneID == "" {
-		return
-	}
-	if err := tmuxrun.SetPaneProjectRoot(paneID, projectRoot); err != nil {
-		lg.Debug("dashboard project root hint: %v", err)
-	}
-}
-
-type childLoadResult struct {
-	Children       []ghissue.Issue
-	ParentBody     string
-	StrongChildren map[int]bool
-	ChildNoun      string
-}
-
-func loadChildren(cfg *cliflags.Config, gh ghissue.Runner, lg *log.Logger) (childLoadResult, exitcode.Code) {
-	if cfg.ParentMode == cliflags.ModeProject {
-		return loadProjectChildren(cfg, gh, lg)
-	}
-	return loadIssueChildren(cfg, gh, lg)
-}
-
-func loadIssueChildren(cfg *cliflags.Config, gh ghissue.Runner, lg *log.Logger) (childLoadResult, exitcode.Code) {
-	lg.Info("fetching sub-issues of #%d", cfg.Parent)
-	subIssues, err := gh.SubIssueList(cfg.Parent)
-	if err != nil {
-		lg.Err("sub-issues fetch failed: %v", err)
-		return childLoadResult{}, exitcode.Env
-	}
-
-	parentBody, err := gh.ParentBody(cfg.Parent)
-	if err != nil {
-		lg.Warn("could not read parent body (#%d); skipping task-list scan", cfg.Parent)
-		parentBody = ""
-	}
-
-	bodyNums := ghissue.TaskListNumbers(parentBody)
-	loaded, added := mergeExtraChildren(cfg, gh, subIssues, bodyNums, true, lg)
-	assignTaskListWaves(loaded, ghissue.TaskListWaves(parentBody))
-	if added > 0 {
-		lg.Info("parent body / --include added %d extra child reference(s) not in sub-issue API", added)
-	}
-
-	return childLoadResult{
-		Children:       loaded,
-		ParentBody:     parentBody,
-		StrongChildren: issueSet(subIssues),
-		ChildNoun:      "sub-issues",
-	}, exitcode.OK
-}
-
-func loadProjectChildren(cfg *cliflags.Config, gh ghissue.Runner, lg *log.Logger) (childLoadResult, exitcode.Code) {
-	repo, err := gh.RepoNameWithOwner()
-	if err != nil {
-		lg.Err("could not resolve repo via 'gh repo view' in project root (required for project mode cross-repo filter)")
-		return childLoadResult{}, exitcode.Env
-	}
-	lg.Info("mode: project (status=%s, repo=%s)", cfg.ProjectStatus, repo)
-	lg.Info("fetching items from Project %s", cfg.ParentRef)
-
-	res, err := gh.ProjectItems(cfg.ProjectOwnerType, cfg.ProjectOwner, cfg.ProjectNumber, repo, cfg.ProjectStatus)
-	if err != nil {
-		lg.Err("%v", err)
-		return childLoadResult{}, exitcode.Env
-	}
-	if res.MissingStatus && cfg.ProjectStatus != "all" {
-		lg.Warn("Project '%s' has no Status field; ignoring --project-status %s and falling back to all items", res.ProjectTitle, cfg.ProjectStatus)
-		cfg.ProjectStatus = "all"
-	}
-	for _, cross := range res.CrossRepoWarnings {
-		lg.Warn("skipping cross-repo project item: %s (project root repo: %s)", cross, repo)
-	}
-
-	loaded, added := mergeExtraChildren(cfg, gh, res.Issues, nil, false, lg)
-	if added > 0 {
-		lg.Info("--include added %d extra child reference(s) not in project items", added)
-	}
-
-	return childLoadResult{
-		Children:       loaded,
-		StrongChildren: issueSet(res.Issues),
-		ChildNoun:      "project items",
-	}, exitcode.OK
-}
-
-func mergeExtraChildren(cfg *cliflags.Config, gh ghissue.Runner, base []ghissue.Issue, bodyNums []int, skipParent bool, lg *log.Logger) ([]ghissue.Issue, int) {
-	existing := map[int]bool{}
-	if skipParent {
-		existing[cfg.Parent] = true
-	}
-	for _, s := range base {
-		existing[s.Number] = true
-	}
-
-	extraNums := append([]int{}, bodyNums...)
-	extraNums = append(extraNums, cfg.Include...)
-	var extra []ghissue.Issue
-	for _, num := range extraNums {
-		if existing[num] {
-			continue
-		}
-		detail, err := gh.IssueDetail(num)
-		if err != nil {
-			lg.Warn("parent body / --include references #%d but issue lookup failed; skipping", num)
-			continue
-		}
-		extra = append(extra, detail)
-		existing[num] = true
-	}
-	return ghissue.MergeExtra(base, extra), len(extra)
-}
-
-func assignTaskListWaves(issues []ghissue.Issue, waves map[int]string) {
-	for i := range issues {
-		if wave := waves[issues[i].Number]; wave != "" {
-			issues[i].Wave = wave
-		}
-	}
-}
-
-func issueSet(issues []ghissue.Issue) map[int]bool {
-	out := map[int]bool{}
-	for _, issue := range issues {
-		out[issue.Number] = true
-	}
-	return out
-}
-
-func mergeFanned(primary, fallback map[int]bool) map[int]bool {
-	out := map[int]bool{}
-	for num := range primary {
-		out[num] = true
-	}
-	for num := range fallback {
-		out[num] = true
-	}
-	return out
-}
-
-func loadRunState(cfg *cliflags.Config, projectRoot string, lg *log.Logger) (state.Store, *state.LockedStore, exitcode.Code) {
-	if cfg.DryRun {
-		store, err := state.LoadProject(projectRoot)
-		if err != nil {
-			lg.Err("%v", err)
-			return state.Store{}, nil, exitcode.Env
-		}
-		return store, nil, exitcode.OK
-	}
-	if err := worktree.EnsureLocalExclude(projectRoot); err != nil {
-		lg.Err("prepare local git exclude: %v", err)
-		return state.Store{}, nil, exitcode.Env
-	}
-	locked, err := state.LockProject(projectRoot)
-	if err != nil {
-		lg.Err("%v", err)
-		return state.Store{}, nil, exitcode.Env
-	}
-	return locked.Store, locked, exitcode.OK
-}
-
-func existingWorktreeFanned(cfg *cliflags.Config, projectRoot string, issues []ghissue.Issue, sharedAcrossParents map[int]bool) map[int]bool {
-	out := map[int]bool{}
-	worktreeNames := existingWorktreeNames(filepath.Join(projectRoot, ".fanout", "worktrees"))
-	for _, issue := range issues {
-		slug := naming.Slug(issue.Title, issue.Number)
-		slugOverridden := false
-		if name := cfg.FindName(issue.Number); name != nil && name.SlugHint != "" {
-			slug = naming.EnsureIssueSuffix(name.SlugHint, issue.Number)
-			slugOverridden = true
-		}
-		if sharedAcrossParents[issue.Number] {
-			if !slugOverridden {
-				slug = naming.QualifySlugForParent(slug, cfg.ParentRef, issue.Number)
-			}
-			if worktreeNameMatchesExact(worktreeNames, slug) {
-				out[issue.Number] = true
-			}
-			continue
-		}
-		if worktreeNameMatchesIssue(worktreeNames, slug, issue.Number) {
-			out[issue.Number] = true
-		}
-	}
-	return out
-}
-
-func existingWorktreeNames(root string) []string {
-	entries, err := os.ReadDir(root)
-	if err != nil {
-		return nil
-	}
-	names := make([]string, 0, len(entries))
-	for _, entry := range entries {
-		if entry.IsDir() {
-			names = append(names, entry.Name())
-		}
-	}
-	return names
-}
-
-func worktreeNameMatchesExact(names []string, slug string) bool {
-	return slices.Contains(names, slug)
-}
-
-func worktreeNameMatchesIssue(names []string, exactSlug string, issueNum int) bool {
-	issueSuffix := fmt.Sprintf("-%d", issueNum)
-	for _, name := range names {
-		if name == exactSlug || strings.HasSuffix(name, issueSuffix) {
-			return true
-		}
-	}
-	return false
-}
-
-func executePlan(cfg *cliflags.Config, lg *log.Logger, info *fanoutruntime.Info, gh ghissue.Runner, targets []ghissue.Issue, resolvedSettings settings.Settings, hookConfig hooks.Config, recorder panelaunch.StateRecorder, sharedAcrossParents map[int]bool, c log.Palette, commandName string, teamCtx *briefing.TeamContext) executionResult {
-	launcher := &panelaunch.Launcher{Cfg: cfg, Log: lg, Info: info, Recorder: recorder, Palette: c, CommandName: commandName}
-	var result executionResult
-	for i, issue := range targets {
-		// Hydrate body lazily for issues that came from the Sub-issues API
-		// path (body=""), unless --unblocked-only already did it upfront.
-		if issue.Body == "" {
-			if detail, err := gh.IssueDetail(issue.Number); err == nil {
-				issue.Body = detail.Body
-			}
-		}
-		// Fail fast: stop after the first failed child launch.
-		if !launcher.LaunchOK(panelaunch.NewIssueRequest(cfg, info.ProjectRoot, issue, resolvedSettings, hookConfig, sharedAcrossParents[issue.Number], teamCtx)) {
-			result.Failed++
-			break
-		}
-		result.Created++
-		result.CreatedNums = append(result.CreatedNums, issue.Number)
-		if i < len(targets)-1 {
-			if cfg.SleepBetween > 0 {
-				sleepBetweenIssues(time.Duration(cfg.SleepBetween * float64(time.Second)))
-			}
-		}
-	}
-	return result
 }

--- a/cmd/fanout/main_test.go
+++ b/cmd/fanout/main_test.go
@@ -1,89 +1,15 @@
 package main
 
 import (
-	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
-	"github.com/butaosuinu/fanout/internal/app/cliflags"
-	"github.com/butaosuinu/fanout/internal/core/exitcode"
-	"github.com/butaosuinu/fanout/internal/infra/ghissue"
-	"github.com/butaosuinu/fanout/internal/infra/hooks"
-	"github.com/butaosuinu/fanout/internal/infra/log"
-	fanoutruntime "github.com/butaosuinu/fanout/internal/infra/runtime"
-	"github.com/butaosuinu/fanout/internal/infra/settings"
+	"github.com/butaosuinu/fanout/internal/app/run"
 	fanouttui "github.com/butaosuinu/fanout/internal/ui/tui"
 )
-
-func TestExecutePlanSleepsBetweenDryRunIssues(t *testing.T) {
-	dir := t.TempDir()
-
-	oldSleep := sleepBetweenIssues
-	var sleeps []time.Duration
-	sleepBetweenIssues = func(d time.Duration) {
-		sleeps = append(sleeps, d)
-	}
-	t.Cleanup(func() { sleepBetweenIssues = oldSleep })
-
-	cfg := &cliflags.Config{
-		Agent:        "claude",
-		DryRun:       true,
-		SleepBetween: 0.25,
-	}
-	lg := log.NewWith(io.Discard, io.Discard, false)
-	info := &fanoutruntime.Info{
-		Session:     "test",
-		Target:      "%caller",
-		ProjectRoot: dir,
-	}
-	targets := []ghissue.Issue{
-		{Number: 1, Title: "one", State: "OPEN", Body: "body"},
-		{Number: 2, Title: "two", State: "OPEN", Body: "body"},
-	}
-
-	result := executePlan(cfg, lg, info, ghissue.Runner{}, targets, settings.Defaults(), hooks.EmptyConfig(), nil, nil, log.Palette{}, "fanout", nil)
-
-	if result.Created != 2 || result.Failed != 0 {
-		t.Fatalf("executePlan result = %+v, want 2 created and 0 failed", result)
-	}
-	if len(sleeps) != 1 {
-		t.Fatalf("sleep calls = %d, want 1", len(sleeps))
-	}
-	if want := 250 * time.Millisecond; sleeps[0] != want {
-		t.Fatalf("sleep duration = %s, want %s", sleeps[0], want)
-	}
-}
-
-func TestLoadRunStateIgnoresLockFileWhenNoWorktreeIsPrepared(t *testing.T) {
-	repo := t.TempDir()
-	gitCmdTest(t, repo, "init")
-
-	cfg := &cliflags.Config{}
-	lg := log.NewWith(io.Discard, io.Discard, false)
-	_, recorder, code := loadRunState(cfg, repo, lg)
-	if code != exitcode.OK {
-		t.Fatalf("loadRunState code = %d, want %d", code, exitcode.OK)
-	}
-	if recorder == nil {
-		t.Fatal("loadRunState returned nil recorder for live run")
-	}
-	t.Cleanup(func() { _ = recorder.Unlock() })
-
-	if _, err := os.Stat(filepath.Join(repo, ".fanout", "state.json.lock")); err != nil {
-		t.Fatalf("state lock was not created: %v", err)
-	}
-	exclude, err := os.ReadFile(filepath.Join(repo, ".git", "info", "exclude"))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !strings.Contains(string(exclude), ".fanout/state.json.lock\n") {
-		t.Fatalf("exclude = %q, want state lock pattern", exclude)
-	}
-}
 
 func installFakeExecutable(t *testing.T, name string) {
 	t.Helper()
@@ -247,7 +173,7 @@ func TestTUILaunchCommandForwardsEnhancedKeysValue(t *testing.T) {
 	for _, value := range []string{"", "0", "1"} {
 		t.Setenv(fanouttui.EnhancedKeysEnv, value)
 		got := tuiLaunchCommand("fanout", "/tmp/repo")
-		if !strings.Contains(got, " && "+fanouttui.EnhancedKeysEnv+"="+shellQuote(value)+" ") {
+		if !strings.Contains(got, " && "+fanouttui.EnhancedKeysEnv+"="+run.ShellQuote(value)+" ") {
 			t.Fatalf("tuiLaunchCommand() = %q with %s=%q, want forwarded env prefix", got, fanouttui.EnhancedKeysEnv, value)
 		}
 	}

--- a/cmd/fanout/plancmd.go
+++ b/cmd/fanout/plancmd.go
@@ -2,31 +2,22 @@ package main
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 	"regexp"
-	"slices"
 	"strconv"
 	"strings"
-	"time"
 
-	"github.com/butaosuinu/fanout/internal/app/briefing"
 	"github.com/butaosuinu/fanout/internal/app/cliflags"
 	"github.com/butaosuinu/fanout/internal/app/lifecycle"
 	"github.com/butaosuinu/fanout/internal/app/panelaunch"
+	"github.com/butaosuinu/fanout/internal/app/run"
 	"github.com/butaosuinu/fanout/internal/app/statusreport"
 	"github.com/butaosuinu/fanout/internal/core/exitcode"
 	"github.com/butaosuinu/fanout/internal/core/naming"
 	"github.com/butaosuinu/fanout/internal/core/planspec"
-	"github.com/butaosuinu/fanout/internal/infra/atomicfs"
-	"github.com/butaosuinu/fanout/internal/infra/ghissue"
 	"github.com/butaosuinu/fanout/internal/infra/hooks"
 	"github.com/butaosuinu/fanout/internal/infra/log"
-	fanoutruntime "github.com/butaosuinu/fanout/internal/infra/runtime"
-	"github.com/butaosuinu/fanout/internal/infra/settings"
 	"github.com/butaosuinu/fanout/internal/infra/state"
 	"github.com/butaosuinu/fanout/internal/infra/team"
-	"github.com/butaosuinu/fanout/internal/infra/worktree"
 )
 
 const planSubcommand = "plan"
@@ -39,65 +30,6 @@ var (
 	// definition.
 	rePlanTaskID = team.TaskIDRE
 )
-
-type planCommandConfig struct {
-	SpecArg            string
-	SpecPath           string
-	Agent              string
-	AgentOverrides     []cliflags.AgentOverride
-	BaseBranch         string
-	BranchPrefix       string
-	Limit              int
-	OnlyArg            string
-	SkipArg            string
-	Only               []string
-	Skip               []string
-	Session            string
-	SleepBetween       float64
-	NoRefresh          bool
-	DryRun             bool
-	Debug              bool
-	UnblockedOnly      bool
-	Team               bool
-	StatusMode         bool
-	Format             string
-	CloseTaskID        string
-	MergeTaskID        string
-	CleanupMode        bool
-	formatExplicit     bool
-	AutoPullRequest    *bool
-	PRReviewGate       *bool
-	BriefingCodeReview *bool
-	AgentTeamsHint     *bool
-	PRVisualization    *bool
-	DashboardKeybind   *bool
-}
-
-type taskPlan struct {
-	TotalTasks      int
-	AfterFilter     int
-	UnfannedCount   int
-	Targets         []planspec.Task
-	AlreadyFanned   []string
-	AlreadyComplete []string
-	FilteredOnly    []planspec.Task
-	FilteredSkip    []planspec.Task
-	MissingOnly     []string
-	BlockedRows     []taskBlockedRow
-	LimitDeferred   []planspec.Task
-	SourceArgument  string
-}
-
-type taskBlockedRow struct {
-	Task planspec.Task
-	Refs string
-}
-
-type taskExecutionResult struct {
-	Created    int
-	Failed     int
-	CreatedIDs []string
-}
 
 func isPlanRequest(args []string) bool {
 	return len(args) > 0 && args[0] == planSubcommand
@@ -118,7 +50,7 @@ func cmdPlan(args []string, lg *log.Logger, commandName string) exitcode.Code {
 	if cfg.Debug {
 		lg = log.New(true)
 	}
-	if cfg.actionMode() {
+	if cfg.ActionMode() {
 		if exitOnMissingDeps(missingDeps(depNeeds{git: true, gh: cfg.StatusMode || cfg.CleanupMode}), lg) {
 			return exitcode.Env
 		}
@@ -129,146 +61,19 @@ func cmdPlan(args []string, lg *log.Logger, commandName string) exitcode.Code {
 		return exitcode.Env
 	}
 
-	cliCfg := cfg.cliConfig()
-	rt, code := resolveRuntime(cliCfg, lg)
+	cliCfg := cfg.CLIConfig()
+	rt, code := run.ResolveRuntime(cliCfg, lg)
 	if code != exitcode.OK {
 		return code
 	}
 	cfg.Agent = cliCfg.Agent
 
-	_, code = runPlanWithRuntime(cfg, rt, lg, commandName)
+	_, code = run.PlanTasks(cfg, rt, lg, commandName, bindDashboardKey)
 	return code
 }
 
-// runPlanWithRuntime runs the live/dry-run plan lane against an already
-// resolved runtime. cmdPlan owns parsing, dependency checks, and runtime
-// resolution before calling this.
-func runPlanWithRuntime(cfg planCommandConfig, rt *runtimeInfo, lg *log.Logger, commandName string) (taskExecutionResult, exitcode.Code) {
-	resolvedSettings := settings.Resolve(rt.info.ProjectRoot, settings.CLIOverrides{
-		AutoPullRequest:    cfg.AutoPullRequest,
-		PRReviewGate:       cfg.PRReviewGate,
-		BriefingCodeReview: cfg.BriefingCodeReview,
-		AgentTeamsHint:     cfg.AgentTeamsHint,
-		PRVisualization:    cfg.PRVisualization,
-		DashboardKeybind:   cfg.DashboardKeybind,
-	}, lg.Warn)
-	hookConfig := hooks.LoadUserConfig(lg)
-
-	cfg.SpecPath = resolvePlanSpecPath(rt.info.ProjectRoot, cfg.SpecArg)
-	spec, err := planspec.LoadWithoutResolvedNameChecks(cfg.SpecPath)
-	if err != nil {
-		lg.Err("%v", err)
-		return taskExecutionResult{}, exitcode.Env
-	}
-	cfg.BaseBranch, err = resolvePlanBaseBranch(cfg, spec, rt.info.ProjectRoot)
-	if err != nil {
-		lg.Err("%v", err)
-		return taskExecutionResult{}, exitcode.Env
-	}
-	if err := validatePlanExecutionNames(spec, cfg); err != nil {
-		lg.Err("validate plan execution names %s: %v", cfg.SpecPath, err)
-		return taskExecutionResult{}, exitcode.Env
-	}
-	cliCfg := cfg.cliConfig()
-
-	store, recorder, code := loadPlanState(cfg, rt.info.ProjectRoot, lg)
-	if code != exitcode.OK {
-		return taskExecutionResult{}, code
-	}
-	if recorder != nil {
-		defer func() {
-			if err := recorder.Unlock(); err != nil {
-				lg.Warn("unlock fanout state: %v", err)
-			}
-		}()
-	}
-	copyLivePlanSpec := func() exitcode.Code {
-		if cfg.DryRun {
-			return exitcode.OK
-		}
-		if err := copyPlanSpec(cfg.SpecPath, rt.info.ProjectRoot, spec.Plan.Slug); err != nil {
-			lg.Err("copy plan spec: %v", err)
-			return exitcode.Env
-		}
-		return exitcode.OK
-	}
-	cfg.SpecArg = planRerunSpecArg(cfg, spec)
-
-	parentRef := panelaunch.PlanParentRef(spec.Plan.Slug)
-	fanned := mergeTaskFanned(store.FannedTaskIDsForParent(parentRef), existingPlanWorktreeFanned(rt.info.ProjectRoot, spec))
-	plan := buildTaskPlan(cfg, spec, fanned, func(task planspec.Task) bool {
-		return planTaskComplete(rt.gh, cliCfg, rt.info.ProjectRoot, store, spec, task, lg)
-	})
-	logTaskPlanDetails(plan, lg)
-
-	if plan.AfterFilter == 0 {
-		if code := copyLivePlanSpec(); code != exitcode.OK {
-			return taskExecutionResult{}, code
-		}
-		lg.Info("all plan tasks filtered out by --only/--skip. nothing to do.")
-		return taskExecutionResult{}, exitcode.OK
-	}
-	if plan.UnfannedCount == 0 {
-		if code := copyLivePlanSpec(); code != exitcode.OK {
-			return taskExecutionResult{}, code
-		}
-		if len(plan.AlreadyComplete) == 0 {
-			lg.Ok("all %d plan task(s) already have a fanout pane. nothing to do.", len(plan.AlreadyFanned))
-		} else {
-			lg.Ok("all %d selected plan task(s) already have a fanout pane or are complete. nothing to do.", plan.AfterFilter)
-		}
-		return taskExecutionResult{}, exitcode.OK
-	}
-	if err := validateTaskAgents(cliCfg, plan.Targets, plan.LimitDeferred); err != nil {
-		lg.Err("%s", err.Error())
-		return taskExecutionResult{}, exitcode.Env
-	}
-	if code := copyLivePlanSpec(); code != exitcode.OK {
-		return taskExecutionResult{}, code
-	}
-
-	logAlreadyFannedTasks(plan.AlreadyFanned, lg)
-	logAlreadyCompleteTasks(plan.AlreadyComplete, lg)
-	lg.Info("plan %s: %d task(s)", spec.Plan.Slug, plan.TotalTasks)
-	lg.Info("will create %d pane(s); deferred (blocked): %d; deferred (--limit): %d",
-		len(plan.Targets), len(plan.BlockedRows), len(plan.LimitDeferred))
-
-	c := lg.Colors()
-	if cfg.DryRun {
-		printTaskDryRunPlan(plan, lg, c)
-	}
-
-	var teamCtx *briefing.TeamContext
-	if cfg.Team {
-		teamCtx = buildTaskTeamContext(rt.info.ProjectRoot, parentRef, plan.Targets)
-	}
-
-	result := executeTaskPlan(cliCfg, lg, rt.info, spec, plan.Targets, resolvedSettings, hookConfig, recorder, c, commandName, teamCtx)
-	printTaskSummary(plan, result, cfg, lg, c, commandName)
-
-	if !cfg.DryRun && result.Created > 0 {
-		bindDashboardKey(lg, resolvedSettings.DashboardKeybind)
-	}
-
-	// Seed the peers registry for --team runs, fail-fast partial successes
-	// included. Best-effort: this runs outside the executeTaskPlan loop and a
-	// failure only warns, never changes the exit code.
-	if cfg.Team && len(result.CreatedIDs) > 0 {
-		if cfg.DryRun {
-			fmt.Fprintf(lg.Stdout(), "%s# would seed team registry: %d peer(s) -> %s%s\n", c.Dim, len(result.CreatedIDs), teamCtx.DBPath, c.Reset)
-		} else {
-			seedTaskTeamRegistry(lg, teamCtx.DBPath, recorder.Store, parentRef, result.CreatedIDs)
-		}
-	}
-
-	if result.Failed > 0 {
-		return result, exitcode.Env
-	}
-	return result, exitcode.OK
-}
-
-func parsePlanCommand(args []string, lg *log.Logger) (planCommandConfig, exitcode.Code) {
-	cfg := planCommandConfig{SleepBetween: cliflags.DefaultSleepBetween, Format: cliflags.DefaultFormat}
+func parsePlanCommand(args []string, lg *log.Logger) (run.PlanCommandConfig, exitcode.Code) {
+	cfg := run.PlanCommandConfig{SleepBetween: cliflags.DefaultSleepBetween, Format: cliflags.DefaultFormat}
 	var limitRaw, sleepRaw string
 	var rawAgents []string
 
@@ -284,7 +89,7 @@ func parsePlanCommand(args []string, lg *log.Logger) (planCommandConfig, exitcod
 		"--session":       func(v string) { cfg.Session = v },
 		"--format": func(v string) {
 			cfg.Format = v
-			cfg.formatExplicit = true
+			cfg.FormatExplicit = true
 		},
 		"--sleep": func(v string) { sleepRaw = v },
 	}
@@ -315,7 +120,7 @@ func parsePlanCommand(args []string, lg *log.Logger) (planCommandConfig, exitcod
 		if handle, ok := valueOptions[arg]; ok {
 			if i+1 >= len(args) {
 				lg.Err("%s requires an argument", arg)
-				return planCommandConfig{}, exitcode.Env
+				return run.PlanCommandConfig{}, exitcode.Env
 			}
 			handle(args[i+1])
 			i += 2
@@ -329,12 +134,12 @@ func parsePlanCommand(args []string, lg *log.Logger) (planCommandConfig, exitcod
 		if strings.HasPrefix(arg, "-") {
 			lg.Err("unknown plan option: %s", arg)
 			fmt.Fprint(lg.Stderr(), planUsage)
-			return planCommandConfig{}, exitcode.Invocation
+			return run.PlanCommandConfig{}, exitcode.Invocation
 		}
 		if cfg.SpecArg != "" {
 			lg.Err("unexpected plan argument: %s", arg)
 			fmt.Fprint(lg.Stderr(), planUsage)
-			return planCommandConfig{}, exitcode.Invocation
+			return run.PlanCommandConfig{}, exitcode.Invocation
 		}
 		cfg.SpecArg = arg
 		i++
@@ -342,85 +147,81 @@ func parsePlanCommand(args []string, lg *log.Logger) (planCommandConfig, exitcod
 
 	if cfg.SpecArg == "" {
 		fmt.Fprint(lg.Stderr(), planUsage)
-		return planCommandConfig{}, exitcode.Invocation
+		return run.PlanCommandConfig{}, exitcode.Invocation
 	}
 	if code := validatePlanActionFlags(cfg, limitRaw, sleepRaw, len(rawAgents) > 0, lg); code != exitcode.OK {
-		return planCommandConfig{}, code
+		return run.PlanCommandConfig{}, code
 	}
 	for _, raw := range rawAgents {
 		if err := parsePlanAgentArg(&cfg, raw); err != nil {
 			lg.Err("%s", err.Error())
-			return planCommandConfig{}, exitcode.Env
+			return run.PlanCommandConfig{}, exitcode.Env
 		}
 	}
 	if limitRaw != "" {
 		n, err := parsePlanPositiveInt("--limit", limitRaw)
 		if err != nil {
 			lg.Err("%s", err.Error())
-			return planCommandConfig{}, exitcode.Env
+			return run.PlanCommandConfig{}, exitcode.Env
 		}
 		cfg.Limit = n
 	}
 	if sleepRaw != "" {
 		if !rePlanNumber.MatchString(sleepRaw) {
 			lg.Err("--sleep must be a number, got: %s", sleepRaw)
-			return planCommandConfig{}, exitcode.Env
+			return run.PlanCommandConfig{}, exitcode.Env
 		}
 		n, _ := strconv.ParseFloat(sleepRaw, 64)
 		cfg.SleepBetween = n
 	}
-	if err := validatePlanBaseBranch("--base-branch", cfg.BaseBranch); err != nil {
+	if err := run.ValidatePlanBaseBranch("--base-branch", cfg.BaseBranch); err != nil {
 		lg.Err("%v", err)
-		return planCommandConfig{}, exitcode.Env
+		return run.PlanCommandConfig{}, exitcode.Env
 	}
 	if cfg.BranchPrefix != "" && strings.ContainsAny(cfg.BranchPrefix, " \t\r\n") {
 		lg.Err("--branch-prefix must not contain whitespace, got: %s", cfg.BranchPrefix)
-		return planCommandConfig{}, exitcode.Env
+		return run.PlanCommandConfig{}, exitcode.Env
 	}
 	if cfg.CloseTaskID != "" {
 		if err := validatePlanTaskID("--close", cfg.CloseTaskID); err != nil {
 			lg.Err("%s", err.Error())
-			return planCommandConfig{}, exitcode.Env
+			return run.PlanCommandConfig{}, exitcode.Env
 		}
 	}
 	if cfg.MergeTaskID != "" {
 		if err := validatePlanTaskID("--merge", cfg.MergeTaskID); err != nil {
 			lg.Err("%s", err.Error())
-			return planCommandConfig{}, exitcode.Env
+			return run.PlanCommandConfig{}, exitcode.Env
 		}
 	}
 	if cfg.OnlyArg != "" && cfg.SkipArg != "" {
 		lg.Err("--only and --skip are mutually exclusive")
-		return planCommandConfig{}, exitcode.Env
+		return run.PlanCommandConfig{}, exitcode.Env
 	}
 	var err error
 	if cfg.OnlyArg != "" {
 		cfg.Only, err = parseTaskIDCSV("--only", cfg.OnlyArg)
 		if err != nil {
 			lg.Err("%s", err.Error())
-			return planCommandConfig{}, exitcode.Env
+			return run.PlanCommandConfig{}, exitcode.Env
 		}
 	}
 	if cfg.SkipArg != "" {
 		cfg.Skip, err = parseTaskIDCSV("--skip", cfg.SkipArg)
 		if err != nil {
 			lg.Err("%s", err.Error())
-			return planCommandConfig{}, exitcode.Env
+			return run.PlanCommandConfig{}, exitcode.Env
 		}
 	}
 	return cfg, exitcode.OK
 }
 
-func (cfg planCommandConfig) actionMode() bool {
-	return cfg.StatusMode || cfg.CloseTaskID != "" || cfg.MergeTaskID != "" || cfg.CleanupMode
-}
-
-func validatePlanActionFlags(cfg planCommandConfig, limitRaw, sleepRaw string, hasAgentFlags bool, lg *log.Logger) exitcode.Code {
+func validatePlanActionFlags(cfg run.PlanCommandConfig, limitRaw, sleepRaw string, hasAgentFlags bool, lg *log.Logger) exitcode.Code {
 	if cfg.Format != "json" && cfg.Format != "table" {
 		lg.Err("--format must be one of json,table, got: %s", cfg.Format)
 		return exitcode.Env
 	}
-	if cfg.formatExplicit && !cfg.StatusMode {
+	if cfg.FormatExplicit && !cfg.StatusMode {
 		lg.Err("--format can only be used with --status")
 		return exitcode.Invocation
 	}
@@ -533,7 +334,7 @@ func planLifecycleConflict(lg *log.Logger, flag string) exitcode.Code {
 	return exitcode.Invocation
 }
 
-func planLifecycleFlagName(cfg planCommandConfig) string {
+func planLifecycleFlagName(cfg run.PlanCommandConfig) string {
 	switch {
 	case cfg.CloseTaskID != "":
 		return "--close"
@@ -560,29 +361,6 @@ func validatePlanTaskID(flag, value string) error {
 	return nil
 }
 
-func (cfg planCommandConfig) cliConfig() *cliflags.Config {
-	return &cliflags.Config{
-		ParentRef:          planSubcommand,
-		Agent:              cfg.Agent,
-		AgentOverrides:     cfg.AgentOverrides,
-		BaseBranch:         cfg.BaseBranch,
-		BranchPrefix:       cfg.BranchPrefix,
-		Session:            cfg.Session,
-		SleepBetween:       cfg.SleepBetween,
-		NoRefresh:          cfg.NoRefresh,
-		DryRun:             cfg.DryRun,
-		Debug:              cfg.Debug,
-		UnblockedOnly:      cfg.UnblockedOnly,
-		Team:               cfg.Team,
-		AutoPullRequest:    cfg.AutoPullRequest,
-		PRReviewGate:       cfg.PRReviewGate,
-		BriefingCodeReview: cfg.BriefingCodeReview,
-		AgentTeamsHint:     cfg.AgentTeamsHint,
-		PRVisualization:    cfg.PRVisualization,
-		DashboardKeybind:   cfg.DashboardKeybind,
-	}
-}
-
 func parsePlanPositiveInt(flag, raw string) (int, error) {
 	if !rePlanPositiveInt.MatchString(raw) {
 		return 0, fmt.Errorf("%s must be a positive integer, got: %s", flag, raw)
@@ -604,7 +382,7 @@ func parseTaskIDCSV(flag, csv string) ([]string, error) {
 	return out, nil
 }
 
-func parsePlanAgentArg(cfg *planCommandConfig, raw string) error {
+func parsePlanAgentArg(cfg *run.PlanCommandConfig, raw string) error {
 	if !strings.Contains(raw, "=") {
 		cfg.Agent = raw
 		return nil
@@ -623,85 +401,13 @@ func parsePlanAgentArg(cfg *planCommandConfig, raw string) error {
 	return nil
 }
 
-func resolvePlanBaseBranch(cfg planCommandConfig, spec planspec.Spec, projectRoot string) (string, error) {
-	if cfg.BaseBranch != "" {
-		return cfg.BaseBranch, nil
-	}
-	if spec.Plan.BaseBranch != "" {
-		if err := validatePlanBaseBranch("plan.base_branch", spec.Plan.BaseBranch); err != nil {
-			return "", err
-		}
-		return spec.Plan.BaseBranch, nil
-	}
-	return worktree.ResolveDefaultBranchAllowMissingOrigin(projectRoot), nil
-}
-
-func validatePlanBaseBranch(label, value string) error {
-	if value != "" && strings.ContainsAny(value, " \t\r\n") {
-		return fmt.Errorf("%s must not contain whitespace, got: %s", label, value)
-	}
-	return nil
-}
-
-func planRerunSpecArg(cfg planCommandConfig, spec planspec.Spec) string {
-	if cfg.DryRun {
-		return cfg.SpecArg
-	}
-	return spec.Plan.Slug
-}
-
-func resolvePlanSpecPath(projectRoot, arg string) string {
-	if filepath.IsAbs(arg) || strings.ContainsRune(arg, os.PathSeparator) || strings.HasSuffix(arg, ".json") {
-		return arg
-	}
-	return filepath.Join(projectRoot, ".fanout", "plans", arg+".json")
-}
-
-func loadPlanState(cfg planCommandConfig, projectRoot string, lg *log.Logger) (state.Store, *state.LockedStore, exitcode.Code) {
-	if cfg.DryRun {
-		store, err := state.LoadProject(projectRoot)
-		if err != nil {
-			lg.Err("%v", err)
-			return state.Store{}, nil, exitcode.Env
-		}
-		return store, nil, exitcode.OK
-	}
-	if err := worktree.EnsureLocalExclude(projectRoot); err != nil {
-		lg.Err("prepare local git exclude: %v", err)
-		return state.Store{}, nil, exitcode.Env
-	}
-	locked, err := state.LockProject(projectRoot)
-	if err != nil {
-		lg.Err("%v", err)
-		return state.Store{}, nil, exitcode.Env
-	}
-	return locked.Store, locked, exitcode.OK
-}
-
-func copyPlanSpec(src, projectRoot, slug string) error {
-	dst := filepath.Join(projectRoot, ".fanout", "plans", slug+".json")
-	srcAbs, srcErr := filepath.Abs(src)
-	dstAbs, dstErr := filepath.Abs(dst)
-	if srcErr == nil && dstErr == nil && srcAbs == dstAbs {
-		return nil
-	}
-	data, err := os.ReadFile(src)
-	if err != nil {
-		return err
-	}
-	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-		return err
-	}
-	return atomicfs.WriteFile(dst, data, 0o644)
-}
-
-func cmdPlanLifecycle(cfg planCommandConfig, lg *log.Logger) exitcode.Code {
+func cmdPlanLifecycle(cfg run.PlanCommandConfig, lg *log.Logger) exitcode.Code {
 	mode := planActionModeFlag(cfg)
 	rt, code := resolveStateRuntimeForMode(mode, lg)
 	if code != exitcode.OK {
 		return code
 	}
-	cfg.SpecPath = resolvePlanSpecPath(rt.projectRoot, cfg.SpecArg)
+	cfg.SpecPath = run.ResolvePlanSpecPath(rt.projectRoot, cfg.SpecArg)
 	spec, code := loadPlanActionSpec(cfg, lg)
 	if code != exitcode.OK {
 		return code
@@ -729,7 +435,7 @@ func cmdPlanLifecycle(cfg planCommandConfig, lg *log.Logger) exitcode.Code {
 	}
 }
 
-func planActionModeFlag(cfg planCommandConfig) string {
+func planActionModeFlag(cfg run.PlanCommandConfig) string {
 	switch {
 	case cfg.StatusMode:
 		return "--status"
@@ -744,7 +450,7 @@ func planActionModeFlag(cfg planCommandConfig) string {
 	}
 }
 
-func loadPlanActionSpec(cfg planCommandConfig, lg *log.Logger) (planspec.Spec, exitcode.Code) {
+func loadPlanActionSpec(cfg run.PlanCommandConfig, lg *log.Logger) (planspec.Spec, exitcode.Code) {
 	spec, err := planspec.LoadWithoutResolvedNameChecks(cfg.SpecPath)
 	if err != nil {
 		lg.Err("%s: %v", planActionModeFlag(cfg), err)
@@ -756,22 +462,22 @@ func loadPlanActionSpec(cfg planCommandConfig, lg *log.Logger) (planspec.Spec, e
 	return spec, exitcode.OK
 }
 
-func validatePlanActionSpecNames(cfg planCommandConfig, spec planspec.Spec, lg *log.Logger) (planspec.Spec, exitcode.Code) {
-	if err := validatePlanExecutionNames(spec, cfg); err != nil {
+func validatePlanActionSpecNames(cfg run.PlanCommandConfig, spec planspec.Spec, lg *log.Logger) (planspec.Spec, exitcode.Code) {
+	if err := run.ValidatePlanExecutionNames(spec, cfg); err != nil {
 		lg.Err("%s: validate plan execution names %s: %v", planActionModeFlag(cfg), cfg.SpecPath, err)
 		return planspec.Spec{}, planActionInputCode(cfg)
 	}
 	return spec, exitcode.OK
 }
 
-func planActionInputCode(cfg planCommandConfig) exitcode.Code {
+func planActionInputCode(cfg run.PlanCommandConfig) exitcode.Code {
 	if cfg.StatusMode {
 		return exitcode.Invocation
 	}
 	return exitcode.Env
 }
 
-func cmdPlanStatus(cfg planCommandConfig, spec planspec.Spec, projectRoot, statePath string, lg *log.Logger) exitcode.Code {
+func cmdPlanStatus(cfg run.PlanCommandConfig, spec planspec.Spec, projectRoot, statePath string, lg *log.Logger) exitcode.Code {
 	if projectRoot == "" || !dirExists(projectRoot) {
 		lg.Err("--status: project_root is not a directory: %s (state=%s)", emptyLabel(projectRoot), statePath)
 		return exitcode.Invocation
@@ -794,7 +500,7 @@ func cmdPlanStatus(cfg planCommandConfig, spec planspec.Spec, projectRoot, state
 	return statusreport.WritePlanReport(report, lg)
 }
 
-func planStatusBranch(cfg planCommandConfig, spec planspec.Spec, store state.Store, parent string, task planspec.Task) string {
+func planStatusBranch(cfg run.PlanCommandConfig, spec planspec.Spec, store state.Store, parent string, task planspec.Task) string {
 	if branch := recordedTaskBranch(store, parent, task.ID); branch != "" {
 		return branch
 	}
@@ -810,367 +516,11 @@ func recordedTaskBranch(store state.Store, parent, taskID string) string {
 	return ""
 }
 
-func planTaskBranch(cfg planCommandConfig, spec planspec.Spec, task planspec.Task) string {
+func planTaskBranch(cfg run.PlanCommandConfig, spec planspec.Spec, task planspec.Task) string {
 	if task.Branch != "" {
 		return task.Branch
 	}
 	return naming.BranchName("", cfg.BranchPrefix, panelaunch.PlanTaskSlug(spec.Plan.Slug, task))
-}
-
-func validatePlanExecutionNames(spec planspec.Spec, cfg planCommandConfig) error {
-	seenSlugs := map[string]int{}
-	seenBranches := map[string]int{}
-	for i, task := range spec.Tasks {
-		slug := panelaunch.PlanTaskSlug(spec.Plan.Slug, task)
-		if prev, ok := seenSlugs[slug]; ok {
-			return fmt.Errorf("tasks[%d] final slug %q duplicates tasks[%d]", i, slug, prev)
-		}
-		seenSlugs[slug] = i
-
-		branch := task.Branch
-		if branch == "" {
-			branch = naming.BranchName("", cfg.BranchPrefix, slug)
-		}
-		if prev, ok := seenBranches[branch]; ok {
-			return fmt.Errorf("tasks[%d] final branch %q duplicates tasks[%d]", i, branch, prev)
-		}
-		seenBranches[branch] = i
-	}
-	return nil
-}
-
-func mergeTaskFanned(primary, fallback map[string]bool) map[string]bool {
-	out := map[string]bool{}
-	for id := range primary {
-		out[id] = true
-	}
-	for id := range fallback {
-		out[id] = true
-	}
-	return out
-}
-
-func existingPlanWorktreeFanned(projectRoot string, spec planspec.Spec) map[string]bool {
-	out := map[string]bool{}
-	worktreeNames := existingWorktreeNames(filepath.Join(projectRoot, ".fanout", "worktrees"))
-	for _, task := range spec.Tasks {
-		if worktreeNameMatchesExact(worktreeNames, panelaunch.PlanTaskSlug(spec.Plan.Slug, task)) {
-			out[task.ID] = true
-		}
-	}
-	return out
-}
-
-func buildTaskPlan(cfg planCommandConfig, spec planspec.Spec, fanned map[string]bool, taskComplete func(planspec.Task) bool) taskPlan {
-	plan := taskPlan{
-		TotalTasks:     len(spec.Tasks),
-		SourceArgument: cfg.SpecArg,
-	}
-	filtered, onlyRows, skipRows, missingOnly := filterTaskOnlySkip(spec.Tasks, cfg.Only, cfg.Skip)
-	plan.FilteredOnly = onlyRows
-	plan.FilteredSkip = skipRows
-	plan.MissingOnly = missingOnly
-	plan.AfterFilter = len(filtered)
-	if plan.AfterFilter == 0 {
-		return plan
-	}
-
-	targets, skipped := splitAlreadyFannedTasks(filtered, fanned)
-	plan.Targets = targets
-	plan.AlreadyFanned = skipped
-	plan.UnfannedCount = len(targets)
-	if plan.UnfannedCount == 0 {
-		return plan
-	}
-
-	if cfg.UnblockedOnly {
-		complete := cachedTaskComplete(taskComplete)
-		plan.Targets, plan.AlreadyComplete = splitCompleteTasks(plan.Targets, complete)
-		plan.UnfannedCount = len(plan.Targets)
-		if plan.UnfannedCount == 0 {
-			return plan
-		}
-		plan.Targets, plan.BlockedRows = splitPlanBlocked(plan.Targets, spec.Tasks, complete)
-	}
-	plan.Targets, plan.LimitDeferred = applyTaskLimit(plan.Targets, cfg.Limit)
-	return plan
-}
-
-func filterTaskOnlySkip(tasks []planspec.Task, only, skip []string) (kept, filteredOnly, filteredSkip []planspec.Task, missingOnly []string) {
-	if len(only) == 0 && len(skip) == 0 {
-		return tasks, nil, nil, nil
-	}
-
-	taskSet := map[string]bool{}
-	for _, task := range tasks {
-		taskSet[task.ID] = true
-	}
-	for _, id := range only {
-		if !taskSet[id] {
-			missingOnly = append(missingOnly, id)
-		}
-	}
-
-	onlySet := stringSet(only)
-	skipSet := stringSet(skip)
-	for _, task := range tasks {
-		switch {
-		case len(only) > 0 && !onlySet[task.ID]:
-			filteredOnly = append(filteredOnly, task)
-		case len(skip) > 0 && skipSet[task.ID]:
-			filteredSkip = append(filteredSkip, task)
-		default:
-			kept = append(kept, task)
-		}
-	}
-	return kept, filteredOnly, filteredSkip, missingOnly
-}
-
-func splitAlreadyFannedTasks(tasks []planspec.Task, fanned map[string]bool) (targets []planspec.Task, skipped []string) {
-	for _, task := range tasks {
-		if fanned[task.ID] {
-			skipped = append(skipped, task.ID)
-			continue
-		}
-		targets = append(targets, task)
-	}
-	return targets, skipped
-}
-
-func splitCompleteTasks(tasks []planspec.Task, taskComplete func(planspec.Task) bool) (targets []planspec.Task, skipped []string) {
-	for _, task := range tasks {
-		if taskComplete(task) {
-			skipped = append(skipped, task.ID)
-			continue
-		}
-		targets = append(targets, task)
-	}
-	return targets, skipped
-}
-
-func splitPlanBlocked(targets, allTasks []planspec.Task, taskComplete func(planspec.Task) bool) (kept []planspec.Task, blocked []taskBlockedRow) {
-	byID := map[string]planspec.Task{}
-	for _, task := range allTasks {
-		byID[task.ID] = task
-	}
-	targetIDs := map[string]bool{}
-	for _, task := range targets {
-		targetIDs[task.ID] = true
-	}
-	cache := map[string]bool{}
-	for _, task := range targets {
-		var openDeps []string
-		for _, depID := range task.BlockedBy {
-			dep, ok := byID[depID]
-			if !ok {
-				continue
-			}
-			complete, ok := cache[depID]
-			if !ok {
-				complete = taskComplete(dep)
-				cache[depID] = complete
-			}
-			if complete {
-				continue
-			}
-			if targetIDs[depID] {
-				openDeps = append(openDeps, depID)
-				continue
-			}
-			openDeps = append(openDeps, depID)
-		}
-		if len(openDeps) > 0 {
-			blocked = append(blocked, taskBlockedRow{Task: task, Refs: strings.Join(openDeps, ", ")})
-			continue
-		}
-		kept = append(kept, task)
-	}
-	return kept, blocked
-}
-
-func cachedTaskComplete(taskComplete func(planspec.Task) bool) func(planspec.Task) bool {
-	cache := map[string]bool{}
-	return func(task planspec.Task) bool {
-		complete, ok := cache[task.ID]
-		if !ok {
-			complete = taskComplete(task)
-			cache[task.ID] = complete
-		}
-		return complete
-	}
-}
-
-func planTaskComplete(gh ghissue.Runner, cfg *cliflags.Config, projectRoot string, store state.Store, spec planspec.Spec, task planspec.Task, lg *log.Logger) bool {
-	branch := task.Branch
-	if branch == "" {
-		branch = naming.BranchName("", cfg.BranchPrefix, panelaunch.PlanTaskSlug(spec.Plan.Slug, task))
-	}
-	prs, err := gh.PRsForBranch(branch)
-	if err != nil {
-		lg.Warn("%s: could not resolve blocker PRs for branch %s; treating as incomplete: %v", task.ID, branch, err)
-		return false
-	}
-	for _, pr := range prs {
-		if strings.EqualFold(pr.State, "MERGED") || pr.MergedAt != nil {
-			return true
-		}
-	}
-	if len(prs) > 0 {
-		return false
-	}
-
-	parentRef := panelaunch.PlanParentRef(spec.Plan.Slug)
-	if _, ok := store.FindTask(parentRef, task.ID); ok {
-		return false
-	}
-	if worktreeNameMatchesExact(existingWorktreeNames(filepath.Join(projectRoot, ".fanout", "worktrees")), panelaunch.PlanTaskSlug(spec.Plan.Slug, task)) {
-		return false
-	}
-	return false
-}
-
-func applyTaskLimit(tasks []planspec.Task, limit int) (targets, deferred []planspec.Task) {
-	if limit > 0 && len(tasks) > limit {
-		return tasks[:limit], tasks[limit:]
-	}
-	return tasks, nil
-}
-
-func executeTaskPlan(cfg *cliflags.Config, lg *log.Logger, info *fanoutruntime.Info, spec planspec.Spec, targets []planspec.Task, resolvedSettings settings.Settings, hookConfig hooks.Config, recorder panelaunch.StateRecorder, c log.Palette, commandName string, teamCtx *briefing.TeamContext) taskExecutionResult {
-	launcher := &panelaunch.Launcher{Cfg: cfg, Log: lg, Info: info, Recorder: recorder, Palette: c, CommandName: commandName}
-	var result taskExecutionResult
-	for i, task := range targets {
-		req := panelaunch.NewTaskRequest(cfg, info.ProjectRoot, spec, task, resolvedSettings, hookConfig, teamCtx)
-		if !launcher.LaunchOK(req) {
-			result.Failed++
-			break
-		}
-		result.Created++
-		result.CreatedIDs = append(result.CreatedIDs, task.ID)
-		if i < len(targets)-1 && cfg.SleepBetween > 0 {
-			sleepBetweenIssues(time.Duration(cfg.SleepBetween * float64(time.Second)))
-		}
-	}
-	return result
-}
-
-func stringSet(values []string) map[string]bool {
-	set := make(map[string]bool, len(values))
-	for _, value := range values {
-		set[value] = true
-	}
-	return set
-}
-
-func logTaskPlanDetails(plan taskPlan, lg *log.Logger) {
-	for _, id := range plan.MissingOnly {
-		lg.Warn("--only: %s not in plan task set (ignored)", id)
-	}
-	for _, row := range plan.BlockedRows {
-		lg.Info("deferred: %s (blocked by %s)", row.Task.ID, row.Refs)
-	}
-}
-
-func logAlreadyFannedTasks(skipped []string, lg *log.Logger) {
-	if len(skipped) == 0 {
-		return
-	}
-	slices.Sort(skipped)
-	lg.Info("already fanned-out (skipping): %s", strings.Join(skipped, " "))
-}
-
-func logAlreadyCompleteTasks(skipped []string, lg *log.Logger) {
-	if len(skipped) == 0 {
-		return
-	}
-	slices.Sort(skipped)
-	lg.Info("already complete (skipping): %s", strings.Join(skipped, " "))
-}
-
-func printTaskDryRunPlan(plan taskPlan, lg *log.Logger, c log.Palette) {
-	if len(plan.FilteredOnly) > 0 || len(plan.FilteredSkip) > 0 {
-		fmt.Fprintf(lg.Stdout(), "\n%sfiltered out:%s\n", c.Info, c.Reset)
-		for _, row := range plan.FilteredOnly {
-			fmt.Fprintf(lg.Stdout(), "  %s %s - not in --only\n", row.ID, row.Title)
-		}
-		for _, row := range plan.FilteredSkip {
-			fmt.Fprintf(lg.Stdout(), "  %s %s - in --skip\n", row.ID, row.Title)
-		}
-		fmt.Fprintln(lg.Stdout())
-	}
-
-	if len(plan.BlockedRows) > 0 {
-		fmt.Fprintf(lg.Stdout(), "\n%sdeferred (blocked):%s\n", c.Info, c.Reset)
-		for _, row := range plan.BlockedRows {
-			fmt.Fprintf(lg.Stdout(), "  %s %s - blocked by %s\n", row.Task.ID, row.Task.Title, row.Refs)
-		}
-		fmt.Fprintln(lg.Stdout())
-	}
-}
-
-func printTaskSummary(plan taskPlan, result taskExecutionResult, cfg planCommandConfig, lg *log.Logger, c log.Palette, commandName string) {
-	fmt.Fprintln(lg.Stdout())
-	if result.Created > 0 {
-		lg.Ok("created: %d", result.Created)
-	}
-	if result.Failed > 0 {
-		lg.Err("failed:  %d", result.Failed)
-	}
-	if len(plan.AlreadyFanned) > 0 {
-		lg.Info("skipped (already fanned-out): %d", len(plan.AlreadyFanned))
-	}
-	if len(plan.AlreadyComplete) > 0 {
-		lg.Info("skipped (complete): %d", len(plan.AlreadyComplete))
-	}
-	if total := len(plan.FilteredOnly) + len(plan.FilteredSkip); total > 0 {
-		lg.Info("skipped (filtered): %d", total)
-	}
-	if len(plan.BlockedRows) > 0 {
-		lg.Info("deferred (blocked): %d", len(plan.BlockedRows))
-	}
-
-	if len(plan.LimitDeferred) == 0 {
-		return
-	}
-	if result.Failed > 0 {
-		lg.Info("deferred (--limit): %d", len(plan.LimitDeferred))
-		lg.Warn("not printing --limit rerun hint because this run failed before all selected targets completed")
-		return
-	}
-	fmt.Fprintf(lg.Stdout(), "\n%sDeferred %d task(s) due to --limit. Rerun with:%s\n", c.Info, len(plan.LimitDeferred), c.Reset)
-	ids := taskIDCSV(plan.LimitDeferred)
-	fmt.Fprintf(lg.Stdout(), "  %s\n", strings.Join(taskIDs(plan.LimitDeferred), " "))
-	cliCfg := cfg.cliConfig()
-	fmt.Fprintf(lg.Stdout(), "  %s plan %s --only %s%s%s%s%s%s%s%s\n",
-		shellQuote(commandName),
-		shellQuote(cfg.SpecArg),
-		shellQuote(ids),
-		boolFlag(" --unblocked-only", cfg.UnblockedOnly),
-		boolFlag(" --team", cfg.Team),
-		settingsFlags(cliCfg),
-		worktreeFlags(cliCfg),
-		agentFlagsForTasks(cfg.Agent, cfg.AgentOverrides, plan.LimitDeferred),
-		optFlag("--session", cfg.Session),
-		optFlag("--sleep", sleepFlagValue(cfg.SleepBetween)))
-}
-
-func taskIDCSV(tasks []planspec.Task) string {
-	return strings.Join(taskIDs(tasks), ",")
-}
-
-func taskIDs(tasks []planspec.Task) []string {
-	ids := make([]string, len(tasks))
-	for i, task := range tasks {
-		ids[i] = task.ID
-	}
-	return ids
-}
-
-func sleepFlagValue(v float64) string {
-	if v == cliflags.DefaultSleepBetween {
-		return ""
-	}
-	return strconv.FormatFloat(v, 'f', -1, 64)
 }
 
 const planUsage = `Usage: fanout plan <spec.json | plan-slug> [options]

--- a/cmd/fanout/plancmd_test.go
+++ b/cmd/fanout/plancmd_test.go
@@ -7,13 +7,11 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/butaosuinu/fanout/internal/app/cliflags"
 	"github.com/butaosuinu/fanout/internal/app/panelaunch"
+	"github.com/butaosuinu/fanout/internal/app/run"
 	"github.com/butaosuinu/fanout/internal/core/exitcode"
 	"github.com/butaosuinu/fanout/internal/core/planspec"
-	"github.com/butaosuinu/fanout/internal/infra/ghissue"
 	"github.com/butaosuinu/fanout/internal/infra/log"
-	"github.com/butaosuinu/fanout/internal/infra/state"
 )
 
 func TestPlanTaskSlugQualifiesDefaultAndHonorsExplicit(t *testing.T) {
@@ -25,80 +23,6 @@ func TestPlanTaskSlugQualifiesDefaultAndHonorsExplicit(t *testing.T) {
 	task.Slug = "shared-api-client"
 	if got := panelaunch.PlanTaskSlug("launch-plan", task); got != "shared-api-client" {
 		t.Fatalf("explicit slug = %q", got)
-	}
-}
-
-func TestValidatePlanExecutionNamesRejectsFinalDuplicates(t *testing.T) {
-	tests := []struct {
-		name    string
-		spec    planspec.Spec
-		wantErr string
-	}{
-		{
-			name: "final slug duplicate",
-			spec: planspec.Spec{
-				Plan: planspec.Plan{Slug: "launch-plan"},
-				Tasks: []planspec.Task{
-					{ID: "api-client", Title: "Extract API client"},
-					{ID: "worker", Title: "Worker", Slug: "launch-plan-extract-api-client-api-client"},
-				},
-			},
-			wantErr: "final slug",
-		},
-		{
-			name: "final branch duplicate",
-			spec: planspec.Spec{
-				Plan: planspec.Plan{Slug: "launch-plan"},
-				Tasks: []planspec.Task{
-					{ID: "api-client", Title: "Extract API client"},
-					{ID: "worker", Title: "Worker", Branch: "fanout/launch-plan-extract-api-client-api-client"},
-				},
-			},
-			wantErr: "final branch",
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			err := validatePlanExecutionNames(tc.spec, planCommandConfig{})
-			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
-				t.Fatalf("validatePlanExecutionNames() error = %v, want %q", err, tc.wantErr)
-			}
-		})
-	}
-}
-
-func TestResolvePlanBaseBranchValidatesSpecBranchOnlyWhenUsed(t *testing.T) {
-	spec := planspec.Spec{Plan: planspec.Plan{Slug: "launch-plan", BaseBranch: "release candidate"}}
-
-	got, err := resolvePlanBaseBranch(planCommandConfig{BaseBranch: "main"}, spec, t.TempDir())
-	if err != nil || got != "main" {
-		t.Fatalf("resolvePlanBaseBranch() = %q, %v; want main, nil", got, err)
-	}
-
-	_, err = resolvePlanBaseBranch(planCommandConfig{}, spec, t.TempDir())
-	if err == nil || !strings.Contains(err.Error(), "plan.base_branch must not contain whitespace") {
-		t.Fatalf("resolvePlanBaseBranch() error = %v, want plan.base_branch whitespace error", err)
-	}
-}
-
-func TestResolvePlanBaseBranchUsesCurrentBranchWithoutOrigin(t *testing.T) {
-	repo := t.TempDir()
-	gitCmdTest(t, repo, "init", "-b", "trunk")
-	gitCmdTest(t, repo, "config", "user.email", "fanout@example.test")
-	gitCmdTest(t, repo, "config", "user.name", "Fanout Test")
-	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("base\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	gitCmdTest(t, repo, "add", "README.md")
-	gitCmdTest(t, repo, "commit", "-m", "base")
-
-	got, err := resolvePlanBaseBranch(planCommandConfig{}, planspec.Spec{Plan: planspec.Plan{Slug: "launch-plan"}}, repo)
-	if err != nil {
-		t.Fatalf("resolvePlanBaseBranch() error = %v", err)
-	}
-	if got != "trunk" {
-		t.Fatalf("resolvePlanBaseBranch() = %q, want current branch trunk", got)
 	}
 }
 
@@ -121,17 +45,6 @@ func TestCheckPlanDepsDoesNotRequireGhForUnblockedOnly(t *testing.T) {
 	}
 }
 
-func TestPlanRerunSpecArgUsesCopiedPlanSlugForLiveRuns(t *testing.T) {
-	spec := planspec.Spec{Plan: planspec.Plan{Slug: "launch-plan"}}
-
-	if got := planRerunSpecArg(planCommandConfig{DryRun: true, SpecArg: "/tmp/plan.json"}, spec); got != "/tmp/plan.json" {
-		t.Fatalf("dry-run rerun spec arg = %q, want original path", got)
-	}
-	if got := planRerunSpecArg(planCommandConfig{SpecArg: "/tmp/plan.json"}, spec); got != "launch-plan" {
-		t.Fatalf("live rerun spec arg = %q, want copied plan slug", got)
-	}
-}
-
 func TestParsePlanAgentOverrides(t *testing.T) {
 	cfg := parsePlanOK(t, "launch-plan",
 		"--agent", "claude",
@@ -144,7 +57,7 @@ func TestParsePlanAgentOverrides(t *testing.T) {
 	if cfg.Agent != "codex" {
 		t.Fatalf("Agent = %q, want codex", cfg.Agent)
 	}
-	cliCfg := cfg.cliConfig()
+	cliCfg := cfg.CLIConfig()
 	if got := cliCfg.EffectiveAgent("api-client"); got != "claude" {
 		t.Fatalf("EffectiveAgent(api-client) = %q, want claude", got)
 	}
@@ -213,8 +126,8 @@ func TestParsePlanTeamFlagSetsConfig(t *testing.T) {
 	if !cfg.Team {
 		t.Fatal("cfg.Team = false, want true")
 	}
-	if !cfg.cliConfig().Team {
-		t.Fatal("cliConfig().Team = false, want true (forwarded to executeTaskPlan)")
+	if !cfg.CLIConfig().Team {
+		t.Fatal("CLIConfig().Team = false, want true (forwarded to the task launch lane)")
 	}
 }
 
@@ -241,7 +154,7 @@ func TestParsePlanTeamRejectedInStatusAndLifecycle(t *testing.T) {
 }
 
 func TestPlanStatusAllowsBranchPrefixForFallbackBranches(t *testing.T) {
-	cfg := planCommandConfig{StatusMode: true, Format: "json", BranchPrefix: "custom/"}
+	cfg := run.PlanCommandConfig{StatusMode: true, Format: "json", BranchPrefix: "custom/"}
 
 	if code := validatePlanActionFlags(cfg, "", "", false, log.New(false)); code != exitcode.OK {
 		t.Fatalf("validatePlanActionFlags() = %d, want %d", code, exitcode.OK)
@@ -254,7 +167,7 @@ func TestPlanStatusAllowsBranchPrefixForFallbackBranches(t *testing.T) {
 	}
 }
 
-func parsePlanOK(t *testing.T, args ...string) planCommandConfig {
+func parsePlanOK(t *testing.T, args ...string) run.PlanCommandConfig {
 	t.Helper()
 	var stdout, stderr bytes.Buffer
 	cfg, code := parsePlanCommand(args, log.NewWith(&stdout, &stderr, false))
@@ -262,146 +175,4 @@ func parsePlanOK(t *testing.T, args ...string) planCommandConfig {
 		t.Fatalf("parsePlanCommand(%q) failed with code=%d stdout=%q stderr=%q", args, code, stdout.String(), stderr.String())
 	}
 	return cfg
-}
-
-func TestSplitPlanBlockedKeepsSameRunDependenciesOpen(t *testing.T) {
-	tasks := []planspec.Task{
-		{ID: "base-types", Title: "Define base types"},
-		{ID: "api-client", Title: "Extract API client", BlockedBy: []string{"base-types"}},
-	}
-
-	kept, blocked := splitPlanBlocked(tasks, tasks, func(planspec.Task) bool {
-		return false
-	})
-
-	if len(kept) != 1 || kept[0].ID != "base-types" {
-		t.Fatalf("kept = %+v, want only base-types", kept)
-	}
-	if len(blocked) != 1 || blocked[0].Task.ID != "api-client" || blocked[0].Refs != "base-types" {
-		t.Fatalf("blocked = %+v, want api-client blocked by base-types", blocked)
-	}
-}
-
-func TestSplitPlanBlockedAllowsCompletedTargetDependencies(t *testing.T) {
-	tasks := []planspec.Task{
-		{ID: "base-types", Title: "Define base types"},
-		{ID: "api-client", Title: "Extract API client", BlockedBy: []string{"base-types"}},
-	}
-
-	kept, blocked := splitPlanBlocked(tasks[1:], tasks, func(task planspec.Task) bool {
-		return task.ID == "base-types"
-	})
-
-	if len(blocked) != 0 {
-		t.Fatalf("blocked = %+v, want no blocked rows", blocked)
-	}
-	if len(kept) != 1 || kept[0].ID != "api-client" {
-		t.Fatalf("kept = %+v, want api-client", kept)
-	}
-}
-
-func TestBuildTaskPlanSkipsCompletedTargetsBeforeBlockerCheck(t *testing.T) {
-	spec := planspec.Spec{
-		Plan: planspec.Plan{Slug: "launch-plan"},
-		Tasks: []planspec.Task{
-			{ID: "base-types", Title: "Define base types"},
-			{ID: "api-client", Title: "Extract API client", BlockedBy: []string{"base-types"}},
-		},
-	}
-
-	plan := buildTaskPlan(planCommandConfig{UnblockedOnly: true}, spec, nil, func(task planspec.Task) bool {
-		return task.ID == "base-types"
-	})
-
-	if len(plan.AlreadyComplete) != 1 || plan.AlreadyComplete[0] != "base-types" {
-		t.Fatalf("AlreadyComplete = %+v, want base-types", plan.AlreadyComplete)
-	}
-	if len(plan.BlockedRows) != 0 {
-		t.Fatalf("BlockedRows = %+v, want none", plan.BlockedRows)
-	}
-	if len(plan.Targets) != 1 || plan.Targets[0].ID != "api-client" {
-		t.Fatalf("Targets = %+v, want only api-client", plan.Targets)
-	}
-}
-
-func TestBuildTaskPlanSkipsCompletedLeafTargets(t *testing.T) {
-	spec := planspec.Spec{
-		Plan: planspec.Plan{Slug: "launch-plan"},
-		Tasks: []planspec.Task{
-			{ID: "ui-shell", Title: "Build UI shell"},
-		},
-	}
-
-	plan := buildTaskPlan(planCommandConfig{UnblockedOnly: true}, spec, nil, func(task planspec.Task) bool {
-		return task.ID == "ui-shell"
-	})
-
-	if len(plan.AlreadyComplete) != 1 || plan.AlreadyComplete[0] != "ui-shell" {
-		t.Fatalf("AlreadyComplete = %+v, want ui-shell", plan.AlreadyComplete)
-	}
-	if plan.UnfannedCount != 0 || len(plan.Targets) != 0 {
-		t.Fatalf("targets = %+v (unfanned=%d), want none", plan.Targets, plan.UnfannedCount)
-	}
-}
-
-func TestPlanTaskCompleteTreatsMissingEvidenceAsIncomplete(t *testing.T) {
-	binDir := t.TempDir()
-	ghPath := filepath.Join(binDir, "gh")
-	if err := os.WriteFile(ghPath, []byte("#!/bin/sh\nprintf '[]\\n'\n"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
-
-	projectRoot := t.TempDir()
-	spec := planspec.Spec{
-		Plan:  planspec.Plan{Slug: "launch-plan"},
-		Tasks: []planspec.Task{{ID: "base-types", Title: "Define base types"}},
-	}
-
-	complete := planTaskComplete(
-		ghissue.Runner{Cwd: projectRoot},
-		&cliflags.Config{},
-		projectRoot,
-		state.Store{},
-		spec,
-		spec.Tasks[0],
-		log.New(false),
-	)
-
-	if complete {
-		t.Fatal("planTaskComplete() = true, want false without merged PR, state row, or worktree")
-	}
-}
-
-func TestPlanTaskCompleteTreatsNonMergedPRAsIncomplete(t *testing.T) {
-	binDir := t.TempDir()
-	ghPath := filepath.Join(binDir, "gh")
-	if err := os.WriteFile(ghPath, []byte(`#!/bin/sh
-cat <<'JSON'
-[{"number":42,"state":"OPEN","mergedAt":null,"isDraft":false,"reviewDecision":"","statusCheckRollup":null}]
-JSON
-`), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
-
-	projectRoot := t.TempDir()
-	spec := planspec.Spec{
-		Plan:  planspec.Plan{Slug: "launch-plan"},
-		Tasks: []planspec.Task{{ID: "base-types", Title: "Define base types"}},
-	}
-
-	complete := planTaskComplete(
-		ghissue.Runner{Cwd: projectRoot},
-		&cliflags.Config{},
-		projectRoot,
-		state.Store{},
-		spec,
-		spec.Tasks[0],
-		log.New(false),
-	)
-
-	if complete {
-		t.Fatal("planTaskComplete() = true, want false when branch has a non-merged PR")
-	}
 }

--- a/cmd/fanout/tui.go
+++ b/cmd/fanout/tui.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/butaosuinu/fanout/internal/app/panelaunch"
 	"github.com/butaosuinu/fanout/internal/app/panelayout"
+	"github.com/butaosuinu/fanout/internal/app/run"
 	"github.com/butaosuinu/fanout/internal/core/exitcode"
 	"github.com/butaosuinu/fanout/internal/infra/hooks"
 	"github.com/butaosuinu/fanout/internal/infra/log"
@@ -252,6 +253,6 @@ func tuiLaunchCommand(commandName, projectRoot string) string {
 	// overrides any stale FANOUT_TUI_ENHANCED_KEYS that an earlier run captured in
 	// the tmux session environment — otherwise an old opt-out would persist even
 	// after relaunching from a plain shell with the variable unset.
-	prefix := fanouttui.EnhancedKeysEnv + "=" + shellQuote(os.Getenv(fanouttui.EnhancedKeysEnv)) + " "
-	return "cd " + shellQuote(projectRoot) + " && " + prefix + shellQuote(exe)
+	prefix := fanouttui.EnhancedKeysEnv + "=" + run.ShellQuote(os.Getenv(fanouttui.EnhancedKeysEnv)) + " "
+	return "cd " + run.ShellQuote(projectRoot) + " && " + prefix + run.ShellQuote(exe)
 }

--- a/cmd/fanout/tui_issue.go
+++ b/cmd/fanout/tui_issue.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/butaosuinu/fanout/internal/app/cliflags"
+	"github.com/butaosuinu/fanout/internal/app/run"
 	"github.com/butaosuinu/fanout/internal/app/watch"
 	"github.com/butaosuinu/fanout/internal/core/agent"
 	"github.com/butaosuinu/fanout/internal/infra/ghissue"
@@ -76,7 +77,7 @@ func newTUIListIssueChildrenFunc(projectRoot string) func(parent int) ([]fanoutt
 		if err != nil {
 			return nil, err
 		}
-		open := openIssues(loaded.Children)
+		open := run.OpenIssues(loaded.Children)
 		targets := make([]fanouttui.ChildTarget, 0, len(open))
 		for _, child := range open {
 			targets = append(targets, fanouttui.ChildTarget{
@@ -151,7 +152,7 @@ func launchIssueSessionFromTUI(projectRoot, session, commandName string, resolve
 }
 
 // recordedPaneCountForParent counts state rows under one fan-out parent; the
-// before/after difference is the created-pane count runWithRuntime does not
+// before/after difference is the created-pane count run.Issues does not
 // return. A read failure degrades to 0 rather than failing the launch report.
 func recordedPaneCountForParent(projectRoot, parentRef string) int {
 	store, err := state.LoadProject(projectRoot)

--- a/cmd/fanout/tui_launch.go
+++ b/cmd/fanout/tui_launch.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/butaosuinu/fanout/internal/app/cliflags"
 	"github.com/butaosuinu/fanout/internal/app/panelaunch"
+	"github.com/butaosuinu/fanout/internal/app/run"
 	"github.com/butaosuinu/fanout/internal/core/agent"
 	"github.com/butaosuinu/fanout/internal/core/exitcode"
 	"github.com/butaosuinu/fanout/internal/infra/hooks"
@@ -52,7 +53,7 @@ func launchManualPaneFromTUI(projectRoot, session, commandName string, hookConfi
 	var stdout, stderr bytes.Buffer
 	launchLogger := log.NewWith(&stdout, &stderr, false)
 	cfg := manualPaneConfigForTUIAgent(agentNames[0])
-	_, recorder, code := loadRunState(cfg, projectRoot, launchLogger)
+	_, recorder, code := run.LoadState(cfg.DryRun, projectRoot, launchLogger)
 	if code != exitcode.OK {
 		return "", bufferedLaunchError(stdout, stderr, "load fanout state")
 	}

--- a/cmd/fanout/tui_popup.go
+++ b/cmd/fanout/tui_popup.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/butaosuinu/fanout/internal/app/run"
 	"github.com/butaosuinu/fanout/internal/core/exitcode"
 	"github.com/butaosuinu/fanout/internal/infra/log"
 	"github.com/butaosuinu/fanout/internal/infra/tmuxrun"
@@ -296,7 +297,7 @@ func tuiHelpPopupShellCommand(commandName string, width, height int) string {
 		exe = commandName
 	}
 	parts := []string{
-		shellQuote(exe),
+		run.ShellQuote(exe),
 		tuiHelpPopupCommand,
 		"--width", fmt.Sprintf("%d", width),
 		"--height", fmt.Sprintf("%d", height),
@@ -304,7 +305,7 @@ func tuiHelpPopupShellCommand(commandName string, width, height int) string {
 	// display-popup runs under the tmux server's environment. Forward PATH so a
 	// fallback command name resolves the same way as the parent fanout process.
 	if path := os.Getenv("PATH"); path != "" {
-		parts = append([]string{"PATH=" + shellQuote(path)}, parts...)
+		parts = append([]string{"PATH=" + run.ShellQuote(path)}, parts...)
 	}
 	return strings.Join(parts, " ")
 }
@@ -315,29 +316,29 @@ func tuiNewPanePopupShellCommand(commandName, projectRoot, resultFile, doneFile,
 		exe = commandName
 	}
 	parts := []string{
-		shellQuote(exe),
+		run.ShellQuote(exe),
 		tuiNewPanePopupCommand,
-		"--project-root", shellQuote(projectRoot),
-		"--result-file", shellQuote(resultFile),
-		"--default-agent", shellQuote(defaultAgent),
+		"--project-root", run.ShellQuote(projectRoot),
+		"--result-file", run.ShellQuote(resultFile),
+		"--default-agent", run.ShellQuote(defaultAgent),
 		"--width", fmt.Sprintf("%d", width),
 		"--height", fmt.Sprintf("%d", height),
 	}
 	// Enhanced keyboard input is on by default. Always forward the current value,
 	// including opt-out values, so the helper mirrors the parent TUI.
-	prefix := fanouttui.EnhancedKeysEnv + "=" + shellQuote(os.Getenv(fanouttui.EnhancedKeysEnv))
+	prefix := fanouttui.EnhancedKeysEnv + "=" + run.ShellQuote(os.Getenv(fanouttui.EnhancedKeysEnv))
 	// display-popup runs under the tmux server's environment, not the parent
 	// fanout process's. Forward PATH so the issue picker finds `gh` (and git)
 	// wherever the parent did. Secrets (GH_TOKEN etc.) are deliberately
 	// not inlined: the command line is visible via ps; token-less setups rely
 	// on gh's config-file auth, which needs only HOME.
 	if path := os.Getenv("PATH"); path != "" {
-		prefix = "PATH=" + shellQuote(path) + " " + prefix
+		prefix = "PATH=" + run.ShellQuote(path) + " " + prefix
 	}
 	parts = append([]string{prefix}, parts...)
 	command := strings.Join(parts, " ")
-	markDone := "printf '' > " + shellQuote(doneFile)
-	return "trap " + shellQuote(markDone) + " EXIT HUP INT TERM; " + command
+	markDone := "printf '' > " + run.ShellQuote(doneFile)
+	return "trap " + run.ShellQuote(markDone) + " EXIT HUP INT TERM; " + command
 }
 
 func waitForTUINewPanePopupResult(resultFile, doneFile string, timeout time.Duration) (tuiNewPanePopupResult, error) {

--- a/cmd/fanout/tui_test.go
+++ b/cmd/fanout/tui_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/butaosuinu/fanout/internal/app/cliflags"
 	"github.com/butaosuinu/fanout/internal/app/panelaunch"
+	"github.com/butaosuinu/fanout/internal/app/run"
 	"github.com/butaosuinu/fanout/internal/app/watch"
 	"github.com/butaosuinu/fanout/internal/core/exitcode"
 	"github.com/butaosuinu/fanout/internal/infra/ghissue"
@@ -339,7 +340,7 @@ func TestTUIHelpPopupShellCommandPropagatesPathAndDimensions(t *testing.T) {
 		tuiHelpPopupCommand,
 		"--width 80",
 		"--height 18",
-		"PATH=" + shellQuote(os.Getenv("PATH")),
+		"PATH=" + run.ShellQuote(os.Getenv("PATH")),
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("help popup shell command missing %q:\n%s", want, got)
@@ -351,7 +352,7 @@ func TestTUINewPanePopupShellCommandMarksDoneAndPropagatesEnhancedKeys(t *testin
 	for _, value := range []string{"", "0", "1"} {
 		t.Setenv(fanouttui.EnhancedKeysEnv, value)
 		got := tuiNewPanePopupShellCommand("fanout", "/tmp/repo", "/tmp/result.json", "/tmp/result.done", "codex", 80, 18)
-		if !strings.Contains(got, fanouttui.EnhancedKeysEnv+"="+shellQuote(value)+" ") {
+		if !strings.Contains(got, fanouttui.EnhancedKeysEnv+"="+run.ShellQuote(value)+" ") {
 			t.Fatalf("popup shell command = %q with %s=%q, want forwarded env prefix", got, fanouttui.EnhancedKeysEnv, value)
 		}
 	}
@@ -365,7 +366,7 @@ func TestTUINewPanePopupShellCommandMarksDoneAndPropagatesEnhancedKeys(t *testin
 		"--result-file /tmp/result.json",
 		// The popup runs under the tmux server env; PATH must come from the
 		// parent so the issue/plan pickers can exec gh.
-		"PATH=" + shellQuote(os.Getenv("PATH")),
+		"PATH=" + run.ShellQuote(os.Getenv("PATH")),
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("popup shell command missing %q:\n%s", want, got)

--- a/cmd/fanout/tui_watch.go
+++ b/cmd/fanout/tui_watch.go
@@ -10,8 +10,10 @@ import (
 
 	"github.com/butaosuinu/fanout/internal/app/cliflags"
 	"github.com/butaosuinu/fanout/internal/app/panelaunch"
+	"github.com/butaosuinu/fanout/internal/app/run"
 	"github.com/butaosuinu/fanout/internal/app/watch"
 	"github.com/butaosuinu/fanout/internal/core/exitcode"
+	"github.com/butaosuinu/fanout/internal/core/fanset"
 	"github.com/butaosuinu/fanout/internal/infra/ghissue"
 	"github.com/butaosuinu/fanout/internal/infra/hooks"
 	"github.com/butaosuinu/fanout/internal/infra/log"
@@ -83,7 +85,7 @@ func launchWatchStandalone(projectRoot, session, commandName string, resolvedSet
 func launchStandaloneIssuePane(projectRoot, session, commandName string, cfg *cliflags.Config, resolvedSettings settings.Settings, hookConfig hooks.Config, issue ghissue.Issue) error {
 	var stdout, stderr bytes.Buffer
 	launchLogger := log.NewWith(&stdout, &stderr, false)
-	store, recorder, code := loadRunState(cfg, projectRoot, launchLogger)
+	store, recorder, code := run.LoadState(cfg.DryRun, projectRoot, launchLogger)
 	if code != exitcode.OK {
 		return bufferedLaunchError(stdout, stderr, "load fanout state")
 	}
@@ -120,15 +122,15 @@ func launchParentIssueFanout(projectRoot, session, commandName string, cfg *clif
 	gh := ghissue.Runner{Cwd: projectRoot}
 	var stdout, stderr bytes.Buffer
 	launchLogger := log.NewWith(&stdout, &stderr, false)
-	rt := &runtimeInfo{
-		info: &fanoutruntime.Info{
+	rt := &run.Runtime{
+		Info: &fanoutruntime.Info{
 			Session:     session,
 			Target:      tuiLaunchTarget(session),
 			ProjectRoot: projectRoot,
 		},
-		gh: gh,
+		GH: gh,
 	}
-	if code := runWithRuntime(cfg, launchLogger, rt, commandName); code != exitcode.OK {
+	if code := run.Issues(cfg, launchLogger, rt, commandName, bindDashboardKey); code != exitcode.OK {
 		return watch.ParentLaunchResult{}, bufferedLaunchError(stdout, stderr, "launch parent")
 	}
 	return watchParentResultAfterLaunch(projectRoot, cfg, gh), nil
@@ -161,7 +163,7 @@ func countOpenChildTargets(gh ghissue.Runner, parent int) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	return len(openIssues(loaded.Children)), nil
+	return len(run.OpenIssues(loaded.Children)), nil
 }
 
 func countWatchChildTargets(projectRoot string, gh ghissue.Runner, parent int) (watch.ChildCounts, error) {
@@ -258,25 +260,25 @@ func watchParentHasRemainingTargets(projectRoot string, cfg *cliflags.Config, gh
 	return len(plan.Targets) > 0 || len(plan.BlockedRows) > 0 || len(plan.LimitDeferred) > 0, nil
 }
 
-func buildWatchParentPlan(projectRoot string, cfg *cliflags.Config, gh ghissue.Runner) (Plan, error) {
+func buildWatchParentPlan(projectRoot string, cfg *cliflags.Config, gh ghissue.Runner) (run.Plan, error) {
 	loaded, err := loadWatchParentChildren(gh, cfg.Parent)
 	if err != nil {
-		return Plan{}, err
+		return run.Plan{}, err
 	}
 	store, err := state.LoadProject(projectRoot)
 	if err != nil {
-		return Plan{}, fmt.Errorf("load fanout state: %w", err)
+		return run.Plan{}, fmt.Errorf("load fanout state: %w", err)
 	}
 	sameParentFanned := store.FannedNumbersForParent(cfg.ParentRef)
 	otherParentFanned := store.FannedNumbersForOtherParents(cfg.ParentRef)
-	worktreeFallbackFanned := existingWorktreeFanned(cfg, projectRoot, loaded.Children, otherParentFanned)
-	return buildPlan(
+	worktreeFallbackFanned := run.ExistingWorktreeFanned(cfg, projectRoot, loaded.Children, otherParentFanned)
+	return run.BuildPlan(
 		cfg,
 		loaded.Children,
-		mergeFanned(sameParentFanned, worktreeFallbackFanned),
+		fanset.Union(sameParentFanned, worktreeFallbackFanned),
 		loaded.ParentBody,
 		func(issue *ghissue.Issue) {
-			// Match runWithRuntime: a hydration failure degrades blocker checks
+			// Match run.Issues: a hydration failure degrades blocker checks
 			// for this recomputation but should not make a completed launch fail.
 			_ = gh.HydrateBodyLabels(issue)
 		},
@@ -287,7 +289,7 @@ func buildWatchParentPlan(projectRoot string, cfg *cliflags.Config, gh ghissue.R
 	), nil
 }
 
-func loadWatchParentChildren(gh ghissue.Runner, parent int) (childLoadResult, error) {
+func loadWatchParentChildren(gh ghissue.Runner, parent int) (run.ChildLoadResult, error) {
 	var stdout, stderr bytes.Buffer
 	lg := log.NewWith(&stdout, &stderr, false)
 	cfg := newWatchPlanConfig(parent, 0)
@@ -295,23 +297,23 @@ func loadWatchParentChildren(gh ghissue.Runner, parent int) (childLoadResult, er
 	subIssues, err := gh.SubIssueList(cfg.Parent)
 	if err != nil {
 		lg.Err("sub-issues fetch failed: %v", err)
-		return childLoadResult{}, bufferedLaunchError(stdout, stderr, "load child issues")
+		return run.ChildLoadResult{}, bufferedLaunchError(stdout, stderr, "load child issues")
 	}
 	parentBody, err := gh.ParentBody(cfg.Parent)
 	if err != nil {
 		lg.Err("parent body fetch failed: %v", err)
-		return childLoadResult{}, bufferedLaunchError(stdout, stderr, "load child issues")
+		return run.ChildLoadResult{}, bufferedLaunchError(stdout, stderr, "load child issues")
 	}
 	bodyNums := ghissue.TaskListNumbers(parentBody)
 	loaded, added := mergeWatchExtraChildren(cfg, gh, subIssues, bodyNums, lg)
-	assignTaskListWaves(loaded, ghissue.TaskListWaves(parentBody))
+	run.AssignTaskListWaves(loaded, ghissue.TaskListWaves(parentBody))
 	if added > 0 {
 		lg.Info("parent body added %d extra child reference(s) not in sub-issue API", added)
 	}
-	return childLoadResult{
+	return run.ChildLoadResult{
 		Children:       loaded,
 		ParentBody:     parentBody,
-		StrongChildren: issueSet(subIssues),
+		StrongChildren: run.IssueSet(subIssues),
 		ChildNoun:      "sub-issues",
 	}, nil
 }

--- a/internal/app/run/agents.go
+++ b/internal/app/run/agents.go
@@ -1,4 +1,4 @@
-package main
+package run
 
 import (
 	"fmt"
@@ -9,6 +9,9 @@ import (
 	"github.com/butaosuinu/fanout/internal/infra/ghissue"
 )
 
+// validateIssueAgents checks the resolved agent for every issue target and
+// --limit-deferred issue. Deferred issues are validated for name/known-agent
+// but not for install presence.
 func validateIssueAgents(cfg *cliflags.Config, issues, limitDeferred []ghissue.Issue) error {
 	targets := make([]agentTarget, 0, len(issues)+len(limitDeferred))
 	for _, issue := range issues {
@@ -29,6 +32,7 @@ func validateIssueAgents(cfg *cliflags.Config, issues, limitDeferred []ghissue.I
 	return validateAgentTargets(cfg, targets)
 }
 
+// validateTaskAgents is the plan-lane variant, keyed by task id.
 func validateTaskAgents(cfg *cliflags.Config, tasks, limitDeferred []planspec.Task) error {
 	targets := make([]agentTarget, 0, len(tasks)+len(limitDeferred))
 	for _, task := range tasks {

--- a/internal/app/run/agents_test.go
+++ b/internal/app/run/agents_test.go
@@ -1,4 +1,4 @@
-package main
+package run
 
 import (
 	"os"

--- a/internal/app/run/children.go
+++ b/internal/app/run/children.go
@@ -1,0 +1,197 @@
+package run
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/butaosuinu/fanout/internal/app/cliflags"
+	"github.com/butaosuinu/fanout/internal/core/exitcode"
+	"github.com/butaosuinu/fanout/internal/core/naming"
+	"github.com/butaosuinu/fanout/internal/infra/ghissue"
+	"github.com/butaosuinu/fanout/internal/infra/log"
+)
+
+// ChildLoadResult is the child enumeration both the issue lane and the TUI
+// watch lane consume.
+type ChildLoadResult struct {
+	Children       []ghissue.Issue
+	ParentBody     string
+	StrongChildren map[int]bool
+	ChildNoun      string
+}
+
+func loadChildren(cfg *cliflags.Config, gh ghissue.Runner, lg *log.Logger) (ChildLoadResult, exitcode.Code) {
+	if cfg.ParentMode == cliflags.ModeProject {
+		return loadProjectChildren(cfg, gh, lg)
+	}
+	return loadIssueChildren(cfg, gh, lg)
+}
+
+func loadIssueChildren(cfg *cliflags.Config, gh ghissue.Runner, lg *log.Logger) (ChildLoadResult, exitcode.Code) {
+	lg.Info("fetching sub-issues of #%d", cfg.Parent)
+	subIssues, err := gh.SubIssueList(cfg.Parent)
+	if err != nil {
+		lg.Err("sub-issues fetch failed: %v", err)
+		return ChildLoadResult{}, exitcode.Env
+	}
+
+	parentBody, err := gh.ParentBody(cfg.Parent)
+	if err != nil {
+		lg.Warn("could not read parent body (#%d); skipping task-list scan", cfg.Parent)
+		parentBody = ""
+	}
+
+	bodyNums := ghissue.TaskListNumbers(parentBody)
+	loaded, added := mergeExtraChildren(cfg, gh, subIssues, bodyNums, true, lg)
+	AssignTaskListWaves(loaded, ghissue.TaskListWaves(parentBody))
+	if added > 0 {
+		lg.Info("parent body / --include added %d extra child reference(s) not in sub-issue API", added)
+	}
+
+	return ChildLoadResult{
+		Children:       loaded,
+		ParentBody:     parentBody,
+		StrongChildren: IssueSet(subIssues),
+		ChildNoun:      "sub-issues",
+	}, exitcode.OK
+}
+
+func loadProjectChildren(cfg *cliflags.Config, gh ghissue.Runner, lg *log.Logger) (ChildLoadResult, exitcode.Code) {
+	repo, err := gh.RepoNameWithOwner()
+	if err != nil {
+		lg.Err("could not resolve repo via 'gh repo view' in project root (required for project mode cross-repo filter)")
+		return ChildLoadResult{}, exitcode.Env
+	}
+	lg.Info("mode: project (status=%s, repo=%s)", cfg.ProjectStatus, repo)
+	lg.Info("fetching items from Project %s", cfg.ParentRef)
+
+	res, err := gh.ProjectItems(cfg.ProjectOwnerType, cfg.ProjectOwner, cfg.ProjectNumber, repo, cfg.ProjectStatus)
+	if err != nil {
+		lg.Err("%v", err)
+		return ChildLoadResult{}, exitcode.Env
+	}
+	if res.MissingStatus && cfg.ProjectStatus != "all" {
+		lg.Warn("Project '%s' has no Status field; ignoring --project-status %s and falling back to all items", res.ProjectTitle, cfg.ProjectStatus)
+		cfg.ProjectStatus = "all"
+	}
+	for _, cross := range res.CrossRepoWarnings {
+		lg.Warn("skipping cross-repo project item: %s (project root repo: %s)", cross, repo)
+	}
+
+	loaded, added := mergeExtraChildren(cfg, gh, res.Issues, nil, false, lg)
+	if added > 0 {
+		lg.Info("--include added %d extra child reference(s) not in project items", added)
+	}
+
+	return ChildLoadResult{
+		Children:       loaded,
+		StrongChildren: IssueSet(res.Issues),
+		ChildNoun:      "project items",
+	}, exitcode.OK
+}
+
+func mergeExtraChildren(cfg *cliflags.Config, gh ghissue.Runner, base []ghissue.Issue, bodyNums []int, skipParent bool, lg *log.Logger) ([]ghissue.Issue, int) {
+	existing := map[int]bool{}
+	if skipParent {
+		existing[cfg.Parent] = true
+	}
+	for _, s := range base {
+		existing[s.Number] = true
+	}
+
+	extraNums := append([]int{}, bodyNums...)
+	extraNums = append(extraNums, cfg.Include...)
+	var extra []ghissue.Issue
+	for _, num := range extraNums {
+		if existing[num] {
+			continue
+		}
+		detail, err := gh.IssueDetail(num)
+		if err != nil {
+			lg.Warn("parent body / --include references #%d but issue lookup failed; skipping", num)
+			continue
+		}
+		extra = append(extra, detail)
+		existing[num] = true
+	}
+	return ghissue.MergeExtra(base, extra), len(extra)
+}
+
+// AssignTaskListWaves stamps parent task-list wave labels onto the matching
+// child issues in place.
+func AssignTaskListWaves(issues []ghissue.Issue, waves map[int]string) {
+	for i := range issues {
+		if wave := waves[issues[i].Number]; wave != "" {
+			issues[i].Wave = wave
+		}
+	}
+}
+
+// IssueSet builds a membership set of the given issue numbers.
+func IssueSet(issues []ghissue.Issue) map[int]bool {
+	out := map[int]bool{}
+	for _, issue := range issues {
+		out[issue.Number] = true
+	}
+	return out
+}
+
+// ExistingWorktreeFanned reports which issues already have a worktree directory
+// on disk, used as the action-mode migration fallback for the idempotency
+// check. It is shared by the issue lane and the TUI watch lane.
+func ExistingWorktreeFanned(cfg *cliflags.Config, projectRoot string, issues []ghissue.Issue, sharedAcrossParents map[int]bool) map[int]bool {
+	out := map[int]bool{}
+	worktreeNames := existingWorktreeNames(filepath.Join(projectRoot, ".fanout", "worktrees"))
+	for _, issue := range issues {
+		slug := naming.Slug(issue.Title, issue.Number)
+		slugOverridden := false
+		if name := cfg.FindName(issue.Number); name != nil && name.SlugHint != "" {
+			slug = naming.EnsureIssueSuffix(name.SlugHint, issue.Number)
+			slugOverridden = true
+		}
+		if sharedAcrossParents[issue.Number] {
+			if !slugOverridden {
+				slug = naming.QualifySlugForParent(slug, cfg.ParentRef, issue.Number)
+			}
+			if worktreeNameMatchesExact(worktreeNames, slug) {
+				out[issue.Number] = true
+			}
+			continue
+		}
+		if worktreeNameMatchesIssue(worktreeNames, slug, issue.Number) {
+			out[issue.Number] = true
+		}
+	}
+	return out
+}
+
+func existingWorktreeNames(root string) []string {
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		return nil
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			names = append(names, entry.Name())
+		}
+	}
+	return names
+}
+
+func worktreeNameMatchesExact(names []string, slug string) bool {
+	return slices.Contains(names, slug)
+}
+
+func worktreeNameMatchesIssue(names []string, exactSlug string, issueNum int) bool {
+	issueSuffix := fmt.Sprintf("-%d", issueNum)
+	for _, name := range names {
+		if name == exactSlug || strings.HasSuffix(name, issueSuffix) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/app/run/helpers_test.go
+++ b/internal/app/run/helpers_test.go
@@ -1,0 +1,15 @@
+package run
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func gitCmdTest(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, out)
+	}
+}

--- a/internal/app/run/issues.go
+++ b/internal/app/run/issues.go
@@ -1,0 +1,189 @@
+package run
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/butaosuinu/fanout/internal/app/briefing"
+	"github.com/butaosuinu/fanout/internal/app/cliflags"
+	"github.com/butaosuinu/fanout/internal/app/panelaunch"
+	"github.com/butaosuinu/fanout/internal/core/exitcode"
+	"github.com/butaosuinu/fanout/internal/core/fanset"
+	"github.com/butaosuinu/fanout/internal/infra/ghissue"
+	"github.com/butaosuinu/fanout/internal/infra/hooks"
+	"github.com/butaosuinu/fanout/internal/infra/log"
+	fanoutruntime "github.com/butaosuinu/fanout/internal/infra/runtime"
+	"github.com/butaosuinu/fanout/internal/infra/settings"
+)
+
+type executionResult struct {
+	Created     int
+	Failed      int
+	CreatedNums []int
+}
+
+// Issues runs the issue / Project fan-out lane against an already-resolved
+// runtime. cmd owns parsing, dependency checks, and runtime resolution before
+// calling this; bindKeys is the cmd-side dashboard keybinding hook.
+func Issues(cfg *cliflags.Config, lg *log.Logger, rt *Runtime, commandName string, bindKeys BindKeysFunc) exitcode.Code {
+	resolvedSettings := settings.Resolve(rt.Info.ProjectRoot, settingsOverrides(cfg), lg.Warn)
+	hookConfig := hooks.LoadUserConfig(lg)
+
+	loaded, code := loadChildren(cfg, rt.GH, lg)
+	if code != exitcode.OK {
+		return code
+	}
+
+	totalChildren := len(loaded.Children)
+	if totalChildren == 0 {
+		if cfg.ParentMode == cliflags.ModeProject {
+			lg.Info("no items in Project (after status/repo filter). nothing to do.")
+		} else {
+			lg.Info("no sub-issues on #%d. nothing to do.", cfg.Parent)
+		}
+		return exitcode.OK
+	}
+
+	openCount := len(OpenIssues(loaded.Children))
+	lg.Info("%s: %d total, %d OPEN", loaded.ChildNoun, totalChildren, openCount)
+	if openCount == 0 {
+		lg.Info("no OPEN %s. nothing to do.", loaded.ChildNoun)
+		return exitcode.OK
+	}
+
+	store, recorder, code := LoadState(cfg.DryRun, rt.Info.ProjectRoot, lg)
+	if code != exitcode.OK {
+		return code
+	}
+	if recorder != nil {
+		defer func() {
+			if err := recorder.Unlock(); err != nil {
+				lg.Warn("unlock fanout state: %v", err)
+			}
+		}()
+	}
+
+	sameParentFanned := store.FannedNumbersForParent(cfg.ParentRef)
+	otherParentFanned := store.FannedNumbersForOtherParents(cfg.ParentRef)
+	worktreeFallbackFanned := ExistingWorktreeFanned(cfg, rt.Info.ProjectRoot, loaded.Children, otherParentFanned)
+
+	plan := BuildPlan(
+		cfg,
+		loaded.Children,
+		fanset.Union(sameParentFanned, worktreeFallbackFanned),
+		loaded.ParentBody,
+		func(issue *ghissue.Issue) {
+			if err := rt.GH.HydrateBodyLabels(issue); err != nil {
+				lg.Warn("#%d: could not fetch body/labels for blocker check; treating as unblocked", issue.Number)
+			}
+		},
+		func(num int) string {
+			state, _ := rt.GH.IssueState(num)
+			return state
+		},
+	)
+	logPlanDetails(plan, lg)
+
+	if plan.OpenAfterFilter == 0 {
+		lg.Info("all OPEN sub-issues filtered out by --only/--skip. nothing to do.")
+		return exitcode.OK
+	}
+	if plan.UnfannedCount == 0 {
+		lg.Ok("all %d OPEN sub-issue(s) already have a fanout pane. nothing to do.", len(plan.AlreadyFanned))
+		return exitcode.OK
+	}
+	if err := validateIssueAgents(cfg, plan.Targets, plan.LimitDeferred); err != nil {
+		lg.Err("%s", err.Error())
+		return exitcode.Env
+	}
+
+	logAlreadyFanned(plan.AlreadyFanned, lg)
+	lg.Info("will create %d pane(s); deferred (blocked): %d; deferred (--limit): %d",
+		len(plan.Targets), len(plan.BlockedRows), len(plan.LimitDeferred))
+
+	c := lg.Colors()
+	if cfg.DryRun {
+		printDryRunPlan(plan, lg, c)
+	}
+
+	var teamCtx *briefing.TeamContext
+	if cfg.Team {
+		teamCtx = buildTeamContext(rt.Info.ProjectRoot, cfg.ParentRef, plan.Targets)
+	}
+
+	result := executePlan(cfg, lg, rt.Info, rt.GH, plan.Targets, resolvedSettings, hookConfig, recorder, otherParentFanned, c, commandName, teamCtx)
+	printSummary(plan, result, cfg, lg, c, commandName)
+
+	// Register tmux keybindings so the user can pop the read-only dashboard
+	// (F12 or prefix + D) and same-worktree action menu (prefix + M) from any
+	// fanout pane. The bindings resolve the repo from the pressing pane at
+	// keypress, so they work from child worktree panes and across repos.
+	// Best-effort, live runs only.
+	if !cfg.DryRun && result.Created > 0 {
+		bindKeys(lg, resolvedSettings.DashboardKeybind)
+	}
+
+	// Seed the peers registry for --team runs, fail-fast partial successes
+	// included. Best-effort: this runs outside the executePlan loop and a
+	// failure only warns, never changes the exit code.
+	if cfg.Team && len(result.CreatedNums) > 0 {
+		if cfg.DryRun {
+			fmt.Fprintf(lg.Stdout(), "%s# would seed team registry: %d peer(s) -> %s%s\n", c.Dim, len(result.CreatedNums), teamCtx.DBPath, c.Reset)
+		} else {
+			seedTeamRegistry(lg, teamCtx.DBPath, recorder.Store, cfg.ParentRef, result.CreatedNums)
+		}
+	}
+
+	if result.Failed > 0 {
+		return exitcode.Env
+	}
+	return exitcode.OK
+}
+
+func executePlan(cfg *cliflags.Config, lg *log.Logger, info *fanoutruntime.Info, gh ghissue.Runner, targets []ghissue.Issue, resolvedSettings settings.Settings, hookConfig hooks.Config, recorder panelaunch.StateRecorder, sharedAcrossParents map[int]bool, c log.Palette, commandName string, teamCtx *briefing.TeamContext) executionResult {
+	launcher := &panelaunch.Launcher{Cfg: cfg, Log: lg, Info: info, Recorder: recorder, Palette: c, CommandName: commandName}
+	created, failed := executeFailFast(
+		targets,
+		func(issue ghissue.Issue) int { return issue.Number },
+		func(issue ghissue.Issue) bool {
+			// Hydrate body lazily for issues that came from the Sub-issues API
+			// path (body=""), unless --unblocked-only already did it upfront.
+			if issue.Body == "" {
+				if detail, err := gh.IssueDetail(issue.Number); err == nil {
+					issue.Body = detail.Body
+				}
+			}
+			return launcher.LaunchOK(panelaunch.NewIssueRequest(cfg, info.ProjectRoot, issue, resolvedSettings, hookConfig, sharedAcrossParents[issue.Number], teamCtx))
+		},
+		sleepBetweenFunc(cfg),
+	)
+	return executionResult{Created: len(created), Failed: failed, CreatedNums: created}
+}
+
+// executeFailFast launches targets in order and stops after the first failure,
+// preserving the fail-fast contract both lanes rely on. sleepBetween runs only
+// between successful launches; it decides internally whether to actually sleep.
+func executeFailFast[T any, K comparable](targets []T, key func(T) K, launch func(T) bool, sleepBetween func()) (created []K, failed int) {
+	for i, item := range targets {
+		if !launch(item) {
+			failed++
+			break
+		}
+		created = append(created, key(item))
+		if i < len(targets)-1 {
+			sleepBetween()
+		}
+	}
+	return created, failed
+}
+
+// sleepBetweenFunc yields the between-launch delay closure: a no-op unless
+// --sleep is set, matching the original per-lane `if cfg.SleepBetween > 0`
+// guard.
+func sleepBetweenFunc(cfg *cliflags.Config) func() {
+	return func() {
+		if cfg.SleepBetween > 0 {
+			sleepBetweenIssues(time.Duration(cfg.SleepBetween * float64(time.Second)))
+		}
+	}
+}

--- a/internal/app/run/issues_test.go
+++ b/internal/app/run/issues_test.go
@@ -1,0 +1,53 @@
+package run
+
+import (
+	"io"
+	"testing"
+	"time"
+
+	"github.com/butaosuinu/fanout/internal/app/cliflags"
+	"github.com/butaosuinu/fanout/internal/infra/ghissue"
+	"github.com/butaosuinu/fanout/internal/infra/hooks"
+	"github.com/butaosuinu/fanout/internal/infra/log"
+	fanoutruntime "github.com/butaosuinu/fanout/internal/infra/runtime"
+	"github.com/butaosuinu/fanout/internal/infra/settings"
+)
+
+func TestExecutePlanSleepsBetweenDryRunIssues(t *testing.T) {
+	dir := t.TempDir()
+
+	oldSleep := sleepBetweenIssues
+	var sleeps []time.Duration
+	sleepBetweenIssues = func(d time.Duration) {
+		sleeps = append(sleeps, d)
+	}
+	t.Cleanup(func() { sleepBetweenIssues = oldSleep })
+
+	cfg := &cliflags.Config{
+		Agent:        "claude",
+		DryRun:       true,
+		SleepBetween: 0.25,
+	}
+	lg := log.NewWith(io.Discard, io.Discard, false)
+	info := &fanoutruntime.Info{
+		Session:     "test",
+		Target:      "%caller",
+		ProjectRoot: dir,
+	}
+	targets := []ghissue.Issue{
+		{Number: 1, Title: "one", State: "OPEN", Body: "body"},
+		{Number: 2, Title: "two", State: "OPEN", Body: "body"},
+	}
+
+	result := executePlan(cfg, lg, info, ghissue.Runner{}, targets, settings.Defaults(), hooks.EmptyConfig(), nil, nil, log.Palette{}, "fanout", nil)
+
+	if result.Created != 2 || result.Failed != 0 {
+		t.Fatalf("executePlan result = %+v, want 2 created and 0 failed", result)
+	}
+	if len(sleeps) != 1 {
+		t.Fatalf("sleep calls = %d, want 1", len(sleeps))
+	}
+	if want := 250 * time.Millisecond; sleeps[0] != want {
+		t.Fatalf("sleep duration = %s, want %s", sleeps[0], want)
+	}
+}

--- a/internal/app/run/plan.go
+++ b/internal/app/run/plan.go
@@ -1,4 +1,4 @@
-package main
+package run
 
 import (
 	"fmt"
@@ -6,6 +6,7 @@ import (
 
 	"github.com/butaosuinu/fanout/internal/app/cliflags"
 	"github.com/butaosuinu/fanout/internal/core/blockers"
+	"github.com/butaosuinu/fanout/internal/core/fanset"
 	"github.com/butaosuinu/fanout/internal/infra/ghissue"
 )
 
@@ -29,7 +30,9 @@ type Plan struct {
 	LimitDeferred           []ghissue.Issue
 }
 
-func buildPlan(
+func issueNumber(issue ghissue.Issue) int { return issue.Number }
+
+func BuildPlan(
 	cfg *cliflags.Config,
 	children []ghissue.Issue,
 	fanned map[int]bool,
@@ -37,7 +40,7 @@ func buildPlan(
 	hydrateIssue func(*ghissue.Issue),
 	issueState func(int) string,
 ) Plan {
-	openChildren := openIssues(children)
+	openChildren := OpenIssues(children)
 	plan := Plan{
 		TotalChildren: len(children),
 		OpenCount:     len(openChildren),
@@ -46,7 +49,7 @@ func buildPlan(
 		return plan
 	}
 
-	openChildren, plan.FilteredOnly, plan.FilteredSkip, plan.MissingOnly = filterOnlySkip(openChildren, cfg.Only, cfg.Skip)
+	openChildren, plan.FilteredOnly, plan.FilteredSkip, plan.MissingOnly = fanset.FilterOnlySkip(openChildren, issueNumber, cfg.Only, cfg.Skip)
 	plan.OpenAfterFilter = len(openChildren)
 	if plan.OpenAfterFilter == 0 {
 		return plan
@@ -56,7 +59,7 @@ func buildPlan(
 		hydrateIssues(openChildren, hydrateIssue)
 	}
 
-	targets, skipped := splitAlreadyFanned(openChildren, fanned)
+	targets, skipped := fanset.SplitFanned(openChildren, issueNumber, fanned)
 	plan.Targets = targets
 	plan.AlreadyFanned = skipped
 	plan.UnfannedCount = len(targets)
@@ -68,11 +71,11 @@ func buildPlan(
 		plan.Targets, plan.BlockedRows, plan.BlockedLabelWithoutRefs = splitBlocked(plan.Targets, parentBody, issueState)
 	}
 
-	plan.Targets, plan.LimitDeferred = applyLimit(plan.Targets, cfg.Limit)
+	plan.Targets, plan.LimitDeferred = fanset.ApplyLimit(plan.Targets, cfg.Limit)
 	return plan
 }
 
-func openIssues(issues []ghissue.Issue) []ghissue.Issue {
+func OpenIssues(issues []ghissue.Issue) []ghissue.Issue {
 	open := make([]ghissue.Issue, 0, len(issues))
 	for _, issue := range issues {
 		if issue.State == "OPEN" {
@@ -80,36 +83,6 @@ func openIssues(issues []ghissue.Issue) []ghissue.Issue {
 		}
 	}
 	return open
-}
-
-func filterOnlySkip(issues []ghissue.Issue, only, skip []int) (kept, filteredOnly, filteredSkip []ghissue.Issue, missingOnly []int) {
-	if len(only) == 0 && len(skip) == 0 {
-		return issues, nil, nil, nil
-	}
-
-	openSet := map[int]bool{}
-	for _, issue := range issues {
-		openSet[issue.Number] = true
-	}
-	for _, num := range only {
-		if !openSet[num] {
-			missingOnly = append(missingOnly, num)
-		}
-	}
-
-	onlySet := intSet(only)
-	skipSet := intSet(skip)
-	for _, issue := range issues {
-		switch {
-		case len(only) > 0 && !onlySet[issue.Number]:
-			filteredOnly = append(filteredOnly, issue)
-		case len(skip) > 0 && skipSet[issue.Number]:
-			filteredSkip = append(filteredSkip, issue)
-		default:
-			kept = append(kept, issue)
-		}
-	}
-	return kept, filteredOnly, filteredSkip, missingOnly
 }
 
 func hydrateIssues(issues []ghissue.Issue, hydrateIssue func(*ghissue.Issue)) {
@@ -122,17 +95,6 @@ func hydrateIssues(issues []ghissue.Issue, hydrateIssue func(*ghissue.Issue)) {
 		}
 		hydrateIssue(&issues[i])
 	}
-}
-
-func splitAlreadyFanned(issues []ghissue.Issue, fanned map[int]bool) (targets []ghissue.Issue, skipped []int) {
-	for _, issue := range issues {
-		if fanned[issue.Number] {
-			skipped = append(skipped, issue.Number)
-			continue
-		}
-		targets = append(targets, issue)
-	}
-	return targets, skipped
 }
 
 func splitBlocked(issues []ghissue.Issue, parentBody string, issueState func(int) string) (kept []ghissue.Issue, blocked []blockedRow, blockedLabelWithoutRefs []int) {
@@ -189,19 +151,4 @@ func formatOpenBlockers(blockers []int) string {
 		parts[i] = fmt.Sprintf("OPEN #%d", num)
 	}
 	return strings.Join(parts, ", ")
-}
-
-func applyLimit(issues []ghissue.Issue, limit int) (targets, deferred []ghissue.Issue) {
-	if limit > 0 && len(issues) > limit {
-		return issues[:limit], issues[limit:]
-	}
-	return issues, nil
-}
-
-func intSet(nums []int) map[int]bool {
-	set := make(map[int]bool, len(nums))
-	for _, num := range nums {
-		set[num] = true
-	}
-	return set
 }

--- a/internal/app/run/plan_test.go
+++ b/internal/app/run/plan_test.go
@@ -1,4 +1,4 @@
-package main
+package run
 
 import (
 	"os"
@@ -23,7 +23,7 @@ func TestBuildPlanOnlyIdempotencyAndLimit(t *testing.T) {
 		Limit: 1,
 	}
 
-	plan := buildPlan(cfg, children, map[int]bool{104: true}, "", nil, nil)
+	plan := BuildPlan(cfg, children, map[int]bool{104: true}, "", nil, nil)
 
 	assertEqual(t, "total", plan.TotalChildren, 4)
 	assertEqual(t, "open", plan.OpenCount, 3)
@@ -57,7 +57,7 @@ func TestExistingWorktreeFannedUsesDeterministicSlugAndOverride(t *testing.T) {
 		{Number: 105, Title: "Retitled child", State: "OPEN"},
 	}
 
-	got := existingWorktreeFanned(cfg, root, issues, nil)
+	got := ExistingWorktreeFanned(cfg, root, issues, nil)
 
 	if !got[101] || !got[102] || !got[103] || !got[105] {
 		t.Fatalf("expected #101, #102, #103, and #105 to be fanned, got %#v", got)
@@ -67,21 +67,13 @@ func TestExistingWorktreeFannedUsesDeterministicSlugAndOverride(t *testing.T) {
 	}
 }
 
-func TestMergeFannedIncludesMigrationFallback(t *testing.T) {
-	got := mergeFanned(map[int]bool{101: true}, map[int]bool{102: true})
-
-	if !got[101] || !got[102] {
-		t.Fatalf("merged fanned = %#v, want #101 and #102", got)
-	}
-}
-
 func TestExistingWorktreeFannedIgnoresOtherParentDefaultSlug(t *testing.T) {
 	root := t.TempDir()
 	mkdirAll(t, filepath.Join(root, ".fanout", "worktrees", "shared-child-501"))
 	cfg := &cliflags.Config{ParentRef: "200"}
 	issues := []ghissue.Issue{{Number: 501, Title: "Shared child", State: "OPEN"}}
 
-	got := existingWorktreeFanned(cfg, root, issues, map[int]bool{501: true})
+	got := ExistingWorktreeFanned(cfg, root, issues, map[int]bool{501: true})
 
 	if got[501] {
 		t.Fatalf("fanned = %#v, did not want other-parent default slug to skip current parent", got)
@@ -97,7 +89,7 @@ func TestExistingWorktreeFannedIgnoresOtherParentDefaultSlugWhenCurrentSlugOverr
 	}
 	issues := []ghissue.Issue{{Number: 501, Title: "Shared child", State: "OPEN"}}
 
-	got := existingWorktreeFanned(cfg, root, issues, map[int]bool{501: true})
+	got := ExistingWorktreeFanned(cfg, root, issues, map[int]bool{501: true})
 
 	if got[501] {
 		t.Fatalf("fanned = %#v, did not want other-parent default slug to skip current explicit slug", got)
@@ -113,7 +105,7 @@ func TestExistingWorktreeFannedPreservesSharedExplicitSlugFallback(t *testing.T)
 	}
 	issues := []ghissue.Issue{{Number: 501, Title: "Shared child", State: "OPEN"}}
 
-	got := existingWorktreeFanned(cfg, root, issues, map[int]bool{501: true})
+	got := ExistingWorktreeFanned(cfg, root, issues, map[int]bool{501: true})
 
 	if !got[501] {
 		t.Fatalf("fanned = %#v, want current explicit slug fallback", got)
@@ -126,7 +118,7 @@ func TestExistingWorktreeFannedPreservesCurrentParentQualifiedFallback(t *testin
 	cfg := &cliflags.Config{ParentRef: "200"}
 	issues := []ghissue.Issue{{Number: 501, Title: "Shared child", State: "OPEN"}}
 
-	got := existingWorktreeFanned(cfg, root, issues, map[int]bool{501: true})
+	got := ExistingWorktreeFanned(cfg, root, issues, map[int]bool{501: true})
 
 	if !got[501] {
 		t.Fatalf("fanned = %#v, want current-parent qualified fallback", got)
@@ -139,7 +131,7 @@ func TestExistingWorktreeFannedIgnoresGeneratedManualPaneSlug(t *testing.T) {
 	cfg := &cliflags.Config{ParentRef: "200"}
 	issues := []ghissue.Issue{{Number: 12, Title: "Diagnostics", State: "OPEN"}}
 
-	got := existingWorktreeFanned(cfg, root, issues, nil)
+	got := ExistingWorktreeFanned(cfg, root, issues, nil)
 
 	if got[12] {
 		t.Fatalf("fanned = %#v, generated manual slug must not skip issue #12", got)
@@ -154,7 +146,7 @@ func TestBuildPlanSkipFilter(t *testing.T) {
 	}
 	cfg := &cliflags.Config{Skip: []int{202}}
 
-	plan := buildPlan(cfg, children, nil, "", nil, nil)
+	plan := BuildPlan(cfg, children, nil, "", nil, nil)
 
 	assertInts(t, "targets", issueNums(plan.Targets), []int{201, 203})
 	assertInts(t, "filtered skip", issueNums(plan.FilteredSkip), []int{202})
@@ -177,7 +169,7 @@ func TestBuildPlanUnblockedOnly(t *testing.T) {
 	}
 	cfg := &cliflags.Config{UnblockedOnly: true}
 
-	plan := buildPlan(cfg, children, nil, parentBody, nil, func(num int) string {
+	plan := BuildPlan(cfg, children, nil, parentBody, nil, func(num int) string {
 		return states[num]
 	})
 
@@ -199,7 +191,7 @@ func TestBuildPlanHydratesBeforeBlockerCheck(t *testing.T) {
 	cfg := &cliflags.Config{UnblockedOnly: true}
 	hydrated := false
 
-	plan := buildPlan(cfg, children, nil, "", func(issue *ghissue.Issue) {
+	plan := BuildPlan(cfg, children, nil, "", func(issue *ghissue.Issue) {
 		hydrated = true
 		issue.Body = "## Blocked by\n- #601\n"
 	}, func(num int) string {

--- a/internal/app/run/plancmd.go
+++ b/internal/app/run/plancmd.go
@@ -1,0 +1,582 @@
+package run
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/butaosuinu/fanout/internal/app/briefing"
+	"github.com/butaosuinu/fanout/internal/app/cliflags"
+	"github.com/butaosuinu/fanout/internal/app/panelaunch"
+	"github.com/butaosuinu/fanout/internal/core/exitcode"
+	"github.com/butaosuinu/fanout/internal/core/fanset"
+	"github.com/butaosuinu/fanout/internal/core/naming"
+	"github.com/butaosuinu/fanout/internal/core/planspec"
+	"github.com/butaosuinu/fanout/internal/infra/atomicfs"
+	"github.com/butaosuinu/fanout/internal/infra/ghissue"
+	"github.com/butaosuinu/fanout/internal/infra/hooks"
+	"github.com/butaosuinu/fanout/internal/infra/log"
+	"github.com/butaosuinu/fanout/internal/infra/settings"
+	"github.com/butaosuinu/fanout/internal/infra/state"
+	"github.com/butaosuinu/fanout/internal/infra/worktree"
+)
+
+const planSubcommand = "plan"
+
+// PlanCommandConfig is the parsed `fanout plan` configuration. cmd owns
+// parsing and CLI validation; the run lane consumes it to execute the plan.
+type PlanCommandConfig struct {
+	SpecArg            string
+	SpecPath           string
+	Agent              string
+	AgentOverrides     []cliflags.AgentOverride
+	BaseBranch         string
+	BranchPrefix       string
+	Limit              int
+	OnlyArg            string
+	SkipArg            string
+	Only               []string
+	Skip               []string
+	Session            string
+	SleepBetween       float64
+	NoRefresh          bool
+	DryRun             bool
+	Debug              bool
+	UnblockedOnly      bool
+	Team               bool
+	StatusMode         bool
+	Format             string
+	CloseTaskID        string
+	MergeTaskID        string
+	CleanupMode        bool
+	FormatExplicit     bool
+	AutoPullRequest    *bool
+	PRReviewGate       *bool
+	BriefingCodeReview *bool
+	AgentTeamsHint     *bool
+	PRVisualization    *bool
+	DashboardKeybind   *bool
+}
+
+type taskPlan struct {
+	TotalTasks      int
+	AfterFilter     int
+	UnfannedCount   int
+	Targets         []planspec.Task
+	AlreadyFanned   []string
+	AlreadyComplete []string
+	FilteredOnly    []planspec.Task
+	FilteredSkip    []planspec.Task
+	MissingOnly     []string
+	BlockedRows     []taskBlockedRow
+	LimitDeferred   []planspec.Task
+	SourceArgument  string
+}
+
+type taskBlockedRow struct {
+	Task planspec.Task
+	Refs string
+}
+
+type TaskExecutionResult struct {
+	Created    int
+	Failed     int
+	CreatedIDs []string
+}
+
+// PlanTasks runs the live/dry-run plan lane against an already resolved
+// runtime. cmd owns parsing, dependency checks, and runtime resolution before
+// calling this; bindKeys is the cmd-side dashboard keybinding hook.
+func PlanTasks(cfg PlanCommandConfig, rt *Runtime, lg *log.Logger, commandName string, bindKeys BindKeysFunc) (TaskExecutionResult, exitcode.Code) {
+	resolvedSettings := settings.Resolve(rt.Info.ProjectRoot, settingsOverrides(cfg.CLIConfig()), lg.Warn)
+	hookConfig := hooks.LoadUserConfig(lg)
+
+	cfg.SpecPath = ResolvePlanSpecPath(rt.Info.ProjectRoot, cfg.SpecArg)
+	spec, err := planspec.LoadWithoutResolvedNameChecks(cfg.SpecPath)
+	if err != nil {
+		lg.Err("%v", err)
+		return TaskExecutionResult{}, exitcode.Env
+	}
+	cfg.BaseBranch, err = resolvePlanBaseBranch(cfg, spec, rt.Info.ProjectRoot)
+	if err != nil {
+		lg.Err("%v", err)
+		return TaskExecutionResult{}, exitcode.Env
+	}
+	if err := ValidatePlanExecutionNames(spec, cfg); err != nil {
+		lg.Err("validate plan execution names %s: %v", cfg.SpecPath, err)
+		return TaskExecutionResult{}, exitcode.Env
+	}
+	cliCfg := cfg.CLIConfig()
+
+	store, recorder, code := LoadState(cfg.DryRun, rt.Info.ProjectRoot, lg)
+	if code != exitcode.OK {
+		return TaskExecutionResult{}, code
+	}
+	if recorder != nil {
+		defer func() {
+			if err := recorder.Unlock(); err != nil {
+				lg.Warn("unlock fanout state: %v", err)
+			}
+		}()
+	}
+	copyLivePlanSpec := func() exitcode.Code {
+		if cfg.DryRun {
+			return exitcode.OK
+		}
+		if err := copyPlanSpec(cfg.SpecPath, rt.Info.ProjectRoot, spec.Plan.Slug); err != nil {
+			lg.Err("copy plan spec: %v", err)
+			return exitcode.Env
+		}
+		return exitcode.OK
+	}
+	cfg.SpecArg = planRerunSpecArg(cfg, spec)
+
+	parentRef := panelaunch.PlanParentRef(spec.Plan.Slug)
+	fanned := fanset.Union(store.FannedTaskIDsForParent(parentRef), existingPlanWorktreeFanned(rt.Info.ProjectRoot, spec))
+	plan := buildTaskPlan(cfg, spec, fanned, func(task planspec.Task) bool {
+		return planTaskComplete(rt.GH, cliCfg, rt.Info.ProjectRoot, store, spec, task, lg)
+	})
+	logTaskPlanDetails(plan, lg)
+
+	if plan.AfterFilter == 0 {
+		if code := copyLivePlanSpec(); code != exitcode.OK {
+			return TaskExecutionResult{}, code
+		}
+		lg.Info("all plan tasks filtered out by --only/--skip. nothing to do.")
+		return TaskExecutionResult{}, exitcode.OK
+	}
+	if plan.UnfannedCount == 0 {
+		if code := copyLivePlanSpec(); code != exitcode.OK {
+			return TaskExecutionResult{}, code
+		}
+		if len(plan.AlreadyComplete) == 0 {
+			lg.Ok("all %d plan task(s) already have a fanout pane. nothing to do.", len(plan.AlreadyFanned))
+		} else {
+			lg.Ok("all %d selected plan task(s) already have a fanout pane or are complete. nothing to do.", plan.AfterFilter)
+		}
+		return TaskExecutionResult{}, exitcode.OK
+	}
+	if err := validateTaskAgents(cliCfg, plan.Targets, plan.LimitDeferred); err != nil {
+		lg.Err("%s", err.Error())
+		return TaskExecutionResult{}, exitcode.Env
+	}
+	if code := copyLivePlanSpec(); code != exitcode.OK {
+		return TaskExecutionResult{}, code
+	}
+
+	logAlreadyFannedTasks(plan.AlreadyFanned, lg)
+	logAlreadyCompleteTasks(plan.AlreadyComplete, lg)
+	lg.Info("plan %s: %d task(s)", spec.Plan.Slug, plan.TotalTasks)
+	lg.Info("will create %d pane(s); deferred (blocked): %d; deferred (--limit): %d",
+		len(plan.Targets), len(plan.BlockedRows), len(plan.LimitDeferred))
+
+	c := lg.Colors()
+	if cfg.DryRun {
+		printTaskDryRunPlan(plan, lg, c)
+	}
+
+	var teamCtx *briefing.TeamContext
+	if cfg.Team {
+		teamCtx = buildTaskTeamContext(rt.Info.ProjectRoot, parentRef, plan.Targets)
+	}
+
+	result := executeTaskPlan(cliCfg, lg, rt, spec, plan.Targets, resolvedSettings, hookConfig, recorder, c, commandName, teamCtx)
+	printTaskSummary(plan, result, cfg, lg, c, commandName)
+
+	if !cfg.DryRun && result.Created > 0 {
+		bindKeys(lg, resolvedSettings.DashboardKeybind)
+	}
+
+	// Seed the peers registry for --team runs, fail-fast partial successes
+	// included. Best-effort: this runs outside the executeTaskPlan loop and a
+	// failure only warns, never changes the exit code.
+	if cfg.Team && len(result.CreatedIDs) > 0 {
+		if cfg.DryRun {
+			fmt.Fprintf(lg.Stdout(), "%s# would seed team registry: %d peer(s) -> %s%s\n", c.Dim, len(result.CreatedIDs), teamCtx.DBPath, c.Reset)
+		} else {
+			seedTaskTeamRegistry(lg, teamCtx.DBPath, recorder.Store, parentRef, result.CreatedIDs)
+		}
+	}
+
+	if result.Failed > 0 {
+		return result, exitcode.Env
+	}
+	return result, exitcode.OK
+}
+
+// CLIConfig projects the plan config onto the shared cliflags.Config the
+// launch lane and settings/agent helpers consume.
+func (cfg PlanCommandConfig) CLIConfig() *cliflags.Config {
+	return &cliflags.Config{
+		ParentRef:          planSubcommand,
+		Agent:              cfg.Agent,
+		AgentOverrides:     cfg.AgentOverrides,
+		BaseBranch:         cfg.BaseBranch,
+		BranchPrefix:       cfg.BranchPrefix,
+		Session:            cfg.Session,
+		SleepBetween:       cfg.SleepBetween,
+		NoRefresh:          cfg.NoRefresh,
+		DryRun:             cfg.DryRun,
+		Debug:              cfg.Debug,
+		UnblockedOnly:      cfg.UnblockedOnly,
+		Team:               cfg.Team,
+		AutoPullRequest:    cfg.AutoPullRequest,
+		PRReviewGate:       cfg.PRReviewGate,
+		BriefingCodeReview: cfg.BriefingCodeReview,
+		AgentTeamsHint:     cfg.AgentTeamsHint,
+		PRVisualization:    cfg.PRVisualization,
+		DashboardKeybind:   cfg.DashboardKeybind,
+	}
+}
+
+// ActionMode reports whether the plan invocation is a status / lifecycle
+// action rather than a launch.
+func (cfg PlanCommandConfig) ActionMode() bool {
+	return cfg.StatusMode || cfg.CloseTaskID != "" || cfg.MergeTaskID != "" || cfg.CleanupMode
+}
+
+// ResolvePlanSpecPath maps a spec argument (path or plan slug) to a spec file
+// path under the project's .fanout/plans directory.
+func ResolvePlanSpecPath(projectRoot, arg string) string {
+	if filepath.IsAbs(arg) || strings.ContainsRune(arg, os.PathSeparator) || strings.HasSuffix(arg, ".json") {
+		return arg
+	}
+	return filepath.Join(projectRoot, ".fanout", "plans", arg+".json")
+}
+
+func resolvePlanBaseBranch(cfg PlanCommandConfig, spec planspec.Spec, projectRoot string) (string, error) {
+	if cfg.BaseBranch != "" {
+		return cfg.BaseBranch, nil
+	}
+	if spec.Plan.BaseBranch != "" {
+		if err := ValidatePlanBaseBranch("plan.base_branch", spec.Plan.BaseBranch); err != nil {
+			return "", err
+		}
+		return spec.Plan.BaseBranch, nil
+	}
+	return worktree.ResolveDefaultBranchAllowMissingOrigin(projectRoot), nil
+}
+
+// ValidatePlanBaseBranch rejects a base branch containing whitespace. Shared by
+// the plan CLI parser and the run lane's base-branch resolution.
+func ValidatePlanBaseBranch(label, value string) error {
+	if value != "" && strings.ContainsAny(value, " \t\r\n") {
+		return fmt.Errorf("%s must not contain whitespace, got: %s", label, value)
+	}
+	return nil
+}
+
+func planRerunSpecArg(cfg PlanCommandConfig, spec planspec.Spec) string {
+	if cfg.DryRun {
+		return cfg.SpecArg
+	}
+	return spec.Plan.Slug
+}
+
+func copyPlanSpec(src, projectRoot, slug string) error {
+	dst := filepath.Join(projectRoot, ".fanout", "plans", slug+".json")
+	srcAbs, srcErr := filepath.Abs(src)
+	dstAbs, dstErr := filepath.Abs(dst)
+	if srcErr == nil && dstErr == nil && srcAbs == dstAbs {
+		return nil
+	}
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	return atomicfs.WriteFile(dst, data, 0o644)
+}
+
+// ValidatePlanExecutionNames rejects duplicate final slugs / branches across
+// the spec's tasks. Shared by the plan CLI status path and the run lane.
+func ValidatePlanExecutionNames(spec planspec.Spec, cfg PlanCommandConfig) error {
+	seenSlugs := map[string]int{}
+	seenBranches := map[string]int{}
+	for i, task := range spec.Tasks {
+		slug := panelaunch.PlanTaskSlug(spec.Plan.Slug, task)
+		if prev, ok := seenSlugs[slug]; ok {
+			return fmt.Errorf("tasks[%d] final slug %q duplicates tasks[%d]", i, slug, prev)
+		}
+		seenSlugs[slug] = i
+
+		branch := task.Branch
+		if branch == "" {
+			branch = naming.BranchName("", cfg.BranchPrefix, slug)
+		}
+		if prev, ok := seenBranches[branch]; ok {
+			return fmt.Errorf("tasks[%d] final branch %q duplicates tasks[%d]", i, branch, prev)
+		}
+		seenBranches[branch] = i
+	}
+	return nil
+}
+
+func existingPlanWorktreeFanned(projectRoot string, spec planspec.Spec) map[string]bool {
+	out := map[string]bool{}
+	worktreeNames := existingWorktreeNames(filepath.Join(projectRoot, ".fanout", "worktrees"))
+	for _, task := range spec.Tasks {
+		if worktreeNameMatchesExact(worktreeNames, panelaunch.PlanTaskSlug(spec.Plan.Slug, task)) {
+			out[task.ID] = true
+		}
+	}
+	return out
+}
+
+func taskID(task planspec.Task) string { return task.ID }
+
+func buildTaskPlan(cfg PlanCommandConfig, spec planspec.Spec, fanned map[string]bool, taskComplete func(planspec.Task) bool) taskPlan {
+	plan := taskPlan{
+		TotalTasks:     len(spec.Tasks),
+		SourceArgument: cfg.SpecArg,
+	}
+	filtered, onlyRows, skipRows, missingOnly := fanset.FilterOnlySkip(spec.Tasks, taskID, cfg.Only, cfg.Skip)
+	plan.FilteredOnly = onlyRows
+	plan.FilteredSkip = skipRows
+	plan.MissingOnly = missingOnly
+	plan.AfterFilter = len(filtered)
+	if plan.AfterFilter == 0 {
+		return plan
+	}
+
+	targets, skipped := fanset.SplitFanned(filtered, taskID, fanned)
+	plan.Targets = targets
+	plan.AlreadyFanned = skipped
+	plan.UnfannedCount = len(targets)
+	if plan.UnfannedCount == 0 {
+		return plan
+	}
+
+	if cfg.UnblockedOnly {
+		complete := cachedTaskComplete(taskComplete)
+		plan.Targets, plan.AlreadyComplete = splitCompleteTasks(plan.Targets, complete)
+		plan.UnfannedCount = len(plan.Targets)
+		if plan.UnfannedCount == 0 {
+			return plan
+		}
+		plan.Targets, plan.BlockedRows = splitPlanBlocked(plan.Targets, spec.Tasks, complete)
+	}
+	plan.Targets, plan.LimitDeferred = fanset.ApplyLimit(plan.Targets, cfg.Limit)
+	return plan
+}
+
+func splitCompleteTasks(tasks []planspec.Task, taskComplete func(planspec.Task) bool) (targets []planspec.Task, skipped []string) {
+	for _, task := range tasks {
+		if taskComplete(task) {
+			skipped = append(skipped, task.ID)
+			continue
+		}
+		targets = append(targets, task)
+	}
+	return targets, skipped
+}
+
+func splitPlanBlocked(targets, allTasks []planspec.Task, taskComplete func(planspec.Task) bool) (kept []planspec.Task, blocked []taskBlockedRow) {
+	byID := map[string]planspec.Task{}
+	for _, task := range allTasks {
+		byID[task.ID] = task
+	}
+	targetIDs := map[string]bool{}
+	for _, task := range targets {
+		targetIDs[task.ID] = true
+	}
+	cache := map[string]bool{}
+	for _, task := range targets {
+		var openDeps []string
+		for _, depID := range task.BlockedBy {
+			dep, ok := byID[depID]
+			if !ok {
+				continue
+			}
+			complete, ok := cache[depID]
+			if !ok {
+				complete = taskComplete(dep)
+				cache[depID] = complete
+			}
+			if complete {
+				continue
+			}
+			if targetIDs[depID] {
+				openDeps = append(openDeps, depID)
+				continue
+			}
+			openDeps = append(openDeps, depID)
+		}
+		if len(openDeps) > 0 {
+			blocked = append(blocked, taskBlockedRow{Task: task, Refs: strings.Join(openDeps, ", ")})
+			continue
+		}
+		kept = append(kept, task)
+	}
+	return kept, blocked
+}
+
+func cachedTaskComplete(taskComplete func(planspec.Task) bool) func(planspec.Task) bool {
+	cache := map[string]bool{}
+	return func(task planspec.Task) bool {
+		complete, ok := cache[task.ID]
+		if !ok {
+			complete = taskComplete(task)
+			cache[task.ID] = complete
+		}
+		return complete
+	}
+}
+
+func planTaskComplete(gh ghissue.Runner, cfg *cliflags.Config, projectRoot string, store state.Store, spec planspec.Spec, task planspec.Task, lg *log.Logger) bool {
+	branch := task.Branch
+	if branch == "" {
+		branch = naming.BranchName("", cfg.BranchPrefix, panelaunch.PlanTaskSlug(spec.Plan.Slug, task))
+	}
+	prs, err := gh.PRsForBranch(branch)
+	if err != nil {
+		lg.Warn("%s: could not resolve blocker PRs for branch %s; treating as incomplete: %v", task.ID, branch, err)
+		return false
+	}
+	for _, pr := range prs {
+		if strings.EqualFold(pr.State, "MERGED") || pr.MergedAt != nil {
+			return true
+		}
+	}
+	if len(prs) > 0 {
+		return false
+	}
+
+	parentRef := panelaunch.PlanParentRef(spec.Plan.Slug)
+	if _, ok := store.FindTask(parentRef, task.ID); ok {
+		return false
+	}
+	if worktreeNameMatchesExact(existingWorktreeNames(filepath.Join(projectRoot, ".fanout", "worktrees")), panelaunch.PlanTaskSlug(spec.Plan.Slug, task)) {
+		return false
+	}
+	return false
+}
+
+func executeTaskPlan(cfg *cliflags.Config, lg *log.Logger, rt *Runtime, spec planspec.Spec, targets []planspec.Task, resolvedSettings settings.Settings, hookConfig hooks.Config, recorder panelaunch.StateRecorder, c log.Palette, commandName string, teamCtx *briefing.TeamContext) TaskExecutionResult {
+	launcher := &panelaunch.Launcher{Cfg: cfg, Log: lg, Info: rt.Info, Recorder: recorder, Palette: c, CommandName: commandName}
+	created, failed := executeFailFast(
+		targets,
+		taskID,
+		func(task planspec.Task) bool {
+			return launcher.LaunchOK(panelaunch.NewTaskRequest(cfg, rt.Info.ProjectRoot, spec, task, resolvedSettings, hookConfig, teamCtx))
+		},
+		sleepBetweenFunc(cfg),
+	)
+	return TaskExecutionResult{Created: len(created), Failed: failed, CreatedIDs: created}
+}
+
+func logTaskPlanDetails(plan taskPlan, lg *log.Logger) {
+	for _, id := range plan.MissingOnly {
+		lg.Warn("--only: %s not in plan task set (ignored)", id)
+	}
+	for _, row := range plan.BlockedRows {
+		lg.Info("deferred: %s (blocked by %s)", row.Task.ID, row.Refs)
+	}
+}
+
+func logAlreadyFannedTasks(skipped []string, lg *log.Logger) {
+	if len(skipped) == 0 {
+		return
+	}
+	slices.Sort(skipped)
+	lg.Info("already fanned-out (skipping): %s", strings.Join(skipped, " "))
+}
+
+func logAlreadyCompleteTasks(skipped []string, lg *log.Logger) {
+	if len(skipped) == 0 {
+		return
+	}
+	slices.Sort(skipped)
+	lg.Info("already complete (skipping): %s", strings.Join(skipped, " "))
+}
+
+func printTaskDryRunPlan(plan taskPlan, lg *log.Logger, c log.Palette) {
+	if len(plan.FilteredOnly) > 0 || len(plan.FilteredSkip) > 0 {
+		fmt.Fprintf(lg.Stdout(), "\n%sfiltered out:%s\n", c.Info, c.Reset)
+		for _, row := range plan.FilteredOnly {
+			fmt.Fprintf(lg.Stdout(), "  %s %s - not in --only\n", row.ID, row.Title)
+		}
+		for _, row := range plan.FilteredSkip {
+			fmt.Fprintf(lg.Stdout(), "  %s %s - in --skip\n", row.ID, row.Title)
+		}
+		fmt.Fprintln(lg.Stdout())
+	}
+
+	if len(plan.BlockedRows) > 0 {
+		fmt.Fprintf(lg.Stdout(), "\n%sdeferred (blocked):%s\n", c.Info, c.Reset)
+		for _, row := range plan.BlockedRows {
+			fmt.Fprintf(lg.Stdout(), "  %s %s - blocked by %s\n", row.Task.ID, row.Task.Title, row.Refs)
+		}
+		fmt.Fprintln(lg.Stdout())
+	}
+}
+
+func printTaskSummary(plan taskPlan, result TaskExecutionResult, cfg PlanCommandConfig, lg *log.Logger, c log.Palette, commandName string) {
+	fmt.Fprintln(lg.Stdout())
+	if result.Created > 0 {
+		lg.Ok("created: %d", result.Created)
+	}
+	if result.Failed > 0 {
+		lg.Err("failed:  %d", result.Failed)
+	}
+	if len(plan.AlreadyFanned) > 0 {
+		lg.Info("skipped (already fanned-out): %d", len(plan.AlreadyFanned))
+	}
+	if len(plan.AlreadyComplete) > 0 {
+		lg.Info("skipped (complete): %d", len(plan.AlreadyComplete))
+	}
+	if total := len(plan.FilteredOnly) + len(plan.FilteredSkip); total > 0 {
+		lg.Info("skipped (filtered): %d", total)
+	}
+	if len(plan.BlockedRows) > 0 {
+		lg.Info("deferred (blocked): %d", len(plan.BlockedRows))
+	}
+
+	if len(plan.LimitDeferred) == 0 {
+		return
+	}
+	if result.Failed > 0 {
+		lg.Info("deferred (--limit): %d", len(plan.LimitDeferred))
+		lg.Warn("not printing --limit rerun hint because this run failed before all selected targets completed")
+		return
+	}
+	fmt.Fprintf(lg.Stdout(), "\n%sDeferred %d task(s) due to --limit. Rerun with:%s\n", c.Info, len(plan.LimitDeferred), c.Reset)
+	ids := taskIDCSV(plan.LimitDeferred)
+	fmt.Fprintf(lg.Stdout(), "  %s\n", strings.Join(taskIDs(plan.LimitDeferred), " "))
+	cliCfg := cfg.CLIConfig()
+	fmt.Fprintf(lg.Stdout(), "  %s plan %s --only %s%s%s%s%s%s%s%s\n",
+		ShellQuote(commandName),
+		ShellQuote(cfg.SpecArg),
+		ShellQuote(ids),
+		boolFlag(" --unblocked-only", cfg.UnblockedOnly),
+		boolFlag(" --team", cfg.Team),
+		settingsFlags(cliCfg),
+		worktreeFlags(cliCfg),
+		agentFlagsForTasks(cfg.Agent, cfg.AgentOverrides, plan.LimitDeferred),
+		optFlag("--session", cfg.Session),
+		optFlag("--sleep", sleepFlagValue(cfg.SleepBetween)))
+}
+
+func taskIDCSV(tasks []planspec.Task) string {
+	return strings.Join(taskIDs(tasks), ",")
+}
+
+func taskIDs(tasks []planspec.Task) []string {
+	ids := make([]string, len(tasks))
+	for i, task := range tasks {
+		ids[i] = task.ID
+	}
+	return ids
+}
+
+func sleepFlagValue(v float64) string {
+	if v == cliflags.DefaultSleepBetween {
+		return ""
+	}
+	return strconv.FormatFloat(v, 'f', -1, 64)
+}

--- a/internal/app/run/plancmd_test.go
+++ b/internal/app/run/plancmd_test.go
@@ -1,0 +1,241 @@
+package run
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/butaosuinu/fanout/internal/app/cliflags"
+	"github.com/butaosuinu/fanout/internal/core/planspec"
+	"github.com/butaosuinu/fanout/internal/infra/ghissue"
+	"github.com/butaosuinu/fanout/internal/infra/log"
+	"github.com/butaosuinu/fanout/internal/infra/state"
+)
+
+func TestValidatePlanExecutionNamesRejectsFinalDuplicates(t *testing.T) {
+	tests := []struct {
+		name    string
+		spec    planspec.Spec
+		wantErr string
+	}{
+		{
+			name: "final slug duplicate",
+			spec: planspec.Spec{
+				Plan: planspec.Plan{Slug: "launch-plan"},
+				Tasks: []planspec.Task{
+					{ID: "api-client", Title: "Extract API client"},
+					{ID: "worker", Title: "Worker", Slug: "launch-plan-extract-api-client-api-client"},
+				},
+			},
+			wantErr: "final slug",
+		},
+		{
+			name: "final branch duplicate",
+			spec: planspec.Spec{
+				Plan: planspec.Plan{Slug: "launch-plan"},
+				Tasks: []planspec.Task{
+					{ID: "api-client", Title: "Extract API client"},
+					{ID: "worker", Title: "Worker", Branch: "fanout/launch-plan-extract-api-client-api-client"},
+				},
+			},
+			wantErr: "final branch",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidatePlanExecutionNames(tc.spec, PlanCommandConfig{})
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Fatalf("ValidatePlanExecutionNames() error = %v, want %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestResolvePlanBaseBranchValidatesSpecBranchOnlyWhenUsed(t *testing.T) {
+	spec := planspec.Spec{Plan: planspec.Plan{Slug: "launch-plan", BaseBranch: "release candidate"}}
+
+	got, err := resolvePlanBaseBranch(PlanCommandConfig{BaseBranch: "main"}, spec, t.TempDir())
+	if err != nil || got != "main" {
+		t.Fatalf("resolvePlanBaseBranch() = %q, %v; want main, nil", got, err)
+	}
+
+	_, err = resolvePlanBaseBranch(PlanCommandConfig{}, spec, t.TempDir())
+	if err == nil || !strings.Contains(err.Error(), "plan.base_branch must not contain whitespace") {
+		t.Fatalf("resolvePlanBaseBranch() error = %v, want plan.base_branch whitespace error", err)
+	}
+}
+
+func TestResolvePlanBaseBranchUsesCurrentBranchWithoutOrigin(t *testing.T) {
+	repo := t.TempDir()
+	gitCmdTest(t, repo, "init", "-b", "trunk")
+	gitCmdTest(t, repo, "config", "user.email", "fanout@example.test")
+	gitCmdTest(t, repo, "config", "user.name", "Fanout Test")
+	if err := os.WriteFile(filepath.Join(repo, "README.md"), []byte("base\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitCmdTest(t, repo, "add", "README.md")
+	gitCmdTest(t, repo, "commit", "-m", "base")
+
+	got, err := resolvePlanBaseBranch(PlanCommandConfig{}, planspec.Spec{Plan: planspec.Plan{Slug: "launch-plan"}}, repo)
+	if err != nil {
+		t.Fatalf("resolvePlanBaseBranch() error = %v", err)
+	}
+	if got != "trunk" {
+		t.Fatalf("resolvePlanBaseBranch() = %q, want current branch trunk", got)
+	}
+}
+
+func TestPlanRerunSpecArgUsesCopiedPlanSlugForLiveRuns(t *testing.T) {
+	spec := planspec.Spec{Plan: planspec.Plan{Slug: "launch-plan"}}
+
+	if got := planRerunSpecArg(PlanCommandConfig{DryRun: true, SpecArg: "/tmp/plan.json"}, spec); got != "/tmp/plan.json" {
+		t.Fatalf("dry-run rerun spec arg = %q, want original path", got)
+	}
+	if got := planRerunSpecArg(PlanCommandConfig{SpecArg: "/tmp/plan.json"}, spec); got != "launch-plan" {
+		t.Fatalf("live rerun spec arg = %q, want copied plan slug", got)
+	}
+}
+
+func TestSplitPlanBlockedKeepsSameRunDependenciesOpen(t *testing.T) {
+	tasks := []planspec.Task{
+		{ID: "base-types", Title: "Define base types"},
+		{ID: "api-client", Title: "Extract API client", BlockedBy: []string{"base-types"}},
+	}
+
+	kept, blocked := splitPlanBlocked(tasks, tasks, func(planspec.Task) bool {
+		return false
+	})
+
+	if len(kept) != 1 || kept[0].ID != "base-types" {
+		t.Fatalf("kept = %+v, want only base-types", kept)
+	}
+	if len(blocked) != 1 || blocked[0].Task.ID != "api-client" || blocked[0].Refs != "base-types" {
+		t.Fatalf("blocked = %+v, want api-client blocked by base-types", blocked)
+	}
+}
+
+func TestSplitPlanBlockedAllowsCompletedTargetDependencies(t *testing.T) {
+	tasks := []planspec.Task{
+		{ID: "base-types", Title: "Define base types"},
+		{ID: "api-client", Title: "Extract API client", BlockedBy: []string{"base-types"}},
+	}
+
+	kept, blocked := splitPlanBlocked(tasks[1:], tasks, func(task planspec.Task) bool {
+		return task.ID == "base-types"
+	})
+
+	if len(blocked) != 0 {
+		t.Fatalf("blocked = %+v, want no blocked rows", blocked)
+	}
+	if len(kept) != 1 || kept[0].ID != "api-client" {
+		t.Fatalf("kept = %+v, want api-client", kept)
+	}
+}
+
+func TestBuildTaskPlanSkipsCompletedTargetsBeforeBlockerCheck(t *testing.T) {
+	spec := planspec.Spec{
+		Plan: planspec.Plan{Slug: "launch-plan"},
+		Tasks: []planspec.Task{
+			{ID: "base-types", Title: "Define base types"},
+			{ID: "api-client", Title: "Extract API client", BlockedBy: []string{"base-types"}},
+		},
+	}
+
+	plan := buildTaskPlan(PlanCommandConfig{UnblockedOnly: true}, spec, nil, func(task planspec.Task) bool {
+		return task.ID == "base-types"
+	})
+
+	if len(plan.AlreadyComplete) != 1 || plan.AlreadyComplete[0] != "base-types" {
+		t.Fatalf("AlreadyComplete = %+v, want base-types", plan.AlreadyComplete)
+	}
+	if len(plan.BlockedRows) != 0 {
+		t.Fatalf("BlockedRows = %+v, want none", plan.BlockedRows)
+	}
+	if len(plan.Targets) != 1 || plan.Targets[0].ID != "api-client" {
+		t.Fatalf("Targets = %+v, want only api-client", plan.Targets)
+	}
+}
+
+func TestBuildTaskPlanSkipsCompletedLeafTargets(t *testing.T) {
+	spec := planspec.Spec{
+		Plan: planspec.Plan{Slug: "launch-plan"},
+		Tasks: []planspec.Task{
+			{ID: "ui-shell", Title: "Build UI shell"},
+		},
+	}
+
+	plan := buildTaskPlan(PlanCommandConfig{UnblockedOnly: true}, spec, nil, func(task planspec.Task) bool {
+		return task.ID == "ui-shell"
+	})
+
+	if len(plan.AlreadyComplete) != 1 || plan.AlreadyComplete[0] != "ui-shell" {
+		t.Fatalf("AlreadyComplete = %+v, want ui-shell", plan.AlreadyComplete)
+	}
+	if plan.UnfannedCount != 0 || len(plan.Targets) != 0 {
+		t.Fatalf("targets = %+v (unfanned=%d), want none", plan.Targets, plan.UnfannedCount)
+	}
+}
+
+func TestPlanTaskCompleteTreatsMissingEvidenceAsIncomplete(t *testing.T) {
+	binDir := t.TempDir()
+	ghPath := filepath.Join(binDir, "gh")
+	if err := os.WriteFile(ghPath, []byte("#!/bin/sh\nprintf '[]\\n'\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	projectRoot := t.TempDir()
+	spec := planspec.Spec{
+		Plan:  planspec.Plan{Slug: "launch-plan"},
+		Tasks: []planspec.Task{{ID: "base-types", Title: "Define base types"}},
+	}
+
+	complete := planTaskComplete(
+		ghissue.Runner{Cwd: projectRoot},
+		&cliflags.Config{},
+		projectRoot,
+		state.Store{},
+		spec,
+		spec.Tasks[0],
+		log.New(false),
+	)
+
+	if complete {
+		t.Fatal("planTaskComplete() = true, want false without merged PR, state row, or worktree")
+	}
+}
+
+func TestPlanTaskCompleteTreatsNonMergedPRAsIncomplete(t *testing.T) {
+	binDir := t.TempDir()
+	ghPath := filepath.Join(binDir, "gh")
+	if err := os.WriteFile(ghPath, []byte(`#!/bin/sh
+cat <<'JSON'
+[{"number":42,"state":"OPEN","mergedAt":null,"isDraft":false,"reviewDecision":"","statusCheckRollup":null}]
+JSON
+`), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	projectRoot := t.TempDir()
+	spec := planspec.Spec{
+		Plan:  planspec.Plan{Slug: "launch-plan"},
+		Tasks: []planspec.Task{{ID: "base-types", Title: "Define base types"}},
+	}
+
+	complete := planTaskComplete(
+		ghissue.Runner{Cwd: projectRoot},
+		&cliflags.Config{},
+		projectRoot,
+		state.Store{},
+		spec,
+		spec.Tasks[0],
+		log.New(false),
+	)
+
+	if complete {
+		t.Fatal("planTaskComplete() = true, want false when branch has a non-merged PR")
+	}
+}

--- a/internal/app/run/report.go
+++ b/internal/app/run/report.go
@@ -1,4 +1,4 @@
-package main
+package run
 
 import (
 	"fmt"
@@ -11,12 +11,6 @@ import (
 	"github.com/butaosuinu/fanout/internal/infra/ghissue"
 	"github.com/butaosuinu/fanout/internal/infra/log"
 )
-
-type executionResult struct {
-	Created     int
-	Failed      int
-	CreatedNums []int
-}
 
 func logPlanDetails(plan Plan, lg *log.Logger) {
 	for _, num := range plan.MissingOnly {
@@ -99,10 +93,10 @@ func printSummary(plan Plan, result executionResult, cfg *cliflags.Config, lg *l
 			statusFlag = optFlag("--project-status", cfg.ProjectStatus)
 		}
 		fmt.Fprintf(lg.Stdout(), "  %s %s%s --include %s --only %s%s%s%s%s%s%s%s%s\n",
-			shellQuote(commandName), shellQuote(cfg.ParentRef),
+			ShellQuote(commandName), ShellQuote(cfg.ParentRef),
 			statusFlag,
-			shellQuote(deferredCSV),
-			shellQuote(deferredCSV),
+			ShellQuote(deferredCSV),
+			ShellQuote(deferredCSV),
 			boolFlag(" --unblocked-only", cfg.UnblockedOnly),
 			boolFlag(" --team", cfg.Team),
 			codexPlanModeFlag(cfg),
@@ -126,7 +120,7 @@ func optFlag(flag, value string) string {
 	if value == "" {
 		return ""
 	}
-	return " " + flag + " " + shellQuote(value)
+	return " " + flag + " " + ShellQuote(value)
 }
 
 func boolFlag(flagWithLeadSpace string, on bool) string {
@@ -225,7 +219,9 @@ func boolSettingFlag(onFlag, offFlag string, v *bool) string {
 	return " " + offFlag
 }
 
-func shellQuote(s string) string {
+// ShellQuote renders s as a single copy-paste-safe POSIX shell token for the
+// --limit rerun hints.
+func ShellQuote(s string) string {
 	if s == "" {
 		return "''"
 	}

--- a/internal/app/run/report_test.go
+++ b/internal/app/run/report_test.go
@@ -1,4 +1,4 @@
-package main
+package run
 
 import (
 	"bytes"
@@ -140,7 +140,7 @@ func TestPrintTaskSummaryPreservesDeferredAgentOverridesInLimitRerunHint(t *test
 	plan := taskPlan{
 		LimitDeferred: []planspec.Task{{ID: "api-client"}},
 	}
-	cfg := planCommandConfig{
+	cfg := PlanCommandConfig{
 		SpecArg:      "launch-plan",
 		Agent:        "claude",
 		SleepBetween: cliflags.DefaultSleepBetween,
@@ -150,7 +150,7 @@ func TestPrintTaskSummaryPreservesDeferredAgentOverridesInLimitRerunHint(t *test
 		},
 	}
 
-	printTaskSummary(plan, taskExecutionResult{}, cfg, lg, log.Palette{}, "fanout-go")
+	printTaskSummary(plan, TaskExecutionResult{}, cfg, lg, log.Palette{}, "fanout-go")
 
 	got := out.String()
 	want := "  fanout-go plan launch-plan --only api-client --agent claude --agent 'api-client=codex'\n"
@@ -184,7 +184,7 @@ func TestPrintSummarySuppressesLimitRerunHintAfterFailure(t *testing.T) {
 	}
 }
 
-// TestShellQuoteIsCopyPasteSafe pins shellQuote and, more importantly, proves
+// TestShellQuoteIsCopyPasteSafe pins ShellQuote and, more importantly, proves
 // the property that actually matters for the --limit rerun hint: the quoted
 // token must evaluate back to the original argument under a POSIX shell, so the
 // printed command is copy-paste-safe. This is the path reached by metacharacter
@@ -220,19 +220,19 @@ func TestShellQuoteIsCopyPasteSafe(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			got := shellQuote(c.in)
+			got := ShellQuote(c.in)
 			if got != c.want {
-				t.Errorf("shellQuote(%q) = %q, want %q", c.in, got, c.want)
+				t.Errorf("ShellQuote(%q) = %q, want %q", c.in, got, c.want)
 			}
 			// Round-trip: a POSIX shell must parse the quoted token back into the
-			// exact original string (a single argument). If shellQuote under-quoted,
+			// exact original string (a single argument). If ShellQuote under-quoted,
 			// `sh` would split or expand it and the output would not match.
 			out, err := exec.Command("sh", "-c", "printf %s "+got).Output()
 			if err != nil {
-				t.Fatalf("sh failed on shellQuote(%q)=%q: %v", c.in, got, err)
+				t.Fatalf("sh failed on ShellQuote(%q)=%q: %v", c.in, got, err)
 			}
 			if string(out) != c.in {
-				t.Errorf("round-trip: sh parsed shellQuote(%q)=%q as %q, want %q", c.in, got, string(out), c.in)
+				t.Errorf("round-trip: sh parsed ShellQuote(%q)=%q as %q, want %q", c.in, got, string(out), c.in)
 			}
 		})
 	}

--- a/internal/app/run/runtime.go
+++ b/internal/app/run/runtime.go
@@ -1,0 +1,117 @@
+package run
+
+import (
+	"os"
+	"strings"
+	"time"
+
+	"github.com/butaosuinu/fanout/internal/app/cliflags"
+	"github.com/butaosuinu/fanout/internal/core/exitcode"
+	"github.com/butaosuinu/fanout/internal/infra/ghissue"
+	"github.com/butaosuinu/fanout/internal/infra/gitroot"
+	"github.com/butaosuinu/fanout/internal/infra/log"
+	fanoutruntime "github.com/butaosuinu/fanout/internal/infra/runtime"
+	"github.com/butaosuinu/fanout/internal/infra/settings"
+	"github.com/butaosuinu/fanout/internal/infra/state"
+	"github.com/butaosuinu/fanout/internal/infra/tmuxrun"
+	"github.com/butaosuinu/fanout/internal/infra/worktree"
+)
+
+// sleepBetweenIssues is the rate-limit seam shared by both fan-out lanes.
+// Tests swap it to observe the between-launch delay without real sleeping.
+var sleepBetweenIssues = time.Sleep
+
+// BindKeysFunc registers the dashboard / worktree-action tmux keybindings after
+// a live run. cmd owns the implementation (it depends on the dashboard command's
+// key constants); the run lanes call it back through this seam.
+type BindKeysFunc func(lg *log.Logger, enabled bool)
+
+// Runtime is the resolved tmux/git/gh context both lanes execute against.
+type Runtime struct {
+	Info *fanoutruntime.Info
+	GH   ghissue.Runner
+}
+
+// ResolveRuntime resolves the tmux target and git project root, validates the
+// agent selection, and records the invoking pane's project-root hint for the
+// dashboard. It is shared by the issue lane (cmd main) and the plan lane
+// (cmd plan).
+func ResolveRuntime(cfg *cliflags.Config, lg *log.Logger) (*Runtime, exitcode.Code) {
+	info, err := fanoutruntime.Resolve(cfg.Session)
+	if err != nil {
+		lg.Err("%s", err.Error())
+		return nil, exitcode.Env
+	}
+
+	if cfg.Agent == "" {
+		cfg.Agent = os.Getenv("FANOUT_AGENT")
+	}
+	if cfg.Agent == "" && len(cfg.AgentOverrides) == 0 {
+		lg.Err("agent is required; pass --agent <name> or set FANOUT_AGENT")
+		return nil, exitcode.Env
+	}
+
+	lg.Info("tmux session: %s", info.Session)
+	lg.Info("tmux target:  %s", info.Target)
+	lg.Info("project root: %s", info.ProjectRoot)
+
+	if !gitroot.IsWorkTree(info.ProjectRoot) {
+		lg.Err("project root %s is not a git work tree; cannot resolve GitHub repo", info.ProjectRoot)
+		return nil, exitcode.Env
+	}
+	if !cfg.DryRun {
+		markCurrentPaneProjectRoot(info.ProjectRoot, lg)
+	}
+	return &Runtime{
+		Info: info,
+		GH:   ghissue.Runner{Cwd: info.ProjectRoot},
+	}, exitcode.OK
+}
+
+func markCurrentPaneProjectRoot(projectRoot string, lg *log.Logger) {
+	paneID := strings.TrimSpace(os.Getenv("TMUX_PANE"))
+	if paneID == "" {
+		return
+	}
+	if err := tmuxrun.SetPaneProjectRoot(paneID, projectRoot); err != nil {
+		lg.Debug("dashboard project root hint: %v", err)
+	}
+}
+
+// settingsOverrides folds the CLI setting toggles into a settings.CLIOverrides
+// literal; both lanes resolve settings through the same mapping.
+func settingsOverrides(cfg *cliflags.Config) settings.CLIOverrides {
+	return settings.CLIOverrides{
+		AutoPullRequest:    cfg.AutoPullRequest,
+		PRReviewGate:       cfg.PRReviewGate,
+		BriefingCodeReview: cfg.BriefingCodeReview,
+		AgentTeamsHint:     cfg.AgentTeamsHint,
+		PRVisualization:    cfg.PRVisualization,
+		DashboardKeybind:   cfg.DashboardKeybind,
+	}
+}
+
+// LoadState opens the fanout state store for a run: read-only for dry-runs,
+// and lock-backed (after preparing the local git exclude) for live runs. Both
+// lanes share it; loadRunState / loadPlanState were byte-identical apart from
+// their config type, so only the dry-run flag is threaded here.
+func LoadState(dryRun bool, projectRoot string, lg *log.Logger) (state.Store, *state.LockedStore, exitcode.Code) {
+	if dryRun {
+		store, err := state.LoadProject(projectRoot)
+		if err != nil {
+			lg.Err("%v", err)
+			return state.Store{}, nil, exitcode.Env
+		}
+		return store, nil, exitcode.OK
+	}
+	if err := worktree.EnsureLocalExclude(projectRoot); err != nil {
+		lg.Err("prepare local git exclude: %v", err)
+		return state.Store{}, nil, exitcode.Env
+	}
+	locked, err := state.LockProject(projectRoot)
+	if err != nil {
+		lg.Err("%v", err)
+		return state.Store{}, nil, exitcode.Env
+	}
+	return locked.Store, locked, exitcode.OK
+}

--- a/internal/app/run/runtime_test.go
+++ b/internal/app/run/runtime_test.go
@@ -1,0 +1,38 @@
+package run
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/butaosuinu/fanout/internal/core/exitcode"
+	"github.com/butaosuinu/fanout/internal/infra/log"
+)
+
+func TestLoadStateIgnoresLockFileWhenNoWorktreeIsPrepared(t *testing.T) {
+	repo := t.TempDir()
+	gitCmdTest(t, repo, "init")
+
+	lg := log.NewWith(io.Discard, io.Discard, false)
+	_, recorder, code := LoadState(false, repo, lg)
+	if code != exitcode.OK {
+		t.Fatalf("LoadState code = %d, want %d", code, exitcode.OK)
+	}
+	if recorder == nil {
+		t.Fatal("LoadState returned nil recorder for live run")
+	}
+	t.Cleanup(func() { _ = recorder.Unlock() })
+
+	if _, err := os.Stat(filepath.Join(repo, ".fanout", "state.json.lock")); err != nil {
+		t.Fatalf("state lock was not created: %v", err)
+	}
+	exclude, err := os.ReadFile(filepath.Join(repo, ".git", "info", "exclude"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(exclude), ".fanout/state.json.lock\n") {
+		t.Fatalf("exclude = %q, want state lock pattern", exclude)
+	}
+}

--- a/internal/app/run/team.go
+++ b/internal/app/run/team.go
@@ -1,4 +1,4 @@
-package main
+package run
 
 import (
 	"fmt"
@@ -57,49 +57,28 @@ func teamParentLabel(parentRef string) string {
 }
 
 // seedTeamRegistry upserts the panes created this run into the per-parent
-// peers table. Messaging is best-effort by design: every failure is a warning
-// and the fan-out result is never affected.
+// peers table, looked up by issue number.
 func seedTeamRegistry(lg *log.Logger, dbPath string, st state.Store, parentRef string, created []int) {
-	db, err := team.Open(dbPath)
-	if err != nil {
-		lg.Warn("team: %v", err)
-		return
-	}
-	defer func() {
-		if err := db.Close(); err != nil {
-			lg.Warn("team: close registry db: %v", err)
-		}
-	}()
-	if err := team.EnsureSchema(db); err != nil {
-		lg.Warn("team: %v", err)
-		return
-	}
-
-	// One timestamp for the run so a cohort launched together joins together.
-	now := team.Now()
-	seeded := 0
-	for _, num := range created {
-		pane, ok := st.Find(parentRef, num)
-		if !ok {
-			lg.Warn("team: #%d: no state row to seed into the peers registry", num)
-			continue
-		}
-		if err := team.UpsertPeer(db, pane, now); err != nil {
-			lg.Warn("team: %v", err)
-			continue
-		}
-		seeded++
-	}
-	if seeded > 0 {
-		lg.Ok("team: seeded %d peer(s) -> %s", seeded, dbPath)
-	}
+	seedRegistry(lg, dbPath, created,
+		func(num int) (state.Pane, bool) { return st.Find(parentRef, num) },
+		func(num int) string { return fmt.Sprintf("#%d", num) },
+	)
 }
 
-// seedTaskTeamRegistry is the issue-less plan variant of seedTeamRegistry: it
-// upserts the plan-task panes created this run into the per-parent peers table,
-// looked up by task id. Best-effort by design: every failure is a warning and
-// the fan-out result is never affected.
+// seedTaskTeamRegistry is the issue-less plan variant: it upserts the plan-task
+// panes created this run into the per-parent peers table, looked up by task id.
 func seedTaskTeamRegistry(lg *log.Logger, dbPath string, st state.Store, parentRef string, createdIDs []string) {
+	seedRegistry(lg, dbPath, createdIDs,
+		func(id string) (state.Pane, bool) { return st.FindTask(parentRef, id) },
+		func(id string) string { return id },
+	)
+}
+
+// seedRegistry is the shared best-effort peer-registry seeder for both lanes.
+// Messaging is best-effort by design: every failure is a warning and the
+// fan-out result is never affected. find resolves a created key to its state
+// row; label renders the key for the missing-row warning ("#42" or a task id).
+func seedRegistry[K any](lg *log.Logger, dbPath string, created []K, find func(K) (state.Pane, bool), label func(K) string) {
 	db, err := team.Open(dbPath)
 	if err != nil {
 		lg.Warn("team: %v", err)
@@ -118,10 +97,10 @@ func seedTaskTeamRegistry(lg *log.Logger, dbPath string, st state.Store, parentR
 	// One timestamp for the run so a cohort launched together joins together.
 	now := team.Now()
 	seeded := 0
-	for _, id := range createdIDs {
-		pane, ok := st.FindTask(parentRef, id)
+	for _, key := range created {
+		pane, ok := find(key)
 		if !ok {
-			lg.Warn("team: %s: no state row to seed into the peers registry", id)
+			lg.Warn("team: %s: no state row to seed into the peers registry", label(key))
 			continue
 		}
 		if err := team.UpsertPeer(db, pane, now); err != nil {

--- a/internal/app/run/team_test.go
+++ b/internal/app/run/team_test.go
@@ -1,4 +1,4 @@
-package main
+package run
 
 import (
 	"bytes"

--- a/internal/core/fanset/fanset.go
+++ b/internal/core/fanset/fanset.go
@@ -1,0 +1,92 @@
+// Package fanset holds pure generic set and selection helpers shared by the
+// issue fan-out lane (int issue numbers) and the plan fan-out lane (string
+// task ids). Keeping the selection algebra in one place lets both lanes share
+// the exact same nil/empty-slice and append-order semantics their dry-run
+// golden output depends on.
+package fanset
+
+// Set builds a membership set keyed by K.
+func Set[K comparable](keys []K) map[K]bool {
+	set := make(map[K]bool, len(keys))
+	for _, k := range keys {
+		set[k] = true
+	}
+	return set
+}
+
+// Union merges membership sets into a fresh, always-non-nil map: a key present
+// in any input is present in the result. It replaces the per-lane mergeFanned
+// helpers, whose only job was to fold the same-parent and worktree-fallback
+// fanned sets together.
+func Union[K comparable](sets ...map[K]bool) map[K]bool {
+	out := map[K]bool{}
+	for _, s := range sets {
+		for k := range s {
+			out[k] = true
+		}
+	}
+	return out
+}
+
+// FilterOnlySkip partitions items by the --only / --skip selectors keyed by K.
+// It returns the kept items, the items dropped for being outside --only, the
+// items dropped for being in --skip, and the --only keys absent from items.
+//
+// The branch order, append order, and the early nil-return when neither
+// selector is set are load-bearing: the dry-run "filtered out:" section is
+// emitted only when FilteredOnly/FilteredSkip are non-empty, and its row order
+// mirrors the input order.
+func FilterOnlySkip[T any, K comparable](items []T, key func(T) K, only, skip []K) (kept, filteredOnly, filteredSkip []T, missingOnly []K) {
+	if len(only) == 0 && len(skip) == 0 {
+		return items, nil, nil, nil
+	}
+
+	present := map[K]bool{}
+	for _, item := range items {
+		present[key(item)] = true
+	}
+	for _, k := range only {
+		if !present[k] {
+			missingOnly = append(missingOnly, k)
+		}
+	}
+
+	onlySet := Set(only)
+	skipSet := Set(skip)
+	for _, item := range items {
+		k := key(item)
+		switch {
+		case len(only) > 0 && !onlySet[k]:
+			filteredOnly = append(filteredOnly, item)
+		case len(skip) > 0 && skipSet[k]:
+			filteredSkip = append(filteredSkip, item)
+		default:
+			kept = append(kept, item)
+		}
+	}
+	return kept, filteredOnly, filteredSkip, missingOnly
+}
+
+// SplitFanned partitions items into those not yet fanned out (targets) and the
+// keys of those already fanned (skipped), preserving input order.
+func SplitFanned[T any, K comparable](items []T, key func(T) K, fanned map[K]bool) (targets []T, skipped []K) {
+	for _, item := range items {
+		k := key(item)
+		if fanned[k] {
+			skipped = append(skipped, k)
+			continue
+		}
+		targets = append(targets, item)
+	}
+	return targets, skipped
+}
+
+// ApplyLimit caps items to the first limit entries and returns the remainder as
+// deferred. A non-positive limit or a slice already within the limit defers
+// nothing (nil).
+func ApplyLimit[T any](items []T, limit int) (targets, deferred []T) {
+	if limit > 0 && len(items) > limit {
+		return items[:limit], items[limit:]
+	}
+	return items, nil
+}

--- a/internal/core/fanset/fanset_test.go
+++ b/internal/core/fanset/fanset_test.go
@@ -1,0 +1,178 @@
+package fanset
+
+import (
+	"reflect"
+	"testing"
+)
+
+func intKey(n int) int { return n }
+
+func TestSet(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []int
+		want map[int]bool
+	}{
+		{name: "nil input yields empty non-nil set", in: nil, want: map[int]bool{}},
+		{name: "dedupes repeated keys", in: []int{1, 1, 2}, want: map[int]bool{1: true, 2: true}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Set(tt.in)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("Set(%v) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUnion(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []map[int]bool
+		want map[int]bool
+	}{
+		{name: "no inputs yields empty non-nil map", in: nil, want: map[int]bool{}},
+		{
+			name: "merges disjoint sets (migration fallback fold)",
+			in:   []map[int]bool{{101: true}, {102: true}},
+			want: map[int]bool{101: true, 102: true},
+		},
+		{
+			name: "overlapping keys collapse",
+			in:   []map[int]bool{{1: true, 2: true}, {2: true, 3: true}},
+			want: map[int]bool{1: true, 2: true, 3: true},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := Union(tt.in...)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("Union(%v) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFilterOnlySkip(t *testing.T) {
+	tests := []struct {
+		name             string
+		items            []int
+		only             []int
+		skip             []int
+		wantKept         []int
+		wantFilteredOnly []int
+		wantFilteredSkip []int
+		wantMissingOnly  []int
+	}{
+		{
+			// Neither selector set: kept aliases the input and the three drop
+			// slices stay nil, so the dry-run "filtered out:" section is skipped.
+			name:     "no selectors returns input and nil drops",
+			items:    []int{1, 2, 3},
+			wantKept: []int{1, 2, 3},
+		},
+		{
+			name:             "only keeps listed and reports missing",
+			items:            []int{1, 2, 3},
+			only:             []int{1, 3, 99},
+			wantKept:         []int{1, 3},
+			wantFilteredOnly: []int{2},
+			wantMissingOnly:  []int{99},
+		},
+		{
+			name:             "skip drops listed",
+			items:            []int{1, 2, 3},
+			skip:             []int{2},
+			wantKept:         []int{1, 3},
+			wantFilteredSkip: []int{2},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kept, filteredOnly, filteredSkip, missingOnly := FilterOnlySkip(tt.items, intKey, tt.only, tt.skip)
+			if !reflect.DeepEqual(kept, tt.wantKept) {
+				t.Fatalf("kept = %#v, want %#v", kept, tt.wantKept)
+			}
+			if !reflect.DeepEqual(filteredOnly, tt.wantFilteredOnly) {
+				t.Fatalf("filteredOnly = %#v, want %#v", filteredOnly, tt.wantFilteredOnly)
+			}
+			if !reflect.DeepEqual(filteredSkip, tt.wantFilteredSkip) {
+				t.Fatalf("filteredSkip = %#v, want %#v", filteredSkip, tt.wantFilteredSkip)
+			}
+			if !reflect.DeepEqual(missingOnly, tt.wantMissingOnly) {
+				t.Fatalf("missingOnly = %#v, want %#v", missingOnly, tt.wantMissingOnly)
+			}
+		})
+	}
+}
+
+// TestFilterOnlySkipNoSelectorsAliasesInput pins that the no-selector path
+// returns the exact input slice (kept is the same backing array), not a copy —
+// the behavior both lanes relied on before this extraction.
+func TestFilterOnlySkipNoSelectorsAliasesInput(t *testing.T) {
+	items := []int{1, 2, 3}
+	kept, _, _, _ := FilterOnlySkip(items, intKey, nil, nil)
+	if len(kept) != len(items) || &kept[0] != &items[0] {
+		t.Fatalf("kept did not alias the input slice")
+	}
+}
+
+func TestSplitFanned(t *testing.T) {
+	tests := []struct {
+		name        string
+		items       []int
+		fanned      map[int]bool
+		wantTargets []int
+		wantSkipped []int
+	}{
+		{
+			name:        "none fanned keeps all and skips nothing",
+			items:       []int{1, 2},
+			wantTargets: []int{1, 2},
+		},
+		{
+			name:        "fanned keys collected in input order",
+			items:       []int{1, 2, 3},
+			fanned:      map[int]bool{1: true, 3: true},
+			wantTargets: []int{2},
+			wantSkipped: []int{1, 3},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			targets, skipped := SplitFanned(tt.items, intKey, tt.fanned)
+			if !reflect.DeepEqual(targets, tt.wantTargets) {
+				t.Fatalf("targets = %#v, want %#v", targets, tt.wantTargets)
+			}
+			if !reflect.DeepEqual(skipped, tt.wantSkipped) {
+				t.Fatalf("skipped = %#v, want %#v", skipped, tt.wantSkipped)
+			}
+		})
+	}
+}
+
+func TestApplyLimit(t *testing.T) {
+	tests := []struct {
+		name         string
+		items        []int
+		limit        int
+		wantTargets  []int
+		wantDeferred []int
+	}{
+		{name: "zero limit defers nothing", items: []int{1, 2}, limit: 0, wantTargets: []int{1, 2}},
+		{name: "limit at length defers nothing", items: []int{1, 2}, limit: 2, wantTargets: []int{1, 2}},
+		{name: "limit below length splits", items: []int{1, 2, 3}, limit: 1, wantTargets: []int{1}, wantDeferred: []int{2, 3}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			targets, deferred := ApplyLimit(tt.items, tt.limit)
+			if !reflect.DeepEqual(targets, tt.wantTargets) {
+				t.Fatalf("targets = %#v, want %#v", targets, tt.wantTargets)
+			}
+			if !reflect.DeepEqual(deferred, tt.wantDeferred) {
+				t.Fatalf("deferred = %#v, want %#v", deferred, tt.wantDeferred)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 概要

4 層再配置の最終実装 PR。cmd に残っていた両レーンの実行系を移送し、cmd/fanout を composition root に純化する。

### core/fanset(純ジェネリクス)
issue(int)/task(string)で二重化していた計画フィルタ 4 対を統合: `FilterOnlySkip` / `SplitFanned` / `ApplyLimit` / `Set` / `Union`。nil/空スライス区別・分岐順・入力エイリアスを旧実装と同一に固定(dry-run golden の filtered out セクション有無に効く)。buildPlan↔buildTaskPlan 本体と splitBlocked はセマンティクスが異なるため統合しない。

### app/run(両レーンの移送先)
run/runWithRuntime・plancmd 実行系・plan.go・report.go・team.go を移送。共通ヘルパ: `LoadState`(loadRunState↔loadPlanState は完全同一だった)、`executeFailFast[T,K]`(fail-fast + 成功間 sleep)、`seedRegistry`、settingsOverrides、ResolveRuntime。runWithRuntime↔runPlanWithRuntime は注入点過剰になるため統合せず Issues / PlanTasks として並置。

### main ディスパッチ
isXxxRequest 13 個 + cfg フラグの二段ディスパッチを順序保存の first-match-wins テーブルへ。`__tui-new-pane-popup` / `__tui-help-popup` / `__codex-plan-tui` は単一定数参照 + `TestSelfExecSubcommandNames` で文字列固定。`version` / `commit` は release.yml が `-X main.version` を名指しするため main.go に恒久固定。

## 検証
- code-review Workflow(high)3 件(過剰エクスポート)対応済み / codex approve
- dry-run / summary / rerun golden 全 50 シナリオ バイト不変 / make lint 0 issues / make test 全 green
- 文言検査: 旧 6 ファイルとの文字列リテラル集合差分で実質的損失ゼロ(seedRegistry の label 注入は実行時出力バイト一致)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVKpKSXDTZbZqMw8cu1MUg