### PR TITLE
feat: H/M/A 正典から PR review risk を機械判定する tools/reviewrisk を追加

### DIFF
--- a/.github/workflows/review-risk-guard.yml
+++ b/.github/workflows/review-risk-guard.yml
@@ -1,0 +1,123 @@
+# Base-side self-modification guard for the review-risk tooling.
+#
+# review-risk.yml runs on `pull_request`, so its self-modification guard executes
+# from the PR's merge ref — the workflow definition the PR itself edited. A PR
+# that strips or weakens that guard removes the very check meant to pin it to
+# critical, so the S6 fail-closed never fires.
+#
+# This workflow runs on `pull_request_target`, which ALWAYS executes the base
+# branch's copy of the definition. A PR cannot change what runs here — the guard
+# lives on trunk, out of the PR's reach.
+#
+# pull_request_target runs with a write-scoped token, so the iron rule is: never
+# execute PR-authored code. This job runs no build, no Go, no PR scripts. It only
+# `git fetch`es the PR head (fetching moves objects, it does not run them) and
+# diffs it against the merge base. actions/checkout stays on its default ref (the
+# base SHA), so every file on disk is base-side and trusted.
+name: review-risk-guard
+
+on: pull_request_target
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: review-risk-guard-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review-risk-guard:
+    name: PR review risk guard (base-side)
+    runs-on: ubuntu-latest
+    # Fork PRs get a github.token without label/comment write access; skip rather
+    # than fail noisily. This also means the guard is advisory for same-repo PRs
+    # only (see docs/review-risk.ja.md).
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      # Default ref = the base branch SHA (pull_request_target). This is the
+      # trusted base-side checkout; the PR's tree is never checked out here.
+      # persist-credentials: false — the gh steps below get their token via
+      # GH_TOKEN env, so no write-scoped token is left in .git/config. fetch of a
+      # public SHA below needs no credentials.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      # Fetch the PR head by SHA and diff it against the merge base for the risk
+      # tooling paths only. `git fetch` transfers objects without executing any
+      # PR code, so it is safe under pull_request_target. HEAD_SHA comes via env
+      # (never interpolated into the shell) to keep the PR out of the command.
+      - name: Self-modification guard
+        id: guard
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          git fetch origin "$HEAD_SHA"
+          # HEAD is the base branch (base-side checkout); FETCH_HEAD is the PR head.
+          base="$(git merge-base HEAD FETCH_HEAD)"
+          # `git diff --quiet` with a pathspec, no pipe (a `| grep -q` here dies of
+          # SIGPIPE under pipefail on large diffs). Rename old-paths out of these
+          # trees still match. Only when this touches the risk tooling do we fix the
+          # verdict; otherwise exit clean and let review-risk.yml judge normally.
+          if ! git diff --quiet "$base" FETCH_HEAD -- tools/reviewrisk .github/workflows/review-risk.yml .github/workflows/review-risk-guard.yml; then
+            {
+              echo '<!-- review-risk -->'
+              echo '## Review risk: **CRITICAL**'
+              echo
+              echo '人間精読必須。risk 判定ツール自身(`tools/reviewrisk/` / `review-risk.yml` / `review-risk-guard.yml`)が変更されているため、base ブランチ側で走る自己改変ガード(`pull_request_target`)が fail-closed で critical に固定しました(S6 相当)。この workflow は base 側の定義で実行されるため、PR からは無効化できません。'
+            } > comment.md
+            echo "self=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Apply review:critical label
+        if: steps.guard.outputs.self == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          # Idempotent label creation: ignore the error when a label already
+          # exists rather than forcing a color update via --force.
+          gh label create "review:none" --color cccccc --description "PR review risk: none" 2>/dev/null || true
+          gh label create "review:low" --color 0e8a16 --description "PR review risk: low" 2>/dev/null || true
+          gh label create "review:medium" --color fbca04 --description "PR review risk: medium" 2>/dev/null || true
+          gh label create "review:high" --color d93f0b --description "PR review risk: high" 2>/dev/null || true
+          gh label create "review:critical" --color b60205 --description "PR review risk: critical" 2>/dev/null || true
+
+          existing_labels="$(gh pr view "$PR" --json labels --jq '.labels[].name')"
+          while IFS= read -r label; do
+            case "$label" in
+              review:*)
+                if [ "$label" != "review:critical" ]; then
+                  gh pr edit "$PR" --remove-label "$label"
+                fi
+                ;;
+            esac
+          done <<< "$existing_labels"
+
+          gh pr edit "$PR" --add-label "review:critical"
+
+      - name: Update sticky comment
+        if: steps.guard.outputs.self == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          # The startswith marker must match reviewRiskMarker in tools/reviewrisk/report.go.
+          existing_id="$(gh api "repos/$GH_REPO/issues/$PR/comments" --paginate \
+            --jq '[.[] | select(.body | startswith("<!-- review-risk -->"))][0].id // empty')"
+
+          if [ -n "$existing_id" ]; then
+            gh api --method PATCH "repos/$GH_REPO/issues/comments/$existing_id" -F body=@comment.md
+          else
+            gh api --method POST "repos/$GH_REPO/issues/$PR/comments" -F body=@comment.md
+          fi

--- a/.github/workflows/review-risk-guard.yml
+++ b/.github/workflows/review-risk-guard.yml
@@ -65,10 +65,13 @@ jobs:
           # verdict; otherwise exit clean and let review-risk.yml judge normally.
           if ! git diff --quiet "$base" FETCH_HEAD -- tools/reviewrisk .github/workflows/review-risk.yml .github/workflows/review-risk-guard.yml; then
             {
-              echo '<!-- review-risk -->'
-              echo '## Review risk: **CRITICAL**'
+              # Own marker, distinct from review-risk.yml's <!-- review-risk -->:
+              # a PR-side judge (possibly stripped of its guard) updates only its
+              # own marker comment, so it cannot overwrite this verdict.
+              echo '<!-- review-risk-guard -->'
+              echo '## Review risk: **CRITICAL**(base 側ガード)'
               echo
-              echo '人間精読必須。risk 判定ツール自身(`tools/reviewrisk/` / `review-risk.yml` / `review-risk-guard.yml`)が変更されているため、base ブランチ側で走る自己改変ガード(`pull_request_target`)が fail-closed で critical に固定しました(S6 相当)。この workflow は base 側の定義で実行されるため、PR からは無効化できません。'
+              echo '人間精読必須。risk 判定ツール自身(`tools/reviewrisk/` / `review-risk.yml` / `review-risk-guard.yml`)が変更されているため、base ブランチ側で走る自己改変ガード(`pull_request_target`)が fail-closed で critical に固定しました(S6 相当)。この workflow は base 側の定義で実行されるため、PR からは無効化できません。PR 側 workflow が `review-risk` のコメントやラベルを上書きしても、このコメントがガードの判定として残ります。'
             } > comment.md
             echo "self=true" >> "$GITHUB_OUTPUT"
           fi
@@ -112,9 +115,11 @@ jobs:
         run: |
           set -euo pipefail
 
-          # The startswith marker must match reviewRiskMarker in tools/reviewrisk/report.go.
+          # The guard's own marker (NOT report.go's <!-- review-risk -->): this
+          # sticky comment is separate from the judge's so the PR-side workflow
+          # cannot overwrite it.
           existing_id="$(gh api "repos/$GH_REPO/issues/$PR/comments" --paginate \
-            --jq '[.[] | select(.body | startswith("<!-- review-risk -->"))][0].id // empty')"
+            --jq '[.[] | select(.body | startswith("<!-- review-risk-guard -->"))][0].id // empty')"
 
           if [ -n "$existing_id" ]; then
             gh api --method PATCH "repos/$GH_REPO/issues/comments/$existing_id" -F body=@comment.md

--- a/.github/workflows/review-risk.yml
+++ b/.github/workflows/review-risk.yml
@@ -1,0 +1,104 @@
+name: review-risk
+
+on: pull_request
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: review-risk-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review-risk:
+    name: PR review risk
+    runs-on: ubuntu-latest
+    # Fork PRs get a github.token without label/comment write access; skip
+    # rather than fail noisily.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # The judge step compiles and runs PR-authored Go code; do not leave
+          # the write-scoped job token in .git/config for it to read. The gh
+          # steps below receive the token via GH_TOKEN instead.
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Judge review risk
+        id: risk
+        run: |
+          set -euo pipefail
+          # Fail-closed self-modification guard: when the PR touches the risk
+          # tool or this workflow, the PR-side implementation cannot be trusted
+          # to judge itself (it could weaken S6). Skip running it and pin the
+          # verdict to critical — the unmodified tool would report S6 here anyway.
+          base="$(git merge-base "origin/$GITHUB_BASE_REF" HEAD)"
+          if git diff --name-only "$base" HEAD | grep -qE '^(tools/reviewrisk/|\.github/workflows/review-risk\.yml$)'; then
+            {
+              echo '<!-- review-risk -->'
+              echo '## Review risk: **CRITICAL**'
+              echo
+              echo '人間精読必須。risk 判定ツール自身(`tools/reviewrisk/` または `review-risk.yml`)が変更されているため、PR 側ツールの判定は使わず workflow が fail-closed で critical に固定しました(S6 相当)。'
+            } > comment.md
+            echo "level=critical" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          go run ./tools/reviewrisk --base "origin/$GITHUB_BASE_REF" --format json > risk.json
+          go run ./tools/reviewrisk --base "origin/$GITHUB_BASE_REF" --format markdown > comment.md
+          echo "level=$(jq -r .level risk.json)" >> "$GITHUB_OUTPUT"
+
+      - name: Apply review:<level> label
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+          LEVEL: ${{ steps.risk.outputs.level }}
+        run: |
+          set -euo pipefail
+
+          # Idempotent label creation: ignore the error when a label already
+          # exists rather than forcing a color update via --force.
+          gh label create "review:none" --color cccccc --description "PR review risk: none" 2>/dev/null || true
+          gh label create "review:low" --color 0e8a16 --description "PR review risk: low" 2>/dev/null || true
+          gh label create "review:medium" --color fbca04 --description "PR review risk: medium" 2>/dev/null || true
+          gh label create "review:high" --color d93f0b --description "PR review risk: high" 2>/dev/null || true
+          gh label create "review:critical" --color b60205 --description "PR review risk: critical" 2>/dev/null || true
+
+          existing_labels="$(gh pr view "$PR" --json labels --jq '.labels[].name')"
+          while IFS= read -r label; do
+            case "$label" in
+              review:*)
+                if [ "$label" != "review:$LEVEL" ]; then
+                  gh pr edit "$PR" --remove-label "$label"
+                fi
+                ;;
+            esac
+          done <<< "$existing_labels"
+
+          gh pr edit "$PR" --add-label "review:$LEVEL"
+
+      - name: Update sticky comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          # The startswith marker must match reviewRiskMarker in tools/reviewrisk/report.go.
+          existing_id="$(gh api "repos/$GH_REPO/issues/$PR/comments" --paginate \
+            --jq '[.[] | select(.body | startswith("<!-- review-risk -->"))][0].id // empty')"
+
+          if [ -n "$existing_id" ]; then
+            gh api --method PATCH "repos/$GH_REPO/issues/comments/$existing_id" -F body=@comment.md
+          else
+            gh api --method POST "repos/$GH_REPO/issues/$PR/comments" -F body=@comment.md
+          fi

--- a/.github/workflows/review-risk.yml
+++ b/.github/workflows/review-risk.yml
@@ -27,19 +27,16 @@ jobs:
           # steps below receive the token via GH_TOKEN instead.
           persist-credentials: false
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-
-      - name: Judge review risk
-        id: risk
+      # Fail-closed self-modification guard, before Set up Go so a PR that also
+      # breaks go.mod still reaches the critical label/comment instead of dying
+      # in setup-go. When the PR touches the risk tool or this workflow, the
+      # PR-side implementation cannot be trusted to judge itself (it could weaken
+      # S6); pin the verdict to critical — the unmodified tool would report S6
+      # here anyway. Shell only, no Go needed.
+      - name: Self-modification guard
+        id: guard
         run: |
           set -euo pipefail
-          # Fail-closed self-modification guard: when the PR touches the risk
-          # tool or this workflow, the PR-side implementation cannot be trusted
-          # to judge itself (it could weaken S6). Skip running it and pin the
-          # verdict to critical — the unmodified tool would report S6 here anyway.
           # `git diff --quiet` with a pathspec: no pipe (a `| grep -q` here dies
           # of SIGPIPE under pipefail and skips the guard on large diffs), and
           # the old-path side of a rename out of these trees still matches.
@@ -51,9 +48,20 @@ jobs:
               echo
               echo '人間精読必須。risk 判定ツール自身(`tools/reviewrisk/` または `review-risk.yml`)が変更されているため、PR 側ツールの判定は使わず workflow が fail-closed で critical に固定しました(S6 相当)。'
             } > comment.md
-            echo "level=critical" >> "$GITHUB_OUTPUT"
-            exit 0
+            echo "self=true" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Set up Go
+        if: steps.guard.outputs.self != 'true'
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Judge review risk
+        id: risk
+        if: steps.guard.outputs.self != 'true'
+        run: |
+          set -euo pipefail
           go run ./tools/reviewrisk --base "origin/$GITHUB_BASE_REF" --format json > risk.json
           go run ./tools/reviewrisk --base "origin/$GITHUB_BASE_REF" --format markdown > comment.md
           echo "level=$(jq -r .level risk.json)" >> "$GITHUB_OUTPUT"
@@ -63,7 +71,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
           PR: ${{ github.event.pull_request.number }}
-          LEVEL: ${{ steps.risk.outputs.level }}
+          LEVEL: ${{ steps.guard.outputs.self == 'true' && 'critical' || steps.risk.outputs.level }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/review-risk.yml
+++ b/.github/workflows/review-risk.yml
@@ -41,7 +41,7 @@ jobs:
           # of SIGPIPE under pipefail and skips the guard on large diffs), and
           # the old-path side of a rename out of these trees still matches.
           base="$(git merge-base "origin/$GITHUB_BASE_REF" HEAD)"
-          if ! git diff --quiet "$base" HEAD -- tools/reviewrisk .github/workflows/review-risk.yml; then
+          if ! git diff --quiet "$base" HEAD -- tools/reviewrisk .github/workflows/review-risk.yml .github/workflows/review-risk-guard.yml; then
             {
               echo '<!-- review-risk -->'
               echo '## Review risk: **CRITICAL**'

--- a/.github/workflows/review-risk.yml
+++ b/.github/workflows/review-risk.yml
@@ -40,8 +40,11 @@ jobs:
           # tool or this workflow, the PR-side implementation cannot be trusted
           # to judge itself (it could weaken S6). Skip running it and pin the
           # verdict to critical — the unmodified tool would report S6 here anyway.
+          # `git diff --quiet` with a pathspec: no pipe (a `| grep -q` here dies
+          # of SIGPIPE under pipefail and skips the guard on large diffs), and
+          # the old-path side of a rename out of these trees still matches.
           base="$(git merge-base "origin/$GITHUB_BASE_REF" HEAD)"
-          if git diff --name-only "$base" HEAD | grep -qE '^(tools/reviewrisk/|\.github/workflows/review-risk\.yml$)'; then
+          if ! git diff --quiet "$base" HEAD -- tools/reviewrisk .github/workflows/review-risk.yml; then
             {
               echo '<!-- review-risk -->'
               echo '## Review risk: **CRITICAL**'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -152,6 +152,13 @@ packages can rely on AI review.
   blocked pane shows a permission/input dialog and the nudge's Enter could
   activate the focused control.
 
+`tools/reviewrisk` turns that H/M/A canon into an automated `review:<level>`
+judgment on every PR (`make review-risk` runs it locally; see
+`docs/review-risk.ja.md`). Changing a package's review class means updating
+`tools/reviewrisk/rules.go` in the same PR, or a docsync test fails CI.
+`tools/` sits outside `internal/`/`cmd/` and `internal/arch` pins it to
+stdlib-only imports, so repo-support code stays isolated from the product.
+
 ## Behavior Boundaries
 
 - Child enumeration unions GitHub Sub-issues and same-repo parent task-list

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ GOLANGCI_LINT_VERSION ?= $(shell cat .golangci-lint-version)
 GOLANGCI_LINT_BIN     := $(CURDIR)/.cache/tools/golangci-lint-$(GOLANGCI_LINT_VERSION)
 GOLANGCI_LINT_CACHE   ?= $(CURDIR)/.cache/golangci-lint
 
-.PHONY: install link uninstall build-go build-web clean-go clean-web install-integrations link-integrations uninstall-integrations go-test test test-web test-tier1 test-tier2 lint lint-go lint-shell lint-web fmt fmt-web fix vuln check-bats
+.PHONY: install link uninstall build-go build-web clean-go clean-web install-integrations link-integrations uninstall-integrations go-test test test-web test-tier1 test-tier2 lint lint-go lint-shell lint-web fmt fmt-web fix vuln check-bats review-risk
 
 # The dashboard web UI (web/, React + Vite) is built into $(STATIC_DIR) and
 # embedded via go:embed. The bundle is never committed, so building the binary
@@ -156,6 +156,8 @@ uninstall: uninstall-integrations
 #                       `lint` on purpose: it fetches the vulnerability DB over
 #                       the network and can fail on new CVEs without any code
 #                       change, so it is not a deterministic lint gate.
+# `make review-risk`   — PR review risk level for the working diff (see
+#                       docs/review-risk.ja.md); CI runs the same tool.
 #
 # bats-core is required: `brew install bats-core` (macOS) or `apt install bats`
 # (Debian/Ubuntu). check-bats prints the install hint before failing.
@@ -222,3 +224,6 @@ fix:
 
 vuln:
 	GOCACHE="$(GOCACHE)" $(GO) tool govulncheck ./...
+
+review-risk:
+	GOCACHE="$(GOCACHE)" $(GO) run ./tools/reviewrisk

--- a/docs/architecture.ja.md
+++ b/docs/architecture.ja.md
@@ -14,6 +14,7 @@ composition root。層ルールの正典実装は `internal/arch/arch_test.go` �
 | `infra` | 外部プロセス・ファイルシステム・DB | core / infra | 制約なし |
 | `ui` | TUI・web ダッシュボード | core / app / infra / ui | 制約なし |
 | `cmd` | composition root(`cmd/fanout`) | core / app / infra / ui | import される側になってはならない — 他パッケージからの `cmd/...` import は全面禁止 |
+| `tools` | repo 支援メタツール(PR review risk 判定など製品コード外) | tools のみ(本体層は import 不可・被 import も不可) | stdlib のみ(arch ガードが強制) |
 
 依存の向きは一方向で、`ui -> app -> core` が主経路、`app` と `ui` はどちらも
 `infra` に直接手を伸ばせる。強制するのは `internal/arch` の Go テスト
@@ -91,6 +92,7 @@ A のみの PR は AI レビューで可**。M はどちらも変更内容次第
 | infra | `tty` | 端末判定 | A |
 | infra | `execx` | コマンド実行の薄いラッパ | A |
 | infra | `browser` | ブラウザ起動 | A |
+| tools | `tools/reviewrisk` | PR review risk 判定(物差し。ルール変更はレビュー配線を変える) | H |
 | web | `web/index.html` | no-referrer・外部 fetch 方針(token 漏洩境界) | H |
 | web | `web/src/hooks` / `web/src/lib` | SSE/polling transport・token 付き `/api/*` 呼び出し | M |
 | web | 上記以外の `web/src`(components / styles / tests) | 表示 | A |
@@ -147,3 +149,5 @@ A のみの PR は AI レビューで可**。M はどちらも変更内容次第
    `TestInternalTreeShape` が拒否する。
 2. 層ルールに合わない import は `internal/arch` の CI が落とす。
 3. この文書の「パッケージ表」に層・責務・Review クラスを追記する。
+4. クラスの追加・変更は `tools/reviewrisk/rules.go` のルール表を同時更新する
+   (docsync テストが不一致を CI で落とす)。詳細は `docs/review-risk.ja.md`。

--- a/docs/review-risk.ja.md
+++ b/docs/review-risk.ja.md
@@ -63,12 +63,12 @@ doc 上 `view.go` / `compact.go` / `styles.go` の A 行は「ほか」付きの
 |---|---|---|
 | S1 | test-deleted | `*_test.go` / `*.bats` / `web/src/**/*.test.*` の削除(D)。rename でテスト形状が失われる場合も含む |
 | S2 | measure-deleted | `tests/{golden,fixtures,bin}/**` の削除(D)。rename で測定対象外へ移す場合も含む |
-| S3 | skip-added | 追加行に `\bt\.(Skip\|Skipf\|SkipNow)\(`、vitest の skip 形(`.skip(` / `.skipIf(` / `.skip.` 連鎖 / `skip: true` / `xit(` / `xdescribe(` / `xtest(`。対象は `*.test.ts(x)` と `web/src/test/**`)、bats(`tests/bats/**` の `.bats` と `.bash`)の `^\s*skip\b` |
+| S3 | skip-added | 追加行に `\bt\.(Skip\|Skipf\|SkipNow)\(`、vitest の skip 形(`.skip(` / `.skipIf(` / `.skip.` 連鎖 / `skip: true` / `xit(` / `xdescribe(` / `xtest(`。対象は `*.test.ts(x)` と `web/src/test/**`)、bats(`tests/bats/**` の `.bats` と `.bash`)のコマンド位置の `skip`(行頭と `&&` / `\|\|` / `;` / `then` 等の後。`[[ $CI == true ]] && skip` も拾う) |
 | S4 | guard-modified | `internal/arch/` の変更 |
 | S5 | review-gate-modified | `.claude/` と post-work-review gate(`codex/tools/post-work-review*` / `codex/agents/post-work-*` / `codex/skills/post-work-review/` / `claude/skills/post-work-review/`)の変更 |
 | S6 | risk-tool-modified | `tools/reviewrisk/` または `review-risk.yml` の変更 |
 | S7 | installer-modified | `install.sh` の変更 |
-| S8 | ci-workflow-deleted | `.github/workflows/` 配下の `.yml`/`.yaml` の削除(D)。rename で配下外へ移す・拡張子を変えて無効化する場合も含む |
+| S8 | ci-workflow-deleted | `.github/workflows/` 直下の `.yml`/`.yaml` の削除(D)。rename による無効化(配下外への移動・拡張子変更・サブディレクトリへの移動)も含む |
 
 ### high に押し上げ(S9-S10)
 

--- a/docs/review-risk.ja.md
+++ b/docs/review-risk.ja.md
@@ -68,7 +68,7 @@ doc 上 `view.go` / `compact.go` / `styles.go` の A 行は「ほか」付きの
 | S3 | skip-added | 追加行に `\b\w+\.(Skip\|Skipf\|SkipNow)\(`(receiver 名は固定せず `t` 以外の `*testing.T`/`*testing.B`、例 `tb.Skip(` / `b.Skip(` も拾う。`t.Skipped()` は Skip 直後の `(` 要求で非マッチ)、vitest の skip 形(`.skip(` / `.skipIf(` / `.skip.` 連鎖 / `skip: true` / `xit(` / `xdescribe(` / `xtest(`。対象は `*.test.ts(x)` / `*.spec.ts(x)` と `web/src/test/**`)、bats(`tests/bats/**` の `.bats` と `.bash`)のコマンド位置の `skip`(行頭と `&&` / `\|\|` / `;` / `then` 等の後。`[[ $CI == true ]] && skip` も拾う) |
 | S4 | guard-modified | `internal/arch/` の変更 |
 | S5 | review-gate-modified | `.claude/` と post-work-review gate(`codex/tools/post-work-review*` / `codex/agents/post-work-*` / `codex/skills/post-work-review/` / `claude/skills/post-work-review/`)の変更 |
-| S6 | risk-tool-modified | `tools/reviewrisk/` または `review-risk.yml` の変更 |
+| S6 | risk-tool-modified | `tools/reviewrisk/` または `review-risk.yml` / `review-risk-guard.yml` の変更 |
 | S7 | installer-modified | `install.sh` の変更 |
 | S8 | ci-workflow-deleted | `.github/workflows/` 直下の `.yml`/`.yaml` の削除(D)。rename による無効化(配下外への移動・拡張子変更・サブディレクトリへの移動)も含む |
 
@@ -136,10 +136,10 @@ go run ./tools/reviewrisk [--base <ref>] [--format text|markdown|json] [--fail-a
 書き込み token を `.git/config` に残さない(gh を呼ぶステップだけが env 経由で
 token を受け取る)。
 
-1. PR が `tools/reviewrisk/` か `review-risk.yml` 自身を変更している場合
-   (rename で外へ移す場合も pathspec 判定で含む)、PR 側ツールの判定は信用せず
-   (S6 の安全弁を PR 側が緩められるため)、workflow が fail-closed で critical
-   に固定する。この self-modification guard は Set up Go より前の shell 専用
+1. PR が `tools/reviewrisk/` か `review-risk.yml` / `review-risk-guard.yml` 自身を
+   変更している場合(rename で外へ移す場合も pathspec 判定で含む)、PR 側ツールの
+   判定は信用せず(S6 の安全弁を PR 側が緩められるため)、workflow が fail-closed で
+   critical に固定する。この self-modification guard は Set up Go より前の shell 専用
    ステップで、PR 側の `go.mod` に依存しない — ツール改変と同時に `go.mod` を
    壊す PR でも setup-go で落ちず critical ラベル/コメントに到達する。それ以外は
    `--format json` と `--format markdown` を実行し、`jq -r .level` で level を
@@ -150,6 +150,18 @@ token を受け取る)。
    外し、現在の level を付ける。
 3. PR コメントを `<!-- review-risk -->` マーカーで検索し、あれば内容を
    置き換え、なければ新規投稿する(sticky コメント)。
+
+`review-risk.yml` は `pull_request` で走るため、self-modification guard も PR の
+merge ref 側 — PR が編集した後の定義 — で実行される。PR が guard 自体を削除・緩和
+すると S6 の critical 固定に届かない。これを塞ぐのが `review-risk-guard.yml` で、
+`pull_request_target` を使い常に base ブランチ側の定義を実行する。base 側で走る
+ため PR からは無効化できず、PR コードは一切実行しない(checkout は base のみ、PR
+head は `git fetch` で取り込んで diff を取るだけ)。risk ツール系のパスに差分が
+あるときだけ critical ラベルと sticky コメントを固定し、なければ即終了する。
+
+限界: 同一 repo の PR はどの workflow からも書き込み token を得られるため、この
+ラベルは悪意ある作者に対する防御ではなく advisory にとどまる(この境界は設計
+どおり)。
 
 判定はブランチ保護ルールに足さない。CI green と level ラベルは別軸で、
 critical でも CI が通ればマージ自体は可能 — 人間が読むかどうかの判断材料を

--- a/docs/review-risk.ja.md
+++ b/docs/review-risk.ja.md
@@ -157,11 +157,14 @@ merge ref 側 — PR が編集した後の定義 — で実行される。PR が
 `pull_request_target` を使い常に base ブランチ側の定義を実行する。base 側で走る
 ため PR からは無効化できず、PR コードは一切実行しない(checkout は base のみ、PR
 head は `git fetch` で取り込んで diff を取るだけ)。risk ツール系のパスに差分が
-あるときだけ critical ラベルと sticky コメントを固定し、なければ即終了する。
+あるときだけ critical ラベルとコメントを固定し、なければ即終了する。guard の
+コメントは judge とは別マーカー `<!-- review-risk-guard -->` の独立 sticky
+comment — guard を剥がした PR 側 workflow が `review-risk` 側のコメントやラベルを
+後から上書きしても、guard の判定はコメントとして残る(push ごとに再主張もされる)。
 
-限界: 同一 repo の PR はどの workflow からも書き込み token を得られるため、この
-ラベルは悪意ある作者に対する防御ではなく advisory にとどまる(この境界は設計
-どおり)。
+限界: 同一 repo の PR はどの workflow からも書き込み token を得られるため、
+ラベル自体は悪意ある作者に対する防御ではなく advisory にとどまる(この境界は
+設計どおり)。
 
 判定はブランチ保護ルールに足さない。CI green と level ラベルは別軸で、
 critical でも CI が通ればマージ自体は可能 — 人間が読むかどうかの判断材料を

--- a/docs/review-risk.ja.md
+++ b/docs/review-risk.ja.md
@@ -65,10 +65,10 @@ doc 上 `view.go` / `compact.go` / `styles.go` の A 行は「ほか」付きの
 | S2 | measure-deleted | `tests/{golden,fixtures,bin}/**` の削除(D)。rename で測定対象外へ移す場合も含む |
 | S3 | skip-added | 追加行に `\bt\.(Skip\|Skipf\|SkipNow)\(`、vitest の skip 形(`.skip(` / `.skipIf(` / `.skip.` 連鎖 / `skip: true` / `xit(` / `xdescribe(` / `xtest(`。対象は `*.test.ts(x)` と `web/src/test/**`)、bats(`tests/bats/**` の `.bats` と `.bash`)の `^\s*skip\b` |
 | S4 | guard-modified | `internal/arch/` の変更 |
-| S5 | review-gate-modified | `.claude/` と post-work-review gate(`codex/tools/post-work-review*` / `codex/skills/post-work-review/` / `claude/skills/post-work-review/`)の変更 |
+| S5 | review-gate-modified | `.claude/` と post-work-review gate(`codex/tools/post-work-review*` / `codex/agents/post-work-*` / `codex/skills/post-work-review/` / `claude/skills/post-work-review/`)の変更 |
 | S6 | risk-tool-modified | `tools/reviewrisk/` または `review-risk.yml` の変更 |
 | S7 | installer-modified | `install.sh` の変更 |
-| S8 | ci-workflow-deleted | `.github/workflows/` 配下の削除(D)。rename で配下外へ移す場合も含む |
+| S8 | ci-workflow-deleted | `.github/workflows/` 配下の `.yml`/`.yaml` の削除(D)。rename で配下外へ移す・拡張子を変えて無効化する場合も含む |
 
 ### high に押し上げ(S9-S10)
 

--- a/docs/review-risk.ja.md
+++ b/docs/review-risk.ja.md
@@ -24,9 +24,11 @@ PR に反映する。判定は advisory — マージはブロックしない。
 2. Go テストペアリング: `foo_test.go` は `foo.go` の file rule を継承する。
    ただしパッケージの prefix rule がその file rule より重ければそちらを採る
    — テストをパッケージのクラスより軽く落とすことはしない
-3. web テスト上書き: `web/src/` 配下の `*.test.ts(x)` と `web/src/test/**` は
-   常に A(`docs/architecture.ja.md` の「tests は A」の行に従う。hooks/lib の
-   M より優先する非対称)
+3. web テスト上書き: `web/src/` 配下の `*.test.ts(x)` / `*.spec.ts(x)` と
+   `web/src/test/**` は常に A(`docs/architecture.ja.md` の「tests は A」の行に
+   従う。hooks/lib の M より優先する非対称)。`.spec` も含むのは
+   `web/vite.config.ts` が `test.include` を上書きせず vitest 既定で
+   `.spec` も収集するため
 4. `prefixRules` の longest-prefix wins
 5. どれにも一致しない → unclassified → **fail-closed で high**(S9)
 
@@ -61,9 +63,9 @@ doc 上 `view.go` / `compact.go` / `styles.go` の A 行は「ほか」付きの
 
 | ID | 名前 | 条件 |
 |---|---|---|
-| S1 | test-deleted | `*_test.go` / `*.bats` / `web/src/**/*.test.*` の削除(D)。rename でテスト形状が失われる場合も含む |
+| S1 | test-deleted | `*_test.go` / `*.bats` / `web/src/**/*.test.ts(x)` / `web/src/**/*.spec.ts(x)` / `web/src/test/**` の削除(D)。rename でテスト形状が失われる場合(`.test.ts` → `.test.disabled.ts` など vitest が収集しない接尾辞への改名)も含む |
 | S2 | measure-deleted | `tests/{golden,fixtures,bin}/**` の削除(D)。rename で測定対象外へ移す場合も含む |
-| S3 | skip-added | 追加行に `\bt\.(Skip\|Skipf\|SkipNow)\(`、vitest の skip 形(`.skip(` / `.skipIf(` / `.skip.` 連鎖 / `skip: true` / `xit(` / `xdescribe(` / `xtest(`。対象は `*.test.ts(x)` と `web/src/test/**`)、bats(`tests/bats/**` の `.bats` と `.bash`)のコマンド位置の `skip`(行頭と `&&` / `\|\|` / `;` / `then` 等の後。`[[ $CI == true ]] && skip` も拾う) |
+| S3 | skip-added | 追加行に `\b\w+\.(Skip\|Skipf\|SkipNow)\(`(receiver 名は固定せず `t` 以外の `*testing.T`/`*testing.B`、例 `tb.Skip(` / `b.Skip(` も拾う。`t.Skipped()` は Skip 直後の `(` 要求で非マッチ)、vitest の skip 形(`.skip(` / `.skipIf(` / `.skip.` 連鎖 / `skip: true` / `xit(` / `xdescribe(` / `xtest(`。対象は `*.test.ts(x)` / `*.spec.ts(x)` と `web/src/test/**`)、bats(`tests/bats/**` の `.bats` と `.bash`)のコマンド位置の `skip`(行頭と `&&` / `\|\|` / `;` / `then` 等の後。`[[ $CI == true ]] && skip` も拾う) |
 | S4 | guard-modified | `internal/arch/` の変更 |
 | S5 | review-gate-modified | `.claude/` と post-work-review gate(`codex/tools/post-work-review*` / `codex/agents/post-work-*` / `codex/skills/post-work-review/` / `claude/skills/post-work-review/`)の変更 |
 | S6 | risk-tool-modified | `tools/reviewrisk/` または `review-risk.yml` の変更 |

--- a/docs/review-risk.ja.md
+++ b/docs/review-risk.ja.md
@@ -63,9 +63,9 @@ doc 上 `view.go` / `compact.go` / `styles.go` の A 行は「ほか」付きの
 |---|---|---|
 | S1 | test-deleted | `*_test.go` / `*.bats` / `web/src/**/*.test.*` の削除(D)。rename でテスト形状が失われる場合も含む |
 | S2 | measure-deleted | `tests/{golden,fixtures,bin}/**` の削除(D)。rename で測定対象外へ移す場合も含む |
-| S3 | skip-added | 追加行に `\bt\.(Skip\|Skipf\|SkipNow)\(`、`.skip(` / `xit(` / `xdescribe(`、bats(`tests/bats/**` の `.bats` と `.bash`)の `^\s*skip\b` |
+| S3 | skip-added | 追加行に `\bt\.(Skip\|Skipf\|SkipNow)\(`、vitest の skip 形(`.skip(` / `.skipIf(` / `.skip.` 連鎖 / `skip: true` / `xit(` / `xdescribe(` / `xtest(`。対象は `*.test.ts(x)` と `web/src/test/**`)、bats(`tests/bats/**` の `.bats` と `.bash`)の `^\s*skip\b` |
 | S4 | guard-modified | `internal/arch/` の変更 |
-| S5 | review-gate-modified | `.claude/` の変更 |
+| S5 | review-gate-modified | `.claude/` と post-work-review gate(`codex/tools/post-work-review*` / `codex/skills/post-work-review/` / `claude/skills/post-work-review/`)の変更 |
 | S6 | risk-tool-modified | `tools/reviewrisk/` または `review-risk.yml` の変更 |
 | S7 | installer-modified | `install.sh` の変更 |
 | S8 | ci-workflow-deleted | `.github/workflows/` 配下の削除(D)。rename で配下外へ移す場合も含む |
@@ -76,11 +76,11 @@ doc 上 `view.go` / `compact.go` / `styles.go` の A 行は「ほか」付きの
 実装そのもの。`S10 invariant-hit` は `docs/architecture.ja.md` の人間必見の
 不変条件に出てくる文字列の追加・削除行を grep する: `requireToken` /
 `127.0.0.1` / `__tui-new-pane-popup` / `__tui-help-popup` / `__codex-plan-tui` /
-`main.version`。`FANOUT_[A-Z_]{2,}` は、その名前が削除行に現れ、かつ追加行の
-どこにも同名が現れない場合だけ発火する(全ファイル横断の集合差 removed−added)。
-行移動や再インデントで同名が追加行にも戻るケースを誤検知しないための判定で、
-env 変数参照の追加は日常的だが既存参照の削除はシェル/CI/doc 側の呼び出し元を
-壊しうる。`.md` ファイルは S10 の対象外。散文が不変条件の文字列を引用しても(この文書や
+`main.version`。`FANOUT_[A-Z_]{2,}` は、その名前が削除行に現れ、かつ**同じ
+ファイルの**追加行に同名が現れない場合だけ発火する(ファイル単位の集合差)。
+同一ファイル内の行移動・再インデントは誤検知しないが、別ファイルにコメントや
+フィクスチャとして同名を足しても実参照の削除は隠せない。env 変数参照の追加は
+日常的だが既存参照の削除はシェル/CI/doc 側の呼び出し元を壊しうる。`.md` ファイルは S10 の対象外。散文が不変条件の文字列を引用しても(この文書や
 architecture.ja.md の不変条件カタログ自体、インストール手順の
 `FANOUT_VERSION=` 例)、それは不変条件へのコード変更ではない。
 
@@ -134,11 +134,11 @@ go run ./tools/reviewrisk [--base <ref>] [--format text|markdown|json] [--fail-a
 書き込み token を `.git/config` に残さない(gh を呼ぶステップだけが env 経由で
 token を受け取る)。
 
-1. PR が `tools/reviewrisk/` か `review-risk.yml` 自身を変更している場合、
-   PR 側ツールの判定は信用せず(S6 の安全弁を PR 側が緩められるため)、
-   workflow が fail-closed で critical に固定する。それ以外は
-   `--format json` と `--format markdown` を実行し、`jq -r .level` で level を
-   取り出す。
+1. PR が `tools/reviewrisk/` か `review-risk.yml` 自身を変更している場合
+   (rename で外へ移す場合も pathspec 判定で含む)、PR 側ツールの判定は信用せず
+   (S6 の安全弁を PR 側が緩められるため)、workflow が fail-closed で critical
+   に固定する。それ以外は `--format json` と `--format markdown` を実行し、
+   `jq -r .level` で level を取り出す。
 2. `review:none` / `review:low` / `review:medium` / `review:high` /
    `review:critical` の 5 ラベルを冪等に作成し(既存なら作成コマンドが失敗する
    ので無視する)、PR に付いている `review:*` ラベルのうち現在の level 以外を

--- a/docs/review-risk.ja.md
+++ b/docs/review-risk.ja.md
@@ -63,7 +63,7 @@ doc 上 `view.go` / `compact.go` / `styles.go` の A 行は「ほか」付きの
 
 | ID | 名前 | 条件 |
 |---|---|---|
-| S1 | test-deleted | `*_test.go` / `*.bats` / `web/src/**/*.test.ts(x)` / `web/src/**/*.spec.ts(x)` / `web/src/test/**` の削除(D)。rename でテスト形状が失われる場合(`.test.ts` → `.test.disabled.ts` など vitest が収集しない接尾辞への改名)も含む |
+| S1 | test-deleted | `*_test.go` / `tests/bats/**` の `.bats`・`.bash`(`helpers.bash` などソースされる bats ヘルパ)/ `web/src/**/*.test.ts(x)` / `web/src/**/*.spec.ts(x)` / `web/src/test/**` の削除(D)。rename でテスト形状が失われる場合(`.test.ts` → `.test.disabled.ts` など vitest が収集しない接尾辞への改名)も含む |
 | S2 | measure-deleted | `tests/{golden,fixtures,bin}/**` の削除(D)。rename で測定対象外へ移す場合も含む |
 | S3 | skip-added | 追加行に `\b\w+\.(Skip\|Skipf\|SkipNow)\(`(receiver 名は固定せず `t` 以外の `*testing.T`/`*testing.B`、例 `tb.Skip(` / `b.Skip(` も拾う。`t.Skipped()` は Skip 直後の `(` 要求で非マッチ)、vitest の skip 形(`.skip(` / `.skipIf(` / `.skip.` 連鎖 / `skip: true` / `xit(` / `xdescribe(` / `xtest(`。対象は `*.test.ts(x)` / `*.spec.ts(x)` と `web/src/test/**`)、bats(`tests/bats/**` の `.bats` と `.bash`)のコマンド位置の `skip`(行頭と `&&` / `\|\|` / `;` / `then` 等の後。`[[ $CI == true ]] && skip` も拾う) |
 | S4 | guard-modified | `internal/arch/` の変更 |
@@ -139,8 +139,11 @@ token を受け取る)。
 1. PR が `tools/reviewrisk/` か `review-risk.yml` 自身を変更している場合
    (rename で外へ移す場合も pathspec 判定で含む)、PR 側ツールの判定は信用せず
    (S6 の安全弁を PR 側が緩められるため)、workflow が fail-closed で critical
-   に固定する。それ以外は `--format json` と `--format markdown` を実行し、
-   `jq -r .level` で level を取り出す。
+   に固定する。この self-modification guard は Set up Go より前の shell 専用
+   ステップで、PR 側の `go.mod` に依存しない — ツール改変と同時に `go.mod` を
+   壊す PR でも setup-go で落ちず critical ラベル/コメントに到達する。それ以外は
+   `--format json` と `--format markdown` を実行し、`jq -r .level` で level を
+   取り出す。
 2. `review:none` / `review:low` / `review:medium` / `review:high` /
    `review:critical` の 5 ラベルを冪等に作成し(既存なら作成コマンドが失敗する
    ので無視する)、PR に付いている `review:*` ラベルのうち現在の level 以外を

--- a/docs/review-risk.ja.md
+++ b/docs/review-risk.ja.md
@@ -1,0 +1,183 @@
+# PR review risk 判定(tools/reviewrisk)
+
+`tools/reviewrisk` は PR の変更パスから `docs/architecture.ja.md` の H/M/A
+レビュークラスを引き、5 段階の risk level を機械的に判定する repo 専用ツール。
+CI(`review-risk.yml`)が判定結果を `review:<level>` ラベルと sticky コメントで
+PR に反映する。判定は advisory — マージはブロックしない。
+
+## レベル定義
+
+| Level | 条件 | ガイダンス |
+|---|---|---|
+| none | 変更ファイルが全て NONE クラス | レビュー不要(docs のみ)。CI green でマージ可 |
+| low | 最大クラスが A | AI レビュー(`/code-review`)で可 |
+| medium | 最大クラスが M | `/code-review` + M ファイルを人間が斜め読み |
+| high | 最大クラスが H、または S9/S10 発火 | 人間レビュー必須。AI は補助 |
+| critical | S1-S8 のいずれか発火 | 人間精読必須(検証系・ガード系への接触) |
+
+## 判定の仕組み
+
+判定の芯は `classifyPath` 一つ。ファイルパスを 1 本ずつ次の優先順で評価する。
+
+1. `fileRules` の完全一致(`docs/architecture.ja.md` のファイル粒度の行、
+   go.mod や Makefile など doc に行を持たない extra ファイルの両方を含む)
+2. Go テストペアリング: `foo_test.go` は `foo.go` の file rule を継承する。
+   ただしパッケージの prefix rule がその file rule より重ければそちらを採る
+   — テストをパッケージのクラスより軽く落とすことはしない
+3. web テスト上書き: `web/src/` 配下の `*.test.ts(x)` と `web/src/test/**` は
+   常に A(`docs/architecture.ja.md` の「tests は A」の行に従う。hooks/lib の
+   M より優先する非対称)
+4. `prefixRules` の longest-prefix wins
+5. どれにも一致しない → unclassified → **fail-closed で high**(S9)
+
+rename(R)は新旧パスの両方を classifyPath に通し、重い方のクラスで判定する。
+H パッケージから M/A へ `git mv` しても軽く扱わない。
+
+`fileRules` と `prefixRules` は `Source` フィールドで由来を持つ。
+`SourceDocTable` は `docs/architecture.ja.md` のパッケージ表に対応する行、
+`SourceExtra` は doc に行のない補完ルール(go.mod / tests/ / .github/ など)。
+doc パッケージ表が正典で、`SourceExtra` は正典が触れていないパスを埋める側 —
+どちらのソースも classifyPath の評価順では区別しない。
+
+### 意図的な非対称
+
+`cmd/fanout/` と `internal/ui/tui/` には catch-all prefix rule がある
+(それぞれ M)。`internal/ui/dashboard/` 直下と `web/` 直下には置いていない —
+doc がそれぞれのファイルを全列挙しているため、新規ファイルは unclassified に
+落ちて high になる。doc とルール表の同時更新を強制するための設計で、埋め忘れ
+ではない。
+
+doc 上 `view.go` / `compact.go` / `styles.go` の A 行は「ほか」付きの開放集合
+として書かれているが、ルール表はこの 3 ファイルに閉じている。未列挙の描画
+ファイルは A と推測せず M の catch-all に落とす。新しい描画ファイルを足す
+たびに rules.go の更新を要求する安全側の判断。
+
+## エスカレーションシグナル
+
+パス分類だけでなく、diff の中身も grep して判定を上に振る。全シグナルは
+`--format markdown` / `--format json` の理由リストに出る。
+
+### critical に直結(S1-S8)
+
+| ID | 名前 | 条件 |
+|---|---|---|
+| S1 | test-deleted | `*_test.go` / `*.bats` / `web/src/**/*.test.*` の削除(D)。rename でテスト形状が失われる場合も含む |
+| S2 | measure-deleted | `tests/{golden,fixtures,bin}/**` の削除(D)。rename で測定対象外へ移す場合も含む |
+| S3 | skip-added | 追加行に `\bt\.(Skip\|Skipf\|SkipNow)\(`、`.skip(` / `xit(` / `xdescribe(`、bats(`tests/bats/**` の `.bats` と `.bash`)の `^\s*skip\b` |
+| S4 | guard-modified | `internal/arch/` の変更 |
+| S5 | review-gate-modified | `.claude/` の変更 |
+| S6 | risk-tool-modified | `tools/reviewrisk/` または `review-risk.yml` の変更 |
+| S7 | installer-modified | `install.sh` の変更 |
+| S8 | ci-workflow-deleted | `.github/workflows/` 配下の削除(D)。rename で配下外へ移す場合も含む |
+
+### high に押し上げ(S9-S10)
+
+`S9 unclassified-path` は classifyPath が一致しなかったパス。fail-closed の
+実装そのもの。`S10 invariant-hit` は `docs/architecture.ja.md` の人間必見の
+不変条件に出てくる文字列の追加・削除行を grep する: `requireToken` /
+`127.0.0.1` / `__tui-new-pane-popup` / `__tui-help-popup` / `__codex-plan-tui` /
+`main.version`。`FANOUT_[A-Z_]{2,}` は、その名前が削除行に現れ、かつ追加行の
+どこにも同名が現れない場合だけ発火する(全ファイル横断の集合差 removed−added)。
+行移動や再インデントで同名が追加行にも戻るケースを誤検知しないための判定で、
+env 変数参照の追加は日常的だが既存参照の削除はシェル/CI/doc 側の呼び出し元を
+壊しうる。`.md` ファイルは S10 の対象外。散文が不変条件の文字列を引用しても(この文書や
+architecture.ja.md の不変条件カタログ自体、インストール手順の
+`FANOUT_VERSION=` 例)、それは不変条件へのコード変更ではない。
+
+### 1 段バンプ(S11)
+
+`S11 large-diff` は NONE 以外のファイルの追加+削除行数の合計が 800 行超、
+またはファイル数が 30 超。low か medium のときだけ +1 する(high/critical を
+更に押し上げはしない)。閾値はどちらも名前付き定数。
+
+### 集約順序
+
+```
+base   = max(levelForClass(f) for f in files)
+level  = max(base, high) if S9 or S10 fired else base
+level  = level + 1       if S11 fired and level in {low, medium}
+level  = critical        if any of S1..S8 fired
+```
+
+Files は path 昇順、Reasons は (Level 降順, Signal, File) 順でソートする —
+同じ diff は常に同じ出力になる。
+
+## ローカル実行
+
+```
+go run ./tools/reviewrisk [--base <ref>] [--format text|markdown|json] [--fail-at <level>]
+```
+
+- `--base` の既定値は `origin/main`(無ければ `main`)。比較起点は
+  `git merge-base <ref> HEAD`。そこから**作業ツリー**までの差分を見るので、
+  未コミットの変更も判定に入る(未追跡ファイルは git diff に出ないため対象外)。
+  CI は clean checkout なので `merge-base..HEAD` と同じ結果になる。
+- git は全て read-only。base 解決の `rev-parse --verify` と `merge-base`、
+  それに diff 3 本 — `diff --name-status -M`(ファイル一覧と rename 検出)、
+  `diff --numstat -M`(行数。rename は併合パスを新パスへ正規化して計上)、
+  `diff -U0`(grep 対象の追加/削除行)。いずれも `core.quotepath=off` で
+  非 ASCII パスをそのまま出す。
+- 終了コードは既定で常に 0(advisory)。`--fail-at <level>` を指定したときだけ、
+  判定結果がその level 以上なら 1 を返す。git 実行失敗や flag 不正などの
+  運用エラーは 2。
+- `--format markdown` は sticky コメントの本文そのもの: 先頭に
+  `<!-- review-risk -->` マーカー、理由リスト、ファイル別クラス表を
+  `<details>` に畳んだもの。
+
+`make review-risk` はこの CLI を素の設定で実行する薄いラッパ。
+
+## CI 挙動
+
+`review-risk.yml` は `pull_request` イベントで走り、fork からの PR には
+走らない(`head.repo.full_name == github.repository` ガード)。checkout は
+`persist-credentials: false` — judge ステップは PR 側の Go コードを実行するため、
+書き込み token を `.git/config` に残さない(gh を呼ぶステップだけが env 経由で
+token を受け取る)。
+
+1. PR が `tools/reviewrisk/` か `review-risk.yml` 自身を変更している場合、
+   PR 側ツールの判定は信用せず(S6 の安全弁を PR 側が緩められるため)、
+   workflow が fail-closed で critical に固定する。それ以外は
+   `--format json` と `--format markdown` を実行し、`jq -r .level` で level を
+   取り出す。
+2. `review:none` / `review:low` / `review:medium` / `review:high` /
+   `review:critical` の 5 ラベルを冪等に作成し(既存なら作成コマンドが失敗する
+   ので無視する)、PR に付いている `review:*` ラベルのうち現在の level 以外を
+   外し、現在の level を付ける。
+3. PR コメントを `<!-- review-risk -->` マーカーで検索し、あれば内容を
+   置き換え、なければ新規投稿する(sticky コメント)。
+
+判定はブランチ保護ルールに足さない。CI green と level ラベルは別軸で、
+critical でも CI が通ればマージ自体は可能 — 人間が読むかどうかの判断材料を
+渡すだけの advisory 運用。
+
+## LLM の位置づけ
+
+ツールは LLM を一切呼ばない。`docs/pr-review-visualization-v2.ja.md` の
+「CLI は LLM を呼ばない」という横断原則をそのまま踏襲する。medium 以上の
+ガイダンス文が `/code-review` を指すのも次アクションの指針であって、ツール
+自身が判断や要約を LLM に投げているわけではない。
+
+## `docs/pr-review-visualization-v2.ja.md` 案 1 との関係
+
+案 1(親 #175、子 #176-179)は fanout CLI 汎用の risk lane 構想で、任意の repo
+に riskPaths glob や CI 結果を設定して使う想定だった。`tools/reviewrisk` は
+それとは別物 — この repo の H/M/A 正典をそのままルール化した repo-local な
+先行実装で、fanout 本体には同梱しない。案 1 の一般化が要るときは、この実装の
+ルール表・シグナル設計をリファレンスにできる。
+
+## v2 候補(未実装)
+
+- `go/ast` で H パッケージの exported シグネチャ変更を検出し、変更なしなら
+  シグナルを弱める。
+- コメントのみの変更(diff 全行が `//` / docstring)を客観的に判定し、
+  de-escalation の材料にする。
+
+どちらも「機械的シグナルの追加」であって LLM 判断は導入しない。実装は
+この文書に記録するだけで、v1 のスコープには含めない。
+
+## rules.go を変更するとき
+
+クラスを追加・変更したら `tools/reviewrisk/rules.go` のルール表を必ず
+同時更新する。`docsync_test.go` が `docs/architecture.ja.md` のパッケージ表と
+`rules.go` の食い違いを CI で落とす — 手順は
+`docs/architecture.ja.md` の「新規パッケージの追加手順」を参照。

--- a/internal/arch/arch_test.go
+++ b/internal/arch/arch_test.go
@@ -25,7 +25,8 @@ const (
 	layerInfra layer = "infra"
 	layerUI    layer = "ui"
 	layerCmd   layer = "cmd"
-	layerMeta  layer = "meta" // internal/arch itself: test-only, imports no module packages
+	layerTools layer = "tools" // repo meta-tooling under tools/: stdlib-only, imports no module packages
+	layerMeta  layer = "meta"  // internal/arch itself: test-only, imports no module packages
 )
 
 // explicitLayers classifies the packages that live outside the four layer
@@ -47,6 +48,7 @@ var prefixLayers = []struct {
 	{"internal/infra/", layerInfra},
 	{"internal/ui/", layerUI},
 	{"cmd/", layerCmd},
+	{"tools/", layerTools},
 }
 
 // allowedImports is the layer dependency direction: a key layer may import
@@ -60,6 +62,9 @@ var allowedImports = map[layer]map[layer]bool{
 	layerInfra: {layerCore: true, layerInfra: true},
 	layerUI:    {layerCore: true, layerApp: true, layerInfra: true, layerUI: true},
 	layerCmd:   {layerCore: true, layerApp: true, layerInfra: true, layerUI: true},
+	// tools may import only tools; TestToolsStdlibOnly further bans even that,
+	// pinning the tree to the standard library alone.
+	layerTools: {layerTools: true},
 }
 
 // legacyDirectionAllowlist grandfathers layer violations that existed before
@@ -168,8 +173,8 @@ var (
 	scanErr  error
 )
 
-// repoFiles parses every *.go file under internal/ and cmd/ (imports only),
-// once per test binary, and resolves the module path from go.mod.
+// repoFiles parses every *.go file under internal/, cmd/, and tools/ (imports
+// only), once per test binary, and resolves the module path from go.mod.
 func repoFiles(t *testing.T) []goFile {
 	t.Helper()
 	scanOnce.Do(func() { scanned, scanErr = scanRepo() })
@@ -223,8 +228,15 @@ func scanRepo() (repoScan, error) {
 	}
 	fset := token.NewFileSet()
 	scan := repoScan{root: root, modulePath: modPath}
-	for _, top := range []string{"internal", "cmd"} {
-		err := filepath.WalkDir(filepath.Join(root, top), func(p string, d fs.DirEntry, err error) error {
+	for _, top := range []string{"internal", "cmd", "tools"} {
+		topPath := filepath.Join(root, top)
+		// A checkout without one of these trees (e.g. tools/ deleted) still
+		// exercises the others; TestScanSanity turns the resulting gap into a
+		// clear counts[...] == 0 failure instead of a fatal walk error here.
+		if _, statErr := os.Stat(topPath); errors.Is(statErr, fs.ErrNotExist) {
+			continue
+		}
+		err := filepath.WalkDir(topPath, func(p string, d fs.DirEntry, err error) error {
 			if err != nil {
 				return err
 			}
@@ -272,9 +284,9 @@ func scanRepo() (repoScan, error) {
 	return scan, nil
 }
 
-// TestAllPackagesClassified guarantees every package under internal/ and cmd/,
-// and every module-internal import target, resolves to a layer, so a new
-// package cannot ship unclassified.
+// TestAllPackagesClassified guarantees every package under internal/, cmd/, and
+// tools/, and every module-internal import target, resolves to a layer, so a
+// new package cannot ship unclassified.
 func TestAllPackagesClassified(t *testing.T) {
 	seen := make(map[string]bool)
 	var unclassified []string
@@ -415,13 +427,40 @@ func TestCorePurity(t *testing.T) {
 	}
 }
 
-// TestPackageMainOnlyInCmd pins package main declarations to cmd/fanout and
-// forbids every package from importing cmd/... .
+// TestToolsStdlibOnly pins the tools/ tree to standard-library imports only:
+// no module-internal packages (stronger than the layer direction, which would
+// permit tools -> tools) and no third-party modules. This keeps repo meta-tools
+// physically separate from product code at the directory level, so a PR that
+// touches tools/ can never reach into internal/ or cmd/.
+func TestToolsStdlibOnly(t *testing.T) {
+	for _, f := range repoFiles(t) {
+		if l, ok := classify(f.pkgDir); !ok || l != layerTools {
+			continue
+		}
+		for _, imp := range f.imports {
+			if rel, ok := moduleRel(imp.path); ok {
+				t.Errorf("%s:%d: %s may not import %s (tools/ is stdlib-only, no module-internal imports)", f.relPath, imp.line, f.pkgDir, rel)
+				continue
+			}
+			if !stdlibImport(imp.path) {
+				t.Errorf("%s:%d: %s may not import %q (tools/ is stdlib-only, no third-party modules)", f.relPath, imp.line, f.pkgDir, imp.path)
+			}
+		}
+	}
+}
+
+// TestPackageMainOnlyInCmd pins package main declarations to cmd/fanout (the
+// one product composition root) and tools/ subdirectories (repo meta-tools,
+// each its own main, kept stdlib-only by TestToolsStdlibOnly), and forbids
+// every package from importing cmd/... . A bare tools/ file is not allowed:
+// classify() leaves tools/-direct files unclassified, so every tool must live
+// in its own subdirectory.
 func TestPackageMainOnlyInCmd(t *testing.T) {
 	for _, f := range repoFiles(t) {
 		underCmdFanout := f.pkgDir == "cmd/fanout" || strings.HasPrefix(f.pkgDir, "cmd/fanout/")
-		if f.pkgName == "main" && !underCmdFanout {
-			t.Errorf("%s:%d: package main is only allowed under cmd/fanout", f.relPath, f.pkgLine)
+		underTools := strings.HasPrefix(f.pkgDir, "tools/")
+		if f.pkgName == "main" && !underCmdFanout && !underTools {
+			t.Errorf("%s:%d: package main is only allowed under cmd/fanout or tools/", f.relPath, f.pkgLine)
 		}
 		for _, imp := range f.imports {
 			if imp.path != scanned.modulePath+"/cmd" && !strings.HasPrefix(imp.path, scanned.modulePath+"/cmd/") {
@@ -443,8 +482,8 @@ func TestScanSanity(t *testing.T) {
 		top, _, _ := strings.Cut(f.pkgDir, "/")
 		counts[top]++
 	}
-	if counts["internal"] == 0 || counts["cmd"] == 0 {
-		t.Errorf("scanRepo() saw internal=%d cmd=%d files, want both > 0", counts["internal"], counts["cmd"])
+	if counts["internal"] == 0 || counts["cmd"] == 0 || counts["tools"] == 0 {
+		t.Errorf("scanRepo() saw internal=%d cmd=%d tools=%d files, want all > 0", counts["internal"], counts["cmd"], counts["tools"])
 	}
 	if scanned.modulePath == "" || strings.ContainsAny(scanned.modulePath, " \t\"") {
 		t.Errorf("readModulePath() = %q, want a plausible module path", scanned.modulePath)

--- a/tools/reviewrisk/class.go
+++ b/tools/reviewrisk/class.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Class is the PR review weight of a file, mirroring the H/M/A/NONE classes in
+// docs/architecture.ja.md. ClassUnknown is the zero value and marks a path no
+// rule matched, so a stray Rule{} fails closed to the highest review weight.
+type Class int
+
+const (
+	ClassUnknown Class = iota
+	ClassNone
+	ClassA
+	ClassM
+	ClassH
+)
+
+// String renders the class for JSON and the report's class column.
+func (c Class) String() string {
+	switch c {
+	case ClassNone:
+		return "NONE"
+	case ClassA:
+		return "A"
+	case ClassM:
+		return "M"
+	case ClassH:
+		return "H"
+	default:
+		return "?"
+	}
+}
+
+// MarshalJSON emits the class as its short label ("H"/"M"/"A"/"NONE"/"?").
+func (c Class) MarshalJSON() ([]byte, error) {
+	return json.Marshal(c.String())
+}
+
+// Level is the risk level reported for the whole diff. The ordering
+// none<low<medium<high<critical drives aggregation (the max wins).
+type Level int
+
+const (
+	LevelNone Level = iota
+	LevelLow
+	LevelMedium
+	LevelHigh
+	LevelCritical
+)
+
+// String renders the level for JSON, the review:<level> label, and text output.
+func (l Level) String() string {
+	switch l {
+	case LevelNone:
+		return "none"
+	case LevelLow:
+		return "low"
+	case LevelMedium:
+		return "medium"
+	case LevelHigh:
+		return "high"
+	case LevelCritical:
+		return "critical"
+	default:
+		return "unknown"
+	}
+}
+
+// MarshalJSON emits the level as its lowercase name.
+func (l Level) MarshalJSON() ([]byte, error) {
+	return json.Marshal(l.String())
+}
+
+// levelForClass maps a file's review class to its base risk level. ClassUnknown
+// fails closed to high: an unmatched path is never quietly treated as low risk.
+func levelForClass(c Class) Level {
+	switch c {
+	case ClassNone:
+		return LevelNone
+	case ClassA:
+		return LevelLow
+	case ClassM:
+		return LevelMedium
+	case ClassH:
+		return LevelHigh
+	default: // ClassUnknown
+		return LevelHigh
+	}
+}
+
+// parseLevel resolves the --fail-at argument to a Level.
+func parseLevel(s string) (Level, error) {
+	switch s {
+	case "none":
+		return LevelNone, nil
+	case "low":
+		return LevelLow, nil
+	case "medium":
+		return LevelMedium, nil
+	case "high":
+		return LevelHigh, nil
+	case "critical":
+		return LevelCritical, nil
+	default:
+		return LevelNone, fmt.Errorf("unknown level %q (want none|low|medium|high|critical)", s)
+	}
+}
+
+// levelGuidance is the next-action sentence printed per level. The tool never
+// calls an LLM; medium and above only point the reader at /code-review.
+var levelGuidance = map[Level]string{
+	LevelNone:     "レビュー不要(docs のみ)。CI green でマージ可",
+	LevelLow:      "AI レビュー(/code-review)で可",
+	LevelMedium:   "/code-review + M ファイルを人間が斜め読み",
+	LevelHigh:     "人間レビュー必須。AI は補助",
+	LevelCritical: "人間精読必須(検証系・ガード系への接触)",
+}

--- a/tools/reviewrisk/diff.go
+++ b/tools/reviewrisk/diff.go
@@ -1,0 +1,226 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// resolveBase resolves the diff base to a concrete commit. An empty explicit ref
+// falls back to origin/main then main (whichever git rev-parse --verify finds
+// first); a non-empty ref is verified as-is. The returned value is the
+// merge-base of that ref and HEAD, so the diff reflects only what this branch
+// added, not commits the base gained since it forked.
+func resolveBase(explicit string) (string, error) {
+	ref := explicit
+	if ref == "" {
+		for _, cand := range []string{"origin/main", "main"} {
+			if _, err := runGit("rev-parse", "--verify", "--quiet", cand); err == nil {
+				ref = cand
+				break
+			}
+		}
+		if ref == "" {
+			return "", errors.New("no base ref found (tried origin/main, main); pass --base")
+		}
+	} else if _, err := runGit("rev-parse", "--verify", "--quiet", ref); err != nil {
+		return "", fmt.Errorf("base ref %q not found: %w", ref, err)
+	}
+	mb, err := runGit("merge-base", ref, "HEAD")
+	if err != nil {
+		return "", fmt.Errorf("merge-base %s HEAD: %w", ref, err)
+	}
+	return strings.TrimSpace(mb), nil
+}
+
+// loadDiff runs the three read-only git diffs (--name-status -M, --numstat -M,
+// and -U0) between base and the working tree and assembles them into a Diff: the
+// file list with rename detection, per-file added/deleted counts, and the +/-
+// content lines the escalation greps scan. Dropping HEAD makes the base the only
+// argument, so the diff spans base..working tree and sees uncommitted edits
+// (untracked files stay invisible to git diff). core.quotepath=off keeps
+// non-ASCII paths literal so classifyPath matches them.
+func loadDiff(base string) (Diff, error) {
+	nameStatus, err := runGit("-c", "core.quotepath=off", "diff", "--name-status", "-M", base)
+	if err != nil {
+		return Diff{}, err
+	}
+	numstat, err := runGit("-c", "core.quotepath=off", "diff", "--numstat", "-M", base)
+	if err != nil {
+		return Diff{}, err
+	}
+	// -M here too: without rename detection a pure rename dumps the whole file
+	// as removed+added lines, and pre-existing t.Skip / invariant references
+	// would misfire S3/S10 on a PR that only moved the file.
+	unified, err := runGit("-c", "core.quotepath=off", "diff", "-U0", "-M", base)
+	if err != nil {
+		return Diff{}, err
+	}
+
+	files := parseNameStatus(nameStatus)
+	counts := parseNumstat(numstat)
+	for i := range files {
+		if e, ok := counts[files[i].Path]; ok {
+			files[i].Added, files[i].Deleted = e.added, e.deleted
+		} else if e, ok := counts[files[i].OldPath]; ok {
+			files[i].Added, files[i].Deleted = e.added, e.deleted
+		}
+	}
+	added, removed := parseUnified(unified)
+	return Diff{Files: files, AddedLines: added, RemovedLines: removed}, nil
+}
+
+// runGit runs git with args and returns stdout, wrapping a non-zero exit with
+// the trimmed stderr. Every caller is read-only.
+func runGit(args ...string) (string, error) {
+	cmd := exec.Command("git", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(stderr.String()))
+	}
+	return stdout.String(), nil
+}
+
+// parseNameStatus parses `git diff --name-status -M` output. Each line is a
+// tab-separated status letter followed by one path (A/M/D) or, for renames and
+// copies (R<score>/C<score>), the old and new paths.
+func parseNameStatus(out string) []FileChange {
+	var files []FileChange
+	for line := range strings.SplitSeq(out, "\n") {
+		line = strings.TrimRight(line, "\r")
+		if line == "" {
+			continue
+		}
+		fields := strings.Split(line, "\t")
+		if len(fields) < 2 || fields[0] == "" {
+			continue
+		}
+		fc := FileChange{Status: fields[0][0]}
+		switch fc.Status {
+		case 'R', 'C':
+			if len(fields) < 3 {
+				continue
+			}
+			fc.OldPath, fc.Path = fields[1], fields[2]
+		default:
+			fc.Path = fields[1]
+		}
+		files = append(files, fc)
+	}
+	return files
+}
+
+// numstatEntry is one parsed `git diff --numstat` row. A binary file reports "-"
+// for both columns and is recorded as -1/-1.
+type numstatEntry struct {
+	added   int
+	deleted int
+}
+
+// parseNumstat parses `git diff --numstat -M` output into a per-path count map.
+// Columns are added, deleted, path; a binary file's "-" columns become -1. The
+// path column is normalized through numstatPath so a rename's merged form keys
+// on the new path, matching the name-status entry.
+func parseNumstat(out string) map[string]numstatEntry {
+	counts := make(map[string]numstatEntry)
+	for line := range strings.SplitSeq(out, "\n") {
+		line = strings.TrimRight(line, "\r")
+		if line == "" {
+			continue
+		}
+		fields := strings.Split(line, "\t")
+		if len(fields) < 3 {
+			continue
+		}
+		var e numstatEntry
+		if fields[0] == "-" || fields[1] == "-" {
+			e.added, e.deleted = -1, -1
+		} else {
+			e.added, _ = strconv.Atoi(fields[0])
+			e.deleted, _ = strconv.Atoi(fields[1])
+		}
+		counts[numstatPath(fields[2])] = e
+	}
+	return counts
+}
+
+// numstatPath collapses the merged rename forms `git diff --numstat -M` emits so
+// the result is the new path, matching the name-status new path. A brace group
+// `dir/{old => new}/rest` becomes `dir/new/rest` (an empty old, `{ => new}`,
+// yields just the new side); a brace-less whole-path `old => new` takes the new
+// side. A field with no ` => ` passes through unchanged.
+func numstatPath(field string) string {
+	if open := strings.IndexByte(field, '{'); open >= 0 {
+		if shut := strings.IndexByte(field[open:], '}'); shut >= 0 {
+			shut += open
+			if _, newPart, ok := strings.Cut(field[open+1:shut], " => "); ok {
+				return field[:open] + newPart + field[shut+1:]
+			}
+		}
+	}
+	if _, newPath, ok := strings.Cut(field, " => "); ok {
+		return newPath
+	}
+	return field
+}
+
+// parseUnified extracts the +/- content lines per file from `git diff -U0`
+// output as a small state machine. Each `diff --git ` line opens a header and
+// resets the current file; while in the header the `--- a/<path>` line records
+// the old path and the `+++ b/<path>` line sets the current file; the first
+// `@@` hunk line closes the header. Added lines key to the new path and
+// removed lines to the old path — a deletion or a rename onto a different
+// path (including code renamed to .md) keeps its dropped content attributed
+// to the code-side path, so S10 still sees invariant references it removed.
+// Only outside the header does a leading +/- mark a content line, so an added
+// line that reads `++ x` (raw `+++ x`) or a removed line `-- x` (raw `--- x`)
+// is counted as content, not mistaken for a header. A real content line always
+// carries a +/- marker, so it can never look like a `diff --git ` line.
+func parseUnified(out string) (added, removed map[string][]string) {
+	added = make(map[string][]string)
+	removed = make(map[string][]string)
+	var cur, oldPath string
+	inHeader := false
+	for line := range strings.SplitSeq(out, "\n") {
+		switch {
+		case strings.HasPrefix(line, "diff --git "):
+			inHeader = true
+			cur, oldPath = "", ""
+		case inHeader && strings.HasPrefix(line, "--- "):
+			if p := stripDiffPathPrefix(strings.TrimRight(line[4:], "\r")); p != "/dev/null" {
+				oldPath = p
+			}
+		case inHeader && strings.HasPrefix(line, "+++ "):
+			if p := stripDiffPathPrefix(strings.TrimRight(line[4:], "\r")); p != "/dev/null" {
+				cur = p
+			} else {
+				cur = "" // deletion: nothing was added under the new path
+			}
+		case strings.HasPrefix(line, "@@"):
+			inHeader = false
+		case !inHeader && strings.HasPrefix(line, "+"):
+			if cur != "" {
+				added[cur] = append(added[cur], line[1:])
+			}
+		case !inHeader && strings.HasPrefix(line, "-"):
+			if oldPath != "" {
+				removed[oldPath] = append(removed[oldPath], line[1:])
+			}
+		}
+	}
+	return added, removed
+}
+
+// stripDiffPathPrefix drops the git diff `a/` or `b/` path prefix. /dev/null and
+// any other path pass through unchanged.
+func stripDiffPathPrefix(p string) string {
+	if strings.HasPrefix(p, "a/") || strings.HasPrefix(p, "b/") {
+		return p[2:]
+	}
+	return p
+}

--- a/tools/reviewrisk/diff.go
+++ b/tools/reviewrisk/diff.go
@@ -151,15 +151,25 @@ func parseNumstat(out string) map[string]numstatEntry {
 
 // numstatPath collapses the merged rename forms `git diff --numstat -M` emits so
 // the result is the new path, matching the name-status new path. A brace group
-// `dir/{old => new}/rest` becomes `dir/new/rest` (an empty old, `{ => new}`,
-// yields just the new side); a brace-less whole-path `old => new` takes the new
-// side. A field with no ` => ` passes through unchanged.
+// `dir/{old => new}/rest` becomes `dir/new/rest`; an empty new side
+// (`dir/{old => }/file.go`, a rename that only drops a path segment) collapses
+// the doubled slash to `dir/file.go`, and an empty old side (`{ => new}`) yields
+// just the new side. A brace-less whole-path `old => new` takes the new side. A
+// field with no ` => ` passes through unchanged.
 func numstatPath(field string) string {
 	if open := strings.IndexByte(field, '{'); open >= 0 {
 		if shut := strings.IndexByte(field[open:], '}'); shut >= 0 {
 			shut += open
 			if _, newPart, ok := strings.Cut(field[open+1:shut], " => "); ok {
-				return field[:open] + newPart + field[shut+1:]
+				prefix, suffix := field[:open], field[shut+1:]
+				// An empty new side (dir/{old => }/file.go) leaves prefix ending
+				// in '/' and suffix beginning with '/'. Splicing an empty middle
+				// between them doubles the separator (dir//file.go) and misses
+				// the name-status new path, so drop the redundant slash.
+				if newPart == "" {
+					suffix = strings.TrimPrefix(suffix, "/")
+				}
+				return prefix + newPart + suffix
 			}
 		}
 	}

--- a/tools/reviewrisk/diff_test.go
+++ b/tools/reviewrisk/diff_test.go
@@ -1,0 +1,225 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+// TestParseNameStatus pins the git diff --name-status -M parser: A/M/D carry one
+// path, R<score>/C<score> carry old and new, and blank lines are skipped.
+func TestParseNameStatus(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want []FileChange
+	}{
+		{
+			name: "A/M/D each carry a single path",
+			in:   "A\tcmd/fanout/new.go\nM\tinternal/core/naming/slug.go\nD\ttests/bats/old.bats\n",
+			want: []FileChange{
+				{Status: 'A', Path: "cmd/fanout/new.go"},
+				{Status: 'M', Path: "internal/core/naming/slug.go"},
+				{Status: 'D', Path: "tests/bats/old.bats"},
+			},
+		},
+		{
+			name: "R100 records old and new paths",
+			in:   "R100\tinternal/old/foo.go\tinternal/new/foo.go\n",
+			want: []FileChange{{Status: 'R', OldPath: "internal/old/foo.go", Path: "internal/new/foo.go"}},
+		},
+		{
+			name: "C75 copy records old and new paths",
+			in:   "C75\ta.go\tb.go\n",
+			want: []FileChange{{Status: 'C', OldPath: "a.go", Path: "b.go"}},
+		},
+		{
+			name: "blank lines are skipped",
+			in:   "\nA\tgo.mod\n\n",
+			want: []FileChange{{Status: 'A', Path: "go.mod"}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseNameStatus(tt.in)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseNameStatus(%q) = %#v, want %#v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestParseNumstat pins the git diff --numstat parser: integer columns parse as
+// counts, a binary file's "-" columns become -1/-1, and a rename's merged path
+// column keys on the new path.
+func TestParseNumstat(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want map[string]numstatEntry
+	}{
+		{
+			name: "text file columns parse as integers",
+			in:   "5\t3\tinternal/core/naming/slug.go\n",
+			want: map[string]numstatEntry{"internal/core/naming/slug.go": {added: 5, deleted: 3}},
+		},
+		{
+			name: "binary file dashes become -1",
+			in:   "-\t-\tweb/public/logo.png\n",
+			want: map[string]numstatEntry{"web/public/logo.png": {added: -1, deleted: -1}},
+		},
+		{
+			name: "multiple rows accumulate",
+			in:   "1\t0\ta.go\n0\t2\tb.go\n",
+			want: map[string]numstatEntry{"a.go": {added: 1}, "b.go": {deleted: 2}},
+		},
+		{
+			// A rename's brace form must key on the new path so loadDiff finds it.
+			name: "rename brace form keys on the new path",
+			in:   "2\t1\tinternal/{old => new}/foo.go\n",
+			want: map[string]numstatEntry{"internal/new/foo.go": {added: 2, deleted: 1}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseNumstat(tt.in)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseNumstat(%q) = %#v, want %#v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestNumstatPath pins the rename-path normalization: git's merged brace form
+// and its brace-less whole-path form both collapse to the new path, while a
+// plain path (even one containing no ` => `) passes through unchanged.
+func TestNumstatPath(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "brace group in the middle takes the new side",
+			in:   "internal/{old => new}/foo.go",
+			want: "internal/new/foo.go",
+		},
+		{
+			name: "brace-less whole path takes the new side",
+			in:   "old/path.go => new/path.go",
+			want: "new/path.go",
+		},
+		{
+			name: "empty old side yields just the new segment",
+			in:   "dir/{ => sub}/file.go",
+			want: "dir/sub/file.go",
+		},
+		{
+			name: "plain path without an arrow is unchanged",
+			in:   "internal/core/naming/slug.go",
+			want: "internal/core/naming/slug.go",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := numstatPath(tt.in); got != tt.want {
+				t.Errorf("numstatPath(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestParseUnified pins the -U0 content extraction: added lines key to the
+// `+++ b/` path and removed lines to the `--- a/` path with the marker
+// stripped — so a whole-file delete and a rename onto a different path (even
+// code renamed to .md) keep dropped content attributed to the old code path
+// for S10. Crucially, a content line that reads `++ x` (raw `+++ x`) or
+// `-- x` (raw `--- x`) is counted as content, not mistaken for a header.
+func TestParseUnified(t *testing.T) {
+	tests := []struct {
+		name        string
+		in          string
+		wantAdded   map[string][]string
+		wantRemoved map[string][]string
+	}{
+		{
+			name: "modified file records both added and removed lines",
+			in: "diff --git a/foo.go b/foo.go\n" +
+				"index 111..222 100644\n" +
+				"--- a/foo.go\n" +
+				"+++ b/foo.go\n" +
+				"@@ -1,0 +2 @@\n" +
+				"+added one\n" +
+				"@@ -5 +6,0 @@\n" +
+				"-removed one\n",
+			wantAdded:   map[string][]string{"foo.go": {"added one"}},
+			wantRemoved: map[string][]string{"foo.go": {"removed one"}},
+		},
+		{
+			name: "deleted file keys its removed lines to the old path",
+			in: "diff --git a/gone.go b/gone.go\n" +
+				"deleted file mode 100644\n" +
+				"index 333..000\n" +
+				"--- a/gone.go\n" +
+				"+++ /dev/null\n" +
+				"@@ -1,2 +0,0 @@\n" +
+				"-old line a\n" +
+				"-old line b\n",
+			wantAdded:   map[string][]string{},
+			wantRemoved: map[string][]string{"gone.go": {"old line a", "old line b"}},
+		},
+		{
+			name: "rename onto .md keys removed lines to the old code path",
+			in: "diff --git a/internal/infra/settings/x.go b/docs/x-notes.md\n" +
+				"similarity index 60%\n" +
+				"rename from internal/infra/settings/x.go\n" +
+				"rename to docs/x-notes.md\n" +
+				"--- a/internal/infra/settings/x.go\n" +
+				"+++ b/docs/x-notes.md\n" +
+				"@@ -3 +3 @@\n" +
+				"-if requireToken(r) {\n" +
+				"+prose replacement\n",
+			wantAdded:   map[string][]string{"docs/x-notes.md": {"prose replacement"}},
+			wantRemoved: map[string][]string{"internal/infra/settings/x.go": {"if requireToken(r) {"}},
+		},
+		{
+			name: "added file uses the new path from +++ b/",
+			in: "diff --git a/new.go b/new.go\n" +
+				"new file mode 100644\n" +
+				"index 000..444\n" +
+				"--- /dev/null\n" +
+				"+++ b/new.go\n" +
+				"@@ -0,0 +1,2 @@\n" +
+				"+brand new a\n" +
+				"+brand new b\n",
+			wantAdded:   map[string][]string{"new.go": {"brand new a", "brand new b"}},
+			wantRemoved: map[string][]string{},
+		},
+		{
+			// Content lines whose text begins with + or - become raw +++/--- lines.
+			// Once past the @@ hunk they must be attributed to foo.go, not parsed
+			// as headers (the old prefix-only check switched files or dropped them).
+			name: "plus/minus-leading content is not mistaken for a header",
+			in: "diff --git a/foo.go b/foo.go\n" +
+				"index 111..222 100644\n" +
+				"--- a/foo.go\n" +
+				"+++ b/foo.go\n" +
+				"@@ -1,0 +2 @@\n" +
+				"+++ requireToken junk\n" +
+				"@@ -5 +6,0 @@\n" +
+				"--- FANOUT_X removed\n",
+			wantAdded:   map[string][]string{"foo.go": {"++ requireToken junk"}},
+			wantRemoved: map[string][]string{"foo.go": {"-- FANOUT_X removed"}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotAdded, gotRemoved := parseUnified(tt.in)
+			if !reflect.DeepEqual(gotAdded, tt.wantAdded) {
+				t.Errorf("parseUnified(...) added = %#v, want %#v", gotAdded, tt.wantAdded)
+			}
+			if !reflect.DeepEqual(gotRemoved, tt.wantRemoved) {
+				t.Errorf("parseUnified(...) removed = %#v, want %#v", gotRemoved, tt.wantRemoved)
+			}
+		})
+	}
+}

--- a/tools/reviewrisk/diff_test.go
+++ b/tools/reviewrisk/diff_test.go
@@ -78,6 +78,14 @@ func TestParseNumstat(t *testing.T) {
 			in:   "2\t1\tinternal/{old => new}/foo.go\n",
 			want: map[string]numstatEntry{"internal/new/foo.go": {added: 2, deleted: 1}},
 		},
+		{
+			// A segment-dropping rename emits an empty new side; the doubled
+			// slash must collapse so the key matches the name-status new path
+			// (else Added/Deleted fall to 0).
+			name: "segment-dropping rename keys on the collapsed new path",
+			in:   "3\t1\tdir/{old => }/file.go\n",
+			want: map[string]numstatEntry{"dir/file.go": {added: 3, deleted: 1}},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -112,6 +120,13 @@ func TestNumstatPath(t *testing.T) {
 			name: "empty old side yields just the new segment",
 			in:   "dir/{ => sub}/file.go",
 			want: "dir/sub/file.go",
+		},
+		{
+			// A rename that only drops a path segment (dir/old/file.go ->
+			// dir/file.go) has an empty new side; the doubled slash collapses.
+			name: "empty new side collapses the doubled slash",
+			in:   "dir/{old => }/file.go",
+			want: "dir/file.go",
 		},
 		{
 			name: "plain path without an arrow is unchanged",

--- a/tools/reviewrisk/docsync_test.go
+++ b/tools/reviewrisk/docsync_test.go
@@ -1,0 +1,388 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+)
+
+// These tests keep the classification rules in rules.go in lockstep with the
+// package table in docs/architecture.ja.md (the H/M/A class canon). If a doc
+// row and its rule drift apart, one of these fails in CI so the two are always
+// edited together.
+
+// docRow is one parsed data row of the "## パッケージ表" table: its layer and
+// class columns plus the raw package cell (column 2) the tokens come from.
+// catchAll marks the open-ended rows ("上記以外" / "…ほか") that describe a
+// bucket rather than an enumerable set of packages.
+type docRow struct {
+	layer       string
+	packageCell string
+	class       Class
+	catchAll    bool
+	lineNo      int
+}
+
+// docLayerBase maps the table's layer column to the repo-relative base
+// directory a bare package token lives under. tools/web tokens are already full
+// repo-relative paths, so their base is empty.
+var docLayerBase = map[string]string{
+	"meta":  "internal",
+	"core":  "internal/core",
+	"app":   "internal/app",
+	"infra": "internal/infra",
+	"ui":    "internal/ui",
+	"cmd":   "cmd/fanout",
+	"tools": "",
+	"web":   "",
+}
+
+// docKnownExts are the file-name extensions the doc table spells out. A token
+// carrying one of these is treated as a file to classify directly; any other
+// token is a directory that gets a synthetic __probe__ file.
+var docKnownExts = []string{".go", ".tsx", ".ts", ".html", ".css", ".json", ".yaml", ".yml", ".md", ".sh"}
+
+var backtickTokenRe = regexp.MustCompile("`([^`]+)`")
+
+// TestDocSyncPackageTable is the forward direction: every package-table row in
+// the doc must resolve, through classifyPath, to the class the row declares.
+// Bare package tokens are probed as <dir>/__probe__.<ext>; file tokens (and the
+// `dashboard`(`server.go`) form, where a directory token scopes the files) are
+// classified as-is. A mismatch means the doc and rules.go disagree.
+func TestDocSyncPackageTable(t *testing.T) {
+	rows := parsePackageTable(t, readArchDoc(t))
+	// A broken parser must not pass vacuously: the table has well over 45 rows.
+	if len(rows) < 45 {
+		t.Fatalf("parsePackageTable() = %d data rows, want >= 45 (the parser likely broke)", len(rows))
+	}
+
+	var catchAllPairs []string
+	for _, row := range rows {
+		if _, ok := docLayerBase[row.layer]; !ok {
+			t.Errorf("line %d: unknown layer %q in the package table (add it to docLayerBase)", row.lineNo, row.layer)
+			continue
+		}
+		if row.catchAll {
+			catchAllPairs = append(catchAllPairs, row.layer+":"+row.class.String())
+		}
+		paths := docProbePaths(row)
+		if len(paths) == 0 && !row.catchAll {
+			t.Errorf("line %d: package cell %q yielded no classifiable token", row.lineNo, row.packageCell)
+			continue
+		}
+		for _, p := range paths {
+			r, ok := classifyPath(p)
+			if !ok {
+				t.Errorf("line %d: classifyPath(%q) is unclassified, but the doc table declares it class %v", row.lineNo, p, row.class)
+				continue
+			}
+			if r.Class != row.class {
+				t.Errorf("line %d: classifyPath(%q) class = %v, doc table declares %v", row.lineNo, p, r.Class, row.class)
+			}
+			if r.Source != SourceDocTable {
+				t.Errorf("line %d: classifyPath(%q) matched extra rule %q, but a package-table row must map to a doc-table rule", row.lineNo, p, r.ID)
+			}
+		}
+	}
+
+	// The open-ended rows are pinned by (layer, class) so one cannot silently
+	// appear, disappear, or change class. Today: cmd rest (M), the two tui
+	// buckets (M for wiring, A for the view layer), and web display (A).
+	slices.Sort(catchAllPairs)
+	wantCatchAll := []string{"cmd:M", "ui:A", "ui:M", "web:A"}
+	if !slices.Equal(catchAllPairs, wantCatchAll) {
+		t.Errorf("catch-all rows (layer:class) = %v, want %v", catchAllPairs, wantCatchAll)
+	}
+}
+
+// TestDocSyncReverse is the reverse direction: every SourceDocTable rule in
+// rules.go must correspond to a package-table row of the same class. A rule with
+// no matching row is stale (the doc dropped it); a class mismatch is a conflict.
+func TestDocSyncReverse(t *testing.T) {
+	docClasses := collectDocRuleClasses(t)
+	check := func(id string, class Class, where string) {
+		got, ok := docClasses[id]
+		if !ok {
+			t.Errorf("%s (rule %q, class %v) has no matching package-table row (stale rule — remove it or restore the doc row)", where, id, class)
+			return
+		}
+		if got != class {
+			t.Errorf("%s (rule %q) is class %v in rules.go but %v in the doc table", where, id, class, got)
+		}
+	}
+	// fileRules iteration order is undefined, but each check is independent.
+	for p, r := range fileRules {
+		if r.Source == SourceDocTable {
+			check(r.ID, r.Class, "fileRules["+p+"]")
+		}
+	}
+	for _, pr := range prefixRules {
+		if pr.rule.Source == SourceDocTable {
+			check(pr.rule.ID, pr.rule.Class, "prefixRules["+pr.prefix+"]")
+		}
+	}
+}
+
+// TestInvariantPatternsAppearInDoc pins the S10 invariant greps to the doc: each
+// DocLiteral must appear in architecture.ja.md's invariant catalog. A renamed
+// invariant in the doc that leaves the grep pattern stale (or vice versa) fails
+// here instead of silently dropping off the human-must-read watch list.
+func TestInvariantPatternsAppearInDoc(t *testing.T) {
+	content := readArchDoc(t)
+	for _, ip := range invariantPatterns {
+		if !strings.Contains(content, ip.DocLiteral) {
+			t.Errorf("invariant %q: DocLiteral %q does not appear in docs/architecture.ja.md", ip.Name, ip.DocLiteral)
+		}
+	}
+}
+
+// TestRepoTreeFullyClassified walks every git-tracked file through classifyPath
+// and asserts none is unclassified. It is the fail-closed backstop: a new
+// top-level file or directory that falls through every rule surfaces here as a
+// concrete path to add a rule for, mirroring internal/arch's
+// TestAllPackagesClassified.
+func TestRepoTreeFullyClassified(t *testing.T) {
+	root := repoRootDir(t)
+	out, err := exec.Command("git", "-C", root, "ls-files", "-z").Output()
+	if err != nil {
+		t.Fatalf("git ls-files: %v", err)
+	}
+	files := strings.Split(strings.TrimRight(string(out), "\x00"), "\x00")
+	// Guard against a broken invocation making the loop vacuous.
+	if len(files) < 100 {
+		t.Fatalf("git ls-files returned %d tracked files, want a full checkout (>= 100)", len(files))
+	}
+	var unclassified []string
+	for _, f := range files {
+		if f == "" {
+			continue
+		}
+		if _, ok := classifyPath(f); !ok {
+			unclassified = append(unclassified, f)
+		}
+	}
+	slices.Sort(unclassified)
+	for _, f := range unclassified {
+		t.Errorf("classifyPath(%q) is unclassified: add a rule in rules.go (a tracked file fell through the fail-closed gap)", f)
+	}
+}
+
+// docProbePaths returns the repo-relative paths a package-table row should
+// classify to. File tokens (known extension) are classified directly, scoped by
+// any directory token in the same cell (the `dashboard`(`server.go`) form).
+// When the cell names only directories, each is probed as a synthetic
+// __probe__ file. Glob tokens (`newpane*.go`) are skipped: they name a set, not
+// a file.
+func docProbePaths(row docRow) []string {
+	base := docLayerBase[row.layer]
+	ext := ".go"
+	if row.layer == "web" {
+		ext = ".tsx"
+	}
+	var dirTokens, fileTokens []string
+	for _, tok := range backtickTokens(row.packageCell) {
+		if strings.Contains(tok, "*") {
+			continue
+		}
+		if hasKnownExt(tok) {
+			fileTokens = append(fileTokens, tok)
+		} else {
+			dirTokens = append(dirTokens, tok)
+		}
+	}
+	var paths []string
+	if len(fileTokens) > 0 {
+		// File tokens win: a directory token only scopes them, it is not
+		// probed on its own (probing the bare tui dir would classify M, but the
+		// A-view row is defined by its enumerated files).
+		dirPrefix := base
+		for _, d := range dirTokens {
+			dirPrefix = path.Join(dirPrefix, d)
+		}
+		for _, f := range fileTokens {
+			paths = append(paths, path.Join(dirPrefix, f))
+		}
+		return paths
+	}
+	for _, d := range dirTokens {
+		paths = append(paths, path.Join(base, d, "__probe__"+ext))
+	}
+	return paths
+}
+
+// collectDocRuleClasses probes every package-table row and records, per matched
+// rule ID, the class the doc assigns it. TestDocSyncReverse reads this to detect
+// rules that no longer have a doc row.
+func collectDocRuleClasses(t *testing.T) map[string]Class {
+	t.Helper()
+	rows := parsePackageTable(t, readArchDoc(t))
+	out := make(map[string]Class)
+	for _, row := range rows {
+		for _, p := range docProbePaths(row) {
+			if r, ok := classifyPath(p); ok {
+				out[r.ID] = r.Class
+			}
+		}
+	}
+	return out
+}
+
+func hasKnownExt(tok string) bool {
+	for _, e := range docKnownExts {
+		if strings.HasSuffix(tok, e) {
+			return true
+		}
+	}
+	return false
+}
+
+func backtickTokens(s string) []string {
+	m := backtickTokenRe.FindAllStringSubmatch(s, -1)
+	out := make([]string, 0, len(m))
+	for _, g := range m {
+		out = append(out, g[1])
+	}
+	return out
+}
+
+// parsePackageTable extracts the data rows of the "## パッケージ表" section,
+// dropping the header and separator rows. It fails the test on a malformed row
+// (not 4 columns, or a final cell that is not H/M/A) so parser drift is loud.
+func parsePackageTable(t *testing.T, content string) []docRow {
+	t.Helper()
+	lines := strings.Split(content, "\n")
+	start := -1
+	for i, l := range lines {
+		if strings.TrimSpace(l) == "## パッケージ表" {
+			start = i
+			break
+		}
+	}
+	if start < 0 {
+		t.Fatal("docs/architecture.ja.md: '## パッケージ表' section not found")
+	}
+	var rows []docRow
+	for i := start + 1; i < len(lines); i++ {
+		raw := lines[i]
+		if strings.HasPrefix(raw, "## ") {
+			break // next section
+		}
+		trimmed := strings.TrimSpace(raw)
+		if !strings.HasPrefix(trimmed, "|") {
+			continue // prose, not a table row
+		}
+		if isSeparatorRow(trimmed) {
+			continue
+		}
+		cells, ok := tableCells(trimmed)
+		if !ok {
+			t.Fatalf("line %d: cannot parse table row into 4 cells: %s", i+1, raw)
+		}
+		if cells[3] == "Class" {
+			continue // header row
+		}
+		class, ok := parseClassLabel(cells[3])
+		if !ok {
+			t.Fatalf("line %d: final cell %q is not a class (want H/M/A): %s", i+1, cells[3], raw)
+		}
+		pkgCell := cells[1]
+		rows = append(rows, docRow{
+			layer:       cells[0],
+			packageCell: pkgCell,
+			class:       class,
+			catchAll:    strings.Contains(pkgCell, "以外") || strings.Contains(pkgCell, "ほか"),
+			lineNo:      i + 1,
+		})
+	}
+	return rows
+}
+
+// tableCells splits a markdown table row on its pipes and returns the four
+// trimmed inner cells, or ok=false if the row is not 4-column.
+func tableCells(row string) ([]string, bool) {
+	parts := strings.Split(row, "|")
+	if len(parts) < 3 {
+		return nil, false
+	}
+	inner := parts[1 : len(parts)-1] // drop the empty ends the outer pipes make
+	if len(inner) != 4 {
+		return nil, false
+	}
+	cells := make([]string, len(inner))
+	for i, c := range inner {
+		cells[i] = strings.TrimSpace(c)
+	}
+	return cells, true
+}
+
+// isSeparatorRow reports whether a table row is the |---|---| separator (only
+// pipes, dashes, colons, and spaces, with at least one dash).
+func isSeparatorRow(row string) bool {
+	for _, r := range row {
+		switch r {
+		case '|', '-', ':', ' ', '\t':
+		default:
+			return false
+		}
+	}
+	return strings.Contains(row, "-")
+}
+
+func parseClassLabel(s string) (Class, bool) {
+	switch s {
+	case "H":
+		return ClassH, true
+	case "M":
+		return ClassM, true
+	case "A":
+		return ClassA, true
+	default:
+		return ClassUnknown, false
+	}
+}
+
+// readArchDoc returns the contents of docs/architecture.ja.md, resolving the
+// repo root by walking up from the test's working directory.
+func readArchDoc(t *testing.T) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(repoRootDir(t), "docs", "architecture.ja.md"))
+	if err != nil {
+		t.Fatalf("read architecture.ja.md: %v", err)
+	}
+	return string(data)
+}
+
+func repoRootDir(t *testing.T) string {
+	t.Helper()
+	root, err := findRepoRoot()
+	if err != nil {
+		t.Fatalf("findRepoRoot() = %v, want the repo root", err)
+	}
+	return root
+}
+
+// findRepoRoot walks up from the working directory (the package dir under
+// `go test`) to the first go.mod. It reimplements internal/arch's helper: this
+// tree is stdlib-only and cannot import module packages.
+func findRepoRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", errors.New("no go.mod found above the test working directory")
+		}
+		dir = parent
+	}
+}

--- a/tools/reviewrisk/docsync_test.go
+++ b/tools/reviewrisk/docsync_test.go
@@ -104,27 +104,37 @@ func TestDocSyncPackageTable(t *testing.T) {
 // TestDocSyncReverse is the reverse direction: every SourceDocTable rule in
 // rules.go must correspond to a package-table row of the same class. A rule with
 // no matching row is stale (the doc dropped it); a class mismatch is a conflict.
+// fileRules are matched per PATH, not per rule ID: several files share one ID
+// (e.g. the cmd H set), so an ID-level check would keep passing after the doc
+// dropped a single file's row while its sibling still supplies the ID.
 func TestDocSyncReverse(t *testing.T) {
-	docClasses := collectDocRuleClasses(t)
-	check := func(id string, class Class, where string) {
-		got, ok := docClasses[id]
-		if !ok {
-			t.Errorf("%s (rule %q, class %v) has no matching package-table row (stale rule — remove it or restore the doc row)", where, id, class)
-			return
-		}
-		if got != class {
-			t.Errorf("%s (rule %q) is class %v in rules.go but %v in the doc table", where, id, class, got)
-		}
-	}
+	docFiles := collectDocFilePaths(t)
 	// fileRules iteration order is undefined, but each check is independent.
 	for p, r := range fileRules {
-		if r.Source == SourceDocTable {
-			check(r.ID, r.Class, "fileRules["+p+"]")
+		if r.Source != SourceDocTable {
+			continue
+		}
+		got, ok := docFiles[p]
+		if !ok {
+			t.Errorf("fileRules[%q] (rule %q, class %v) is not enumerated in the package table (stale rule — remove it or restore the doc row)", p, r.ID, r.Class)
+			continue
+		}
+		if got != r.Class {
+			t.Errorf("fileRules[%q] (rule %q) is class %v in rules.go but %v in the doc table", p, r.ID, r.Class, got)
 		}
 	}
+	docClasses := collectDocRuleClasses(t)
 	for _, pr := range prefixRules {
-		if pr.rule.Source == SourceDocTable {
-			check(pr.rule.ID, pr.rule.Class, "prefixRules["+pr.prefix+"]")
+		if pr.rule.Source != SourceDocTable {
+			continue
+		}
+		got, ok := docClasses[pr.rule.ID]
+		if !ok {
+			t.Errorf("prefixRules[%s] (rule %q, class %v) has no matching package-table row (stale rule — remove it or restore the doc row)", pr.prefix, pr.rule.ID, pr.rule.Class)
+			continue
+		}
+		if got != pr.rule.Class {
+			t.Errorf("prefixRules[%s] (rule %q) is class %v in rules.go but %v in the doc table", pr.prefix, pr.rule.ID, pr.rule.Class, got)
 		}
 	}
 }
@@ -214,6 +224,36 @@ func docProbePaths(row docRow) []string {
 		paths = append(paths, path.Join(base, d, "__probe__"+ext))
 	}
 	return paths
+}
+
+// collectDocFilePaths returns every concrete file path the package table
+// enumerates (file tokens scoped by their dir tokens), with the row's class.
+// TestDocSyncReverse matches fileRules against it per path.
+func collectDocFilePaths(t *testing.T) map[string]Class {
+	t.Helper()
+	out := make(map[string]Class)
+	for _, row := range parsePackageTable(t, readArchDoc(t)) {
+		base := docLayerBase[row.layer]
+		var dirTokens, fileTokens []string
+		for _, tok := range backtickTokens(row.packageCell) {
+			if strings.Contains(tok, "*") {
+				continue
+			}
+			if hasKnownExt(tok) {
+				fileTokens = append(fileTokens, tok)
+			} else {
+				dirTokens = append(dirTokens, tok)
+			}
+		}
+		dirPrefix := base
+		for _, d := range dirTokens {
+			dirPrefix = path.Join(dirPrefix, d)
+		}
+		for _, f := range fileTokens {
+			out[path.Join(dirPrefix, f)] = row.class
+		}
+	}
+	return out
 }
 
 // collectDocRuleClasses probes every package-table row and records, per matched

--- a/tools/reviewrisk/docsync_test.go
+++ b/tools/reviewrisk/docsync_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"errors"
+	"maps"
 	"os"
 	"os/exec"
 	"path"
@@ -123,18 +124,22 @@ func TestDocSyncReverse(t *testing.T) {
 			t.Errorf("fileRules[%q] (rule %q) is class %v in rules.go but %v in the doc table", p, r.ID, r.Class, got)
 		}
 	}
-	docClasses := collectDocRuleClasses(t)
+	// prefixRules are matched per PREFIX for the same reason: web/src/hooks/ and
+	// web/src/lib/ share the web-transport ID, so dropping one dir from the doc
+	// must still surface as a stale prefix rule.
+	docDirs := collectDocDirClasses(t)
 	for _, pr := range prefixRules {
 		if pr.rule.Source != SourceDocTable {
 			continue
 		}
-		got, ok := docClasses[pr.rule.ID]
+		dir := strings.TrimSuffix(pr.prefix, "/")
+		classes, ok := docDirs[dir]
 		if !ok {
 			t.Errorf("prefixRules[%s] (rule %q, class %v) has no matching package-table row (stale rule — remove it or restore the doc row)", pr.prefix, pr.rule.ID, pr.rule.Class)
 			continue
 		}
-		if got != pr.rule.Class {
-			t.Errorf("prefixRules[%s] (rule %q) is class %v in rules.go but %v in the doc table", pr.prefix, pr.rule.ID, pr.rule.Class, got)
+		if !classes[pr.rule.Class] {
+			t.Errorf("prefixRules[%s] (rule %q) is class %v in rules.go but the doc table assigns %s only %v", pr.prefix, pr.rule.ID, pr.rule.Class, dir, slices.Sorted(maps.Keys(classes)))
 		}
 	}
 }
@@ -256,18 +261,40 @@ func collectDocFilePaths(t *testing.T) map[string]Class {
 	return out
 }
 
-// collectDocRuleClasses probes every package-table row and records, per matched
-// rule ID, the class the doc assigns it. TestDocSyncReverse reads this to detect
-// rules that no longer have a doc row.
-func collectDocRuleClasses(t *testing.T) map[string]Class {
+// collectDocDirClasses returns every directory the package table names — each
+// dir token resolved individually against the row's layer base, plus the bare
+// base for file-only rows (the cmd rows enumerate files but still pin
+// cmd/fanout) — mapped to the set of classes its rows declare. A dir can carry
+// several classes (internal/ui/tui appears in an H, an M, and an A row), so
+// TestDocSyncReverse checks membership, not equality.
+func collectDocDirClasses(t *testing.T) map[string]map[Class]bool {
 	t.Helper()
-	rows := parsePackageTable(t, readArchDoc(t))
-	out := make(map[string]Class)
-	for _, row := range rows {
-		for _, p := range docProbePaths(row) {
-			if r, ok := classifyPath(p); ok {
-				out[r.ID] = r.Class
+	out := make(map[string]map[Class]bool)
+	add := func(dir string, c Class) {
+		if out[dir] == nil {
+			out[dir] = make(map[Class]bool)
+		}
+		out[dir][c] = true
+	}
+	for _, row := range parsePackageTable(t, readArchDoc(t)) {
+		base := docLayerBase[row.layer]
+		var dirTokens []string
+		hasFile := false
+		for _, tok := range backtickTokens(row.packageCell) {
+			if strings.Contains(tok, "*") {
+				continue
 			}
+			if hasKnownExt(tok) {
+				hasFile = true
+			} else {
+				dirTokens = append(dirTokens, tok)
+			}
+		}
+		for _, d := range dirTokens {
+			add(path.Join(base, d), row.class)
+		}
+		if len(dirTokens) == 0 && hasFile && base != "" {
+			add(base, row.class)
 		}
 	}
 	return out

--- a/tools/reviewrisk/main.go
+++ b/tools/reviewrisk/main.go
@@ -1,0 +1,82 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+)
+
+func main() { os.Exit(run(os.Args[1:], os.Stdout, os.Stderr)) }
+
+// run parses flags, loads the base..working-tree diff, evaluates the risk, and
+// writes the chosen format to stdout. It returns 0 on success, 1 only when
+// --fail-at is set and the level reaches it, and 2 for any operational error
+// (bad flag, unknown format/level, or a failed git call). os.Exit lives only in
+// main so run stays testable.
+func run(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("reviewrisk", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	base := fs.String("base", "", "diff base ref (default: origin/main, then main)")
+	format := fs.String("format", "text", "output format: text|markdown|json")
+	failAt := fs.String("fail-at", "", "exit 1 when the level reaches this (none|low|medium|high|critical)")
+	if err := fs.Parse(args); err != nil {
+		// -h/--help is not an error: flag already printed usage, exit 0.
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
+		return 2
+	}
+
+	switch *format {
+	case "text", "markdown", "json":
+	default:
+		fmt.Fprintf(stderr, "reviewrisk: invalid --format %q (want text|markdown|json)\n", *format)
+		return 2
+	}
+
+	var failLevel Level
+	haveFailAt := *failAt != ""
+	if haveFailAt {
+		lv, err := parseLevel(*failAt)
+		if err != nil {
+			fmt.Fprintf(stderr, "reviewrisk: %v\n", err)
+			return 2
+		}
+		failLevel = lv
+	}
+
+	baseRef, err := resolveBase(*base)
+	if err != nil {
+		fmt.Fprintf(stderr, "reviewrisk: %v\n", err)
+		return 2
+	}
+	d, err := loadDiff(baseRef)
+	if err != nil {
+		fmt.Fprintf(stderr, "reviewrisk: %v\n", err)
+		return 2
+	}
+
+	report := evaluate(d)
+	var out string
+	switch *format {
+	case "text":
+		out = report.Text()
+	case "markdown":
+		out = report.Markdown()
+	case "json":
+		b, err := report.JSON()
+		if err != nil {
+			fmt.Fprintf(stderr, "reviewrisk: %v\n", err)
+			return 2
+		}
+		out = string(b)
+	}
+	fmt.Fprintln(stdout, out)
+
+	if haveFailAt && report.Level >= failLevel {
+		return 1
+	}
+	return 0
+}

--- a/tools/reviewrisk/main_test.go
+++ b/tools/reviewrisk/main_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// newCleanRepo creates a throwaway git repo with a single commit, chdirs into
+// it, and isolates git from user/system config. loadDiff diffs base..working
+// tree, so a clean checkout guarantees an empty diff regardless of the state of
+// the repo the test binary was built in. t.Chdir/t.Setenv mark the test serial.
+func newCleanRepo(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	env := append(os.Environ(),
+		"GIT_CONFIG_GLOBAL=/dev/null",
+		"GIT_CONFIG_SYSTEM=/dev/null",
+		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@example.com",
+		"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@example.com",
+	)
+	git := func(args ...string) {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = dir
+		cmd.Env = env
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %s: %v: %s", strings.Join(args, " "), err, out)
+		}
+	}
+	git("init")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("seed\n"), 0o644); err != nil {
+		t.Fatalf("write seed file: %v", err)
+	}
+	git("add", "README.md")
+	git("commit", "-m", "seed")
+
+	t.Chdir(dir)
+	// run()'s own git calls inherit the process env and cwd; isolate them too.
+	t.Setenv("GIT_CONFIG_GLOBAL", "/dev/null")
+	t.Setenv("GIT_CONFIG_SYSTEM", "/dev/null")
+}
+
+// TestRunFlagValidation pins the operational-error exits: a bad flag, an unknown
+// --format, and an unknown --fail-at all return 2 before any git call.
+func TestRunFlagValidation(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "unknown flag", args: []string{"--nope"}},
+		{name: "invalid format", args: []string{"--format", "bogus"}},
+		{name: "invalid fail-at level", args: []string{"--fail-at", "bogus"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			if got := run(tt.args, &stdout, &stderr); got != 2 {
+				t.Errorf("run(%v) = %d, want 2 (stderr: %s)", tt.args, got, stderr.String())
+			}
+		})
+	}
+}
+
+// TestRunHelp pins that -h/--help is not an operational error: flag prints usage
+// and run returns 0, never 2.
+func TestRunHelp(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "long help flag", args: []string{"--help"}},
+		{name: "short help flag", args: []string{"-h"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			if got := run(tt.args, &stdout, &stderr); got != 0 {
+				t.Errorf("run(%v) = %d, want 0 (stderr: %s)", tt.args, got, stderr.String())
+			}
+		})
+	}
+}
+
+// TestRunFailAtExitCode pins the advisory-gate semantics against an empty diff
+// in a clean throwaway repo (--base HEAD -> base..working tree is empty, level
+// none): --fail-at low stays 0 because none < low, while --fail-at none exits 1
+// because none >= none. The default (no --fail-at) always exits 0.
+func TestRunFailAtExitCode(t *testing.T) {
+	newCleanRepo(t)
+	tests := []struct {
+		name string
+		args []string
+		want int
+	}{
+		{name: "no fail-at always exits 0", args: []string{"--base", "HEAD"}, want: 0},
+		{name: "level below fail-at exits 0", args: []string{"--base", "HEAD", "--fail-at", "low"}, want: 0},
+		{name: "level at fail-at exits 1", args: []string{"--base", "HEAD", "--fail-at", "none"}, want: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			if got := run(tt.args, &stdout, &stderr); got != tt.want {
+				t.Errorf("run(%v) = %d, want %d (stderr: %s)", tt.args, got, tt.want, stderr.String())
+			}
+		})
+	}
+}
+
+// TestRunEmitsFormat checks the happy path writes the requested format to stdout
+// on an empty diff in a clean throwaway repo.
+func TestRunEmitsFormat(t *testing.T) {
+	newCleanRepo(t)
+	tests := []struct {
+		name       string
+		format     string
+		wantSubstr string
+	}{
+		{name: "text", format: "text", wantSubstr: "Review risk: NONE"},
+		{name: "markdown", format: "markdown", wantSubstr: "<!-- review-risk -->"},
+		{name: "json", format: "json", wantSubstr: `"level": "none"`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			if got := run([]string{"--base", "HEAD", "--format", tt.format}, &stdout, &stderr); got != 0 {
+				t.Fatalf("run(--format %s) = %d, want 0 (stderr: %s)", tt.format, got, stderr.String())
+			}
+			if !strings.Contains(stdout.String(), tt.wantSubstr) {
+				t.Errorf("run(--format %s) stdout missing %q, got:\n%s", tt.format, tt.wantSubstr, stdout.String())
+			}
+		})
+	}
+}

--- a/tools/reviewrisk/report.go
+++ b/tools/reviewrisk/report.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"text/tabwriter"
+)
+
+// minusSign is the U+2212 minus used in the "+A −D" diff-size summaries, shared
+// by Text and Markdown so both render identically.
+const minusSign = "−"
+
+// reviewRiskMarker leads the Markdown sticky comment so CI can find and replace
+// the same comment. Must match the jq startswith filter in
+// .github/workflows/review-risk.yml.
+const reviewRiskMarker = "<!-- review-risk -->"
+
+// plusMinus formats an added/deleted pair as "+A −D".
+func plusMinus(added, deleted int) string {
+	return fmt.Sprintf("+%d %s%d", added, minusSign, deleted)
+}
+
+// Text renders the report for a terminal: the level and its guidance, the
+// escalation reasons, and an aligned per-file table whose header carries the
+// diff stats.
+func (r Report) Text() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Review risk: %s — %s\n", strings.ToUpper(r.Level.String()), levelGuidance[r.Level])
+
+	if len(r.Reasons) > 0 {
+		b.WriteString("\n理由:\n")
+		for _, rs := range r.Reasons {
+			file := rs.File
+			if file == "" {
+				file = "-"
+			}
+			fmt.Fprintf(&b, "  [%s] %s  %s  %s\n", rs.Level, rs.Signal, file, rs.Detail)
+		}
+	}
+
+	if len(r.Files) > 0 {
+		fmt.Fprintf(&b, "\nファイル (%d files, %s):\n", r.Stats.Files, plusMinus(r.Stats.Added, r.Stats.Deleted))
+		tw := tabwriter.NewWriter(&b, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(tw, "  St\tClass\tLevel\tRule\tFile")
+		for _, f := range r.Files {
+			fmt.Fprintf(tw, "  %s\t%s\t%s\t%s\t%s\n", f.Status, f.Class, f.Level, f.RuleID, f.Path)
+		}
+		_ = tw.Flush()
+	}
+
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// Markdown renders the sticky-comment body. It leads with the review-risk marker
+// so CI can find and update the same comment, states the level and guidance,
+// lists the reasons, and folds the per-file class table into a <details>.
+func (r Report) Markdown() string {
+	var b strings.Builder
+	b.WriteString(reviewRiskMarker + "\n")
+	fmt.Fprintf(&b, "## Review risk: **%s**\n\n", strings.ToUpper(r.Level.String()))
+	b.WriteString(levelGuidance[r.Level] + "\n\n")
+
+	b.WriteString("### 理由\n\n")
+	if len(r.Reasons) == 0 {
+		b.WriteString("- エスカレーションシグナルなし\n\n")
+	} else {
+		for _, rs := range r.Reasons {
+			file := rs.File
+			if file == "" {
+				file = "(diff 全体)"
+			}
+			fmt.Fprintf(&b, "- **[%s]** `%s` — `%s`: %s\n", rs.Level, rs.Signal, file, rs.Detail)
+		}
+		b.WriteString("\n")
+	}
+
+	fmt.Fprintf(&b, "<details><summary>ファイル別クラス (%d files, %s)</summary>\n\n", r.Stats.Files, plusMinus(r.Stats.Added, r.Stats.Deleted))
+	b.WriteString("| File | St | Class | Level | Rule |\n")
+	b.WriteString("|---|---|---|---|---|\n")
+	for _, f := range r.Files {
+		fmt.Fprintf(&b, "| `%s` | %s | %s | %s | %s |\n", f.Path, f.Status, f.Class, f.Level, f.RuleID)
+	}
+	b.WriteString("\n</details>\n\n")
+
+	b.WriteString("判定ルール: docs/review-risk.ja.md / docs/architecture.ja.md\n")
+	return b.String()
+}
+
+// JSON renders the report as indented JSON. Level and Class marshal to their
+// string labels via their MarshalJSON methods.
+func (r Report) JSON() ([]byte, error) {
+	return json.MarshalIndent(r, "", "  ")
+}

--- a/tools/reviewrisk/report_test.go
+++ b/tools/reviewrisk/report_test.go
@@ -1,0 +1,155 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// sampleReport is a two-file high report used across the output-format tests.
+func sampleReport() Report {
+	return Report{
+		Level: LevelHigh,
+		Files: []FileReport{
+			{Path: "internal/infra/state/store.go", Status: "M", Class: ClassH, Level: LevelHigh, RuleID: "infra-state", Note: "state.json と lock の読み書き"},
+			{Path: "internal/ui/dashboard/newthing.go", Status: "A", Class: ClassUnknown, Level: LevelHigh, RuleID: "unclassified", Note: "未分類"},
+		},
+		Reasons: []Reason{
+			{Signal: sigInvariantHit, Level: LevelHigh, File: "internal/infra/state/store.go", Detail: "不変条件 requireToken に接触"},
+			{Signal: sigUnclassifiedPath, Level: LevelHigh, File: "internal/ui/dashboard/newthing.go", Detail: "未分類パス(fail-closed で high)"},
+		},
+		Stats: Stats{Files: 2, Added: 30, Deleted: 4},
+	}
+}
+
+// TestReportMarkdown pins the sticky-comment shape: the marker leads, the level
+// and guidance render, reasons keep report order, and the per-file class table
+// sits inside the <details>.
+func TestReportMarkdown(t *testing.T) {
+	md := sampleReport().Markdown()
+
+	if !strings.HasPrefix(md, "<!-- review-risk -->\n") {
+		t.Errorf("Markdown() must start with the review-risk marker, got:\n%s", md)
+	}
+	wants := []string{
+		"## Review risk: **HIGH**",
+		"人間レビュー必須。AI は補助",
+		"### 理由",
+		"<details><summary>ファイル別クラス (2 files, +30 −4)</summary>",
+		"| File | St | Class | Level | Rule |",
+		"| `internal/infra/state/store.go` | M | H | high | infra-state |",
+		"| `internal/ui/dashboard/newthing.go` | A | ? | high | unclassified |",
+		"</details>",
+		"判定ルール: docs/review-risk.ja.md / docs/architecture.ja.md",
+	}
+	for _, w := range wants {
+		if !strings.Contains(md, w) {
+			t.Errorf("Markdown() missing %q, got:\n%s", w, md)
+		}
+	}
+
+	// The table lives inside the <details>, not before it.
+	if strings.Index(md, "<details") > strings.Index(md, "| File | St |") {
+		t.Errorf("Markdown() renders the table before <details>, got:\n%s", md)
+	}
+	// Reasons keep report order: the invariant reason precedes the unclassified.
+	if strings.Index(md, sigInvariantHit) > strings.Index(md, sigUnclassifiedPath) {
+		t.Errorf("Markdown() reason order not preserved, got:\n%s", md)
+	}
+}
+
+// TestReportText pins the terminal output: the level and guidance headline, the
+// reasons list, and the file-table header that carries the diff stats. The stats
+// appear once (the old duplicate footer line is gone).
+func TestReportText(t *testing.T) {
+	txt := sampleReport().Text()
+	wants := []string{
+		"Review risk: HIGH — 人間レビュー必須。AI は補助",
+		sigInvariantHit,
+		sigUnclassifiedPath,
+		"internal/infra/state/store.go",
+		"ファイル (2 files, +30 −4):",
+	}
+	for _, w := range wants {
+		if !strings.Contains(txt, w) {
+			t.Errorf("Text() missing %q, got:\n%s", w, txt)
+		}
+	}
+	if strings.Contains(txt, "stats:") {
+		t.Errorf("Text() still prints the duplicate stats footer, got:\n%s", txt)
+	}
+}
+
+// TestReportJSON pins the JSON encoding: level and class marshal to their string
+// labels and the structure round-trips through a decode.
+func TestReportJSON(t *testing.T) {
+	b, err := sampleReport().JSON()
+	if err != nil {
+		t.Fatalf("JSON() error = %v", err)
+	}
+	var got struct {
+		Level string `json:"level"`
+		Files []struct {
+			Path  string `json:"path"`
+			Class string `json:"class"`
+			Level string `json:"level"`
+			Rule  string `json:"rule"`
+		} `json:"files"`
+		Reasons []struct {
+			Signal string `json:"signal"`
+			Level  string `json:"level"`
+		} `json:"reasons"`
+		Stats struct {
+			Files   int `json:"files"`
+			Added   int `json:"added"`
+			Deleted int `json:"deleted"`
+		} `json:"stats"`
+	}
+	if err := json.Unmarshal(b, &got); err != nil {
+		t.Fatalf("json.Unmarshal(JSON()) error = %v", err)
+	}
+	if got.Level != "high" {
+		t.Errorf("JSON() level = %q, want %q", got.Level, "high")
+	}
+	if len(got.Files) != 2 {
+		t.Fatalf("JSON() files = %d, want 2", len(got.Files))
+	}
+	if got.Files[0].Class != "H" || got.Files[0].Level != "high" {
+		t.Errorf("JSON() files[0] class/level = %q/%q, want H/high", got.Files[0].Class, got.Files[0].Level)
+	}
+	if got.Files[1].Class != "?" || got.Files[1].Rule != "unclassified" {
+		t.Errorf("JSON() files[1] class/rule = %q/%q, want ?/unclassified", got.Files[1].Class, got.Files[1].Rule)
+	}
+	if got.Stats.Files != 2 || got.Stats.Added != 30 || got.Stats.Deleted != 4 {
+		t.Errorf("JSON() stats = %+v, want {2 30 4}", got.Stats)
+	}
+	if len(got.Reasons) != 2 || got.Reasons[0].Level != "high" {
+		t.Errorf("JSON() reasons = %+v, want 2 high reasons", got.Reasons)
+	}
+}
+
+// TestSortReasons pins the reason ordering used by every format: level
+// descending, then signal id, then file.
+func TestSortReasons(t *testing.T) {
+	rs := []Reason{
+		{Signal: sigUnclassifiedPath, Level: LevelHigh, File: "z.go"},
+		{Signal: sigTestDeleted, Level: LevelCritical, File: "b.go"},
+		{Signal: sigInvariantHit, Level: LevelHigh, File: "a.go"},
+		{Signal: sigTestDeleted, Level: LevelCritical, File: "a.go"},
+	}
+	sortReasons(rs)
+	want := []struct {
+		signal string
+		file   string
+	}{
+		{sigTestDeleted, "a.go"},      // critical, S1, a
+		{sigTestDeleted, "b.go"},      // critical, S1, b
+		{sigInvariantHit, "a.go"},     // high, S10 sorts before S9
+		{sigUnclassifiedPath, "z.go"}, // high, S9
+	}
+	for i, w := range want {
+		if rs[i].Signal != w.signal || rs[i].File != w.file {
+			t.Errorf("sortReasons()[%d] = %s/%s, want %s/%s", i, rs[i].Signal, rs[i].File, w.signal, w.file)
+		}
+	}
+}

--- a/tools/reviewrisk/rules.go
+++ b/tools/reviewrisk/rules.go
@@ -1,0 +1,238 @@
+package main
+
+import "strings"
+
+// Rule values reused across several exact-match paths that share one doc row.
+var (
+	ruleCmdH       = Rule{ID: "cmd-h-files", Class: ClassH, Source: SourceDocTable, Note: "dispatch・self-exec・launch 配線・state 書き換えを伴う cmd エントリ"}
+	ruleDashboardM = Rule{ID: "dashboard-m-files", Class: ClassM, Source: SourceDocTable, Note: "state/tmux ポーリング・SSE・embed"}
+	ruleTuiA       = Rule{ID: "tui-a-files", Class: ClassA, Source: SourceDocTable, Note: "TUI の View 層(描画・整形)"}
+	ruleWebBundle  = Rule{ID: "extra-web-bundle", Class: ClassH, Source: SourceExtra, Note: "token を扱う埋め込みバンドルの生成系"}
+	ruleWebConfig  = Rule{ID: "extra-web-config", Class: ClassM, Source: SourceExtra, Note: "web ビルド設定"}
+	ruleLintConfig = Rule{ID: "extra-lint-config", Class: ClassM, Source: SourceExtra, Note: "Go lint 設定"}
+	ruleAgentGuide = Rule{ID: "extra-agent-guide", Class: ClassM, Source: SourceExtra, Note: "エージェント作業規約"}
+	ruleReadme     = Rule{ID: "extra-readme", Class: ClassNone, Source: SourceExtra, Note: "利用者向け説明"}
+)
+
+// fileRules classify a repo-relative path by exact match. File-level rows in the
+// package table land here (a doc row that pins individual .go files) alongside
+// extra top-level files that have no package-table row.
+var fileRules = map[string]Rule{
+	// cmd/fanout H set: dispatch/self-exec/launch wiring and state rewrites.
+	"cmd/fanout/main.go":            ruleCmdH,
+	"cmd/fanout/tui_popup.go":       ruleCmdH,
+	"cmd/fanout/tui_launch.go":      ruleCmdH,
+	"cmd/fanout/worktree_action.go": ruleCmdH,
+	"cmd/fanout/codex_plan_tui.go":  ruleCmdH,
+	"cmd/fanout/tui_restore.go":     ruleCmdH,
+	"cmd/fanout/tui_watch.go":       ruleCmdH,
+
+	// dashboard H files (server mux / runfile trust gate / capture-pane chain).
+	"internal/ui/dashboard/server.go":  {ID: "dashboard-server", Class: ClassH, Source: SourceDocTable, Note: "localhost web サーバの mux・token 検証"},
+	"internal/ui/dashboard/runfile.go": {ID: "dashboard-runfile", Class: ClassH, Source: SourceDocTable, Note: "token を含む dashboard.json・reuse/trust ゲート"},
+	"internal/ui/dashboard/peek.go":    {ID: "dashboard-peek-plan", Class: ClassH, Source: SourceDocTable, Note: "capture-pane 前の検証チェーン"},
+	"internal/ui/dashboard/plan.go":    {ID: "dashboard-peek-plan", Class: ClassH, Source: SourceDocTable, Note: "capture-pane 前の検証チェーン(codexPlanMode 限定)"},
+
+	// dashboard M files.
+	"internal/ui/dashboard/poller.go": ruleDashboardM,
+	"internal/ui/dashboard/sse.go":    ruleDashboardM,
+	"internal/ui/dashboard/embed.go":  ruleDashboardM,
+
+	// tui: actions.go is H, the view/format trio is A; the tui prefix rule
+	// classifies every other tui file M.
+	"internal/ui/tui/actions.go": {ID: "tui-actions", Class: ClassH, Source: SourceDocTable, Note: "lifecycle(close/merge/cleanup)実行の配線と確認フロー"},
+	"internal/ui/tui/view.go":    ruleTuiA,
+	"internal/ui/tui/compact.go": ruleTuiA,
+	"internal/ui/tui/styles.go":  ruleTuiA,
+
+	// web token-leak boundary.
+	"web/index.html": {ID: "web-index", Class: ClassH, Source: SourceDocTable, Note: "no-referrer・外部 fetch 方針(token 漏洩境界)"},
+
+	// Extra files with no package-table row.
+	"go.mod":     {ID: "extra-gomod", Class: ClassH, Source: SourceExtra, Note: "依存サプライチェーン"},
+	"go.sum":     {ID: "extra-gosum", Class: ClassM, Source: SourceExtra, Note: "依存 lock 追随"},
+	"install.sh": {ID: "extra-install-sh", Class: ClassH, Source: SourceExtra, Note: "curl|sh 配布経路"},
+	"Makefile":   {ID: "extra-makefile", Class: ClassH, Source: SourceExtra, Note: "test・install 定義"},
+
+	"web/package.json":   ruleWebBundle,
+	"web/pnpm-lock.yaml": ruleWebBundle,
+	"web/vite.config.ts": ruleWebBundle,
+
+	"web/tsconfig.json":  ruleWebConfig,
+	"web/.nvmrc":         ruleWebConfig,
+	"web/.oxlintrc.json": ruleWebConfig,
+	"web/.oxfmtrc.json":  ruleWebConfig,
+
+	".golangci.yml":          ruleLintConfig,
+	".golangci-lint-version": ruleLintConfig,
+
+	".gitignore": {ID: "extra-gitignore", Class: ClassM, Source: SourceExtra, Note: "追跡除外設定"},
+
+	"CLAUDE.md": ruleAgentGuide,
+	"AGENTS.md": ruleAgentGuide,
+
+	// architecture.ja.md is the class canon; it overrides the docs/ NONE prefix.
+	"docs/architecture.ja.md": {ID: "extra-arch-doc", Class: ClassM, Source: SourceExtra, Note: "クラス正典(docs/ の NONE を上書き)"},
+
+	"README.md":    ruleReadme,
+	"README.ja.md": ruleReadme,
+	"RELEASE.md":   {ID: "extra-release-doc", Class: ClassNone, Source: SourceExtra, Note: "リリース手順"},
+	"LICENSE":      {ID: "extra-license", Class: ClassNone, Source: SourceExtra, Note: "ライセンス"},
+
+	".git-blame-ignore-revs": {ID: "extra-blame-ignore", Class: ClassNone, Source: SourceExtra, Note: "blame 除外リビジョン"},
+}
+
+// prefixRules classify by longest matching path prefix (see longestPrefixRule).
+// Package rows in the doc land here; the trailing slash means only files under
+// the directory match, never a bare directory token.
+var prefixRules = []struct {
+	prefix string
+	rule   Rule
+}{
+	// meta: the only layer guard.
+	{"internal/arch/", Rule{ID: "arch", Class: ClassH, Source: SourceDocTable, Note: "層ルールの CI 強制(唯一のガード)"}},
+
+	// infra H.
+	{"internal/infra/state/", Rule{ID: "infra-state", Class: ClassH, Source: SourceDocTable, Note: "state.json と lock の読み書き"}},
+	{"internal/infra/worktree/", Rule{ID: "infra-worktree", Class: ClassH, Source: SourceDocTable, Note: "base branch 解決・refresh・worktree add"}},
+	{"internal/infra/hooks/", Rule{ID: "infra-hooks", Class: ClassH, Source: SourceDocTable, Note: "ライフサイクルフック実行"}},
+	{"internal/infra/selfupdate/", Rule{ID: "infra-selfupdate", Class: ClassH, Source: SourceDocTable, Note: "自己アップデート"}},
+	{"internal/infra/team/", Rule{ID: "infra-team", Class: ClassH, Source: SourceDocTable, Note: "team SQLite バス"}},
+	{"internal/infra/settings/", Rule{ID: "infra-settings", Class: ClassH, Source: SourceDocTable, Note: "設定解決の安全ゲート"}},
+
+	// infra M.
+	{"internal/infra/ghissue/", Rule{ID: "infra-ghissue", Class: ClassM, Source: SourceDocTable, Note: "GitHub issue/PR 読み書き"}},
+	{"internal/infra/gitstat/", Rule{ID: "infra-gitstat", Class: ClassM, Source: SourceDocTable, Note: "git 差分・状態取得"}},
+	{"internal/infra/tmuxrun/", Rule{ID: "infra-tmuxrun", Class: ClassM, Source: SourceDocTable, Note: "tmux 直接操作"}},
+	{"internal/infra/msgstore/", Rule{ID: "infra-msgstore", Class: ClassM, Source: SourceDocTable, Note: "send/post/inbox/board"}},
+	{"internal/infra/notify/", Rule{ID: "infra-notify", Class: ClassM, Source: SourceDocTable, Note: "通知送出"}},
+	{"internal/infra/runtime/", Rule{ID: "infra-runtime", Class: ClassM, Source: SourceDocTable, Note: "git root・tmux ターゲット解決"}},
+	{"internal/infra/displayname/", Rule{ID: "infra-displayname", Class: ClassM, Source: SourceDocTable, Note: "表示名生成"}},
+	{"internal/infra/codexapp/", Rule{ID: "infra-codexapp", Class: ClassM, Source: SourceDocTable, Note: "Codex app-server クライアント"}},
+	{"internal/infra/atomicfs/", Rule{ID: "infra-atomicfs", Class: ClassM, Source: SourceDocTable, Note: "原子的ファイル書き込み"}},
+	{"internal/infra/gitroot/", Rule{ID: "infra-gitroot", Class: ClassM, Source: SourceDocTable, Note: "git root 探索"}},
+
+	// infra A.
+	{"internal/infra/log/", Rule{ID: "infra-log", Class: ClassA, Source: SourceDocTable, Note: "ロギング"}},
+	{"internal/infra/tty/", Rule{ID: "infra-tty", Class: ClassA, Source: SourceDocTable, Note: "端末判定"}},
+	{"internal/infra/execx/", Rule{ID: "infra-execx", Class: ClassA, Source: SourceDocTable, Note: "コマンド実行の薄いラッパ"}},
+	{"internal/infra/browser/", Rule{ID: "infra-browser", Class: ClassA, Source: SourceDocTable, Note: "ブラウザ起動"}},
+
+	// app H.
+	{"internal/app/watch/", Rule{ID: "app-watch", Class: ClassH, Source: SourceDocTable, Note: "ラベル watcher の 1 サイクル"}},
+	{"internal/app/briefing/", Rule{ID: "app-briefing", Class: ClassH, Source: SourceDocTable, Note: "エージェントに注入するプロンプト本文"}},
+	{"internal/app/lifecycle/", Rule{ID: "app-lifecycle", Class: ClassH, Source: SourceDocTable, Note: "close/merge/cleanup"}},
+	{"internal/app/panelaunch/", Rule{ID: "app-panelaunch", Class: ClassH, Source: SourceDocTable, Note: "pane 生成オーケストレーション"}},
+
+	// app M.
+	{"internal/app/panelayout/", Rule{ID: "app-panelayout", Class: ClassM, Source: SourceDocTable, Note: "ペインレイアウト計算"}},
+	{"internal/app/sessionview/", Rule{ID: "app-sessionview", Class: ClassM, Source: SourceDocTable, Note: "state+tmux+gh の Snapshot"}},
+	{"internal/app/run/", Rule{ID: "app-run", Class: ClassM, Source: SourceDocTable, Note: "executePlan の実行ロジック"}},
+	{"internal/app/statusreport/", Rule{ID: "app-statusreport", Class: ClassM, Source: SourceDocTable, Note: "--status レポート生成"}},
+	{"internal/app/peermsg/", Rule{ID: "app-peermsg", Class: ClassM, Source: SourceDocTable, Note: "fanout msg の実行層"}},
+	{"internal/app/cliflags/", Rule{ID: "app-cliflags", Class: ClassM, Source: SourceDocTable, Note: "フラグ検証(main の分岐)"}},
+
+	// core M.
+	{"internal/core/agent/", Rule{ID: "core-agent", Class: ClassM, Source: SourceDocTable, Note: "エージェント名解決・CLI 検証"}},
+	{"internal/core/planspec/", Rule{ID: "core-planspec", Class: ClassM, Source: SourceDocTable, Note: "fanout plan の JSON スキーマ"}},
+	{"internal/core/naming/", Rule{ID: "core-naming", Class: ClassM, Source: SourceDocTable, Note: "slug・branch 名生成"}},
+	{"internal/core/parentref/", Rule{ID: "core-parentref", Class: ClassM, Source: SourceDocTable, Note: "親参照の正規化"}},
+	{"internal/core/fanset/", Rule{ID: "core-fanset", Class: ClassM, Source: SourceDocTable, Note: "fan-out 対象集合の計算"}},
+	{"internal/core/blockers/", Rule{ID: "core-blockers", Class: ClassM, Source: SourceDocTable, Note: "ブロッカー判定"}},
+
+	// core A.
+	{"internal/core/exitcode/", Rule{ID: "core-exitcode", Class: ClassA, Source: SourceDocTable, Note: "終了コード定義"}},
+	{"internal/core/cliview/", Rule{ID: "core-cliview", Class: ClassA, Source: SourceDocTable, Note: "CLI 出力の整形"}},
+
+	// tui catch-all: file rules above override actions.go(H) and the A trio.
+	{"internal/ui/tui/", Rule{ID: "tui-rest", Class: ClassM, Source: SourceDocTable, Note: "キー処理・フォーム・ポーリングの配線"}},
+
+	// dashboard embed bundle (generated on build).
+	{"internal/ui/dashboard/static/", Rule{ID: "dashboard-static", Class: ClassM, Source: SourceExtra, Note: "embed 対象バンドル"}},
+
+	// cmd catch-all: the doc's "上記以外" row.
+	{"cmd/fanout/", Rule{ID: "cmd-rest", Class: ClassM, Source: SourceDocTable, Note: "フラグ検証・app 層への薄い dispatch"}},
+
+	// tools meta-tooling (this tool). New tools stay unclassified -> high.
+	{"tools/reviewrisk/", Rule{ID: "tools-reviewrisk", Class: ClassH, Source: SourceDocTable, Note: "PR review risk 判定(物差し。ルール変更はレビュー配線を変える)"}},
+
+	// web transport vs display.
+	{"web/src/hooks/", Rule{ID: "web-transport", Class: ClassM, Source: SourceDocTable, Note: "SSE/polling transport・token 付き /api/* 呼び出し"}},
+	{"web/src/lib/", Rule{ID: "web-transport", Class: ClassM, Source: SourceDocTable, Note: "SSE/polling transport・token 付き /api/* 呼び出し"}},
+	{"web/src/", Rule{ID: "web-src", Class: ClassA, Source: SourceDocTable, Note: "表示(components/styles/tests)"}},
+
+	// tests: bin is the test yardstick (H); the suites are M (deletion -> S1/S2).
+	{"tests/bin/", Rule{ID: "tests-bin", Class: ClassH, Source: SourceExtra, Note: "fake gh/tmux/git = テストの物差し"}},
+	{"tests/bats/", Rule{ID: "tests-suite", Class: ClassM, Source: SourceExtra, Note: "bats テスト"}},
+	{"tests/fixtures/", Rule{ID: "tests-suite", Class: ClassM, Source: SourceExtra, Note: "テストフィクスチャ"}},
+	{"tests/golden/", Rule{ID: "tests-suite", Class: ClassM, Source: SourceExtra, Note: "ゴールデン出力"}},
+
+	// CI and repo automation.
+	{".github/workflows/", Rule{ID: "github-workflows", Class: ClassH, Source: SourceExtra, Note: "CI 定義"}},
+	{".github/", Rule{ID: "github-rest", Class: ClassM, Source: SourceExtra, Note: "GitHub 設定"}},
+	{".claude/", Rule{ID: "claude-settings", Class: ClassH, Source: SourceExtra, Note: "PR review gate 等の作業設定"}},
+	{"codex/tools/", Rule{ID: "codex-tools", Class: ClassH, Source: SourceExtra, Note: "install される実行シェル"}},
+	{"claude/", Rule{ID: "claude-prompts", Class: ClassM, Source: SourceExtra, Note: "配布エージェントプロンプト"}},
+	{"codex/", Rule{ID: "codex-prompts", Class: ClassM, Source: SourceExtra, Note: "配布エージェントプロンプト"}},
+	{"hack/", Rule{ID: "hack", Class: ClassM, Source: SourceExtra, Note: "補助スクリプト"}},
+
+	// docs and the docs site are NONE by default (architecture.ja.md overrides).
+	{"docs/", Rule{ID: "docs", Class: ClassNone, Source: SourceExtra, Note: "ドキュメント"}},
+	{"site/", Rule{ID: "site", Class: ClassNone, Source: SourceExtra, Note: "ドキュメントサイト"}},
+}
+
+// classifyPath resolves a repo-relative, slash-separated file path to its Rule.
+// Evaluation order (first hit wins): exact file rule, Go test pairing
+// (foo_test.go inherits foo.go's file rule but never drops below the package's
+// prefix class), web test override, then longest-prefix rule. An unmatched path
+// returns ok=false so the caller fails closed to high (S9 unclassified-path).
+func classifyPath(p string) (Rule, bool) {
+	if r, ok := fileRules[p]; ok {
+		return r, true
+	}
+	if base, ok := strings.CutSuffix(p, "_test.go"); ok {
+		if r, ok := fileRules[base+".go"]; ok {
+			// Keep the test at least as heavy as its directory: a test paired
+			// to an A file inside an M package stays M.
+			if pr, ok := longestPrefixRule(p); ok && pr.Class > r.Class {
+				return pr, true
+			}
+			return r, true
+		}
+	}
+	if isWebTestFile(p) {
+		return Rule{ID: "web-test", Class: ClassA, Source: SourceDocTable, Note: "web テスト(表示クラス扱い)"}, true
+	}
+	return longestPrefixRule(p)
+}
+
+// isWebTestFile reports whether p is a web test under web/src/: either the
+// web/src/test/ harness dir or a *.test.ts(x) file. Per the doc these are class
+// A (display), overriding the web/src/hooks|lib transport prefixes.
+func isWebTestFile(p string) bool {
+	if !strings.HasPrefix(p, "web/src/") {
+		return false
+	}
+	if strings.HasPrefix(p, "web/src/test/") {
+		return true
+	}
+	return strings.HasSuffix(p, ".test.ts") || strings.HasSuffix(p, ".test.tsx")
+}
+
+// longestPrefixRule returns the prefixRules entry with the longest prefix that
+// is a prefix of p, scanning all entries so the result never depends on slice
+// order.
+func longestPrefixRule(p string) (Rule, bool) {
+	best := -1
+	var rule Rule
+	for _, pr := range prefixRules {
+		if len(pr.prefix) > best && strings.HasPrefix(p, pr.prefix) {
+			best = len(pr.prefix)
+			rule = pr.rule
+		}
+	}
+	if best < 0 {
+		return Rule{}, false
+	}
+	return rule, true
+}

--- a/tools/reviewrisk/rules.go
+++ b/tools/reviewrisk/rules.go
@@ -207,8 +207,12 @@ func classifyPath(p string) (Rule, bool) {
 }
 
 // isWebTestFile reports whether p is a web test under web/src/: either the
-// web/src/test/ harness dir or a *.test.ts(x) file. Per the doc these are class
-// A (display), overriding the web/src/hooks|lib transport prefixes.
+// web/src/test/ harness dir or a *.test/*.spec .ts(x) file. Vitest collects both
+// the .test and .spec suffixes (web/vite.config.ts does not override
+// test.include), so both count. Per the doc these are class A (display),
+// overriding the web/src/hooks|lib transport prefixes. This is the single
+// web-test-shape predicate shared by classifyPath's A override, S3 skip
+// detection, and S1's isTestShape.
 func isWebTestFile(p string) bool {
 	if !strings.HasPrefix(p, "web/src/") {
 		return false
@@ -216,7 +220,8 @@ func isWebTestFile(p string) bool {
 	if strings.HasPrefix(p, "web/src/test/") {
 		return true
 	}
-	return strings.HasSuffix(p, ".test.ts") || strings.HasSuffix(p, ".test.tsx")
+	return strings.HasSuffix(p, ".test.ts") || strings.HasSuffix(p, ".test.tsx") ||
+		strings.HasSuffix(p, ".spec.ts") || strings.HasSuffix(p, ".spec.tsx")
 }
 
 // longestPrefixRule returns the prefixRules entry with the longest prefix that

--- a/tools/reviewrisk/rules_test.go
+++ b/tools/reviewrisk/rules_test.go
@@ -1,0 +1,162 @@
+package main
+
+import "testing"
+
+// TestClassifyPath pins classifyPath against a representative path from every
+// doc entry plus the evaluation-order edges (Go test pairing, web test
+// override, longest-prefix wins, and the intentional fail-closed gaps).
+func TestClassifyPath(t *testing.T) {
+	tests := []struct {
+		name  string
+		path  string
+		want  Class
+		found bool
+	}{
+		// --- package-table representatives, one per class band ---
+		{name: "arch layer guard is H", path: "internal/arch/arch_test.go", want: ClassH, found: true},
+		{name: "infra state is H", path: "internal/infra/state/store.go", want: ClassH, found: true},
+		{name: "infra worktree is H", path: "internal/infra/worktree/add.go", want: ClassH, found: true},
+		{name: "infra settings is H", path: "internal/infra/settings/settings.go", want: ClassH, found: true},
+		{name: "infra ghissue is M", path: "internal/infra/ghissue/issue.go", want: ClassM, found: true},
+		{name: "infra atomicfs is M", path: "internal/infra/atomicfs/write.go", want: ClassM, found: true},
+		{name: "infra log is A", path: "internal/infra/log/log.go", want: ClassA, found: true},
+		{name: "infra browser is A", path: "internal/infra/browser/open.go", want: ClassA, found: true},
+		{name: "app briefing is H", path: "internal/app/briefing/render.go", want: ClassH, found: true},
+		{name: "app panelaunch is H", path: "internal/app/panelaunch/launch.go", want: ClassH, found: true},
+		{name: "app run is M", path: "internal/app/run/run.go", want: ClassM, found: true},
+		{name: "app cliflags is M", path: "internal/app/cliflags/flags.go", want: ClassM, found: true},
+		{name: "core naming is M", path: "internal/core/naming/slug.go", want: ClassM, found: true},
+		{name: "core blockers is M", path: "internal/core/blockers/blockers.go", want: ClassM, found: true},
+		{name: "core exitcode is A", path: "internal/core/exitcode/code.go", want: ClassA, found: true},
+		{name: "core cliview is A", path: "internal/core/cliview/view.go", want: ClassA, found: true},
+
+		// --- cmd/fanout: 7 H files plus the catch-all M ---
+		{name: "cmd main is H", path: "cmd/fanout/main.go", want: ClassH, found: true},
+		{name: "cmd tui_popup is H", path: "cmd/fanout/tui_popup.go", want: ClassH, found: true},
+		{name: "cmd tui_launch is H", path: "cmd/fanout/tui_launch.go", want: ClassH, found: true},
+		{name: "cmd worktree_action is H", path: "cmd/fanout/worktree_action.go", want: ClassH, found: true},
+		{name: "cmd codex_plan_tui is H", path: "cmd/fanout/codex_plan_tui.go", want: ClassH, found: true},
+		{name: "cmd tui_restore is H", path: "cmd/fanout/tui_restore.go", want: ClassH, found: true},
+		{name: "cmd tui_watch is H", path: "cmd/fanout/tui_watch.go", want: ClassH, found: true},
+		{name: "cmd rest status.go is M", path: "cmd/fanout/status.go", want: ClassM, found: true},
+
+		// --- dashboard: every file is enumerated; a new file falls through ---
+		{name: "dashboard server is H", path: "internal/ui/dashboard/server.go", want: ClassH, found: true},
+		{name: "dashboard runfile is H", path: "internal/ui/dashboard/runfile.go", want: ClassH, found: true},
+		{name: "dashboard peek is H", path: "internal/ui/dashboard/peek.go", want: ClassH, found: true},
+		{name: "dashboard plan is H", path: "internal/ui/dashboard/plan.go", want: ClassH, found: true},
+		{name: "dashboard poller is M", path: "internal/ui/dashboard/poller.go", want: ClassM, found: true},
+		{name: "dashboard sse is M", path: "internal/ui/dashboard/sse.go", want: ClassM, found: true},
+		{name: "dashboard embed is M", path: "internal/ui/dashboard/embed.go", want: ClassM, found: true},
+		{name: "dashboard new file is unclassified", path: "internal/ui/dashboard/newthing.go", found: false},
+
+		// --- tui: actions H, view/compact/styles A, everything else M ---
+		{name: "tui actions is H", path: "internal/ui/tui/actions.go", want: ClassH, found: true},
+		{name: "tui view is A", path: "internal/ui/tui/view.go", want: ClassA, found: true},
+		{name: "tui compact is A", path: "internal/ui/tui/compact.go", want: ClassA, found: true},
+		{name: "tui styles is A", path: "internal/ui/tui/styles.go", want: ClassA, found: true},
+		{name: "tui rest filter.go is M", path: "internal/ui/tui/filter.go", want: ClassM, found: true},
+
+		// --- Go test pairing: inherit the paired .go file, never below package ---
+		{name: "cmd main_test.go inherits H", path: "cmd/fanout/main_test.go", want: ClassH, found: true},
+		{name: "cmd dispatch_test.go has no H pair so it is M", path: "cmd/fanout/dispatch_test.go", want: ClassM, found: true},
+		{name: "dashboard poller_test.go inherits M", path: "internal/ui/dashboard/poller_test.go", want: ClassM, found: true},
+		{name: "dashboard server_test.go inherits H", path: "internal/ui/dashboard/server_test.go", want: ClassH, found: true},
+		{name: "tui view_test.go stays at package M not A", path: "internal/ui/tui/view_test.go", want: ClassM, found: true},
+
+		// --- web ---
+		{name: "web index.html is H", path: "web/index.html", want: ClassH, found: true},
+		{name: "web hooks transport is M", path: "web/src/hooks/useSnapshot.ts", want: ClassM, found: true},
+		{name: "web lib transport is M", path: "web/src/lib/api.ts", want: ClassM, found: true},
+		{name: "web components are A", path: "web/src/components/App.tsx", want: ClassA, found: true},
+		// web test override beats the hooks transport prefix.
+		{name: "web hooks test file overrides to A", path: "web/src/hooks/useDrawerWidth.test.tsx", want: ClassA, found: true},
+		{name: "web test harness dir is A", path: "web/src/test/server.ts", want: ClassA, found: true},
+		// longest-prefix: lib(M) beats web/src/(A) for a non-test lib file.
+		{name: "web lib file beats web src by longest prefix", path: "web/src/lib/x.ts", want: ClassM, found: true},
+		{name: "web root unknown file is unclassified", path: "web/unknown.txt", found: false},
+
+		// --- extra top-level and prefix rules ---
+		{name: "go.mod is H", path: "go.mod", want: ClassH, found: true},
+		{name: "go.sum is M", path: "go.sum", want: ClassM, found: true},
+		{name: "install.sh is H", path: "install.sh", want: ClassH, found: true},
+		{name: "Makefile is H", path: "Makefile", want: ClassH, found: true},
+		{name: "LICENSE is NONE", path: "LICENSE", want: ClassNone, found: true},
+		{name: "README is NONE", path: "README.md", want: ClassNone, found: true},
+		{name: "README.ja is NONE", path: "README.ja.md", want: ClassNone, found: true},
+		{name: "architecture doc overrides docs NONE to M", path: "docs/architecture.ja.md", want: ClassM, found: true},
+		{name: "other docs are NONE", path: "docs/review-checklist.ja.md", want: ClassNone, found: true},
+		{name: "workflow is H", path: ".github/workflows/test.yml", want: ClassH, found: true},
+		{name: "github rest is M", path: ".github/CODEOWNERS", want: ClassM, found: true},
+		{name: "claude settings is H", path: ".claude/settings.json", want: ClassH, found: true},
+		{name: "codex tools shell is H", path: "codex/tools/post-work-review.sh", want: ClassH, found: true},
+		{name: "codex prompts are M", path: "codex/skills/rescue/SKILL.md", want: ClassM, found: true},
+		{name: "claude prompts are M", path: "claude/commands/fanout.md", want: ClassM, found: true},
+		{name: "tests bin yardstick is H", path: "tests/bin/gh", want: ClassH, found: true},
+		{name: "tests bats suite is M", path: "tests/bats/status.bats", want: ClassM, found: true},
+		{name: "tests golden is M", path: "tests/golden/scenario-plan.txt", want: ClassM, found: true},
+		{name: "site is NONE", path: "site/content/docs/index.md", want: ClassNone, found: true},
+		{name: "hack is M", path: "hack/release.sh", want: ClassM, found: true},
+
+		// --- this tool: repo meta-tooling is H ---
+		{name: "tools reviewrisk rules is H", path: "tools/reviewrisk/rules.go", want: ClassH, found: true},
+
+		// --- genuinely unknown top-level file ---
+		{name: "unknown root file is unclassified", path: "somefile", found: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, ok := classifyPath(tt.path)
+			if ok != tt.found {
+				t.Fatalf("classifyPath(%q) ok = %v, want %v", tt.path, ok, tt.found)
+			}
+			if ok && r.Class != tt.want {
+				t.Errorf("classifyPath(%q) class = %v, want %v", tt.path, r.Class, tt.want)
+			}
+		})
+	}
+}
+
+// TestClassifyPathSource pins the doc-table vs extra provenance the docsync
+// test keys off: package-table rows are SourceDocTable, and files with no such
+// row are SourceExtra.
+func TestClassifyPathSource(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want RuleSource
+	}{
+		{name: "package row is doc-table", path: "internal/infra/state/store.go", want: SourceDocTable},
+		{name: "cmd catch-all is doc-table", path: "cmd/fanout/status.go", want: SourceDocTable},
+		{name: "tools row is doc-table", path: "tools/reviewrisk/rules.go", want: SourceDocTable},
+		{name: "go.mod has no package row so it is extra", path: "go.mod", want: SourceExtra},
+		{name: "architecture doc is extra", path: "docs/architecture.ja.md", want: SourceExtra},
+		{name: "tests bin is extra", path: "tests/bin/gh", want: SourceExtra},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, ok := classifyPath(tt.path)
+			if !ok {
+				t.Fatalf("classifyPath(%q) ok = false, want true", tt.path)
+			}
+			if r.Source != tt.want {
+				t.Errorf("classifyPath(%q) source = %v, want %v", tt.path, r.Source, tt.want)
+			}
+		})
+	}
+}
+
+// TestRuleIDsNonEmpty guards against a typo leaving a rule without a stable ID,
+// since the ID surfaces in the report and CI comment.
+func TestRuleIDsNonEmpty(t *testing.T) {
+	for path, r := range fileRules {
+		if r.ID == "" {
+			t.Errorf("fileRules[%q] has an empty ID", path)
+		}
+	}
+	for _, pr := range prefixRules {
+		if pr.rule.ID == "" {
+			t.Errorf("prefixRules[%q] has an empty ID", pr.prefix)
+		}
+	}
+}

--- a/tools/reviewrisk/rules_test.go
+++ b/tools/reviewrisk/rules_test.go
@@ -72,6 +72,8 @@ func TestClassifyPath(t *testing.T) {
 		// web test override beats the hooks transport prefix.
 		{name: "web hooks test file overrides to A", path: "web/src/hooks/useDrawerWidth.test.tsx", want: ClassA, found: true},
 		{name: "web test harness dir is A", path: "web/src/test/server.ts", want: ClassA, found: true},
+		// vitest collects .spec files too, so a .spec.ts under web/src overrides to A.
+		{name: "web spec file overrides to A", path: "web/src/lib/foo.spec.ts", want: ClassA, found: true},
 		// longest-prefix: lib(M) beats web/src/(A) for a non-test lib file.
 		{name: "web lib file beats web src by longest prefix", path: "web/src/lib/x.ts", want: ClassM, found: true},
 		{name: "web root unknown file is unclassified", path: "web/unknown.txt", found: false},

--- a/tools/reviewrisk/signals.go
+++ b/tools/reviewrisk/signals.go
@@ -36,9 +36,12 @@ const (
 
 // Skip-marker greps for S3, one per test flavor. goSkipRe requires the call
 // paren so t.Skip/Skipf/SkipNow match but t.Skipped() (a status read) does not.
+// tsSkipRe covers the vitest skip spellings: .skip(...), .skipIf(...), chained
+// modifiers like test.skip.concurrent(...), the { skip: true } option, and the
+// x-prefixed aliases.
 var (
 	goSkipRe   = regexp.MustCompile(`\bt\.(Skip|Skipf|SkipNow)\(`)
-	tsSkipRe   = regexp.MustCompile(`\.skip\(|\bxit\(|\bxdescribe\(`)
+	tsSkipRe   = regexp.MustCompile(`\.skip(If)?\s*\(|\.skip\.|\bskip:\s*true|\bxit\(|\bxdescribe\(|\bxtest\(`)
 	batsSkipRe = regexp.MustCompile(`^\s*skip\b`)
 )
 
@@ -139,9 +142,14 @@ func criticalReasons(d Diff) []Reason {
 		if touches(fc, "internal/arch/") {
 			reasons = append(reasons, Reason{Signal: sigGuardModified, Level: LevelCritical, File: fc.Path, Detail: "層ガード(internal/arch)変更"})
 		}
-		// S5 review-gate-modified: any touch of .claude/.
-		if touches(fc, ".claude/") {
-			reasons = append(reasons, Reason{Signal: sigReviewGateChanged, Level: LevelCritical, File: fc.Path, Detail: "PR review gate(.claude)変更"})
+		// S5 review-gate-modified: any touch of .claude/ or the post-work-review
+		// gate pieces installed from codex/ and claude/ (they produce the review
+		// marker the PR gate checks; weakening them weakens the gate itself).
+		if touches(fc, ".claude/") ||
+			touches(fc, "codex/tools/post-work-review") ||
+			touches(fc, "codex/skills/post-work-review/") ||
+			touches(fc, "claude/skills/post-work-review/") {
+			reasons = append(reasons, Reason{Signal: sigReviewGateChanged, Level: LevelCritical, File: fc.Path, Detail: "PR review gate(.claude / post-work-review)変更"})
 		}
 		// S6 risk-tool-modified: this tool or its workflow.
 		if touches(fc, "tools/reviewrisk/") || fc.Path == riskWorkflow || fc.OldPath == riskWorkflow {
@@ -192,44 +200,38 @@ func invariantReasons(d Diff) []Reason {
 }
 
 // envRemovalReasons fires S10 for each FANOUT_* env var name that appears on a
-// removed line but nowhere on an added line. A set difference (removed − added),
-// not a per-line grep, so a line move or re-indent (the same name re-added) does
-// not misfire; adding a name is routine. Markdown files are exempt on both
-// sides, and the reported File is where the name was first removed.
+// removed line of a file without reappearing on an added line of the SAME file.
+// The suppression is per-file on purpose: it forgives line moves and re-indents
+// inside one file, but a mere string occurrence added elsewhere (a comment, a
+// test fixture) must not mask a genuine reference removal. Markdown files are
+// exempt on both sides.
 func envRemovalReasons(d Diff) []Reason {
-	added := make(map[string]bool)
-	for p, lines := range d.AddedLines {
-		if strings.HasSuffix(p, ".md") {
-			continue
-		}
-		for _, l := range lines {
-			for _, name := range envPatternRe.FindAllString(l, -1) {
-				added[name] = true
-			}
-		}
-	}
-	removedAt := make(map[string]string) // name -> representative file
+	var reasons []Reason
 	for _, p := range slices.Sorted(maps.Keys(d.RemovedLines)) {
 		if strings.HasSuffix(p, ".md") {
 			continue
 		}
-		for _, l := range d.RemovedLines[p] {
+		addedHere := make(map[string]bool)
+		for _, l := range d.AddedLines[p] {
 			for _, name := range envPatternRe.FindAllString(l, -1) {
-				if _, ok := removedAt[name]; !ok {
-					removedAt[name] = p
-				}
+				addedHere[name] = true
 			}
 		}
-	}
-	var reasons []Reason
-	for _, name := range slices.Sorted(maps.Keys(removedAt)) {
-		if added[name] {
-			continue
+		removedHere := make(map[string]bool)
+		for _, l := range d.RemovedLines[p] {
+			for _, name := range envPatternRe.FindAllString(l, -1) {
+				removedHere[name] = true
+			}
 		}
-		reasons = append(reasons, Reason{
-			Signal: sigInvariantHit, Level: LevelHigh, File: removedAt[name],
-			Detail: "FANOUT_* env 参照を削除: " + name,
-		})
+		for _, name := range slices.Sorted(maps.Keys(removedHere)) {
+			if addedHere[name] {
+				continue
+			}
+			reasons = append(reasons, Reason{
+				Signal: sigInvariantHit, Level: LevelHigh, File: p,
+				Detail: "FANOUT_* env 参照を削除: " + name,
+			})
+		}
 	}
 	return reasons
 }
@@ -269,14 +271,16 @@ func computeStats(d Diff) Stats {
 }
 
 // skipAddedMatch reports the first added line in a test file that introduces a
-// skip marker, choosing the grep by the file's extension. bats sourced helpers
-// (tests/bats/*.bash) call skip the same way, so they get the bats grep too.
+// skip marker, choosing the grep by the file's shape. bats sourced helpers
+// (tests/bats/*.bash) call skip the same way, so they get the bats grep too,
+// and the web harness under web/src/test/ gets the vitest grep alongside
+// *.test.ts(x) (isWebTestFile covers both).
 func skipAddedMatch(p string, lines []string) (string, bool) {
 	var re *regexp.Regexp
 	switch {
 	case strings.HasSuffix(p, "_test.go"):
 		re = goSkipRe
-	case strings.HasSuffix(p, ".test.ts") || strings.HasSuffix(p, ".test.tsx"):
+	case isWebTestFile(p):
 		re = tsSkipRe
 	case strings.HasSuffix(p, ".bats"):
 		re = batsSkipRe

--- a/tools/reviewrisk/signals.go
+++ b/tools/reviewrisk/signals.go
@@ -38,11 +38,13 @@ const (
 // paren so t.Skip/Skipf/SkipNow match but t.Skipped() (a status read) does not.
 // tsSkipRe covers the vitest skip spellings: .skip(...), .skipIf(...), chained
 // modifiers like test.skip.concurrent(...), the { skip: true } option, and the
-// x-prefixed aliases.
+// x-prefixed aliases. batsSkipRe matches skip in command position — at line
+// start or after &&, ||, ;, {, (, then/else/do — so conditional forms like
+// `[[ $CI == true ]] && skip "flaky"` count, while prose in a comment does not.
 var (
 	goSkipRe   = regexp.MustCompile(`\bt\.(Skip|Skipf|SkipNow)\(`)
 	tsSkipRe   = regexp.MustCompile(`\.skip(If)?\s*\(|\.skip\.|\bskip:\s*true|\bxit\(|\bxdescribe\(|\bxtest\(`)
-	batsSkipRe = regexp.MustCompile(`^\s*skip\b`)
+	batsSkipRe = regexp.MustCompile(`(^|&&|\|\||;|\{|\(|\bthen\b|\belse\b|\bdo\b)\s*skip\b`)
 )
 
 // evaluate classifies every changed file and aggregates the risk level. Order:
@@ -326,11 +328,15 @@ func isTestShape(p string) bool {
 // isMeasurePath reports whether a path is a measurement yardstick: a golden,
 // fixture, or test-bin file whose deletion removes what a test checks against.
 // isWorkflowFile reports whether p is a file GitHub Actions actually runs:
-// under .github/workflows/ AND carrying the required .yml/.yaml extension.
-// A same-directory rename to another extension stops being a workflow.
+// DIRECTLY under .github/workflows/ (Actions ignores subdirectories) AND
+// carrying the required .yml/.yaml extension. A rename to another extension or
+// into a subdirectory stops being a workflow.
 func isWorkflowFile(p string) bool {
-	return strings.HasPrefix(p, ".github/workflows/") &&
-		(strings.HasSuffix(p, ".yml") || strings.HasSuffix(p, ".yaml"))
+	rest, ok := strings.CutPrefix(p, ".github/workflows/")
+	if !ok || strings.Contains(rest, "/") {
+		return false
+	}
+	return strings.HasSuffix(rest, ".yml") || strings.HasSuffix(rest, ".yaml")
 }
 
 func isMeasurePath(p string) bool {

--- a/tools/reviewrisk/signals.go
+++ b/tools/reviewrisk/signals.go
@@ -145,8 +145,11 @@ func criticalReasons(d Diff) []Reason {
 		// S5 review-gate-modified: any touch of .claude/ or the post-work-review
 		// gate pieces installed from codex/ and claude/ (they produce the review
 		// marker the PR gate checks; weakening them weakens the gate itself).
+		// codex/agents/post-work-* are the reviewer/verifier agent definitions
+		// the gate script drives — same gate, same weight.
 		if touches(fc, ".claude/") ||
 			touches(fc, "codex/tools/post-work-review") ||
+			touches(fc, "codex/agents/post-work-") ||
 			touches(fc, "codex/skills/post-work-review/") ||
 			touches(fc, "claude/skills/post-work-review/") {
 			reasons = append(reasons, Reason{Signal: sigReviewGateChanged, Level: LevelCritical, File: fc.Path, Detail: "PR review gate(.claude / post-work-review)変更"})
@@ -159,13 +162,15 @@ func criticalReasons(d Diff) []Reason {
 		if fc.Path == "install.sh" || fc.OldPath == "install.sh" {
 			reasons = append(reasons, Reason{Signal: sigInstallerModified, Level: LevelCritical, File: fc.Path, Detail: "install.sh 変更"})
 		}
-		// S8 ci-workflow-deleted: a deleted workflow file, or a rename that
-		// carries one out of .github/workflows/.
-		if fc.Status == 'D' && strings.HasPrefix(fc.Path, ".github/workflows/") {
+		// S8 ci-workflow-deleted: a deleted workflow file, or a rename that stops
+		// it being one — moving it out of .github/workflows/ OR dropping the
+		// .yml/.yaml extension in place (test.yml -> test.yml.disabled), which
+		// GitHub Actions treats as removal.
+		if fc.Status == 'D' && isWorkflowFile(fc.Path) {
 			reasons = append(reasons, Reason{Signal: sigCIWorkflowDeleted, Level: LevelCritical, File: fc.Path, Detail: "CI workflow 削除"})
 		}
-		if fc.Status == 'R' && strings.HasPrefix(fc.OldPath, ".github/workflows/") && !strings.HasPrefix(fc.Path, ".github/workflows/") {
-			reasons = append(reasons, Reason{Signal: sigCIWorkflowDeleted, Level: LevelCritical, File: fc.Path, Detail: "CI workflow を rename で移動(" + fc.OldPath + ")"})
+		if fc.Status == 'R' && isWorkflowFile(fc.OldPath) && !isWorkflowFile(fc.Path) {
+			reasons = append(reasons, Reason{Signal: sigCIWorkflowDeleted, Level: LevelCritical, File: fc.Path, Detail: "CI workflow を rename で無効化(" + fc.OldPath + ")"})
 		}
 	}
 	// S3 skip-added: an added skip/xit/xdescribe line in a test file.
@@ -320,6 +325,14 @@ func isTestShape(p string) bool {
 
 // isMeasurePath reports whether a path is a measurement yardstick: a golden,
 // fixture, or test-bin file whose deletion removes what a test checks against.
+// isWorkflowFile reports whether p is a file GitHub Actions actually runs:
+// under .github/workflows/ AND carrying the required .yml/.yaml extension.
+// A same-directory rename to another extension stops being a workflow.
+func isWorkflowFile(p string) bool {
+	return strings.HasPrefix(p, ".github/workflows/") &&
+		(strings.HasSuffix(p, ".yml") || strings.HasSuffix(p, ".yaml"))
+}
+
 func isMeasurePath(p string) bool {
 	return strings.HasPrefix(p, "tests/golden/") ||
 		strings.HasPrefix(p, "tests/fixtures/") ||

--- a/tools/reviewrisk/signals.go
+++ b/tools/reviewrisk/signals.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"maps"
-	"path"
 	"regexp"
 	"slices"
 	"sort"
@@ -34,15 +33,17 @@ const (
 	sigLargeDiff         = "S11-large-diff"
 )
 
-// Skip-marker greps for S3, one per test flavor. goSkipRe requires the call
-// paren so t.Skip/Skipf/SkipNow match but t.Skipped() (a status read) does not.
-// tsSkipRe covers the vitest skip spellings: .skip(...), .skipIf(...), chained
-// modifiers like test.skip.concurrent(...), the { skip: true } option, and the
-// x-prefixed aliases. batsSkipRe matches skip in command position — at line
-// start or after &&, ||, ;, {, (, then/else/do — so conditional forms like
-// `[[ $CI == true ]] && skip "flaky"` count, while prose in a comment does not.
+// Skip-marker greps for S3, one per test flavor. goSkipRe matches a
+// *testing.T/*testing.B skip call under any receiver name (t, tb, b …) and
+// requires the call paren so t.Skip/Skipf/SkipNow match but t.Skipped() (a
+// status read) does not. tsSkipRe covers the vitest skip spellings: .skip(...),
+// .skipIf(...), chained modifiers like test.skip.concurrent(...), the
+// { skip: true } option, and the x-prefixed aliases. batsSkipRe matches skip in
+// command position — at line start or after &&, ||, ;, {, (, then/else/do — so
+// conditional forms like `[[ $CI == true ]] && skip "flaky"` count, while prose
+// in a comment does not.
 var (
-	goSkipRe   = regexp.MustCompile(`\bt\.(Skip|Skipf|SkipNow)\(`)
+	goSkipRe   = regexp.MustCompile(`\b\w+\.(Skip|Skipf|SkipNow)\(`)
 	tsSkipRe   = regexp.MustCompile(`\.skip(If)?\s*\(|\.skip\.|\bskip:\s*true|\bxit\(|\bxdescribe\(|\bxtest\(`)
 	batsSkipRe = regexp.MustCompile(`(^|&&|\|\||;|\{|\(|\bthen\b|\belse\b|\bdo\b)\s*skip\b`)
 )
@@ -281,7 +282,7 @@ func computeStats(d Diff) Stats {
 // skip marker, choosing the grep by the file's shape. bats sourced helpers
 // (tests/bats/*.bash) call skip the same way, so they get the bats grep too,
 // and the web harness under web/src/test/ gets the vitest grep alongside
-// *.test.ts(x) (isWebTestFile covers both).
+// *.test.ts(x) and *.spec.ts(x) (isWebTestFile covers all).
 func skipAddedMatch(p string, lines []string) (string, bool) {
 	var re *regexp.Regexp
 	switch {
@@ -305,8 +306,10 @@ func skipAddedMatch(p string, lines []string) (string, bool) {
 }
 
 // isTestShape reports whether a path is a test file: a Go *_test.go, a bats file
-// under tests/bats/, a web *.test.* under web/src/, or anything under
-// web/src/test/.
+// under tests/bats/, or a web test (isWebTestFile: a *.test/*.spec .ts(x) under
+// web/src/, or anything under web/src/test/). Sharing isWebTestFile is what
+// makes a rename that drops the suffix (foo.test.ts -> foo.test.disabled.ts)
+// lose test shape and fire S1 — a substring check would keep it "test-shaped".
 func isTestShape(p string) bool {
 	if strings.HasSuffix(p, "_test.go") {
 		return true
@@ -314,15 +317,7 @@ func isTestShape(p string) bool {
 	if strings.HasPrefix(p, "tests/bats/") && strings.HasSuffix(p, ".bats") {
 		return true
 	}
-	if strings.HasPrefix(p, "web/src/") {
-		if strings.HasPrefix(p, "web/src/test/") {
-			return true
-		}
-		if strings.Contains(path.Base(p), ".test.") {
-			return true
-		}
-	}
-	return false
+	return isWebTestFile(p)
 }
 
 // isMeasurePath reports whether a path is a measurement yardstick: a golden,

--- a/tools/reviewrisk/signals.go
+++ b/tools/reviewrisk/signals.go
@@ -157,8 +157,11 @@ func criticalReasons(d Diff) []Reason {
 			touches(fc, "claude/skills/post-work-review/") {
 			reasons = append(reasons, Reason{Signal: sigReviewGateChanged, Level: LevelCritical, File: fc.Path, Detail: "PR review gate(.claude / post-work-review)変更"})
 		}
-		// S6 risk-tool-modified: this tool or its workflow.
-		if touches(fc, "tools/reviewrisk/") || fc.Path == riskWorkflow || fc.OldPath == riskWorkflow {
+		// S6 risk-tool-modified: this tool or either of its workflows (the
+		// pull_request judge and the base-side pull_request_target guard).
+		if touches(fc, "tools/reviewrisk/") ||
+			fc.Path == riskWorkflow || fc.OldPath == riskWorkflow ||
+			fc.Path == riskGuardWorkflow || fc.OldPath == riskGuardWorkflow {
 			reasons = append(reasons, Reason{Signal: sigRiskToolModified, Level: LevelCritical, File: fc.Path, Detail: "risk 判定ツール自身の変更"})
 		}
 		// S7 installer-modified: install.sh.
@@ -185,7 +188,10 @@ func criticalReasons(d Diff) []Reason {
 	return reasons
 }
 
-const riskWorkflow = ".github/workflows/review-risk.yml"
+const (
+	riskWorkflow      = ".github/workflows/review-risk.yml"
+	riskGuardWorkflow = ".github/workflows/review-risk-guard.yml"
+)
 
 // invariantReasons collects S10 signals: a diff line (added or removed) that hits
 // a human-must-read invariant pattern, plus FANOUT_* env var names dropped by the

--- a/tools/reviewrisk/signals.go
+++ b/tools/reviewrisk/signals.go
@@ -1,0 +1,382 @@
+package main
+
+import (
+	"maps"
+	"path"
+	"regexp"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// largeDiffLines / largeDiffFiles are the S11 thresholds: a diff whose non-NONE
+// files together change more than largeDiffLines lines, or number more than
+// largeDiffFiles, is large enough that a low/medium base gets one extra level.
+const (
+	largeDiffLines = 800
+	largeDiffFiles = 30
+)
+
+// Signal identifiers recorded in Reason.Signal. S1-S8 push straight to critical,
+// S9/S10 bump to high, S11 adds one level to a low/medium base.
+const (
+	sigTestDeleted       = "S1-test-deleted"
+	sigMeasureDeleted    = "S2-measure-deleted"
+	sigSkipAdded         = "S3-skip-added"
+	sigGuardModified     = "S4-guard-modified"
+	sigReviewGateChanged = "S5-review-gate-modified"
+	sigRiskToolModified  = "S6-risk-tool-modified"
+	sigInstallerModified = "S7-installer-modified"
+	sigCIWorkflowDeleted = "S8-ci-workflow-deleted"
+	sigUnclassifiedPath  = "S9-unclassified-path"
+	sigInvariantHit      = "S10-invariant-hit"
+	sigLargeDiff         = "S11-large-diff"
+)
+
+// Skip-marker greps for S3, one per test flavor. goSkipRe requires the call
+// paren so t.Skip/Skipf/SkipNow match but t.Skipped() (a status read) does not.
+var (
+	goSkipRe   = regexp.MustCompile(`\bt\.(Skip|Skipf|SkipNow)\(`)
+	tsSkipRe   = regexp.MustCompile(`\.skip\(|\bxit\(|\bxdescribe\(`)
+	batsSkipRe = regexp.MustCompile(`^\s*skip\b`)
+)
+
+// evaluate classifies every changed file and aggregates the risk level. Order:
+// base = max(levelForClass over files); S9 (unclassified) and S10 (invariant
+// hit) bump to high; S11 (large diff) adds one level to a low/medium base; then
+// any S1-S8 signal forces critical. Every bump appends a Reason. Files are
+// sorted by path and Reasons by (level desc, signal, file) so the output is
+// deterministic.
+func evaluate(d Diff) Report {
+	files := make([]FileReport, 0, len(d.Files))
+	classByPath := make(map[string]Class, len(d.Files))
+	level := LevelNone
+	for _, fc := range d.Files {
+		fr := FileReport{Path: fc.Path, Status: statusString(fc)}
+		rule, ok := classifyPath(fc.Path)
+		if !ok {
+			rule = Rule{Class: ClassUnknown, ID: "unclassified", Note: "未分類(rules.go に要追記)"}
+		}
+		// A rename can carry a file out of a heavier class into a lighter one
+		// (git mv from an H package into M/A). Judge by the heavier endpoint so
+		// the move is not under-reviewed. Only when the new path classified: an
+		// unclassified destination must stay ClassUnknown so S9 fails closed
+		// (e.g. git mv README.md some-new-top-level-file).
+		if ok && fc.Status == 'R' && fc.OldPath != "" {
+			if oldRule, ook := classifyPath(fc.OldPath); ook && oldRule.Class > rule.Class {
+				rule = oldRule
+				rule.Note = oldRule.Note + "(rename 元 " + fc.OldPath + " 由来)"
+			}
+		}
+		fr.Class, fr.RuleID, fr.Note = rule.Class, rule.ID, rule.Note
+		fr.Level = levelForClass(fr.Class)
+		if fr.Level > level {
+			level = fr.Level
+		}
+		classByPath[fr.Path] = fr.Class
+		files = append(files, fr)
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
+
+	var reasons []Reason
+
+	// S9 unclassified-path -> high.
+	for _, fr := range files {
+		if fr.Class == ClassUnknown {
+			level = maxLevel(level, LevelHigh)
+			reasons = append(reasons, Reason{
+				Signal: sigUnclassifiedPath, Level: LevelHigh, File: fr.Path,
+				Detail: "未分類パス(fail-closed で high)",
+			})
+		}
+	}
+
+	// S10 invariant-hit -> high.
+	for _, r := range invariantReasons(d) {
+		level = maxLevel(level, LevelHigh)
+		reasons = append(reasons, r)
+	}
+
+	// S11 large-diff -> +1, only on a low/medium base.
+	if r, ok := largeDiffReason(d, classByPath); ok && (level == LevelLow || level == LevelMedium) {
+		level++
+		r.Level = level
+		reasons = append(reasons, r)
+	}
+
+	// S1-S8 -> critical.
+	if crit := criticalReasons(d); len(crit) > 0 {
+		level = LevelCritical
+		reasons = append(reasons, crit...)
+	}
+
+	sortReasons(reasons)
+	return Report{Level: level, Files: files, Reasons: reasons, Stats: computeStats(d)}
+}
+
+// criticalReasons collects every S1-S8 signal that fired. Any non-empty result
+// forces the report to critical.
+func criticalReasons(d Diff) []Reason {
+	var reasons []Reason
+	for _, fc := range d.Files {
+		// S1 test-deleted: a deleted test file, or a rename that drops test shape.
+		if fc.Status == 'D' && isTestShape(fc.Path) {
+			reasons = append(reasons, Reason{Signal: sigTestDeleted, Level: LevelCritical, File: fc.Path, Detail: "テストファイル削除"})
+		}
+		if fc.Status == 'R' && isTestShape(fc.OldPath) && !isTestShape(fc.Path) {
+			reasons = append(reasons, Reason{Signal: sigTestDeleted, Level: LevelCritical, File: fc.Path, Detail: "rename でテスト形状を喪失(" + fc.OldPath + ")"})
+		}
+		// S2 measure-deleted: a deleted golden/fixture/bin file, or a rename
+		// that carries one out of the measured tree.
+		if fc.Status == 'D' && isMeasurePath(fc.Path) {
+			reasons = append(reasons, Reason{Signal: sigMeasureDeleted, Level: LevelCritical, File: fc.Path, Detail: "測定基準(golden/fixture/bin)削除"})
+		}
+		if fc.Status == 'R' && isMeasurePath(fc.OldPath) && !isMeasurePath(fc.Path) {
+			reasons = append(reasons, Reason{Signal: sigMeasureDeleted, Level: LevelCritical, File: fc.Path, Detail: "rename で測定基準を移動(" + fc.OldPath + ")"})
+		}
+		// S4 guard-modified: any touch of the layer guard.
+		if touches(fc, "internal/arch/") {
+			reasons = append(reasons, Reason{Signal: sigGuardModified, Level: LevelCritical, File: fc.Path, Detail: "層ガード(internal/arch)変更"})
+		}
+		// S5 review-gate-modified: any touch of .claude/.
+		if touches(fc, ".claude/") {
+			reasons = append(reasons, Reason{Signal: sigReviewGateChanged, Level: LevelCritical, File: fc.Path, Detail: "PR review gate(.claude)変更"})
+		}
+		// S6 risk-tool-modified: this tool or its workflow.
+		if touches(fc, "tools/reviewrisk/") || fc.Path == riskWorkflow || fc.OldPath == riskWorkflow {
+			reasons = append(reasons, Reason{Signal: sigRiskToolModified, Level: LevelCritical, File: fc.Path, Detail: "risk 判定ツール自身の変更"})
+		}
+		// S7 installer-modified: install.sh.
+		if fc.Path == "install.sh" || fc.OldPath == "install.sh" {
+			reasons = append(reasons, Reason{Signal: sigInstallerModified, Level: LevelCritical, File: fc.Path, Detail: "install.sh 変更"})
+		}
+		// S8 ci-workflow-deleted: a deleted workflow file, or a rename that
+		// carries one out of .github/workflows/.
+		if fc.Status == 'D' && strings.HasPrefix(fc.Path, ".github/workflows/") {
+			reasons = append(reasons, Reason{Signal: sigCIWorkflowDeleted, Level: LevelCritical, File: fc.Path, Detail: "CI workflow 削除"})
+		}
+		if fc.Status == 'R' && strings.HasPrefix(fc.OldPath, ".github/workflows/") && !strings.HasPrefix(fc.Path, ".github/workflows/") {
+			reasons = append(reasons, Reason{Signal: sigCIWorkflowDeleted, Level: LevelCritical, File: fc.Path, Detail: "CI workflow を rename で移動(" + fc.OldPath + ")"})
+		}
+	}
+	// S3 skip-added: an added skip/xit/xdescribe line in a test file.
+	for _, p := range slices.Sorted(maps.Keys(d.AddedLines)) {
+		if line, ok := skipAddedMatch(p, d.AddedLines[p]); ok {
+			reasons = append(reasons, Reason{Signal: sigSkipAdded, Level: LevelCritical, File: p, Detail: "スキップ追加: " + line})
+		}
+	}
+	return reasons
+}
+
+const riskWorkflow = ".github/workflows/review-risk.yml"
+
+// invariantReasons collects S10 signals: a diff line (added or removed) that hits
+// a human-must-read invariant pattern, plus FANOUT_* env var names dropped by the
+// diff. Markdown files are exempt: prose that quotes an invariant literal (the
+// architecture doc's own catalog, install docs pinning FANOUT_VERSION) is not a
+// code change to that invariant.
+func invariantReasons(d Diff) []Reason {
+	var reasons []Reason
+	for _, p := range unionPaths(d.AddedLines, d.RemovedLines) {
+		if strings.HasSuffix(p, ".md") {
+			continue
+		}
+		for _, ip := range invariantPatterns {
+			if anyMatch(ip.Re, d.AddedLines[p]) || anyMatch(ip.Re, d.RemovedLines[p]) {
+				reasons = append(reasons, Reason{Signal: sigInvariantHit, Level: LevelHigh, File: p, Detail: "不変条件 " + ip.Name + " に接触"})
+			}
+		}
+	}
+	return append(reasons, envRemovalReasons(d)...)
+}
+
+// envRemovalReasons fires S10 for each FANOUT_* env var name that appears on a
+// removed line but nowhere on an added line. A set difference (removed − added),
+// not a per-line grep, so a line move or re-indent (the same name re-added) does
+// not misfire; adding a name is routine. Markdown files are exempt on both
+// sides, and the reported File is where the name was first removed.
+func envRemovalReasons(d Diff) []Reason {
+	added := make(map[string]bool)
+	for p, lines := range d.AddedLines {
+		if strings.HasSuffix(p, ".md") {
+			continue
+		}
+		for _, l := range lines {
+			for _, name := range envPatternRe.FindAllString(l, -1) {
+				added[name] = true
+			}
+		}
+	}
+	removedAt := make(map[string]string) // name -> representative file
+	for _, p := range slices.Sorted(maps.Keys(d.RemovedLines)) {
+		if strings.HasSuffix(p, ".md") {
+			continue
+		}
+		for _, l := range d.RemovedLines[p] {
+			for _, name := range envPatternRe.FindAllString(l, -1) {
+				if _, ok := removedAt[name]; !ok {
+					removedAt[name] = p
+				}
+			}
+		}
+	}
+	var reasons []Reason
+	for _, name := range slices.Sorted(maps.Keys(removedAt)) {
+		if added[name] {
+			continue
+		}
+		reasons = append(reasons, Reason{
+			Signal: sigInvariantHit, Level: LevelHigh, File: removedAt[name],
+			Detail: "FANOUT_* env 参照を削除: " + name,
+		})
+	}
+	return reasons
+}
+
+// largeDiffReason returns the S11 reason when the non-NONE files together exceed
+// the line or file thresholds. Binary files (-1 counts) contribute 0 lines. It
+// reuses the classByPath map evaluate already built (keyed by new path) instead
+// of re-classifying. The caller only applies the bump on a low/medium base; the
+// returned Reason's Level is filled in there.
+func largeDiffReason(d Diff, classByPath map[string]Class) (Reason, bool) {
+	var lines, count int
+	for _, fc := range d.Files {
+		if classByPath[fc.Path] == ClassNone {
+			continue
+		}
+		count++
+		lines += nonNeg(fc.Added) + nonNeg(fc.Deleted)
+	}
+	if lines > largeDiffLines || count > largeDiffFiles {
+		return Reason{
+			Signal: sigLargeDiff, File: "",
+			Detail: "大規模 diff: 非 NONE " + strconv.Itoa(count) + " ファイル / 変更 " + strconv.Itoa(lines) + " 行",
+		}, true
+	}
+	return Reason{}, false
+}
+
+// computeStats totals the whole diff for the report summary. Binary files (-1)
+// contribute 0.
+func computeStats(d Diff) Stats {
+	s := Stats{Files: len(d.Files)}
+	for _, fc := range d.Files {
+		s.Added += nonNeg(fc.Added)
+		s.Deleted += nonNeg(fc.Deleted)
+	}
+	return s
+}
+
+// skipAddedMatch reports the first added line in a test file that introduces a
+// skip marker, choosing the grep by the file's extension. bats sourced helpers
+// (tests/bats/*.bash) call skip the same way, so they get the bats grep too.
+func skipAddedMatch(p string, lines []string) (string, bool) {
+	var re *regexp.Regexp
+	switch {
+	case strings.HasSuffix(p, "_test.go"):
+		re = goSkipRe
+	case strings.HasSuffix(p, ".test.ts") || strings.HasSuffix(p, ".test.tsx"):
+		re = tsSkipRe
+	case strings.HasSuffix(p, ".bats"):
+		re = batsSkipRe
+	case strings.HasPrefix(p, "tests/bats/") && strings.HasSuffix(p, ".bash"):
+		re = batsSkipRe
+	default:
+		return "", false
+	}
+	for _, l := range lines {
+		if re.MatchString(l) {
+			return strings.TrimSpace(l), true
+		}
+	}
+	return "", false
+}
+
+// isTestShape reports whether a path is a test file: a Go *_test.go, a bats file
+// under tests/bats/, a web *.test.* under web/src/, or anything under
+// web/src/test/.
+func isTestShape(p string) bool {
+	if strings.HasSuffix(p, "_test.go") {
+		return true
+	}
+	if strings.HasPrefix(p, "tests/bats/") && strings.HasSuffix(p, ".bats") {
+		return true
+	}
+	if strings.HasPrefix(p, "web/src/") {
+		if strings.HasPrefix(p, "web/src/test/") {
+			return true
+		}
+		if strings.Contains(path.Base(p), ".test.") {
+			return true
+		}
+	}
+	return false
+}
+
+// isMeasurePath reports whether a path is a measurement yardstick: a golden,
+// fixture, or test-bin file whose deletion removes what a test checks against.
+func isMeasurePath(p string) bool {
+	return strings.HasPrefix(p, "tests/golden/") ||
+		strings.HasPrefix(p, "tests/fixtures/") ||
+		strings.HasPrefix(p, "tests/bin/")
+}
+
+// touches reports whether a change's new or old path is under prefix (so a
+// rename out of a guarded tree still fires).
+func touches(fc FileChange, prefix string) bool {
+	return strings.HasPrefix(fc.Path, prefix) ||
+		(fc.OldPath != "" && strings.HasPrefix(fc.OldPath, prefix))
+}
+
+// statusString renders a FileChange status byte for the report's St column.
+func statusString(fc FileChange) string {
+	if fc.Status == 0 {
+		return "?"
+	}
+	return string(fc.Status)
+}
+
+func maxLevel(a, b Level) Level {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func nonNeg(n int) int {
+	if n < 0 {
+		return 0
+	}
+	return n
+}
+
+func anyMatch(re *regexp.Regexp, lines []string) bool {
+	return slices.ContainsFunc(lines, re.MatchString)
+}
+
+// unionPaths returns the sorted union of two content maps' keys.
+func unionPaths(a, b map[string][]string) []string {
+	set := make(map[string]struct{}, len(a)+len(b))
+	for k := range a {
+		set[k] = struct{}{}
+	}
+	for k := range b {
+		set[k] = struct{}{}
+	}
+	return slices.Sorted(maps.Keys(set))
+}
+
+// sortReasons orders reasons deterministically: highest level first, then signal
+// id, then file.
+func sortReasons(rs []Reason) {
+	sort.Slice(rs, func(i, j int) bool {
+		if rs[i].Level != rs[j].Level {
+			return rs[i].Level > rs[j].Level
+		}
+		if rs[i].Signal != rs[j].Signal {
+			return rs[i].Signal < rs[j].Signal
+		}
+		return rs[i].File < rs[j].File
+	})
+}

--- a/tools/reviewrisk/signals.go
+++ b/tools/reviewrisk/signals.go
@@ -306,15 +306,17 @@ func skipAddedMatch(p string, lines []string) (string, bool) {
 }
 
 // isTestShape reports whether a path is a test file: a Go *_test.go, a bats file
-// under tests/bats/, or a web test (isWebTestFile: a *.test/*.spec .ts(x) under
-// web/src/, or anything under web/src/test/). Sharing isWebTestFile is what
-// makes a rename that drops the suffix (foo.test.ts -> foo.test.disabled.ts)
-// lose test shape and fire S1 — a substring check would keep it "test-shaped".
+// or sourced helper under tests/bats/ (.bats or .bash — helpers.bash carries the
+// skip harness skipAddedMatch already scans), or a web test (isWebTestFile: a
+// *.test/*.spec .ts(x) under web/src/, or anything under web/src/test/). Sharing
+// isWebTestFile is what makes a rename that drops the suffix (foo.test.ts ->
+// foo.test.disabled.ts) lose test shape and fire S1 — a substring check would
+// keep it "test-shaped".
 func isTestShape(p string) bool {
 	if strings.HasSuffix(p, "_test.go") {
 		return true
 	}
-	if strings.HasPrefix(p, "tests/bats/") && strings.HasSuffix(p, ".bats") {
+	if strings.HasPrefix(p, "tests/bats/") && (strings.HasSuffix(p, ".bats") || strings.HasSuffix(p, ".bash")) {
 		return true
 	}
 	return isWebTestFile(p)

--- a/tools/reviewrisk/signals_test.go
+++ b/tools/reviewrisk/signals_test.go
@@ -117,6 +117,32 @@ func TestEvaluate(t *testing.T) {
 			wantSig:   []string{sigSkipAdded},
 		},
 		{
+			name: "S3 added describe.skip in the web test harness is critical",
+			diff: Diff{
+				Files:      []FileChange{{Status: 'M', Path: "web/src/test/setup.ts"}},
+				AddedLines: map[string][]string{"web/src/test/setup.ts": {"describe.skip('flaky suite', () => {"}},
+			},
+			wantLevel: LevelCritical,
+			wantSig:   []string{sigSkipAdded},
+		},
+		{
+			name: "S3 added vitest skipIf variant is critical",
+			diff: Diff{
+				Files:      []FileChange{{Status: 'M', Path: "web/src/lib/sort.test.ts"}},
+				AddedLines: map[string][]string{"web/src/lib/sort.test.ts": {"test.skipIf(isCI)('sorts', () => {})"}},
+			},
+			wantLevel: LevelCritical,
+			wantSig:   []string{sigSkipAdded},
+		},
+		{
+			name: "S5 post-work-review gate script change is critical",
+			diff: Diff{
+				Files: []FileChange{{Status: 'M', Path: "codex/tools/post-work-review.sh"}},
+			},
+			wantLevel: LevelCritical,
+			wantSig:   []string{sigReviewGateChanged},
+		},
+		{
 			name:      "S4 arch change is critical",
 			diff:      Diff{Files: []FileChange{{Status: 'M', Path: "internal/arch/arch.go"}}},
 			wantLevel: LevelCritical,
@@ -200,6 +226,21 @@ func TestEvaluate(t *testing.T) {
 			},
 			wantLevel: LevelLow,
 			notSig:    []string{sigInvariantHit},
+		},
+		{
+			// Suppression is per-file: a string occurrence added in another file
+			// (a comment, a fixture) must not mask a real reference removal.
+			name: "S10 FANOUT_ removal fires even when another file adds the same name",
+			diff: Diff{
+				Files: []FileChange{
+					{Status: 'M', Path: "internal/app/sessionview/collect.go"},
+					{Status: 'M', Path: "internal/infra/log/log.go"},
+				},
+				RemovedLines: map[string][]string{"internal/app/sessionview/collect.go": {"os.Getenv(\"FANOUT_STATE_PATH\")"}},
+				AddedLines:   map[string][]string{"internal/infra/log/log.go": {"// see FANOUT_STATE_PATH"}},
+			},
+			wantLevel: LevelHigh,
+			wantSig:   []string{sigInvariantHit},
 		},
 		{
 			name: "S10 renamed FANOUT_ fires for the dropped old name only",

--- a/tools/reviewrisk/signals_test.go
+++ b/tools/reviewrisk/signals_test.go
@@ -185,6 +185,22 @@ func TestEvaluate(t *testing.T) {
 			wantSig:   []string{sigCIWorkflowDeleted},
 		},
 		{
+			// GitHub Actions only runs .yml/.yaml under workflows/, so an in-place
+			// rename to another extension disables the workflow.
+			name:      "S8 in-place rename dropping the yml extension is critical",
+			diff:      Diff{Files: []FileChange{{Status: 'R', OldPath: ".github/workflows/test.yml", Path: ".github/workflows/test.yml.disabled"}}},
+			wantLevel: LevelCritical,
+			wantSig:   []string{sigCIWorkflowDeleted},
+		},
+		{
+			name: "S5 post-work-review agent definition change is critical",
+			diff: Diff{
+				Files: []FileChange{{Status: 'M', Path: "codex/agents/post-work-reviewer.md"}},
+			},
+			wantLevel: LevelCritical,
+			wantSig:   []string{sigReviewGateChanged},
+		},
+		{
 			name:      "S9 unclassified dashboard file is high",
 			diff:      Diff{Files: []FileChange{{Status: 'A', Path: "internal/ui/dashboard/newthing.go"}}},
 			wantLevel: LevelHigh,

--- a/tools/reviewrisk/signals_test.go
+++ b/tools/reviewrisk/signals_test.go
@@ -60,6 +60,15 @@ func TestEvaluate(t *testing.T) {
 			wantSig:   []string{sigTestDeleted},
 		},
 		{
+			// A web test renamed to a suffix vitest no longer collects
+			// (foo.test.ts -> foo.test.disabled.ts) drops test shape: the
+			// suffix check, not a substring, is what catches this.
+			name:      "S1 web rename to an uncollected suffix drops test shape",
+			diff:      Diff{Files: []FileChange{{Status: 'R', OldPath: "web/src/lib/foo.test.ts", Path: "web/src/lib/foo.test.disabled.ts"}}},
+			wantLevel: LevelCritical,
+			wantSig:   []string{sigTestDeleted},
+		},
+		{
 			name:      "rename keeping test shape does not fire S1",
 			diff:      Diff{Files: []FileChange{{Status: 'R', OldPath: "internal/core/naming/a_test.go", Path: "internal/core/naming/b_test.go"}}},
 			wantLevel: LevelMedium, // still classified under core/naming (M)
@@ -99,6 +108,26 @@ func TestEvaluate(t *testing.T) {
 			wantSig:   []string{sigSkipAdded},
 		},
 		{
+			// Skip receiver is not fixed to t: a testing.TB helper (tb) skips too.
+			name: "S3 added tb.Skip under a non-t receiver is critical",
+			diff: Diff{
+				Files:      []FileChange{{Status: 'M', Path: "internal/core/naming/foo_test.go"}},
+				AddedLines: map[string][]string{"internal/core/naming/foo_test.go": {"\ttb.Skip(\"wip\")"}},
+			},
+			wantLevel: LevelCritical,
+			wantSig:   []string{sigSkipAdded},
+		},
+		{
+			// A *testing.B benchmark skips via b.Skip; the receiver name still varies.
+			name: "S3 added b.Skip in a benchmark is critical",
+			diff: Diff{
+				Files:      []FileChange{{Status: 'M', Path: "internal/core/naming/foo_test.go"}},
+				AddedLines: map[string][]string{"internal/core/naming/foo_test.go": {"\tb.Skip(\"bench\")"}},
+			},
+			wantLevel: LevelCritical,
+			wantSig:   []string{sigSkipAdded},
+		},
+		{
 			name: "S3 does not fire on t.Skipped() (a status read, not a skip call)",
 			diff: Diff{
 				Files:      []FileChange{{Status: 'M', Path: "internal/core/naming/foo_test.go"}},
@@ -130,6 +159,16 @@ func TestEvaluate(t *testing.T) {
 			diff: Diff{
 				Files:      []FileChange{{Status: 'M', Path: "web/src/lib/sort.test.ts"}},
 				AddedLines: map[string][]string{"web/src/lib/sort.test.ts": {"test.skipIf(isCI)('sorts', () => {})"}},
+			},
+			wantLevel: LevelCritical,
+			wantSig:   []string{sigSkipAdded},
+		},
+		{
+			// vitest collects .spec files too, so a skip added in one fires S3.
+			name: "S3 added test.skip in a .spec.tsx file is critical",
+			diff: Diff{
+				Files:      []FileChange{{Status: 'M', Path: "web/src/components/foo.spec.tsx"}},
+				AddedLines: map[string][]string{"web/src/components/foo.spec.tsx": {"  test.skip('renders', () => {})"}},
 			},
 			wantLevel: LevelCritical,
 			wantSig:   []string{sigSkipAdded},

--- a/tools/reviewrisk/signals_test.go
+++ b/tools/reviewrisk/signals_test.go
@@ -75,6 +75,21 @@ func TestEvaluate(t *testing.T) {
 			notSig:    []string{sigTestDeleted},
 		},
 		{
+			// A sourced bats helper (tests/bats/helpers.bash) is test shape too:
+			// deleting it drops harness the .bats suites rely on.
+			name:      "S1 deleted bats helper .bash is critical",
+			diff:      Diff{Files: []FileChange{{Status: 'D', Path: "tests/bats/helpers.bash"}}},
+			wantLevel: LevelCritical,
+			wantSig:   []string{sigTestDeleted},
+		},
+		{
+			// Renaming a bats helper out of tests/bats/ loses test shape and fires S1.
+			name:      "S1 rename of a bats helper out of tests/bats drops test shape",
+			diff:      Diff{Files: []FileChange{{Status: 'R', OldPath: "tests/bats/helpers.bash", Path: "docs/helpers.bash"}}},
+			wantLevel: LevelCritical,
+			wantSig:   []string{sigTestDeleted},
+		},
+		{
 			name:      "rename from an H package into docs is judged by the heavier old class",
 			diff:      Diff{Files: []FileChange{{Status: 'R', OldPath: "internal/infra/settings/resolve.go", Path: "docs/resolve-notes.md"}}},
 			wantLevel: LevelHigh, // old path is H (settings), new path is docs (NONE)

--- a/tools/reviewrisk/signals_test.go
+++ b/tools/reviewrisk/signals_test.go
@@ -1,0 +1,326 @@
+package main
+
+import (
+	"fmt"
+	"reflect"
+	"slices"
+	"testing"
+)
+
+// reasonSignals returns the signal ids present in a report, for presence checks.
+func reasonSignals(r Report) []string {
+	out := make([]string, 0, len(r.Reasons))
+	for _, rs := range r.Reasons {
+		out = append(out, rs.Signal)
+	}
+	return out
+}
+
+// TestEvaluate drives the whole aggregation: the base level from file classes,
+// each escalation signal S1-S11, and the interactions the plan pins (FANOUT_
+// removed-only, large-diff caps at the low/medium base, NONE lines excluded).
+func TestEvaluate(t *testing.T) {
+	tests := []struct {
+		name      string
+		diff      Diff
+		wantLevel Level
+		wantSig   []string // signals that must be present
+		notSig    []string // signals that must be absent
+	}{
+		{
+			name:      "empty diff is none",
+			diff:      Diff{},
+			wantLevel: LevelNone,
+		},
+		{
+			name:      "class A file only is low",
+			diff:      Diff{Files: []FileChange{{Status: 'M', Path: "internal/infra/log/log.go"}}},
+			wantLevel: LevelLow,
+		},
+		{
+			name:      "class M file is medium",
+			diff:      Diff{Files: []FileChange{{Status: 'M', Path: "internal/app/run/run.go"}}},
+			wantLevel: LevelMedium,
+		},
+		{
+			name:      "class H file is high",
+			diff:      Diff{Files: []FileChange{{Status: 'M', Path: "internal/infra/state/store.go"}}},
+			wantLevel: LevelHigh,
+		},
+		{
+			name:      "S1 deleted test file is critical",
+			diff:      Diff{Files: []FileChange{{Status: 'D', Path: "internal/core/naming/slug_test.go"}}},
+			wantLevel: LevelCritical,
+			wantSig:   []string{sigTestDeleted},
+		},
+		{
+			name:      "S1 rename dropping test shape is critical",
+			diff:      Diff{Files: []FileChange{{Status: 'R', OldPath: "internal/core/naming/foo_test.go", Path: "internal/core/naming/foo.go"}}},
+			wantLevel: LevelCritical,
+			wantSig:   []string{sigTestDeleted},
+		},
+		{
+			name:      "rename keeping test shape does not fire S1",
+			diff:      Diff{Files: []FileChange{{Status: 'R', OldPath: "internal/core/naming/a_test.go", Path: "internal/core/naming/b_test.go"}}},
+			wantLevel: LevelMedium, // still classified under core/naming (M)
+			notSig:    []string{sigTestDeleted},
+		},
+		{
+			name:      "rename from an H package into docs is judged by the heavier old class",
+			diff:      Diff{Files: []FileChange{{Status: 'R', OldPath: "internal/infra/settings/resolve.go", Path: "docs/resolve-notes.md"}}},
+			wantLevel: LevelHigh, // old path is H (settings), new path is docs (NONE)
+			notSig:    []string{sigTestDeleted, sigMeasureDeleted},
+		},
+		{
+			name:      "rename onto an unclassified path stays fail-closed at S9",
+			diff:      Diff{Files: []FileChange{{Status: 'R', OldPath: "README.md", Path: "some-new-top-level-file"}}},
+			wantLevel: LevelHigh, // NONE old class must not mask the unclassified destination
+			wantSig:   []string{sigUnclassifiedPath},
+		},
+		{
+			name:      "S2 deleted golden is critical",
+			diff:      Diff{Files: []FileChange{{Status: 'D', Path: "tests/golden/scenario-plan.txt"}}},
+			wantLevel: LevelCritical,
+			wantSig:   []string{sigMeasureDeleted},
+		},
+		{
+			name:      "S2 rename out of tests/golden is critical",
+			diff:      Diff{Files: []FileChange{{Status: 'R', OldPath: "tests/golden/scenario-plan.txt", Path: "docs/scenario-plan.txt"}}},
+			wantLevel: LevelCritical,
+			wantSig:   []string{sigMeasureDeleted},
+		},
+		{
+			name: "S3 added t.Skip in a test file is critical",
+			diff: Diff{
+				Files:      []FileChange{{Status: 'M', Path: "internal/core/naming/foo_test.go"}},
+				AddedLines: map[string][]string{"internal/core/naming/foo_test.go": {"\tt.Skip(\"wip\")"}},
+			},
+			wantLevel: LevelCritical,
+			wantSig:   []string{sigSkipAdded},
+		},
+		{
+			name: "S3 does not fire on t.Skipped() (a status read, not a skip call)",
+			diff: Diff{
+				Files:      []FileChange{{Status: 'M', Path: "internal/core/naming/foo_test.go"}},
+				AddedLines: map[string][]string{"internal/core/naming/foo_test.go": {"\tif t.Skipped() {"}},
+			},
+			wantLevel: LevelMedium, // core/naming (M), no S3
+			notSig:    []string{sigSkipAdded},
+		},
+		{
+			name: "S3 added skip in bats helpers.bash is critical",
+			diff: Diff{
+				Files:      []FileChange{{Status: 'M', Path: "tests/bats/helpers.bash"}},
+				AddedLines: map[string][]string{"tests/bats/helpers.bash": {"  skip \"needs docker\""}},
+			},
+			wantLevel: LevelCritical,
+			wantSig:   []string{sigSkipAdded},
+		},
+		{
+			name:      "S4 arch change is critical",
+			diff:      Diff{Files: []FileChange{{Status: 'M', Path: "internal/arch/arch.go"}}},
+			wantLevel: LevelCritical,
+			wantSig:   []string{sigGuardModified},
+		},
+		{
+			name:      "S5 .claude change is critical",
+			diff:      Diff{Files: []FileChange{{Status: 'M', Path: ".claude/settings.json"}}},
+			wantLevel: LevelCritical,
+			wantSig:   []string{sigReviewGateChanged},
+		},
+		{
+			name:      "S6 risk tool change is critical",
+			diff:      Diff{Files: []FileChange{{Status: 'M', Path: "tools/reviewrisk/rules.go"}}},
+			wantLevel: LevelCritical,
+			wantSig:   []string{sigRiskToolModified},
+		},
+		{
+			name:      "S6 risk workflow change is critical",
+			diff:      Diff{Files: []FileChange{{Status: 'M', Path: ".github/workflows/review-risk.yml"}}},
+			wantLevel: LevelCritical,
+			wantSig:   []string{sigRiskToolModified},
+		},
+		{
+			name:      "S7 installer change is critical",
+			diff:      Diff{Files: []FileChange{{Status: 'M', Path: "install.sh"}}},
+			wantLevel: LevelCritical,
+			wantSig:   []string{sigInstallerModified},
+		},
+		{
+			name:      "S8 deleted workflow is critical",
+			diff:      Diff{Files: []FileChange{{Status: 'D', Path: ".github/workflows/test.yml"}}},
+			wantLevel: LevelCritical,
+			wantSig:   []string{sigCIWorkflowDeleted},
+		},
+		{
+			name:      "S8 rename out of workflows is critical",
+			diff:      Diff{Files: []FileChange{{Status: 'R', OldPath: ".github/workflows/test.yml", Path: "hack/test.yml"}}},
+			wantLevel: LevelCritical,
+			wantSig:   []string{sigCIWorkflowDeleted},
+		},
+		{
+			name:      "S9 unclassified dashboard file is high",
+			diff:      Diff{Files: []FileChange{{Status: 'A', Path: "internal/ui/dashboard/newthing.go"}}},
+			wantLevel: LevelHigh,
+			wantSig:   []string{sigUnclassifiedPath},
+		},
+		{
+			name: "S10 invariant added line bumps to high",
+			diff: Diff{
+				Files:      []FileChange{{Status: 'M', Path: "internal/infra/log/log.go"}},
+				AddedLines: map[string][]string{"internal/infra/log/log.go": {"if requireToken(r) {"}},
+			},
+			wantLevel: LevelHigh,
+			wantSig:   []string{sigInvariantHit},
+		},
+		{
+			name: "S10 FANOUT_ removed line bumps to high",
+			diff: Diff{
+				Files:        []FileChange{{Status: 'M', Path: "internal/infra/log/log.go"}},
+				RemovedLines: map[string][]string{"internal/infra/log/log.go": {"os.Getenv(\"FANOUT_DB_PATH\")"}},
+			},
+			wantLevel: LevelHigh,
+			wantSig:   []string{sigInvariantHit},
+		},
+		{
+			name: "S10 FANOUT_ added line does not fire (removed-only)",
+			diff: Diff{
+				Files:      []FileChange{{Status: 'M', Path: "internal/infra/log/log.go"}},
+				AddedLines: map[string][]string{"internal/infra/log/log.go": {"os.Getenv(\"FANOUT_NEW_FLAG\")"}},
+			},
+			wantLevel: LevelLow,
+			notSig:    []string{sigInvariantHit},
+		},
+		{
+			name: "S10 FANOUT_ moved line (removed then re-added) does not fire",
+			diff: Diff{
+				Files:        []FileChange{{Status: 'M', Path: "internal/infra/log/log.go"}},
+				RemovedLines: map[string][]string{"internal/infra/log/log.go": {"\tos.Getenv(\"FANOUT_DB_PATH\")"}},
+				AddedLines:   map[string][]string{"internal/infra/log/log.go": {"    os.Getenv(\"FANOUT_DB_PATH\")"}}, // same name, re-indented
+			},
+			wantLevel: LevelLow,
+			notSig:    []string{sigInvariantHit},
+		},
+		{
+			name: "S10 renamed FANOUT_ fires for the dropped old name only",
+			diff: Diff{
+				Files:        []FileChange{{Status: 'M', Path: "internal/infra/log/log.go"}},
+				RemovedLines: map[string][]string{"internal/infra/log/log.go": {"os.Getenv(\"FANOUT_OLD_FLAG\")"}},
+				AddedLines:   map[string][]string{"internal/infra/log/log.go": {"os.Getenv(\"FANOUT_NEW_FLAG\")"}},
+			},
+			wantLevel: LevelHigh,
+			wantSig:   []string{sigInvariantHit},
+		},
+		{
+			name: "S10 skips markdown quoting an invariant literal",
+			diff: Diff{
+				Files:      []FileChange{{Status: 'M', Path: "docs/architecture.ja.md"}},
+				AddedLines: map[string][]string{"docs/architecture.ja.md": {"- **dashboard は read-only**: `requireToken` が守る"}},
+			},
+			wantLevel: LevelMedium, // architecture.ja.md's own class, no S10 bump
+			notSig:    []string{sigInvariantHit},
+		},
+		{
+			name: "S10 skips FANOUT_ removal in markdown",
+			diff: Diff{
+				Files:        []FileChange{{Status: 'M', Path: "site/content/docs/installation.md"}},
+				RemovedLines: map[string][]string{"site/content/docs/installation.md": {"FANOUT_VERSION=v0.8.0 ./install.sh"}},
+			},
+			wantLevel: LevelNone,
+			notSig:    []string{sigInvariantHit},
+		},
+		{
+			name:      "S11 large diff bumps low to medium",
+			diff:      Diff{Files: []FileChange{{Status: 'M', Path: "internal/infra/log/log.go", Added: 500, Deleted: 400}}},
+			wantLevel: LevelMedium,
+			wantSig:   []string{sigLargeDiff},
+		},
+		{
+			name:      "S11 large diff bumps medium to high",
+			diff:      Diff{Files: []FileChange{{Status: 'M', Path: "internal/app/run/run.go", Added: 900}}},
+			wantLevel: LevelHigh,
+			wantSig:   []string{sigLargeDiff},
+		},
+		{
+			name:      "S11 does not bump a high base",
+			diff:      Diff{Files: []FileChange{{Status: 'M', Path: "internal/infra/state/store.go", Added: 900}}},
+			wantLevel: LevelHigh,
+			notSig:    []string{sigLargeDiff},
+		},
+		{
+			name: "S11 ignores NONE lines when totalling",
+			diff: Diff{Files: []FileChange{
+				{Status: 'M', Path: "README.md", Added: 900},                // NONE: excluded
+				{Status: 'M', Path: "internal/infra/log/log.go", Added: 10}, // A: 10 lines only
+			}},
+			wantLevel: LevelLow,
+			notSig:    []string{sigLargeDiff},
+		},
+		{
+			name: "binary file counts as zero lines for S11",
+			diff: Diff{Files: []FileChange{
+				{Status: 'M', Path: "internal/infra/log/log.go", Added: -1, Deleted: -1}, // binary
+			}},
+			wantLevel: LevelLow,
+			notSig:    []string{sigLargeDiff},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := evaluate(tt.diff)
+			if got.Level != tt.wantLevel {
+				t.Errorf("evaluate(%s) level = %v, want %v", tt.name, got.Level, tt.wantLevel)
+			}
+			sigs := reasonSignals(got)
+			for _, w := range tt.wantSig {
+				if !slices.Contains(sigs, w) {
+					t.Errorf("evaluate(%s) reasons = %v, want signal %q present", tt.name, sigs, w)
+				}
+			}
+			for _, n := range tt.notSig {
+				if slices.Contains(sigs, n) {
+					t.Errorf("evaluate(%s) reasons = %v, want signal %q absent", tt.name, sigs, n)
+				}
+			}
+		})
+	}
+}
+
+// TestEvaluateLargeDiffFileCount pins the S11 file-count threshold (>30) on its
+// own: 31 small non-NONE files trip it even though their line total is tiny.
+func TestEvaluateLargeDiffFileCount(t *testing.T) {
+	var d Diff
+	for i := range largeDiffFiles + 1 {
+		d.Files = append(d.Files, FileChange{Status: 'M', Path: fmt.Sprintf("internal/infra/log/f%d.go", i), Added: 1})
+	}
+	got := evaluate(d)
+	if got.Level != LevelMedium {
+		t.Errorf("evaluate(31 class-A files) level = %v, want medium (S11 file-count bump)", got.Level)
+	}
+	if !slices.Contains(reasonSignals(got), sigLargeDiff) {
+		t.Errorf("evaluate(31 class-A files) reasons = %v, want S11 present", reasonSignals(got))
+	}
+}
+
+// TestEvaluateDeterministic guards the sort promises: repeated evaluation of the
+// same diff yields byte-identical Files and Reasons ordering.
+func TestEvaluateDeterministic(t *testing.T) {
+	d := Diff{Files: []FileChange{
+		{Status: 'D', Path: "tests/golden/z.txt"},
+		{Status: 'M', Path: "internal/arch/arch.go"},
+		{Status: 'A', Path: "internal/ui/dashboard/newthing.go"},
+	}}
+	a := evaluate(d)
+	b := evaluate(d)
+	if !reflect.DeepEqual(a, b) {
+		t.Errorf("evaluate is not deterministic:\n a = %#v\n b = %#v", a, b)
+	}
+	// Files must be path-sorted.
+	paths := make([]string, len(a.Files))
+	for i, f := range a.Files {
+		paths[i] = f.Path
+	}
+	if !slices.IsSorted(paths) {
+		t.Errorf("evaluate files are not path-sorted: %v", paths)
+	}
+}

--- a/tools/reviewrisk/signals_test.go
+++ b/tools/reviewrisk/signals_test.go
@@ -221,6 +221,14 @@ func TestEvaluate(t *testing.T) {
 			wantSig:   []string{sigRiskToolModified},
 		},
 		{
+			// The base-side pull_request_target guard workflow is risk tooling too:
+			// weakening it disables the self-modification defense.
+			name:      "S6 risk guard workflow change is critical",
+			diff:      Diff{Files: []FileChange{{Status: 'M', Path: ".github/workflows/review-risk-guard.yml"}}},
+			wantLevel: LevelCritical,
+			wantSig:   []string{sigRiskToolModified},
+		},
+		{
 			name:      "S7 installer change is critical",
 			diff:      Diff{Files: []FileChange{{Status: 'M', Path: "install.sh"}}},
 			wantLevel: LevelCritical,

--- a/tools/reviewrisk/signals_test.go
+++ b/tools/reviewrisk/signals_test.go
@@ -193,6 +193,32 @@ func TestEvaluate(t *testing.T) {
 			wantSig:   []string{sigCIWorkflowDeleted},
 		},
 		{
+			// Actions ignores subdirectories of workflows/, so this move also
+			// disables the workflow.
+			name:      "S8 rename into a workflows subdirectory is critical",
+			diff:      Diff{Files: []FileChange{{Status: 'R', OldPath: ".github/workflows/test.yml", Path: ".github/workflows/disabled/test.yml"}}},
+			wantLevel: LevelCritical,
+			wantSig:   []string{sigCIWorkflowDeleted},
+		},
+		{
+			name: "S3 conditional bats skip after && is critical",
+			diff: Diff{
+				Files:      []FileChange{{Status: 'M', Path: "tests/bats/tier1_flags.bats"}},
+				AddedLines: map[string][]string{"tests/bats/tier1_flags.bats": {"  [[ $CI == true ]] && skip \"flaky\""}},
+			},
+			wantLevel: LevelCritical,
+			wantSig:   []string{sigSkipAdded},
+		},
+		{
+			name: "S3 does not fire on a bats comment mentioning skip",
+			diff: Diff{
+				Files:      []FileChange{{Status: 'M', Path: "tests/bats/tier1_flags.bats"}},
+				AddedLines: map[string][]string{"tests/bats/tier1_flags.bats": {"# do not skip this scenario"}},
+			},
+			wantLevel: LevelMedium, // tests/bats (M), no S3
+			notSig:    []string{sigSkipAdded},
+		},
+		{
 			name: "S5 post-work-review agent definition change is critical",
 			diff: Diff{
 				Files: []FileChange{{Status: 'M', Path: "codex/agents/post-work-reviewer.md"}},

--- a/tools/reviewrisk/types.go
+++ b/tools/reviewrisk/types.go
@@ -1,0 +1,101 @@
+package main
+
+import "regexp"
+
+// RuleSource records where a Rule came from. SourceDocTable rules mirror the
+// package table in docs/architecture.ja.md and the docsync test cross-checks
+// them; SourceExtra rules cover files with no package-table row (go.mod,
+// tests/, .github/, ...).
+type RuleSource int
+
+const (
+	SourceDocTable RuleSource = iota
+	SourceExtra
+)
+
+// Rule is the classification a path resolves to: its review Class, where the
+// rule is sourced from, a stable ID for reporting, and a one-line note.
+type Rule struct {
+	ID     string
+	Class  Class
+	Source RuleSource
+	Note   string
+}
+
+// FileChange is one entry from git diff --name-status / --numstat. Status is
+// the porcelain letter (A/M/D/R/C); OldPath is set for renames and copies;
+// Added and Deleted are -1 for binary files (numstat reports "-").
+type FileChange struct {
+	Path    string
+	OldPath string
+	Status  byte
+	Added   int
+	Deleted int
+}
+
+// Diff is the parsed base..HEAD diff. AddedLines and RemovedLines hold the +/-
+// content lines per path (from -U0) that the escalation-signal greps scan.
+type Diff struct {
+	Files        []FileChange
+	AddedLines   map[string][]string
+	RemovedLines map[string][]string
+}
+
+// Reason is one escalation signal that fired, with the level it pushed to and
+// the file that triggered it.
+type Reason struct {
+	Signal string `json:"signal"`
+	Level  Level  `json:"level"`
+	File   string `json:"file"`
+	Detail string `json:"detail"`
+}
+
+// FileReport is the per-file row in the report: its resolved class/level and
+// the rule that matched.
+type FileReport struct {
+	Path   string `json:"path"`
+	Status string `json:"status"`
+	Class  Class  `json:"class"`
+	Level  Level  `json:"level"`
+	RuleID string `json:"rule"`
+	Note   string `json:"note"`
+}
+
+// Stats summarizes the diff size for the large-diff signal and the report.
+type Stats struct {
+	Files   int `json:"files"`
+	Added   int `json:"added"`
+	Deleted int `json:"deleted"`
+}
+
+// Report is the whole judgment: the aggregate level, per-file rows, the
+// reasons that escalated it, and the diff stats.
+type Report struct {
+	Level   Level        `json:"level"`
+	Files   []FileReport `json:"files"`
+	Reasons []Reason     `json:"reasons"`
+	Stats   Stats        `json:"stats"`
+}
+
+// invariantPatterns are the S10 grep patterns: a diff that adds or removes a
+// line matching one of these touches a human-must-read invariant and bumps to
+// high. DocLiteral is the plain string the pattern corresponds to in
+// docs/architecture.ja.md, which TestInvariantPatternsAppearInDoc pins so a
+// renamed invariant cannot silently drop off the watch list.
+var invariantPatterns = []struct {
+	Name       string
+	Re         *regexp.Regexp
+	DocLiteral string
+}{
+	{Name: "requireToken", Re: regexp.MustCompile(`requireToken`), DocLiteral: "requireToken"},
+	{Name: "127.0.0.1", Re: regexp.MustCompile(`127\.0\.0\.1`), DocLiteral: "127.0.0.1"},
+	{Name: "__tui-new-pane-popup", Re: regexp.MustCompile(`__tui-new-pane-popup`), DocLiteral: "__tui-new-pane-popup"},
+	{Name: "__tui-help-popup", Re: regexp.MustCompile(`__tui-help-popup`), DocLiteral: "__tui-help-popup"},
+	{Name: "__codex-plan-tui", Re: regexp.MustCompile(`__codex-plan-tui`), DocLiteral: "__codex-plan-tui"},
+	{Name: "main.version", Re: regexp.MustCompile(`main\.version`), DocLiteral: "main.version"},
+}
+
+// envPatternRe matches FANOUT_* env var names. Unlike invariantPatterns it is a
+// removed-line-only signal: dropping a reference to a FANOUT_* variable can
+// break shell/CI/doc callers, but adding one is routine.
+var envPatternRe = regexp.MustCompile(`FANOUT_[A-Z_]{2,}`)


### PR DESCRIPTION
## TL;DR

docs/architecture.ja.md の H/M/A レビュー負荷クラスを機械可読なルール表に写像した repo 専用ツール `tools/reviewrisk` を新設し、PR の変更パスと diff 内容から 5 段階(none/low/medium/high/critical)の review risk を決定論的に判定する。CI(`review-risk.yml`)が `review:<level>` ラベルと sticky コメントを PR に付ける。advisory(マージ非ブロック)・LLM 不使用。

Review effort: 4

## 設計の要点

- **判定は完全に機械的**: `classifyPath`(完全一致 → Go テストペアリング → web テスト上書き → longest-prefix → 未分類は fail-closed で high)+ エスカレーションシグナル S1-S11。全バンプに理由が付き、監査可能
- **doc が正典**: `docsync_test.go` が docs/architecture.ja.md のパッケージ表と `rules.go` の双方向同期を CI 強制。クラス変更は rules.go 同時更新が必須になる
- **tools/ ツリー新設**: `internal/arch` に tools 層ルールを追加し、「本体を import しない/されない・stdlib のみ」をディレクトリレベルで CI 保証(`TestToolsStdlibOnly`)
- **物差し汚染への防御**: テスト/golden の削除・skip 追加・arch/.claude/install.sh/ツール自身の変更は無条件 critical(rename-out 含む)。workflow 側にも self-modification ガード(ツール変更 PR は PR 側ツールを実行せず critical 固定)+ `persist-credentials: false`
- **LLM は最終手段**: ツールは LLM を呼ばず、medium 以上のガイダンス文で `/code-review` へ誘導するのみ
- 案1「機械式リスクレーン」(#175)とは別物の repo-local 先行実装(docs/review-risk.ja.md に関係を明記)

## 検証

- `make lint` 0 issues / `make test` 全 green(Go + web 103 + bats 50)
- 過去マージへのサニティチェック: docs のみ #430 → none、architecture doc 追加 #422 → medium、main dispatch 改変 #421 → high、rename 多数 #420 → high(+1409 −1219 と rename 行数も正しく計上)
- code-review(30 候補検出 → 修正)+ codex review 6 反復(numstat rename・parseUnified ヘッダ誤認・S2/S8 rename-out・workflow セキュリティ 2 件などを修正)で approve
- この PR 自体に review-risk.yml が走り、self-modification ガードで `review:critical` が付くはず — それが動作確認になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HoEEhJuLPGca3xWJC223Jc