### PR TITLE
docs: add v0.9.0 changelog entry and bump install pin example

### DIFF
--- a/site/content/docs/changelog.ja.md
+++ b/site/content/docs/changelog.ja.md
@@ -9,6 +9,16 @@ yomi: changelog
 
 リリースのハイライトを新しい順に並べています。各タグには [GitHub release](https://github.com/butaosuinu/fanout/releases) があり、完全なコミット一覧とビルド済みバイナリ（darwin / linux × amd64 / arm64）を含みます。バージョンは git タグから ldflags 経由で埋め込まれます。`fanout --check-update` で自分の版を確認できます。
 
+## v0.9.0 (2026-07-06)
+
+- **常駐コンソールの刷新。** 引数なしコンソールに、コンパクトな Session switcher(`v` で切り替え)、`1`–`9` の数字ジャンプ、`Z` zoom、AgentState 列、tmux popup のショートカットヘルプを追加し、再起動時にペインを復元するようにしました。任意のペインから `F11` または `prefix T` で復帰できます。[Monitoring]({{< relref "/docs/monitoring" >}}) を参照。
+- **新規 Session modal の強化。** `n` で Prompt と Issue の 2 モードを開けます。Prompt モードは `@`-mention ファイル補完と plan fan-out チェックボックス付きの複数行 prompt、Issue モードは親 / 子 / 単独の issue を marker 表示する GraphQL ページングの issue picker とカウント式の `claude` / `codex` 選択を備えます。[Monitoring]({{< relref "/docs/monitoring" >}}) を参照。
+- **テーマ化とペインの自動レイアウト。** ペインは dmux 相当の自動レイアウトで並び、`#parent · name` ラベル付きの fanout カラーの境界を持ちます。[Monitoring]({{< relref "/docs/monitoring" >}}) を参照。
+- **新しいレビュー skill。** 過去のセッションから再発するツールエラー・CI 失敗・レビュー指摘を掘り出す `session-retro` skill を新設し、`post-work-review` にプロジェクト検証パスとレビューチェックリストを追加しました。[Agent Integrations]({{< relref "/docs/agents" >}}) を参照。
+- **4層の内部アーキテクチャ。** `internal/` を `core` / `app` / `infra` / `ui` の 4 層に再配置し、import 方向を CI で強制するようにしました。挙動は変わりません。正典は `docs/architecture.ja.md` です。
+
+[リリースノート →](https://github.com/butaosuinu/fanout/releases/tag/v0.9.0)
+
 ## v0.8.0 (2026-06-24)
 
 - **ラベル watcher。** 有効化すると、TUI 常駐の watcher が信頼できる `fanout:auto` issue を 1 回限りの fanout session に変えます。起動前に trigger ラベルを `fanout:running` へ付け替え、OPEN な子を持つ issue を親ファンアウトとして分類し、live ペインの上限を尊重します。有効化できるのは user config か `FANOUT_WATCHER*` 環境変数だけです。repo config はラベル、間隔、子 agent、session 上限を設定できますが、checkout を起動側に切り替えることはできません。[Workflow]({{< relref "/docs/workflow" >}}) と [Settings]({{< relref "/docs/settings" >}}) を参照。

--- a/site/content/docs/changelog.md
+++ b/site/content/docs/changelog.md
@@ -9,6 +9,16 @@ yomi: changelog
 
 Release highlights, newest first. Every tag also has a [GitHub release](https://github.com/butaosuinu/fanout/releases) with the full commit list and prebuilt binaries (darwin / linux × amd64 / arm64). Versions come from git tags via ldflags — check yours with `fanout --check-update`.
 
+## v0.9.0 (2026-07-06)
+
+- **Persistent console overhaul.** The no-argument console gained a compact Session switcher (toggle with `v`), `1`–`9` number jumps, `Z` zoom, an AgentState column, and a tmux-popup shortcut help modal, and it restores its panes on restart. Return to it from any pane with `F11` or the `prefix T` binding. See [Monitoring]({{< relref "/docs/monitoring" >}}).
+- **Richer new-session modal.** Pressing `n` opens Prompt and Issue modes. Prompt mode takes a multi-line prompt with `@`-mention file completion and a plan fan-out checkbox; Issue mode adds a GraphQL-paged issue picker that marks parent / child / standalone issues and count-based `claude` / `codex` selection. See [Monitoring]({{< relref "/docs/monitoring" >}}).
+- **Themed, auto-laid-out panes.** Panes tile through a dmux-style auto-layout and carry fanout-colored borders labeled `#parent · name`. See [Monitoring]({{< relref "/docs/monitoring" >}}).
+- **New review skills.** Added the `session-retro` skill, which mines past sessions for recurring tool errors, CI failures, and review findings, and gave `post-work-review` a project-verification pass plus a review checklist. See [Agent Integrations]({{< relref "/docs/agents" >}}).
+- **4-layer internal architecture.** Reorganized `internal/` into `core` / `app` / `infra` / `ui` layers with a CI-enforced import direction. No behavior change; the canonical reference is `docs/architecture.ja.md`.
+
+[Release notes →](https://github.com/butaosuinu/fanout/releases/tag/v0.9.0)
+
 ## v0.8.0 (2026-06-24)
 
 - **Label watcher.** Opt in to a TUI-resident watcher that turns trusted `fanout:auto` issues into one-shot fanout sessions. It swaps the trigger label to `fanout:running` before launch, classifies issues with OPEN children as parent fan-outs, and honors a live-pane budget. Enable it only through user config or `FANOUT_WATCHER*` environment variables; repo config can set the labels, interval, child agent, and session cap but never opt a checkout into launching. See [Workflow]({{< relref "/docs/workflow" >}}) and [Settings]({{< relref "/docs/settings" >}}).

--- a/site/content/docs/installation.ja.md
+++ b/site/content/docs/installation.ja.md
@@ -32,7 +32,7 @@ curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh |
 
 # 配置先や Release tag を指定
 curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh | BIN_DIR=/usr/local/bin sh
-curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh | FANOUT_VERSION=v0.8.0 sh
+curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh | FANOUT_VERSION=v0.9.0 sh
 ```
 
 `install.sh` は OS/arch を自動判定し、最新 Release(または `FANOUT_VERSION` で指定した tag)から `fanout` バイナリと Claude/Codex 連携ファイルを取得して配置します。

--- a/site/content/docs/installation.md
+++ b/site/content/docs/installation.md
@@ -32,7 +32,7 @@ curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh |
 
 # Custom destination or pinned release tag
 curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh | BIN_DIR=/usr/local/bin sh
-curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh | FANOUT_VERSION=v0.8.0 sh
+curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh | FANOUT_VERSION=v0.9.0 sh
 ```
 
 `install.sh` auto-detects your OS/arch, then fetches and installs the `fanout` binary and the Claude/Codex integration files from the latest Release (or the tag given via `FANOUT_VERSION`).


### PR DESCRIPTION
## 概要

v0.9.0 リリース準備。#333(v0.8.0)と同じ慣習で、タグを打つ前に changelog エントリと install pin 例を更新する docs PR。この commit をマージ後に `v0.9.0` タグを打つ。

## 変更

- `site/content/docs/changelog.{md,ja.md}`: v0.9.0 エントリを追加(5 ハイライト)
  - Persistent console overhaul(compact switcher `v` / 数字ジャンプ 1-9 / `Z` zoom / AgentState 列 / tmux popup ヘルプ / ペイン復元 / F11・prefix T 復帰)
  - Richer new-session modal(Prompt / Issue の 2 モード、@-mention 補完、plan fan-out チェックボックス、GraphQL ページング issue picker、カウント式 agent 選択)
  - Themed, auto-laid-out panes(dmux 相当の自動レイアウト、`#parent · name` ラベル境界)
  - New review skills(`session-retro` / `post-work-review` のプロジェクト検証パス + チェックリスト)
  - 4-layer internal architecture(core/app/infra/ui、CI 強制)
- `site/content/docs/installation.{md,ja.md}`: pin 例 `FANOUT_VERSION=v0.8.0` → `v0.9.0`

## 検証

- `make lint` = 0 issues、`make test` = green
- changelog の各 claim を `git log v0.8.0..HEAD` の実マージ PR と突き合わせ確認
- relref 先(`/docs/monitoring`・`/docs/agents`)の存在確認済み
- post-work-review(code-review + codex)完了 — 「Issue and Plan modes」の記述を実装(#400 で Plan モード削除済み)に合わせて修正

> [!NOTE]
> changelog の「Release notes →」リンクと pin 例の `v0.9.0` は、タグを push するまでは 404 になる(#333 と同じ、changelog-precedes-tag 慣習の想定内)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011hLjJnzHJ9z7kXbbmKEkhB