### PR TITLE
docs: 4層アーキテクチャの正典とレビュー負荷マップを追加 (layered 10/10)

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,7 @@
 # #205 squash: .golangci.yml 追加と gofumpt/goimports 一括整形 (#191)
 # (整形差分のほか .golangci.yml と本ファイルの追加を含む squash コミット)
 cf435be5367f905af17b81ba66a41263dc7f214c
+# 4層再配置 layered 2/10: core/infra 層へ 21 パッケージを移動 (#414)
+c46d183e6945f64d40d9ffe162cf6da1de638aed
+# 4層再配置 layered 3/10: app/ui 層へ 8 パッケージを移動 (#415)
+a2c2fb297df543e8db6ffe73695d25ddd261df78

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,22 +92,23 @@ and the PR-review-weight classes (H/M/A) live in `docs/architecture.ja.md`.
   `tui*.go` (no-argument console wiring; the prompt-mode plan fan-out
   launches one coordinator pane at the project root so `fanout plan`'s git
   root stays at the repo, never Codex Plan Mode), and `tui_popup.go`
-  (self-exec popup subcommands). `main.go` / `tui_popup.go` /
-  `tui_launch.go` / `worktree_action.go` / `codex_plan_tui.go` are class H;
-  the remaining cmd files (flag validation and thin dispatch into app) are
+  (self-exec popup subcommands). `main.go` / `tui_popup.go` / `tui_launch.go` / `worktree_action.go` /
+  `codex_plan_tui.go` / `tui_restore.go` / `tui_watch.go` are class H; the
+  remaining cmd files (flag validation and thin dispatch into app) are
   class M.
 - `internal/core` is pure logic with no process/network/FS/DB access:
   `agent` (supported agent names, CLI validation for live mode; allowed
   `os`/`os/exec` in the purity allowlist), `planspec` (the `fanout plan` JSON
   schema; allowed `os` for spec loading), `naming` (deterministic slug/branch
-  generation), and the
-  AI-reviewable `blockers`/`exitcode`/`parentref`/`fanset`/`cliview`.
+  generation; identity-deciding, class M with `parentref`/`fanset`), and the
+  AI-reviewable `blockers`/`exitcode`/`cliview`.
 - `internal/app` orchestrates use cases on top of `core` and `infra`:
   `panelaunch`, `lifecycle`, `watch` (the label-watcher cycle, pure at the
   package boundary via `watch.IO`), and `briefing` (the prompt text injected
   into agents) are class H; `sessionview` (the read-only `Snapshot`
   aggregator shared by the web dashboard and a future TUI), `panelayout`,
-  `run`, `statusreport`, and `peermsg` are class M; `cliflags` is class A.
+  `run`, `statusreport`, `peermsg`, and `cliflags` (flag validation that
+  decides main's lifecycle branches) are class M.
 - `internal/infra` talks to external processes, the filesystem, and the team
   SQLite bus: `state` (`.fanout/state.json` + its lock), `worktree` (`git
   worktree add` under `.fanout/worktrees/<slug>/`), `hooks`, `selfupdate`,
@@ -115,16 +116,17 @@ and the PR-review-weight classes (H/M/A) live in `docs/architecture.ja.md`.
   `modernc.org/sqlite`, WAL mode, file mode `0600`, DB scoped to
   `/tmp/fanout-<repo>-<parent_key>.db` with `FANOUT_DB_PATH` override; pane
   identity resolves from `.fanout/state.json` with the `[fanout #N of #P]`
-  prompt prefix as fallback) are class H; `ghissue`, `gitstat`,
-  `tmuxrun` (direct tmux operations), `msgstore`, `notify`, `runtime` (git
-  root + tmux target resolution), `settings`, `displayname`, and `codexapp`
-  are class M; `atomicfs`, `log`, `tty`, `execx`, `gitroot`, and `browser`
-  are class A.
+  prompt prefix as fallback), and `settings` (the safety gate that blocks
+  repo config from enabling the watcher or notification targets) are class
+  H; `ghissue`, `gitstat`,
+  `tmuxrun` (direct tmux operations), `msgstore`, `notify`, `runtime` (git root + tmux target resolution), `displayname`, `codexapp`,
+  and `atomicfs` (the shared write path for state.json and the tokened
+  dashboard.json) are class M; `log`, `tty`, `execx`, `gitroot`, and
+  `browser` are class A.
 - `internal/ui` holds the TUI (`tui`) and the web dashboard (`dashboard`):
   `server.go` (GET-only mux, token middleware) and `runfile.go` (the tokened
-  `.fanout/dashboard.json` reuse/trust gate) are class H; `poller.go`,
-  `peek.go` (`GET /api/peek`), `plan.go` (`GET /api/plan`), `sse.go`, and
-  `embed.go` are class M. In `tui`, `actions.go` (lifecycle close/merge/
+  `.fanout/dashboard.json` reuse/trust gate) and `peek.go` / `plan.go` (the capture-pane validation chain) are class
+  H; `poller.go`, `sse.go`, and `embed.go` are class M. In `tui`, `actions.go` (lifecycle close/merge/
   cleanup wiring and confirmation flow) is class H, rendering/formatting is
   class A, and the remaining key/form/polling wiring is class M.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,19 +74,55 @@ names, command names, and quoted code unchanged.
 
 ## Architecture Notes
 
-The package map: `cmd/fanout` is the command flow (`main.go` dispatch and
-`executePlan`, `tui.go` no-argument console launch, `pane.go` creation
-orchestration, `plan.go` filtering, `status.go`, `lifecycle.go`, `report.go`).
-`internal/` is
-organized into four layer directories: `internal/core/` (pure logic —
-`agent`, `blockers`, `exitcode`, `naming`, `planspec`), `internal/app/`
-(use-case orchestration — `briefing`, `cliflags`, `lifecycle`, `panelayout`,
-`sessionview`, `watch`), `internal/infra/` (external process/FS/DB —
-`atomicfs`, `displayname`, `ghissue`, `gitstat`, `hooks`, `log`, `msgstore`,
-`notify`, `runtime`, `selfupdate`, `settings`, `state`, `team`, `tmuxrun`,
-`tty`, `worktree`), and `internal/ui/` (`tui`, `dashboard`). Allowed imports:
-core -> core only; app -> core/app/infra; infra -> core/infra; ui -> all;
-importing `cmd/...` is forbidden. `internal/arch` enforces this in CI.
+`internal/` is a 4-layer architecture: `core` (pure logic, no process/network/
+FS/DB), `app` (use-case orchestration), `infra` (external process/FS/DB), and
+`ui` (TUI + web dashboard). Allowed imports: core -> core only; app ->
+core/app/infra; infra -> core/infra; ui -> all four; `cmd/fanout` is the
+composition root and no package may import `cmd/...`. `internal/arch` enforces
+the direction and a core stdlib-purity denylist in CI (depguard is off on
+purpose). Canonical reference, the full package table, the Mermaid dependency
+diagram, and the PR-review-weight classes (H/M/A) live in
+`docs/architecture.ja.md`.
+
+- `cmd/fanout` is the composition root and CLI boundary: `main.go` (the
+  first-match-wins dispatch table, ldflags `version`/`commit` — class H),
+  `plancmd.go` (`fanout plan` flag parsing/validation; execution lives in
+  `app/run`), `status.go` / `lifecycle.go` / `msg.go` (thin dispatch into
+  `app/statusreport`, `app/lifecycle`, `app/peermsg`), `dashboard.go`,
+  `tui*.go` (no-argument console wiring; the prompt-mode plan fan-out
+  launches one coordinator pane at the project root so `fanout plan`'s git
+  root stays at the repo, never Codex Plan Mode), and `tui_popup.go`
+  (self-exec popup subcommands — class H).
+- `internal/core` is pure logic with no process/network/FS/DB access:
+  `agent` (supported agent names, CLI validation for live mode — the only
+  core packages allowed `os`/`os/exec`), `planspec` (the `fanout plan` JSON
+  schema), `naming` (deterministic slug/branch generation), and the
+  AI-reviewable `blockers`/`exitcode`/`parentref`/`fanset`/`cliview`.
+- `internal/app` orchestrates use cases on top of `core` and `infra`:
+  `panelaunch`, `lifecycle`, `watch` (the label-watcher cycle, pure at the
+  package boundary via `watch.IO`), and `briefing` (the prompt text injected
+  into agents) are class H; `sessionview` (the read-only `Snapshot`
+  aggregator shared by the web dashboard and a future TUI), `panelayout`,
+  `run`, `statusreport`, and `peermsg` are class M; `cliflags` is class A.
+- `internal/infra` talks to external processes, the filesystem, and the team
+  SQLite bus: `state` (`.fanout/state.json` + its lock), `worktree` (`git
+  worktree add` under `.fanout/worktrees/<slug>/`), `hooks`, `selfupdate`,
+  and `team` (the `--team`/`fanout msg` per-parent SQLite bus:
+  `modernc.org/sqlite`, WAL mode, file mode `0600`, DB scoped to
+  `/tmp/fanout-<repo>-<parent_key>.db` with `FANOUT_DB_PATH` override; pane
+  identity resolves from `.fanout/state.json` with the `[fanout #N of #P]`
+  prompt prefix as fallback) are class H; `ghissue`, `gitstat`,
+  `tmuxrun` (direct tmux operations), `msgstore`, `notify`, `runtime` (git
+  root + tmux target resolution), `settings`, `displayname`, and `codexapp`
+  are class M; `atomicfs`, `log`, `tty`, `execx`, `gitroot`, and `browser`
+  are class A.
+- `internal/ui` holds the TUI (`tui`) and the web dashboard (`dashboard`):
+  `server.go` (GET-only mux, token middleware, SSE) is class H; `poller.go`,
+  `peek.go` (`GET /api/peek`), and `plan.go` (`GET /api/plan`) are class M;
+  TUI rendering/formatting is class A.
+
+Rule of thumb: a PR that touches a class-H package needs human review; a PR
+touching only class-A packages can rely on AI review.
 
 - Runtime discovery (`internal/infra/runtime`) resolves the git repo root with
   `git rev-parse --show-toplevel`, requires the caller to be inside tmux for
@@ -106,7 +142,7 @@ importing `cmd/...` is forbidden. `internal/arch` enforces this in CI.
 - Keep prompts one line (`oneLinePrompt`). Full issue context belongs in
   `/tmp/fanout-<repo>-<NUM>.md` (`internal/app/briefing`).
 - `--include` widens the child set; `--only` and `--skip` narrow it
-  (`filterOnlySkip`; child enumeration in `mergeExtraChildren` via
+  (`fanset.FilterOnlySkip`; child enumeration in `mergeExtraChildren` via
   `internal/infra/ghissue`). Prose scanning for implicit children lives in the
   Claude/Codex skills, not in the CLI.
 - `--unblocked-only` filters out issues with OPEN blockers (`splitBlocked` +

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,8 @@ and the PR-review-weight classes (H/M/A) live in `docs/architecture.ja.md`.
   `os`/`os/exec` in the purity allowlist), `planspec` (the `fanout plan` JSON
   schema; allowed `os` for spec loading), `naming` (deterministic slug/branch
   generation; identity-deciding, class M with `parentref`/`fanset`), and the
-  AI-reviewable `blockers`/`exitcode`/`cliview`.
+  AI-reviewable `exitcode`/`cliview` (`blockers` is class M: it drives
+  --unblocked-only launch selection and wave computation).
 - `internal/app` orchestrates use cases on top of `core` and `infra`:
   `panelaunch`, `lifecycle`, `watch` (the label-watcher cycle, pure at the
   package boundary via `watch.IO`), and `briefing` (the prompt text injected
@@ -118,11 +119,11 @@ and the PR-review-weight classes (H/M/A) live in `docs/architecture.ja.md`.
   identity resolves from `.fanout/state.json` with the `[fanout #N of #P]`
   prompt prefix as fallback), and `settings` (the safety gate that blocks
   repo config from enabling the watcher or notification targets) are class
-  H; `ghissue`, `gitstat`,
-  `tmuxrun` (direct tmux operations), `msgstore`, `notify`, `runtime` (git root + tmux target resolution), `displayname`, `codexapp`,
+  H; `ghissue` (GitHub reads and mutations: label swaps, dashboard
+  comments), `gitstat`, `tmuxrun` (direct tmux operations), `msgstore`, `notify`, `runtime` (git root + tmux target resolution), `displayname`, `codexapp`,
   and `atomicfs` (the shared write path for state.json and the tokened
-  dashboard.json) are class M; `log`, `tty`, `execx`, `gitroot`, and
-  `browser` are class A.
+  dashboard.json) and `gitroot` (project/state-root resolution input) are class M; `log`,
+  `tty`, `execx`, and `browser` are class A.
 - `internal/ui` holds the TUI (`tui`) and the web dashboard (`dashboard`):
   `server.go` (GET-only mux, token middleware) and `runfile.go` (the tokened
   `.fanout/dashboard.json` reuse/trust gate) and `peek.go` / `plan.go` (the capture-pane validation chain) are class

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -80,9 +80,9 @@ FS/DB), `app` (use-case orchestration), `infra` (external process/FS/DB), and
 core/app/infra; infra -> core/infra; ui -> all four; `cmd/fanout` is the
 composition root and no package may import `cmd/...`. `internal/arch` enforces
 the direction and a core stdlib-purity denylist in CI (depguard is off on
-purpose). Canonical reference, the full package table, the Mermaid dependency
-diagram, and the PR-review-weight classes (H/M/A) live in
-`docs/architecture.ja.md`.
+purpose) and is itself class H — weakening it disables every layer guard.
+Canonical reference, the full package table, the Mermaid dependency diagram,
+and the PR-review-weight classes (H/M/A) live in `docs/architecture.ja.md`.
 
 - `cmd/fanout` is the composition root and CLI boundary: `main.go` (the
   first-match-wins dispatch table, ldflags `version`/`commit` — class H),
@@ -97,9 +97,10 @@ diagram, and the PR-review-weight classes (H/M/A) live in
   the remaining cmd files (flag validation and thin dispatch into app) are
   class M.
 - `internal/core` is pure logic with no process/network/FS/DB access:
-  `agent` (supported agent names, CLI validation for live mode — the only
-  core packages allowed `os`/`os/exec`), `planspec` (the `fanout plan` JSON
-  schema), `naming` (deterministic slug/branch generation), and the
+  `agent` (supported agent names, CLI validation for live mode; allowed
+  `os`/`os/exec` in the purity allowlist), `planspec` (the `fanout plan` JSON
+  schema; allowed `os` for spec loading), `naming` (deterministic slug/branch
+  generation), and the
   AI-reviewable `blockers`/`exitcode`/`parentref`/`fanset`/`cliview`.
 - `internal/app` orchestrates use cases on top of `core` and `infra`:
   `panelaunch`, `lifecycle`, `watch` (the label-watcher cycle, pure at the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,7 +92,9 @@ diagram, and the PR-review-weight classes (H/M/A) live in
   `tui*.go` (no-argument console wiring; the prompt-mode plan fan-out
   launches one coordinator pane at the project root so `fanout plan`'s git
   root stays at the repo, never Codex Plan Mode), and `tui_popup.go`
-  (self-exec popup subcommands — class H).
+  (self-exec popup subcommands). `main.go` / `tui_popup.go` /
+  `tui_launch.go` are class H; the remaining cmd files (flag validation and
+  thin dispatch into app) are class M.
 - `internal/core` is pure logic with no process/network/FS/DB access:
   `agent` (supported agent names, CLI validation for live mode — the only
   core packages allowed `os`/`os/exec`), `planspec` (the `fanout plan` JSON
@@ -117,9 +119,12 @@ diagram, and the PR-review-weight classes (H/M/A) live in
   are class M; `atomicfs`, `log`, `tty`, `execx`, `gitroot`, and `browser`
   are class A.
 - `internal/ui` holds the TUI (`tui`) and the web dashboard (`dashboard`):
-  `server.go` (GET-only mux, token middleware, SSE) is class H; `poller.go`,
-  `peek.go` (`GET /api/peek`), and `plan.go` (`GET /api/plan`) are class M;
-  TUI rendering/formatting is class A.
+  `server.go` (GET-only mux, token middleware) and `runfile.go` (the tokened
+  `.fanout/dashboard.json` reuse/trust gate) are class H; `poller.go`,
+  `peek.go` (`GET /api/peek`), `plan.go` (`GET /api/plan`), `sse.go`, and
+  `embed.go` are class M. In `tui`, `actions.go` (lifecycle close/merge/
+  cleanup wiring and confirmation flow) is class H, rendering/formatting is
+  class A, and the remaining key/form/polling wiring is class M.
 
 Rule of thumb: a PR that touches a class-H package needs human review; a PR
 touching only class-A packages can rely on AI review.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,8 +93,9 @@ diagram, and the PR-review-weight classes (H/M/A) live in
   launches one coordinator pane at the project root so `fanout plan`'s git
   root stays at the repo, never Codex Plan Mode), and `tui_popup.go`
   (self-exec popup subcommands). `main.go` / `tui_popup.go` /
-  `tui_launch.go` are class H; the remaining cmd files (flag validation and
-  thin dispatch into app) are class M.
+  `tui_launch.go` / `worktree_action.go` / `codex_plan_tui.go` are class H;
+  the remaining cmd files (flag validation and thin dispatch into app) are
+  class M.
 - `internal/core` is pure logic with no process/network/FS/DB access:
   `agent` (supported agent names, CLI validation for live mode — the only
   core packages allowed `os`/`os/exec`), `planspec` (the `fanout plan` JSON

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,8 +94,8 @@ and the PR-review-weight classes (H/M/A) live in `docs/architecture.ja.md`.
   `agent` (supported agent names, CLI validation for live mode; allowed
   `os`/`os/exec` in the purity allowlist), `planspec` (the `fanout plan` JSON
   schema; allowed `os` for spec loading), `naming` (deterministic slug/branch
-  generation), and the
-  AI-reviewable `blockers`/`exitcode`/`parentref`/`fanset`/`cliview`.
+  generation; identity-deciding, class M with `parentref`/`fanset`), and the
+  AI-reviewable `blockers`/`exitcode`/`cliview`.
 - `internal/app` orchestrates use cases on top of `core` and `infra`:
   `panelaunch` (pane creation), `lifecycle`, `watch` (the label-watcher
   cycle, pure at the package boundary via `watch.IO`), and `briefing` (the
@@ -110,20 +110,23 @@ and the PR-review-weight classes (H/M/A) live in `docs/architecture.ja.md`.
   `modernc.org/sqlite`, WAL mode, file mode `0600`, DB scoped to
   `/tmp/fanout-<repo>-<parent_key>.db` with `FANOUT_DB_PATH` override; pane
   identity resolves from `.fanout/state.json` with the `[fanout #N of #P]`
-  prompt prefix as fallback) are class H; `ghissue`,
+  prompt prefix as fallback), and `settings` (the safety gate that blocks
+  repo config from enabling the watcher or notification targets) are class
+  H; `ghissue`,
   `gitstat`, `tmuxrun` (direct tmux operations), `msgstore`, `notify`,
-  `runtime` (git root + tmux target resolution), `settings`, `displayname`,
-  and `codexapp` are class M; `atomicfs`, `log`, `tty`, `execx`, `gitroot`,
-  and `browser` are class A.
+  `runtime` (git root + tmux target resolution), `displayname`, `codexapp`,
+  and `atomicfs` (the shared write path for state.json and the tokened
+  dashboard.json) are class M; `log`, `tty`, `execx`, `gitroot`, and
+  `browser` are class A.
 - `internal/ui` holds the TUI (`tui`) and the web dashboard (`dashboard`):
   `server.go` (GET-only mux, token middleware) and `runfile.go` (the tokened
-  `.fanout/dashboard.json` reuse/trust gate) are class H; `poller.go`,
-  `peek.go` (`GET /api/peek`), `plan.go` (`GET /api/plan`), `sse.go`, and
-  `embed.go` are class M. In `tui`, `actions.go` (lifecycle close/merge/
+  `.fanout/dashboard.json` reuse/trust gate) and `peek.go` / `plan.go` (the capture-pane validation chain) are class
+  H; `poller.go`, `sse.go`, and `embed.go` are class M. In `tui`, `actions.go` (lifecycle close/merge/
   cleanup wiring and confirmation flow) is class H, rendering/formatting
   (`view.go` / `compact.go` / `styles.go`) is class A, and
-  the remaining key/form/polling wiring is class M. The dashboard SPA lives
-  in `web/` (React + Vite + TS) and bundles into
+  the remaining key/form/polling wiring is class M. The dashboard SPA lives in `web/` (React + Vite + TS; `index.html`'s
+  no-referrer/external-fetch policy is class H, `src/hooks`+`src/lib`
+  transport is class M, the rest is class A) and bundles into
   `internal/ui/dashboard/static/` via `go:embed`.
 
 The full package table, the Mermaid dependency diagram, the human-must-read

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,14 +88,16 @@ and the PR-review-weight classes (H/M/A) live in `docs/architecture.ja.md`.
   running the fanout-plan skill so `fanout plan`'s git root stays at the repo,
   never Codex Plan Mode), and `tui_popup.go` (self-exec popup subcommands).
   `main.go` / `tui_popup.go` / `tui_launch.go` / `worktree_action.go` /
-  `codex_plan_tui.go` are class H; the remaining cmd files (flag validation
-  and thin dispatch into app) are class M.
+  `codex_plan_tui.go` / `tui_restore.go` / `tui_watch.go` are class H; the
+  remaining cmd files (flag validation and thin dispatch into app) are
+  class M.
 - `internal/core` is pure logic with no process/network/FS/DB access:
   `agent` (supported agent names, CLI validation for live mode; allowed
   `os`/`os/exec` in the purity allowlist), `planspec` (the `fanout plan` JSON
   schema; allowed `os` for spec loading), `naming` (deterministic slug/branch
   generation; identity-deciding, class M with `parentref`/`fanset`), and the
-  AI-reviewable `blockers`/`exitcode`/`cliview`.
+  AI-reviewable `exitcode`/`cliview` (`blockers` is class M: it drives
+  --unblocked-only launch selection and wave computation).
 - `internal/app` orchestrates use cases on top of `core` and `infra`:
   `panelaunch` (pane creation), `lifecycle`, `watch` (the label-watcher
   cycle, pure at the package boundary via `watch.IO`), and `briefing` (the
@@ -112,12 +114,12 @@ and the PR-review-weight classes (H/M/A) live in `docs/architecture.ja.md`.
   identity resolves from `.fanout/state.json` with the `[fanout #N of #P]`
   prompt prefix as fallback), and `settings` (the safety gate that blocks
   repo config from enabling the watcher or notification targets) are class
-  H; `ghissue`,
+  H; `ghissue` (GitHub reads and mutations: label swaps, dashboard comments),
   `gitstat`, `tmuxrun` (direct tmux operations), `msgstore`, `notify`,
   `runtime` (git root + tmux target resolution), `displayname`, `codexapp`,
   and `atomicfs` (the shared write path for state.json and the tokened
-  dashboard.json) are class M; `log`, `tty`, `execx`, `gitroot`, and
-  `browser` are class A.
+  dashboard.json) and `gitroot` (project/state-root resolution input) are class M; `log`,
+  `tty`, `execx`, and `browser` are class A.
 - `internal/ui` holds the TUI (`tui`) and the web dashboard (`dashboard`):
   `server.go` (GET-only mux, token middleware) and `runfile.go` (the tokened
   `.fanout/dashboard.json` reuse/trust gate) and `peek.go` / `plan.go` (the capture-pane validation chain) are class

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,8 +86,9 @@ diagram, and the PR-review-weight classes (H/M/A) live in
   issue-mode popup, `tui_launch.go` manual/plan/attach/shell launch — the
   prompt-mode plan fan-out launches one coordinator pane at the project root
   running the fanout-plan skill so `fanout plan`'s git root stays at the repo,
-  never Codex Plan Mode), and `tui_popup.go` (self-exec popup subcommands —
-  class H).
+  never Codex Plan Mode), and `tui_popup.go` (self-exec popup subcommands).
+  `main.go` / `tui_popup.go` / `tui_launch.go` are class H; the remaining cmd
+  files (flag validation and thin dispatch into app) are class M.
 - `internal/core` is pure logic with no process/network/FS/DB access:
   `agent` (supported agent names, CLI validation for live mode — the only
   core packages allowed `os`/`os/exec`), `planspec` (the `fanout plan` JSON
@@ -113,11 +114,15 @@ diagram, and the PR-review-weight classes (H/M/A) live in
   and `codexapp` are class M; `atomicfs`, `log`, `tty`, `execx`, `gitroot`,
   and `browser` are class A.
 - `internal/ui` holds the TUI (`tui`) and the web dashboard (`dashboard`):
-  `server.go` (GET-only mux, token middleware, SSE) is class H; `poller.go`,
-  `peek.go` (`GET /api/peek`), and `plan.go` (`GET /api/plan`) are class M;
-  TUI rendering/formatting is class A. The dashboard SPA lives in `web/`
-  (React + Vite + TS) and bundles into `internal/ui/dashboard/static/` via
-  `go:embed`.
+  `server.go` (GET-only mux, token middleware) and `runfile.go` (the tokened
+  `.fanout/dashboard.json` reuse/trust gate) are class H; `poller.go`,
+  `peek.go` (`GET /api/peek`), `plan.go` (`GET /api/plan`), `sse.go`, and
+  `embed.go` are class M. In `tui`, `actions.go` (lifecycle close/merge/
+  cleanup wiring and confirmation flow) is class H, rendering/formatting
+  (`view.go` / `paneview.go` / `compact.go` / `styles.go`) is class A, and
+  the remaining key/form/polling wiring is class M. The dashboard SPA lives
+  in `web/` (React + Vite + TS) and bundles into
+  `internal/ui/dashboard/static/` via `go:embed`.
 
 The full package table, the Mermaid dependency diagram, the human-must-read
 invariant catalog, and the burn-down list of known layering debt are the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,9 +73,9 @@ FS/DB), `app` (use-case orchestration), `infra` (external process/FS/DB), and
 core/app/infra; infra -> core/infra; ui -> all four; `cmd/fanout` is the
 composition root and no package may import `cmd/...`. `internal/arch` enforces
 the direction and a core stdlib-purity denylist in CI (depguard is off on
-purpose). Canonical reference, the full package table, the Mermaid dependency
-diagram, and the PR-review-weight classes (H/M/A) live in
-`docs/architecture.ja.md`.
+purpose) and is itself class H — weakening it disables every layer guard.
+Canonical reference, the full package table, the Mermaid dependency diagram,
+and the PR-review-weight classes (H/M/A) live in `docs/architecture.ja.md`.
 
 - `cmd/fanout` is the composition root and CLI boundary: `main.go` (the
   first-match-wins dispatch table, ldflags `version`/`commit` — class H),
@@ -91,17 +91,18 @@ diagram, and the PR-review-weight classes (H/M/A) live in
   `codex_plan_tui.go` are class H; the remaining cmd files (flag validation
   and thin dispatch into app) are class M.
 - `internal/core` is pure logic with no process/network/FS/DB access:
-  `agent` (supported agent names, CLI validation for live mode — the only
-  core packages allowed `os`/`os/exec`), `planspec` (the `fanout plan` JSON
-  schema), `naming` (deterministic slug/branch generation), and the
+  `agent` (supported agent names, CLI validation for live mode; allowed
+  `os`/`os/exec` in the purity allowlist), `planspec` (the `fanout plan` JSON
+  schema; allowed `os` for spec loading), `naming` (deterministic slug/branch
+  generation), and the
   AI-reviewable `blockers`/`exitcode`/`parentref`/`fanset`/`cliview`.
 - `internal/app` orchestrates use cases on top of `core` and `infra`:
   `panelaunch` (pane creation), `lifecycle`, `watch` (the label-watcher
   cycle, pure at the package boundary via `watch.IO`), and `briefing` (the
   prompt text injected into agents) are class H; `sessionview` (the read-only
   `Snapshot` aggregator shared by the web dashboard and a future TUI),
-  `panelayout`, `run`, `statusreport`, and `peermsg` are class M; `cliflags`
-  is class A.
+  `panelayout`, `run`, `statusreport`, `peermsg`, and `cliflags` (flag
+  validation that decides main's lifecycle branches) are class M.
 - `internal/infra` talks to external processes, the filesystem, and the
   team SQLite bus: `state` (`.fanout/state.json` + its lock), `worktree`
   (`git worktree add` under `.fanout/worktrees/<slug>/`), `hooks`,
@@ -120,7 +121,7 @@ diagram, and the PR-review-weight classes (H/M/A) live in
   `peek.go` (`GET /api/peek`), `plan.go` (`GET /api/plan`), `sse.go`, and
   `embed.go` are class M. In `tui`, `actions.go` (lifecycle close/merge/
   cleanup wiring and confirmation flow) is class H, rendering/formatting
-  (`view.go` / `paneview.go` / `compact.go` / `styles.go`) is class A, and
+  (`view.go` / `compact.go` / `styles.go`) is class A, and
   the remaining key/form/polling wiring is class M. The dashboard SPA lives
   in `web/` (React + Vite + TS) and bundles into
   `internal/ui/dashboard/static/` via `go:embed`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,8 +87,9 @@ diagram, and the PR-review-weight classes (H/M/A) live in
   prompt-mode plan fan-out launches one coordinator pane at the project root
   running the fanout-plan skill so `fanout plan`'s git root stays at the repo,
   never Codex Plan Mode), and `tui_popup.go` (self-exec popup subcommands).
-  `main.go` / `tui_popup.go` / `tui_launch.go` are class H; the remaining cmd
-  files (flag validation and thin dispatch into app) are class M.
+  `main.go` / `tui_popup.go` / `tui_launch.go` / `worktree_action.go` /
+  `codex_plan_tui.go` are class H; the remaining cmd files (flag validation
+  and thin dispatch into app) are class M.
 - `internal/core` is pure logic with no process/network/FS/DB access:
   `agent` (supported agent names, CLI validation for live mode — the only
   core packages allowed `os`/`os/exec`), `planspec` (the `fanout plan` JSON

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,126 +67,63 @@ Build the binary with `make build-go` and validate with `make test`.
 
 ## Architecture Notes
 
-- `cmd/fanout/main.go` handles parse dispatch, dependency checks, runtime
-  resolution, child loading, state loading/locking, and the fail-fast
-  `executePlan` loop.
-- `cmd/fanout/plancmd.go` is the issue-less `fanout plan` entrypoint
-  dispatched before normal `cliflags.Parse`. It loads a local plan spec or
-  `.fanout/plans/<slug>.json`, resolves the base branch, builds task rows,
-  applies `--only` / `--skip` / `--limit` / `--unblocked-only`, copies live
-  specs into `.fanout/plans/`, and wires plan `--status`, `--close`, `--merge`,
-  and `--cleanup`.
-- `cmd/fanout/pane.go` is the creation orchestration: briefing render, naming,
-  worktree planning/preparation, tmux split/title/layout, state recording,
-  metadata write, and agent launch.
-- `cmd/fanout/status.go` reads `.fanout/state.json` and queries GitHub PR state.
-  `cmd/fanout/lifecycle.go` implements `--close`, `--merge`, and `--cleanup`
-  against recorded state rows.
-- `cmd/fanout/dashboard.go` implements the `dashboard` subcommand (dispatched
-  before `cliflags.Parse`, like `update`): it starts the read-only web
-  dashboard, handles reuse-if-running, token generation, browser open, and
-  registers the `prefix + D` tmux keybinding (`bindDashboardKey`, also called
-  after a live `executePlan`).
-- `cmd/fanout/tui.go` implements the no-argument persistent TUI console. Plain
-  shells are relaunched into a deterministic fanout-managed tmux session;
-  invocations already inside tmux use the current pane. It also wires the
-  opt-in label watcher into the TUI runtime; no other command path starts the
-  watcher. The `n` new-session popup has two modes: free prompt (manual pane)
-  and issue (OPEN issue picker; children fan out via the watch launch helpers
-  with `UnblockedOnly`, childless issues become `@watch` panes), with a
-  per-child agent assignment step. A prompt-mode plan fan-out checkbox instead
-  launches one coordinator pane at the project root that runs the fanout-plan
-  skill on the raw prompt (`launchPlanPromptFromTUI`; `/fanout plan` for
-  `claude`, `$fanout-plan` for `codex`, never Codex Plan Mode) so `fanout
-  plan`'s git root stays at the repo, not a worktree (`cmd/fanout/tui_issue.go`,
-  `cmd/fanout/tui_launch.go`, `internal/ui/tui/newpane_picker.go`,
-  `internal/ui/tui/newpane_assign.go`).
-- `internal/infra/runtime` resolves the git repository root and the tmux target.
-  Batch pane-creation mode must be invoked from inside tmux. By default fanout
-  targets the invoking pane; `--session` targets a named tmux session.
-- `internal/infra/worktree` owns base branch resolution, refresh, local exclude
-  setup, and `git worktree add` under `.fanout/worktrees/<slug>/`.
-- `internal/infra/tmuxrun` owns direct tmux operations:
-  `split-window -d -h -P -F '#{pane_id}'`, pane titles, tiled layout, agent
-  command send, best-effort pane kill during cleanup, `ListPaneIDs` (liveness
-  for the dashboard), and `BindDashboardKey`.
-- `internal/app/sessionview` is the shared read-only data layer: it aggregates
-  `.fanout/state.json` + tmux liveness + GitHub PR state into a `Snapshot`
-  grouped by parent ("Session"); pane rows carry wave/blockers, CI status, the
-  tmux pane title, and the original prompt. IO is injected via `Collectors`
-  (the `LivePanes` collector returns each live pane's current path and title)
-  so it is pure and unit-testable; both the web dashboard (now) and a future
-  TUI consume the same `Build`.
-- `internal/ui/dashboard` is the localhost web server: `server.go` (GET-only mux,
-  token middleware, SSE, `Cache-Control: no-store` static serving with a
-  fallback page when the bundle is absent), `poller.go` (two-tier state/tmux +
-  throttled gh refresh, broadcast on change), `sse.go` (channel hub), `peek.go`
-  (`GET /api/peek`, a read-only capture-pane of one recorded pane; also the
-  `livePaneView` validation chain `plan.go` reuses), `plan.go`
-  (`GET /api/plan`, the last complete `<proposed_plan>` block of a recorded
-  Codex Plan Mode pane), and `runfile.go` (`.fanout/dashboard.json`
-  reuse-if-running). The SPA itself
-  lives in `web/` (React + Vite + TS, PAPER BREEZE light/dark matching the
-  docs site): `src/lib/` is the pure logic layer (wire types mirroring
-  `sessionview` JSON tags, filter/sort/link builders), `src/hooks/` owns
-  transport (`useSnapshot` SSE + polling fallback, `usePeek`, `usePlan`,
-  `useTheme`), and
-  tests are integration-first (vitest + testing-library + MSW; SSE via a
-  FakeEventSource). `make build-web` emits the bundle into `static/`
-  (deterministic names `assets/app.js` / `assets/app.css`, never committed).
-- `internal/core/agent` maps supported agents (`claude`, `codex`) to launch
-  commands and validates installed CLIs for live mode. The batch lanes accept
-  repeatable per-target agent overrides (`NUM=name` for issue/Project children,
-  `task-id=name` for `fanout plan`) and validate only selected targets.
-- `internal/infra/state` owns `.fanout/state.json` plus `.fanout/state.json.lock`.
-  The coarse lock covers planning and launching so two fanout invocations do
-  not race on the same `(parent, issueNum)` idempotency key. Issue-less plan
-  rows use parent `plan:<slug>`, `issueNum: 0`, and `taskId`; `taskId` is an
-  additive key used by plan idempotency and task lifecycle.
-- `internal/core/planspec` owns the pure JSON schema for `fanout plan`: `version`,
-  `plan` metadata, task validation, deterministic task slug/branch defaults,
-  duplicate/collision checks, and `blocked_by` dependency cycle detection.
-- `internal/core/naming` deterministically generates slugs and branch names.
-  `--name` may override slug, display name, and branch. The skills generate
-  these flags from issue context; the CLI does not call an LLM.
-- `internal/infra/team` + `internal/infra/msgstore` back the `--team` / `fanout msg`
-  sibling-coordination feature (parent #68, waves #69–#71). `internal/infra/team`
-  owns the per-parent SQLite bus: `db.go` opens it with `modernc.org/sqlite`
-  (pure-Go, no external `sqlite3` binary) in WAL mode at file mode `0600` and
-  refuses a group/world-readable or foreign-owned file; `path.go` scopes the
-  DB to `/tmp/fanout-<repo>-<parent_key>.db` (collapsing leading zeros on
-  numeric parents, slugifying Project URLs; `FANOUT_DB_PATH` overrides);
-  `detect.go` resolves the invoking pane's identity from `.fanout/state.json`
-  by `(parent, issueNum)`, with the `[fanout #N of #P]` prompt prefix
-  (`FanoutTagRE`) as a fallback; `registry.go` `UpsertPeer` seeds the roster.
-  `internal/infra/msgstore` is the query layer for send/post/inbox/board/mark-read.
-  `cmd/fanout/team.go` wires `--team` (briefing roster via `buildTeamContext`
-  plus a post-`executePlan` peer seed), and `cmd/fanout/msg.go` is the
-  `fanout msg` island. The briefing coordination section is injected
-  agent-agnostic into the standard briefing for both `claude` and `codex`
-  panes, but `briefing.Render` returns the minimal Codex Plan Mode briefing
-  before appending it, so `--codex-plan-mode` children are seeded into the
-  registry without the coordination section. It is distinct from Claude Code
-  Agent Teams, which is Claude-only and coordinates inside a single session. Messaging is pull-based: nothing in the
-  merged code nudges a pane. The `@fanout_agent_state` (`running` / `done`,
-  set by the launch wrapper in `internal/infra/tmuxrun`) idle-nudge accelerator is a
-  separate, still-unmerged issue (#72) — do not assume an idle gate exists.
-- `internal/app/watch` owns one repository watcher cycle. It is pure at the package
-  boundary: production wires GitHub labels, `.fanout/state.json`, tmux liveness,
-  and launch helpers through `watch.IO`, while unit tests inject fakes. The
-  engine lists `watcherTriggerLabel` issues, swaps them to
-  `watcherRunningLabel` before launch, classifies issues with OPEN children as
-  parent fan-outs and issues without OPEN children as standalone panes, applies
-  the live-pane budget/backoff, and leaves lifecycle label cleanup to
-  `internal/app/lifecycle`.
-- `internal/infra/ghissue`, `internal/core/blockers`, `internal/app/briefing`,
-  `internal/infra/settings`, `internal/infra/displayname`, `internal/infra/atomicfs`,
-  `internal/infra/log`, `internal/infra/tty`, and `internal/core/exitcode` hold the remaining
-  reusable pieces. Plan status and blocked-task completion use
-  `ghissue.Runner.PRsForBranch` (`gh pr list --head <branch>`) because plan
-  tasks have no issue closed-by graph. `briefing.RenderTask` is the plan-task
-  briefing variant; it removes issue-closing footers and asks PR bodies to end
-  with `Plan: <slug> / Task: <id>`.
+`internal/` is a 4-layer architecture: `core` (pure logic, no process/network/
+FS/DB), `app` (use-case orchestration), `infra` (external process/FS/DB), and
+`ui` (TUI + web dashboard). Allowed imports: core -> core only; app ->
+core/app/infra; infra -> core/infra; ui -> all four; `cmd/fanout` is the
+composition root and no package may import `cmd/...`. `internal/arch` enforces
+the direction and a core stdlib-purity denylist in CI (depguard is off on
+purpose). Canonical reference, the full package table, the Mermaid dependency
+diagram, and the PR-review-weight classes (H/M/A) live in
+`docs/architecture.ja.md`.
+
+- `cmd/fanout` is the composition root and CLI boundary: `main.go` (the
+  first-match-wins dispatch table, ldflags `version`/`commit` — class H),
+  `plancmd.go` (`fanout plan` flag parsing/validation; execution lives in
+  `app/run`), `status.go` / `lifecycle.go` / `msg.go` (thin dispatch into
+  `app/statusreport`, `app/lifecycle`, `app/peermsg`), `dashboard.go`,
+  `tui*.go` (the no-argument persistent TUI console wiring: `tui_issue.go`
+  issue-mode popup, `tui_launch.go` manual/plan/attach/shell launch — the
+  prompt-mode plan fan-out launches one coordinator pane at the project root
+  running the fanout-plan skill so `fanout plan`'s git root stays at the repo,
+  never Codex Plan Mode), and `tui_popup.go` (self-exec popup subcommands —
+  class H).
+- `internal/core` is pure logic with no process/network/FS/DB access:
+  `agent` (supported agent names, CLI validation for live mode — the only
+  core packages allowed `os`/`os/exec`), `planspec` (the `fanout plan` JSON
+  schema), `naming` (deterministic slug/branch generation), and the
+  AI-reviewable `blockers`/`exitcode`/`parentref`/`fanset`/`cliview`.
+- `internal/app` orchestrates use cases on top of `core` and `infra`:
+  `panelaunch` (pane creation), `lifecycle`, `watch` (the label-watcher
+  cycle, pure at the package boundary via `watch.IO`), and `briefing` (the
+  prompt text injected into agents) are class H; `sessionview` (the read-only
+  `Snapshot` aggregator shared by the web dashboard and a future TUI),
+  `panelayout`, `run`, `statusreport`, and `peermsg` are class M; `cliflags`
+  is class A.
+- `internal/infra` talks to external processes, the filesystem, and the
+  team SQLite bus: `state` (`.fanout/state.json` + its lock), `worktree`
+  (`git worktree add` under `.fanout/worktrees/<slug>/`), `hooks`,
+  `selfupdate`, and `team` (the `--team`/`fanout msg` per-parent SQLite bus:
+  `modernc.org/sqlite`, WAL mode, file mode `0600`, DB scoped to
+  `/tmp/fanout-<repo>-<parent_key>.db` with `FANOUT_DB_PATH` override; pane
+  identity resolves from `.fanout/state.json` with the `[fanout #N of #P]`
+  prompt prefix as fallback) are class H; `ghissue`,
+  `gitstat`, `tmuxrun` (direct tmux operations), `msgstore`, `notify`,
+  `runtime` (git root + tmux target resolution), `settings`, `displayname`,
+  and `codexapp` are class M; `atomicfs`, `log`, `tty`, `execx`, `gitroot`,
+  and `browser` are class A.
+- `internal/ui` holds the TUI (`tui`) and the web dashboard (`dashboard`):
+  `server.go` (GET-only mux, token middleware, SSE) is class H; `poller.go`,
+  `peek.go` (`GET /api/peek`), and `plan.go` (`GET /api/plan`) are class M;
+  TUI rendering/formatting is class A. The dashboard SPA lives in `web/`
+  (React + Vite + TS) and bundles into `internal/ui/dashboard/static/` via
+  `go:embed`.
+
+The full package table, the Mermaid dependency diagram, the human-must-read
+invariant catalog, and the burn-down list of known layering debt are the
+canonical reference in `docs/architecture.ja.md`. Rule of thumb: a PR that
+touches a class-H package needs human review; a PR touching only class-A
+packages can rely on AI review.
 
 ## Behavior Boundaries
 

--- a/docs/architecture.ja.md
+++ b/docs/architecture.ja.md
@@ -1,0 +1,133 @@
+# アーキテクチャ: 4 層構成
+
+`internal/` は `core` / `app` / `infra` / `ui` の 4 層と、層ルールを強制する
+`internal/arch` からなる。`cmd/fanout` はどの層からも import されない
+composition root。層ルールの正典実装は `internal/arch/arch_test.go` で、この
+文書はその読み方と、PR レビューでどこまで人間が見るかの運用ルールをまとめる。
+
+## 層の責務と依存ルール
+
+| 層 | 責務 | import してよい層 | stdlib 純度 |
+|---|---|---|---|
+| `core` | 純粋ロジック。プロセス起動・ネットワーク・ファイル I/O・DB を持たない | core のみ | `os` / `os/exec` / `net` / `net/http` / `syscall` / `database/sql` / `io/ioutil` 禁止(例外: `core/agent` は `os`+`os/exec`、`core/planspec` は `os` を許可) |
+| `app` | ユースケースのオーケストレーション | core / app / infra | 制約なし |
+| `infra` | 外部プロセス・ファイルシステム・DB | core / infra | 制約なし |
+| `ui` | TUI・web ダッシュボード | core / app / infra / ui | 制約なし |
+| `cmd` | composition root(`cmd/fanout`) | core / app / infra / ui | import される側になってはならない — 他パッケージからの `cmd/...` import は全面禁止 |
+
+依存の向きは一方向で、`ui -> app -> core` が主経路、`app` と `ui` はどちらも
+`infra` に直接手を伸ばせる。強制するのは `internal/arch` の Go テスト
+(`TestLayerImportDirection` ほか)。`.golangci.yml` は depguard をノイズが
+多いとして無効化しているため、層制約の CI ガードはこのテストだけである。
+
+## 依存図
+
+```mermaid
+graph TD
+    cmd[cmd/fanout] --> ui
+    cmd --> app
+    cmd --> infra
+    cmd --> core
+    ui[internal/ui] --> app
+    ui --> infra
+    ui --> core
+    app[internal/app] --> infra
+    app --> core
+    infra[internal/infra] --> core
+```
+
+## パッケージ表
+
+Review クラスは PR レビューの重さを決める。**H を触る PR は人間レビュー必須。
+A のみの PR は AI レビューで可**。M はどちらも変更内容次第で判断する。
+
+| 層 | パッケージ | 責務 | Class |
+|---|---|---|---|
+| infra | `state` | `.fanout/state.json` と lock の読み書き | H |
+| infra | `worktree` | base branch 解決・refresh・`git worktree add` | H |
+| infra | `hooks` | ライフサイクルフック実行 | H |
+| infra | `selfupdate` | 自己アップデート | H |
+| infra | `team` | `--team` / `fanout msg` の SQLite バス | H |
+| app | `watch` | ラベル watcher の 1 サイクル | H |
+| app | `briefing` | エージェントに注入するプロンプト本文の生成 | H |
+| app | `lifecycle` | `--close` / `--merge` / `--cleanup` | H |
+| app | `panelaunch` | pane 生成オーケストレーション | H |
+| ui | `dashboard`(`server.go`) | localhost web サーバの mux・token 検証 | H |
+| cmd | `main.go` / `tui_popup.go` | dispatch・popup 起動 | H |
+| infra | `ghissue` | GitHub issue/PR 読み取り | M |
+| infra | `gitstat` | git 差分・状態取得 | M |
+| infra | `tmuxrun` | tmux 直接操作 | M |
+| infra | `msgstore` | send/post/inbox/board/mark-read | M |
+| infra | `notify` | 通知送出 | M |
+| infra | `runtime` | git root・tmux ターゲット解決 | M |
+| infra | `settings` | 設定解決(default / config / env / CLI) | M |
+| infra | `displayname` | 表示名生成 | M |
+| infra | `codexapp` | Codex app-server クライアント | M |
+| app | `panelayout` | ペインレイアウト計算 | M |
+| app | `sessionview` | state + tmux + gh を集約する Snapshot | M |
+| app | `run` | `executePlan` の実行ロジック | M |
+| app | `statusreport` | `--status` のレポート生成 | M |
+| app | `peermsg` | `fanout msg` の実行層 | M |
+| core | `agent` | エージェント名の解決・CLI 検証 | M |
+| core | `planspec` | `fanout plan` の JSON スキーマ | M |
+| ui | `dashboard`(`poller.go` / `peek.go` / `plan.go`) | state/tmux ポーリング・capture-pane | M |
+| core | `blockers` | ブロッカー判定 | A |
+| core | `naming` | slug・branch 名生成 | A |
+| core | `exitcode` | 終了コード定義 | A |
+| core | `parentref` | 親参照の正規化 | A |
+| core | `fanset` | fan-out 対象集合の計算 | A |
+| core | `cliview` | CLI 出力の整形 | A |
+| app | `cliflags` | フラグパース | A |
+| ui | `tui`(描画・整形) | TUI の View 層 | A |
+| infra | `atomicfs` | 原子的ファイル書き込み | A |
+| infra | `log` | ロギング | A |
+| infra | `tty` | 端末判定 | A |
+| infra | `execx` | コマンド実行の薄いラッパ | A |
+| infra | `gitroot` | git root 探索 | A |
+| infra | `browser` | ブラウザ起動 | A |
+
+## 人間必見の不変条件カタログ
+
+- **state lock の順序と原子性**: `.fanout/state.json.lock` はプランニングと
+  起動の両方をカバーする。ロック区間を狭めると `(parent, issueNum)` の
+  idempotency が壊れる。
+- **worktree refresh は user work を壊さない**: base branch が dirty / ahead /
+  diverged なら強制更新せず fail する。
+- **watch のトリガーラベルはプロンプトインジェクション境界**: issue 本文が
+  そのまま子 briefing になるため、`watcherTriggerLabel` の対象を広げる変更は
+  攻撃面を広げる。
+- **dashboard は read-only・GET-only・localhost・token 必須**: `127.0.0.1`
+  バインド、mutation エンドポイント禁止、token 未検証のリクエストを通さない。
+- **briefing はエージェントに注入されるプロンプト本文**: `briefing.Render` /
+  `RenderTask` の出力はそのままエージェントの入力になる。
+- **self-exec サブコマンド名の固定**: `__tui-new-pane-popup` /
+  `__tui-help-popup` / `__codex-plan-tui` は単一定数で参照し、
+  `TestSelfExecSubcommandNames` が文字列を固定する。名前を変えると
+  実行中バイナリの popup / Plan Mode 連携が壊れる。
+- **ldflags は `-X main.version` 名指し**: バージョン注入変数は
+  `cmd/fanout/main.go` の変数名に固定されており、リネームするとリリース
+  ビルドが壊れる。
+- **`FANOUT_*` env 名は Go 外から文字列参照される**: シェルスクリプト・CI・
+  ドキュメントが env 変数名を直接引用するため、リネームは全参照箇所の同時
+  更新が要る。
+
+## 既知の残課題(burn-down リスト)
+
+- `internal/infra/team/path_test.go` が `internal/app/briefing` を import
+  している(infra -> app)。DB パスと `briefing.Path` が同じ親 slug を導出する
+  ことを固定した副作用で、`internal/arch` の `legacyDirectionAllowlist` に
+  登録済み。フィクスチャを decouple すれば解消できる。
+- `state` パッケージは `Store` 型と `Load`/`Save` の IO が同居している。
+- `sessionview` は純粋な集約ロジックと `Collectors` の IO 束が同じパッケージ
+  にある。
+- `shellQuote` の実装が `app/run` / `app/panelaunch` / `infra/tmuxrun` の
+  3 箇所にある。
+- `app` から `infra` への直接 import は既存分を容認するが、新規コードは
+  `watch.IO` のような port 経由を優先する。
+
+## 新規パッケージの追加手順
+
+1. `internal/<layer>/` 配下に置く。`internal/` 直下への追加は
+   `TestInternalTreeShape` が拒否する。
+2. 層ルールに合わない import は `internal/arch` の CI が落とす。
+3. この文書の「パッケージ表」に層・責務・Review クラスを追記する。

--- a/docs/architecture.ja.md
+++ b/docs/architecture.ja.md
@@ -53,7 +53,10 @@ A のみの PR は AI レビューで可**。M はどちらも変更内容次第
 | app | `lifecycle` | `--close` / `--merge` / `--cleanup` | H |
 | app | `panelaunch` | pane 生成オーケストレーション | H |
 | ui | `dashboard`(`server.go`) | localhost web サーバの mux・token 検証 | H |
-| cmd | `main.go` / `tui_popup.go` | dispatch・popup 起動 | H |
+| ui | `dashboard`(`runfile.go`) | token を含む `.fanout/dashboard.json`・reuse/trust ゲート | H |
+| ui | `tui`(`actions.go`) | lifecycle(close/merge/cleanup)実行の配線と確認フロー | H |
+| cmd | `main.go` / `tui_popup.go` / `tui_launch.go` | dispatch・self-exec popup・launch 配線 | H |
+| cmd | 上記以外(`plancmd.go` / `status.go` / `lifecycle.go` / `msg.go` / `dashboard.go` ほか) | フラグ検証と app 層への薄い dispatch | M |
 | infra | `ghissue` | GitHub issue/PR 読み取り | M |
 | infra | `gitstat` | git 差分・状態取得 | M |
 | infra | `tmuxrun` | tmux 直接操作 | M |
@@ -70,7 +73,8 @@ A のみの PR は AI レビューで可**。M はどちらも変更内容次第
 | app | `peermsg` | `fanout msg` の実行層 | M |
 | core | `agent` | エージェント名の解決・CLI 検証 | M |
 | core | `planspec` | `fanout plan` の JSON スキーマ | M |
-| ui | `dashboard`(`poller.go` / `peek.go` / `plan.go`) | state/tmux ポーリング・capture-pane | M |
+| ui | `dashboard`(`poller.go` / `peek.go` / `plan.go` / `sse.go` / `embed.go`) | state/tmux ポーリング・capture-pane・SSE・embed | M |
+| ui | `tui`(描画・整形以外: `update.go` / `keyboard.go` / `newpane*.go` / `issues.go` / `watch.go` ほか) | キー処理・フォーム・ポーリングの配線 | M |
 | core | `blockers` | ブロッカー判定 | A |
 | core | `naming` | slug・branch 名生成 | A |
 | core | `exitcode` | 終了コード定義 | A |
@@ -78,7 +82,7 @@ A のみの PR は AI レビューで可**。M はどちらも変更内容次第
 | core | `fanset` | fan-out 対象集合の計算 | A |
 | core | `cliview` | CLI 出力の整形 | A |
 | app | `cliflags` | フラグパース | A |
-| ui | `tui`(描画・整形) | TUI の View 層 | A |
+| ui | `tui`(描画・整形: `view.go` / `paneview.go` / `compact.go` / `styles.go` ほか) | TUI の View 層 | A |
 | infra | `atomicfs` | 原子的ファイル書き込み | A |
 | infra | `log` | ロギング | A |
 | infra | `tty` | 端末判定 | A |

--- a/docs/architecture.ja.md
+++ b/docs/architecture.ja.md
@@ -49,24 +49,26 @@ A のみの PR は AI レビューで可**。M はどちらも変更内容次第
 | infra | `hooks` | ライフサイクルフック実行 | H |
 | infra | `selfupdate` | 自己アップデート | H |
 | infra | `team` | `--team` / `fanout msg` の SQLite バス | H |
+| infra | `settings` | 設定解決。repo config からの watcher 有効化・通知先設定を遮断する安全ゲート | H |
 | app | `watch` | ラベル watcher の 1 サイクル | H |
 | app | `briefing` | エージェントに注入するプロンプト本文の生成 | H |
 | app | `lifecycle` | `--close` / `--merge` / `--cleanup` | H |
 | app | `panelaunch` | pane 生成オーケストレーション | H |
 | ui | `dashboard`(`server.go`) | localhost web サーバの mux・token 検証 | H |
 | ui | `dashboard`(`runfile.go`) | token を含む `.fanout/dashboard.json`・reuse/trust ゲート | H |
+| ui | `dashboard`(`peek.go` / `plan.go`) | capture-pane 前の検証チェーン(記録済み pane 以外の端末出力を読まない境界) | H |
 | ui | `tui`(`actions.go`) | lifecycle(close/merge/cleanup)実行の配線と確認フロー | H |
-| cmd | `main.go` / `tui_popup.go` / `tui_launch.go` / `worktree_action.go` / `codex_plan_tui.go` | dispatch・self-exec(popup / Plan TUI)・launch 配線・pane identity 検証 | H |
-| cmd | 上記以外(`plancmd.go` / `status.go` / `lifecycle.go` / `msg.go` / `dashboard.go` / `tui_issue.go` / `tui_restore.go` / `tui_watch.go` / `deps.go` ほか) | フラグ検証と app 層への薄い dispatch | M |
+| cmd | `main.go` / `tui_popup.go` / `tui_launch.go` / `worktree_action.go` / `codex_plan_tui.go` / `tui_restore.go` / `tui_watch.go` | dispatch・self-exec・launch 配線・pane identity 検証・state 書き換えを伴う復元/watch 起動 | H |
+| cmd | 上記以外(`plancmd.go` / `status.go` / `lifecycle.go` / `msg.go` / `dashboard.go` / `tui_issue.go` / `deps.go` ほか) | フラグ検証と app 層への薄い dispatch | M |
 | infra | `ghissue` | GitHub issue/PR 読み取り | M |
 | infra | `gitstat` | git 差分・状態取得 | M |
 | infra | `tmuxrun` | tmux 直接操作 | M |
 | infra | `msgstore` | send/post/inbox/board/mark-read | M |
 | infra | `notify` | 通知送出 | M |
 | infra | `runtime` | git root・tmux ターゲット解決 | M |
-| infra | `settings` | 設定解決(default / config / env / CLI) | M |
 | infra | `displayname` | 表示名生成 | M |
 | infra | `codexapp` | Codex app-server クライアント | M |
+| infra | `atomicfs` | 原子的ファイル書き込み(state.json / token 入り dashboard.json の共通経路) | M |
 | app | `panelayout` | ペインレイアウト計算 | M |
 | app | `sessionview` | state + tmux + gh を集約する Snapshot | M |
 | app | `run` | `executePlan` の実行ロジック | M |
@@ -75,21 +77,23 @@ A のみの PR は AI レビューで可**。M はどちらも変更内容次第
 | app | `cliflags` | フラグ検証(lifecycle 相互排他・親正規化など main の分岐を決める) | M |
 | core | `agent` | エージェント名の解決・CLI 検証 | M |
 | core | `planspec` | `fanout plan` の JSON スキーマ | M |
-| ui | `dashboard`(`poller.go` / `peek.go` / `plan.go` / `sse.go` / `embed.go`) | state/tmux ポーリング・capture-pane・SSE・embed | M |
+| core | `naming` | slug・branch 名生成(worktree/branch identity を決める) | M |
+| core | `parentref` | 親参照の正規化(state/sessionview の parent key) | M |
+| core | `fanset` | fan-out 対象集合の計算(launch 対象の選別) | M |
+| ui | `dashboard`(`poller.go` / `sse.go` / `embed.go`) | state/tmux ポーリング・SSE・embed | M |
 | ui | `tui`(描画・整形以外: `update.go` / `keyboard.go` / `newpane*.go` / `issues.go` / `watch.go` / `paneview.go` ほか) | キー処理・フォーム・ポーリングの配線。`paneview.go` は lifecycle 対象 state root の選択入力(`sourceProjectRoot`)を含む | M |
 | core | `blockers` | ブロッカー判定 | A |
-| core | `naming` | slug・branch 名生成 | A |
 | core | `exitcode` | 終了コード定義 | A |
-| core | `parentref` | 親参照の正規化 | A |
-| core | `fanset` | fan-out 対象集合の計算 | A |
 | core | `cliview` | CLI 出力の整形 | A |
 | ui | `tui`(描画・整形: `view.go` / `compact.go` / `styles.go` ほか) | TUI の View 層 | A |
-| infra | `atomicfs` | 原子的ファイル書き込み | A |
 | infra | `log` | ロギング | A |
 | infra | `tty` | 端末判定 | A |
 | infra | `execx` | コマンド実行の薄いラッパ | A |
 | infra | `gitroot` | git root 探索 | A |
 | infra | `browser` | ブラウザ起動 | A |
+| web | `web/index.html` | no-referrer・外部 fetch 方針(token 漏洩境界) | H |
+| web | `web/src/hooks` / `web/src/lib` | SSE/polling transport・token 付き `/api/*` 呼び出し | M |
+| web | 上記以外の `web/src`(components / styles / tests) | 表示 | A |
 
 ## 人間必見の不変条件カタログ
 

--- a/docs/architecture.ja.md
+++ b/docs/architecture.ja.md
@@ -60,7 +60,7 @@ A のみの PR は AI レビューで可**。M はどちらも変更内容次第
 | ui | `tui`(`actions.go`) | lifecycle(close/merge/cleanup)実行の配線と確認フロー | H |
 | cmd | `main.go` / `tui_popup.go` / `tui_launch.go` / `worktree_action.go` / `codex_plan_tui.go` / `tui_restore.go` / `tui_watch.go` | dispatch・self-exec・launch 配線・pane identity 検証・state 書き換えを伴う復元/watch 起動 | H |
 | cmd | 上記以外(`plancmd.go` / `status.go` / `lifecycle.go` / `msg.go` / `dashboard.go` / `tui_issue.go` / `deps.go` ほか) | フラグ検証と app 層への薄い dispatch | M |
-| infra | `ghissue` | GitHub issue/PR 読み取り | M |
+| infra | `ghissue` | GitHub issue/PR の読み書き(label swap・dashboard comment 投稿などの mutation を含む) | M |
 | infra | `gitstat` | git 差分・状態取得 | M |
 | infra | `tmuxrun` | tmux 直接操作 | M |
 | infra | `msgstore` | send/post/inbox/board/mark-read | M |
@@ -69,6 +69,7 @@ A のみの PR は AI レビューで可**。M はどちらも変更内容次第
 | infra | `displayname` | 表示名生成 | M |
 | infra | `codexapp` | Codex app-server クライアント | M |
 | infra | `atomicfs` | 原子的ファイル書き込み(state.json / token 入り dashboard.json の共通経路) | M |
+| infra | `gitroot` | git root 探索(project root・state root・親 repo 判定の入力) | M |
 | app | `panelayout` | ペインレイアウト計算 | M |
 | app | `sessionview` | state + tmux + gh を集約する Snapshot | M |
 | app | `run` | `executePlan` の実行ロジック | M |
@@ -80,16 +81,15 @@ A のみの PR は AI レビューで可**。M はどちらも変更内容次第
 | core | `naming` | slug・branch 名生成(worktree/branch identity を決める) | M |
 | core | `parentref` | 親参照の正規化(state/sessionview の parent key) | M |
 | core | `fanset` | fan-out 対象集合の計算(launch 対象の選別) | M |
+| core | `blockers` | ブロッカー判定(--unblocked-only の起動対象選別・wave 計算の入力) | M |
 | ui | `dashboard`(`poller.go` / `sse.go` / `embed.go`) | state/tmux ポーリング・SSE・embed | M |
 | ui | `tui`(描画・整形以外: `update.go` / `keyboard.go` / `newpane*.go` / `issues.go` / `watch.go` / `paneview.go` ほか) | キー処理・フォーム・ポーリングの配線。`paneview.go` は lifecycle 対象 state root の選択入力(`sourceProjectRoot`)を含む | M |
-| core | `blockers` | ブロッカー判定 | A |
 | core | `exitcode` | 終了コード定義 | A |
 | core | `cliview` | CLI 出力の整形 | A |
 | ui | `tui`(描画・整形: `view.go` / `compact.go` / `styles.go` ほか) | TUI の View 層 | A |
 | infra | `log` | ロギング | A |
 | infra | `tty` | 端末判定 | A |
 | infra | `execx` | コマンド実行の薄いラッパ | A |
-| infra | `gitroot` | git root 探索 | A |
 | infra | `browser` | ブラウザ起動 | A |
 | web | `web/index.html` | no-referrer・外部 fetch 方針(token 漏洩境界) | H |
 | web | `web/src/hooks` / `web/src/lib` | SSE/polling transport・token 付き `/api/*` 呼び出し | M |

--- a/docs/architecture.ja.md
+++ b/docs/architecture.ja.md
@@ -43,6 +43,7 @@ A のみの PR は AI レビューで可**。M はどちらも変更内容次第
 
 | 層 | パッケージ | 責務 | Class |
 |---|---|---|---|
+| meta | `arch` | 層ルールの CI 強制(唯一のガード)。緩和・allowlist 追加は要精査 | H |
 | infra | `state` | `.fanout/state.json` と lock の読み書き | H |
 | infra | `worktree` | base branch 解決・refresh・`git worktree add` | H |
 | infra | `hooks` | ライフサイクルフック実行 | H |
@@ -71,18 +72,18 @@ A のみの PR は AI レビューで可**。M はどちらも変更内容次第
 | app | `run` | `executePlan` の実行ロジック | M |
 | app | `statusreport` | `--status` のレポート生成 | M |
 | app | `peermsg` | `fanout msg` の実行層 | M |
+| app | `cliflags` | フラグ検証(lifecycle 相互排他・親正規化など main の分岐を決める) | M |
 | core | `agent` | エージェント名の解決・CLI 検証 | M |
 | core | `planspec` | `fanout plan` の JSON スキーマ | M |
 | ui | `dashboard`(`poller.go` / `peek.go` / `plan.go` / `sse.go` / `embed.go`) | state/tmux ポーリング・capture-pane・SSE・embed | M |
-| ui | `tui`(描画・整形以外: `update.go` / `keyboard.go` / `newpane*.go` / `issues.go` / `watch.go` ほか) | キー処理・フォーム・ポーリングの配線 | M |
+| ui | `tui`(描画・整形以外: `update.go` / `keyboard.go` / `newpane*.go` / `issues.go` / `watch.go` / `paneview.go` ほか) | キー処理・フォーム・ポーリングの配線。`paneview.go` は lifecycle 対象 state root の選択入力(`sourceProjectRoot`)を含む | M |
 | core | `blockers` | ブロッカー判定 | A |
 | core | `naming` | slug・branch 名生成 | A |
 | core | `exitcode` | 終了コード定義 | A |
 | core | `parentref` | 親参照の正規化 | A |
 | core | `fanset` | fan-out 対象集合の計算 | A |
 | core | `cliview` | CLI 出力の整形 | A |
-| app | `cliflags` | フラグパース | A |
-| ui | `tui`(描画・整形: `view.go` / `paneview.go` / `compact.go` / `styles.go` ほか) | TUI の View 層 | A |
+| ui | `tui`(描画・整形: `view.go` / `compact.go` / `styles.go` ほか) | TUI の View 層 | A |
 | infra | `atomicfs` | 原子的ファイル書き込み | A |
 | infra | `log` | ロギング | A |
 | infra | `tty` | 端末判定 | A |

--- a/docs/architecture.ja.md
+++ b/docs/architecture.ja.md
@@ -55,8 +55,8 @@ A のみの PR は AI レビューで可**。M はどちらも変更内容次第
 | ui | `dashboard`(`server.go`) | localhost web サーバの mux・token 検証 | H |
 | ui | `dashboard`(`runfile.go`) | token を含む `.fanout/dashboard.json`・reuse/trust ゲート | H |
 | ui | `tui`(`actions.go`) | lifecycle(close/merge/cleanup)実行の配線と確認フロー | H |
-| cmd | `main.go` / `tui_popup.go` / `tui_launch.go` | dispatch・self-exec popup・launch 配線 | H |
-| cmd | 上記以外(`plancmd.go` / `status.go` / `lifecycle.go` / `msg.go` / `dashboard.go` ほか) | フラグ検証と app 層への薄い dispatch | M |
+| cmd | `main.go` / `tui_popup.go` / `tui_launch.go` / `worktree_action.go` / `codex_plan_tui.go` | dispatch・self-exec(popup / Plan TUI)・launch 配線・pane identity 検証 | H |
+| cmd | 上記以外(`plancmd.go` / `status.go` / `lifecycle.go` / `msg.go` / `dashboard.go` / `tui_issue.go` / `tui_restore.go` / `tui_watch.go` / `deps.go` ほか) | フラグ検証と app 層への薄い dispatch | M |
 | infra | `ghissue` | GitHub issue/PR 読み取り | M |
 | infra | `gitstat` | git 差分・状態取得 | M |
 | infra | `tmuxrun` | tmux 直接操作 | M |
@@ -100,14 +100,19 @@ A のみの PR は AI レビューで可**。M はどちらも変更内容次第
 - **watch のトリガーラベルはプロンプトインジェクション境界**: issue 本文が
   そのまま子 briefing になるため、`watcherTriggerLabel` の対象を広げる変更は
   攻撃面を広げる。
-- **dashboard は read-only・GET-only・localhost・token 必須**: `127.0.0.1`
-  バインド、mutation エンドポイント禁止、token 未検証のリクエストを通さない。
+- **dashboard は read-only・GET-only・localhost**: `127.0.0.1` バインドと
+  mutation エンドポイント禁止は全経路。token 必須は `/api/*` のみ
+  (`requireToken`)で、`/healthz` と SPA 配信は token-free(HTML shell が
+  `?token=` を読むため)。この token-free 範囲を広げる変更も狭める変更も
+  人間レビュー対象。
 - **briefing はエージェントに注入されるプロンプト本文**: `briefing.Render` /
   `RenderTask` の出力はそのままエージェントの入力になる。
 - **self-exec サブコマンド名の固定**: `__tui-new-pane-popup` /
-  `__tui-help-popup` / `__codex-plan-tui` は単一定数で参照し、
-  `TestSelfExecSubcommandNames` が文字列を固定する。名前を変えると
-  実行中バイナリの popup / Plan Mode 連携が壊れる。
+  `__tui-help-popup` / `__codex-plan-tui` は `TestSelfExecSubcommandNames` が
+  文字列を固定する。dispatch と popup 起動は単一定数を参照するが、
+  `infra/codexapp/launch.go` の起動コマンド生成はリテラル埋め込みが残る
+  (burn-down 参照)。名前を変えると実行中バイナリの popup / Plan Mode
+  連携が壊れるため、変更時は 3 参照元すべての追随が要る。
 - **ldflags は `-X main.version` 名指し**: バージョン注入変数は
   `cmd/fanout/main.go` の変数名に固定されており、リネームするとリリース
   ビルドが壊れる。
@@ -126,6 +131,8 @@ A のみの PR は AI レビューで可**。M はどちらも変更内容次第
   にある。
 - `shellQuote` の実装が `app/run` / `app/panelaunch` / `infra/tmuxrun` の
   3 箇所にある。
+- `infra/codexapp/launch.go` の起動コマンド生成が `__codex-plan-tui` を
+  リテラル埋め込みしている(`PlanTUICommand` 定数への統一が未了)。
 - `app` から `infra` への直接 import は既存分を容認するが、新規コードは
   `watch.IO` のような port 経由を優先する。
 


### PR DESCRIPTION
## 概要

4 層再配置リファクタリング(全 10 PR)の締め。コード変更なし(docs のみ)。

- `docs/architecture.ja.md` 新設: 4 層の責務・依存ルール(と例外 allowlist)・Mermaid 依存図・パッケージ表(層 × 責務 × **Review クラス H/M/A**)・人間必見の不変条件カタログ 8 件・burn-down リスト 5 件・新規パッケージ追加手順
- 運用ルール: **H(state/worktree/hooks/selfupdate/team/watch/briefing/lifecycle/panelaunch/dashboard server 等)を触る PR は人間レビュー必須。A のみの PR は AI レビューで可**
- CLAUDE.md / AGENTS.md の Architecture Notes をパッケージ逐条列挙から層ベース + 正典ポインタへ書き換え(英日同期)
- .git-blame-ignore-revs に移動ウェーブ 2 本(#414 / #415)の squash コミットを追記

## 検証
make lint 0 issues(Go 変更ゼロ)/ codex approve / doc-style.ja.md 準拠・旧フラットパス残存ゼロを grep 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DVKpKSXDTZbZqMw8cu1MUg