### PR TITLE
[codex] GitHub Actions を Node 24 runtime 対応版に更新

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,7 +28,7 @@ jobs:
       HUGO_VERSION: 0.163.0
       PAGEFIND_VERSION: 1.5.2
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.0
       - name: Install Hugo CLI
         run: |
           curl -fsSL "https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb" -o /tmp/hugo.deb
@@ -36,7 +36,7 @@ jobs:
       - name: Setup Pages
         if: github.event_name != 'pull_request'
         id: pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6.0.0
       - name: Build with Hugo
         env:
           HUGO_ENVIRONMENT: production
@@ -47,7 +47,7 @@ jobs:
           ./pagefind_extended --site site/public
       - name: Upload artifact
         if: github.event_name != 'pull_request'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5.0.0
         with:
           path: site/public
 
@@ -61,4 +61,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,15 +16,15 @@ jobs:
     name: Build web assets
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.0
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6.0.9
         with:
           package_json_file: web/package.json
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.4.0
         with:
           node-version-file: web/.nvmrc
           cache: pnpm
@@ -34,7 +34,7 @@ jobs:
         run: make build-web
 
       - name: Upload bundle
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: web-dist
           path: internal/ui/dashboard/static/
@@ -62,17 +62,17 @@ jobs:
             runner: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6.5.0
         with:
           go-version-file: go.mod
 
       - name: Download web bundle
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           name: web-dist
           path: internal/ui/dashboard/static/
@@ -111,7 +111,7 @@ jobs:
           tar -C dist -czf "artifacts/${asset}" fanout claude codex LICENSE
 
       - name: Upload archive
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: fanout-${{ matrix.goos }}-${{ matrix.goarch }}
           path: artifacts/fanout_${{ matrix.goos }}_${{ matrix.goarch }}.tar.gz
@@ -124,7 +124,7 @@ jobs:
 
     steps:
       - name: Download archives
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           path: artifacts
           merge-multiple: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v7.0.0
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v6.0.9
+        uses: pnpm/action-setup@v5.0.0
         with:
           package_json_file: web/package.json
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
       # The dashboard web bundle is not committed; build it so the embedded
       # asset smoke tests run instead of skipping.
       - name: Set up pnpm
-        uses: pnpm/action-setup@v6.0.9
+        uses: pnpm/action-setup@v5.0.0
         with:
           package_json_file: web/package.json
 
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v7.0.0
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v6.0.9
+        uses: pnpm/action-setup@v5.0.0
         with:
           package_json_file: web/package.json
 
@@ -68,7 +68,7 @@ jobs:
 
       # make test-tier1 builds fanout-go, which embeds the web bundle.
       - name: Set up pnpm
-        uses: pnpm/action-setup@v6.0.9
+        uses: pnpm/action-setup@v5.0.0
         with:
           package_json_file: web/package.json
 
@@ -100,7 +100,7 @@ jobs:
 
       # make test-tier2 builds fanout-go, which embeds the web bundle.
       - name: Set up pnpm
-        uses: pnpm/action-setup@v6.0.9
+        uses: pnpm/action-setup@v5.0.0
         with:
           package_json_file: web/package.json
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,22 +10,22 @@ jobs:
     name: Go unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6.5.0
         with:
           go-version-file: go.mod
 
       # The dashboard web bundle is not committed; build it so the embedded
       # asset smoke tests run instead of skipping.
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6.0.9
         with:
           package_json_file: web/package.json
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.4.0
         with:
           node-version-file: web/.nvmrc
           cache: pnpm
@@ -38,15 +38,15 @@ jobs:
     name: Web UI
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.0
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6.0.9
         with:
           package_json_file: web/package.json
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.4.0
         with:
           node-version-file: web/.nvmrc
           cache: pnpm
@@ -59,21 +59,21 @@ jobs:
     name: Tier 1
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6.5.0
         with:
           go-version-file: go.mod
 
       # make test-tier1 builds fanout-go, which embeds the web bundle.
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6.0.9
         with:
           package_json_file: web/package.json
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.4.0
         with:
           node-version-file: web/.nvmrc
           cache: pnpm
@@ -91,21 +91,21 @@ jobs:
     name: Tier 2
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6.5.0
         with:
           go-version-file: go.mod
 
       # make test-tier2 builds fanout-go, which embeds the web bundle.
       - name: Set up pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6.0.9
         with:
           package_json_file: web/package.json
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6.4.0
         with:
           node-version-file: web/.nvmrc
           cache: pnpm
@@ -125,10 +125,10 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6.5.0
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/vuln.yml
+++ b/.github/workflows/vuln.yml
@@ -19,9 +19,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.0
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6.5.0
         with:
           go-version-file: go.mod
 


### PR DESCRIPTION
TL;DR: GitHub Actions の Node 20 deprecation warning を消すため、workflow の action 参照を Node 24 runtime 対応版へ更新しました。

## 変更内容

- `.github/workflows/test.yml` / `vuln.yml` の `checkout` / `setup-go` / `setup-node` / `pnpm/action-setup` を更新
- `.github/workflows/pages.yml` の Pages 関連 action を更新
- `.github/workflows/release.yml` の artifact upload/download action を更新
- tag 解決リスクを避けるため、実在確認済みの patch tag へ pin

## 確認

- `make lint`
- `make test`
- `post-work-review`: `clean=true`, `findings=0`, marker written for `462921a`
- `git ls-remote --tags` で更新先 tag の存在を確認
- `gh api .../contents/action.yml` で主要 action の `runs.using: node24` を確認

Review effort: 1