### PR TITLE
[codex] Show pane close choices in a popup

### DIFF
--- a/cmd/fanout/dispatch_test.go
+++ b/cmd/fanout/dispatch_test.go
@@ -19,6 +19,7 @@ func TestSelfExecSubcommandNames(t *testing.T) {
 	}{
 		{name: "new pane popup", got: tuiNewPanePopupCommand, want: "__tui-new-pane-popup"},
 		{name: "help popup", got: tuiHelpPopupCommand, want: "__tui-help-popup"},
+		{name: "close popup", got: tuiClosePopupCommand, want: "__tui-close-popup"},
 		{name: "codex plan tui", got: codexapp.PlanTUICommand, want: "__codex-plan-tui"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/fanout/main.go
+++ b/cmd/fanout/main.go
@@ -40,6 +40,7 @@ func main() {
 		{isTUIRequest, func() exitcode.Code { return cmdTUI(commandName, lg) }},
 		{isTUINewPanePopupRequest, func() exitcode.Code { return cmdTUINewPanePopup(os.Args[2:], lg) }},
 		{isTUIHelpPopupRequest, func() exitcode.Code { return cmdTUIHelpPopup(os.Args[2:], lg) }},
+		{isTUIClosePopupRequest, func() exitcode.Code { return cmdTUIClosePopup(os.Args[2:], lg) }},
 		{isCodexPlanTUIRequest, func() exitcode.Code { return cmdCodexPlanTUI(os.Args[2:], lg) }},
 		{isPlanRequest, func() exitcode.Code { return cmdPlan(os.Args[2:], lg, commandName) }},
 		{isDashboardRequest, func() exitcode.Code { return cmdDashboard(os.Args[2:], lg) }},

--- a/cmd/fanout/tui.go
+++ b/cmd/fanout/tui.go
@@ -92,6 +92,7 @@ func cmdTUI(commandName string, lg *log.Logger) exitcode.Code {
 		LaunchPane:          newTUILaunchPaneFunc(projectRoot, session, commandName, hookConfig),
 		NewPanePrompt:       newTUINewPanePromptFunc(projectRoot, commandName),
 		HelpPopup:           newTUIHelpPopupFunc(projectRoot, commandName),
+		CloseChoicePopup:    newTUICloseChoicePopupFunc(projectRoot, commandName),
 		LaunchAttach:        newTUIAttachAgentFunc(projectRoot, session, commandName, hookConfig),
 		// List providers also feed the in-process fallback form (NewPanePrompt
 		// unavailable); the popup process wires its own copies.

--- a/cmd/fanout/tui_popup.go
+++ b/cmd/fanout/tui_popup.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/butaosuinu/fanout/internal/app/lifecycle"
 	"github.com/butaosuinu/fanout/internal/app/run"
 	"github.com/butaosuinu/fanout/internal/core/exitcode"
 	"github.com/butaosuinu/fanout/internal/infra/log"
@@ -19,6 +20,8 @@ import (
 )
 
 const (
+	tuiClosePopupCommand       = "__tui-close-popup"
+	tuiClosePopupMinHeight     = 9
 	tuiHelpPopupCommand        = "__tui-help-popup"
 	tuiHelpPopupMinHeight      = 18
 	tuiNewPanePopupCommand     = "__tui-new-pane-popup"
@@ -27,6 +30,13 @@ const (
 	tuiNewPanePopupResultPoll  = 50 * time.Millisecond
 	tuiNewPanePopupResultWait  = 24 * time.Hour
 )
+
+type tuiClosePopupGeometry struct {
+	PopupWidth    int
+	PopupHeight   int
+	ContentWidth  int
+	ContentHeight int
+}
 
 type tuiHelpPopupGeometry struct {
 	PopupWidth    int
@@ -54,12 +64,27 @@ type tuiNewPanePopupResult struct {
 	Error          string            `json:"error,omitempty"`
 }
 
+type tuiClosePopupRequest struct {
+	PaneLabel string `json:"paneLabel,omitempty"`
+	Mode      string `json:"mode,omitempty"`
+}
+
+type tuiClosePopupResult struct {
+	Canceled bool   `json:"canceled,omitempty"`
+	Mode     string `json:"mode,omitempty"`
+	Error    string `json:"error,omitempty"`
+}
+
 func isTUINewPanePopupRequest(args []string) bool {
 	return len(args) > 0 && args[0] == tuiNewPanePopupCommand
 }
 
 func isTUIHelpPopupRequest(args []string) bool {
 	return len(args) > 0 && args[0] == tuiHelpPopupCommand
+}
+
+func isTUIClosePopupRequest(args []string) bool {
+	return len(args) > 0 && args[0] == tuiClosePopupCommand
 }
 
 func cmdTUIHelpPopup(args []string, lg *log.Logger) exitcode.Code {
@@ -78,6 +103,56 @@ func cmdTUIHelpPopup(args []string, lg *log.Logger) exitcode.Code {
 		return exitcode.Env
 	}
 	return exitcode.OK
+}
+
+func cmdTUIClosePopup(args []string, lg *log.Logger) exitcode.Code {
+	fs := flag.NewFlagSet(tuiClosePopupCommand, flag.ContinueOnError)
+	fs.SetOutput(lg.Stderr())
+	requestFile := fs.String("request-file", "", "request file")
+	resultFile := fs.String("result-file", "", "result file")
+	width := fs.Int("width", 72, "popup width")
+	height := fs.Int("height", 10, "popup height")
+	if err := fs.Parse(args); err != nil {
+		return exitcode.Invocation
+	}
+	if strings.TrimSpace(*requestFile) == "" || strings.TrimSpace(*resultFile) == "" {
+		lg.Err("--request-file and --result-file are required")
+		return exitcode.Invocation
+	}
+
+	var result tuiClosePopupResult
+	code := exitcode.OK
+	request, err := readTUIClosePopupRequest(*requestFile)
+	if err != nil {
+		result = tuiClosePopupResult{Error: err.Error()}
+		code = exitcode.Env
+	} else {
+		mode, err := parseCloseModeName(request.Mode)
+		if err != nil {
+			result = tuiClosePopupResult{Error: err.Error()}
+			code = exitcode.Invocation
+		} else {
+			selected, canceled, runErr := fanouttui.RunCloseChoicePopup(fanouttui.CloseChoicePopupOptions{
+				PaneLabel:   request.PaneLabel,
+				InitialMode: mode,
+				Width:       *width,
+				Height:      *height,
+			})
+			result = tuiClosePopupResult{
+				Canceled: canceled,
+				Mode:     closeModeName(selected),
+			}
+			if runErr != nil {
+				result = tuiClosePopupResult{Error: runErr.Error()}
+				code = exitcode.Env
+			}
+		}
+	}
+	if writeErr := writeTUIClosePopupResult(*resultFile, result); writeErr != nil {
+		lg.Err("write close popup result: %v", writeErr)
+		return exitcode.Env
+	}
+	return code
 }
 
 func cmdTUINewPanePopup(args []string, lg *log.Logger) exitcode.Code {
@@ -127,11 +202,23 @@ func cmdTUINewPanePopup(args []string, lg *log.Logger) exitcode.Code {
 }
 
 func writeTUINewPanePopupResult(path string, result tuiNewPanePopupResult) error {
+	return writePopupJSON(path, result)
+}
+
+func writeTUIClosePopupRequest(path string, request tuiClosePopupRequest) error {
+	return writePopupJSON(path, request)
+}
+
+func writeTUIClosePopupResult(path string, result tuiClosePopupResult) error {
+	return writePopupJSON(path, result)
+}
+
+func writePopupJSON(path string, value any) error {
 	dir := filepath.Dir(path)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}
-	data, err := json.Marshal(result)
+	data, err := json.Marshal(value)
 	if err != nil {
 		return err
 	}
@@ -181,6 +268,69 @@ func newTUIHelpPopupFunc(projectRoot, commandName string) fanouttui.HelpPopupFun
 			Title:    "Keyboard shortcuts",
 			Command:  tuiHelpPopupShellCommand(commandName, geometry.ContentWidth, geometry.ContentHeight),
 		})
+	}
+}
+
+func newTUICloseChoicePopupFunc(projectRoot, commandName string) fanouttui.CloseChoicePopupFunc {
+	return func(req fanouttui.CloseChoiceRequest) (lifecycle.CloseMode, bool, error) {
+		size, err := tmuxrun.CurrentClientSize()
+		if err != nil {
+			return lifecycle.ClosePaneOnly, false, err
+		}
+		geometry, err := tuiClosePopupGeometryForClient(size)
+		if err != nil {
+			return lifecycle.ClosePaneOnly, false, err
+		}
+		resultFile, doneFile, cleanupPopupResult, err := newPopupResultPaths()
+		if err != nil {
+			return lifecycle.ClosePaneOnly, false, err
+		}
+		defer cleanupPopupResult()
+		requestFile := filepath.Join(filepath.Dir(resultFile), "request.json")
+		if writeErr := writeTUIClosePopupRequest(requestFile, tuiClosePopupRequest{
+			PaneLabel: req.PaneLabel,
+			Mode:      closeModeName(req.InitialMode),
+		}); writeErr != nil {
+			return lifecycle.ClosePaneOnly, false, writeErr
+		}
+		displayErr := tmuxrun.DisplayPopup(tmuxrun.PopupOptions{
+			Width:    geometry.PopupWidth,
+			Height:   geometry.PopupHeight,
+			StartDir: projectRoot,
+			Title:    "Close pane",
+			Command: tuiClosePopupShellCommand(
+				commandName,
+				requestFile,
+				resultFile,
+				doneFile,
+				geometry.ContentWidth,
+				geometry.ContentHeight,
+			),
+		})
+		result, readErr := readTUIClosePopupResult(resultFile)
+		if os.IsNotExist(readErr) && displayErr == nil {
+			result, readErr = waitForTUIClosePopupResult(resultFile, doneFile, tuiNewPanePopupResultWait)
+		}
+		if readErr != nil {
+			if displayErr != nil {
+				return lifecycle.ClosePaneOnly, false, displayErr
+			}
+			return lifecycle.ClosePaneOnly, false, readErr
+		}
+		if result.Error != "" {
+			return lifecycle.ClosePaneOnly, false, fmt.Errorf("%s", result.Error)
+		}
+		if result.Canceled {
+			return lifecycle.ClosePaneOnly, true, nil
+		}
+		if displayErr != nil {
+			return lifecycle.ClosePaneOnly, false, displayErr
+		}
+		mode, err := parseCloseModeName(result.Mode)
+		if err != nil {
+			return lifecycle.ClosePaneOnly, false, err
+		}
+		return mode, false, nil
 	}
 }
 
@@ -263,6 +413,22 @@ func tuiHelpPopupGeometryForClient(size tmuxrun.ClientSize) (tuiHelpPopupGeometr
 	}, nil
 }
 
+func tuiClosePopupGeometryForClient(size tmuxrun.ClientSize) (tuiClosePopupGeometry, error) {
+	minPopupHeight := tuiClosePopupMinHeight + tuiNewPanePopupBorderInset
+	if size.Width < 54 || size.Height < minPopupHeight {
+		return tuiClosePopupGeometry{}, fmt.Errorf("tmux client is too small for the close popup: %dx%d", size.Width, size.Height)
+	}
+	popupWidth := min(78, size.Width-4)
+	targetPopupHeight := min(int(math.Floor(float64(size.Height)*0.45)), size.Height-2)
+	popupHeight := max(targetPopupHeight, minPopupHeight)
+	return tuiClosePopupGeometry{
+		PopupWidth:    popupWidth,
+		PopupHeight:   popupHeight,
+		ContentWidth:  popupWidth - tuiNewPanePopupBorderInset,
+		ContentHeight: popupHeight - tuiNewPanePopupBorderInset,
+	}, nil
+}
+
 func tuiNewPanePopupGeometryForClient(size tmuxrun.ClientSize) (tuiNewPanePopupGeometry, error) {
 	minPopupHeight := tuiNewPanePopupMinHeight + tuiNewPanePopupBorderInset
 	if size.Width < 54 || size.Height < minPopupHeight {
@@ -308,6 +474,28 @@ func tuiHelpPopupShellCommand(commandName string, width, height int) string {
 		parts = append([]string{"PATH=" + run.ShellQuote(path)}, parts...)
 	}
 	return strings.Join(parts, " ")
+}
+
+func tuiClosePopupShellCommand(commandName, requestFile, resultFile, doneFile string, width, height int) string {
+	exe, err := os.Executable()
+	if err != nil || strings.TrimSpace(exe) == "" {
+		exe = commandName
+	}
+	parts := []string{
+		run.ShellQuote(exe),
+		tuiClosePopupCommand,
+		"--request-file", run.ShellQuote(requestFile),
+		"--result-file", run.ShellQuote(resultFile),
+		"--width", fmt.Sprintf("%d", width),
+		"--height", fmt.Sprintf("%d", height),
+	}
+	prefix := ""
+	if path := os.Getenv("PATH"); path != "" {
+		prefix = "PATH=" + run.ShellQuote(path) + " "
+	}
+	command := prefix + strings.Join(parts, " ")
+	markDone := "printf '' > " + run.ShellQuote(doneFile)
+	return "trap " + run.ShellQuote(markDone) + " EXIT HUP INT TERM; " + command
 }
 
 func tuiNewPanePopupShellCommand(commandName, projectRoot, resultFile, doneFile, defaultAgent string, width, height int) string {
@@ -363,6 +551,28 @@ func waitForTUINewPanePopupResult(resultFile, doneFile string, timeout time.Dura
 	}
 }
 
+func waitForTUIClosePopupResult(resultFile, doneFile string, timeout time.Duration) (tuiClosePopupResult, error) {
+	deadline := time.Now().Add(timeout)
+	for {
+		result, err := readTUIClosePopupResult(resultFile)
+		if err == nil {
+			return result, nil
+		}
+		if !os.IsNotExist(err) {
+			return tuiClosePopupResult{}, err
+		}
+		if _, err := os.Stat(doneFile); err == nil {
+			return tuiClosePopupResult{Canceled: true}, nil
+		} else if !os.IsNotExist(err) {
+			return tuiClosePopupResult{}, err
+		}
+		if timeout > 0 && time.Now().After(deadline) {
+			return tuiClosePopupResult{}, fmt.Errorf("timed out waiting for close popup result after %s", timeout)
+		}
+		time.Sleep(tuiNewPanePopupResultPoll)
+	}
+}
+
 func readTUINewPanePopupResult(path string) (tuiNewPanePopupResult, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -373,4 +583,54 @@ func readTUINewPanePopupResult(path string) (tuiNewPanePopupResult, error) {
 		return tuiNewPanePopupResult{}, err
 	}
 	return result, nil
+}
+
+func readTUIClosePopupRequest(path string) (tuiClosePopupRequest, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return tuiClosePopupRequest{}, err
+	}
+	var request tuiClosePopupRequest
+	if err := json.Unmarshal(data, &request); err != nil {
+		return tuiClosePopupRequest{}, err
+	}
+	return request, nil
+}
+
+func readTUIClosePopupResult(path string) (tuiClosePopupResult, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return tuiClosePopupResult{}, err
+	}
+	var result tuiClosePopupResult
+	if err := json.Unmarshal(data, &result); err != nil {
+		return tuiClosePopupResult{}, err
+	}
+	return result, nil
+}
+
+func closeModeName(mode lifecycle.CloseMode) string {
+	switch mode {
+	case lifecycle.ClosePaneOnly:
+		return "pane"
+	case lifecycle.CloseWorktree:
+		return "worktree"
+	case lifecycle.CloseEverything:
+		return "everything"
+	default:
+		return "pane"
+	}
+}
+
+func parseCloseModeName(name string) (lifecycle.CloseMode, error) {
+	switch strings.TrimSpace(name) {
+	case "", "pane":
+		return lifecycle.ClosePaneOnly, nil
+	case "worktree":
+		return lifecycle.CloseWorktree, nil
+	case "everything":
+		return lifecycle.CloseEverything, nil
+	default:
+		return lifecycle.ClosePaneOnly, fmt.Errorf("unknown close mode %q", name)
+	}
 }

--- a/cmd/fanout/tui_test.go
+++ b/cmd/fanout/tui_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/butaosuinu/fanout/internal/app/cliflags"
+	"github.com/butaosuinu/fanout/internal/app/lifecycle"
 	"github.com/butaosuinu/fanout/internal/app/panelaunch"
 	"github.com/butaosuinu/fanout/internal/app/run"
 	"github.com/butaosuinu/fanout/internal/app/watch"
@@ -243,6 +244,42 @@ func TestTUIHelpPopupGeometryUsesClientDimensions(t *testing.T) {
 	}
 }
 
+func TestTUIClosePopupGeometryUsesClientDimensions(t *testing.T) {
+	got, err := tuiClosePopupGeometryForClient(tmuxrun.ClientSize{Width: 160, Height: 50})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := tuiClosePopupGeometry{PopupWidth: 78, PopupHeight: 22, ContentWidth: 76, ContentHeight: 20}
+	if got != want {
+		t.Fatalf("close popup geometry = %#v, want %#v", got, want)
+	}
+
+	got, err = tuiClosePopupGeometryForClient(tmuxrun.ClientSize{Width: 80, Height: 24})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want = tuiClosePopupGeometry{PopupWidth: 76, PopupHeight: 11, ContentWidth: 74, ContentHeight: 9}
+	if got != want {
+		t.Fatalf("80x24 close popup geometry = %#v, want %#v", got, want)
+	}
+
+	got, err = tuiClosePopupGeometryForClient(tmuxrun.ClientSize{Width: 80, Height: 11})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want = tuiClosePopupGeometry{PopupWidth: 76, PopupHeight: 11, ContentWidth: 74, ContentHeight: 9}
+	if got != want {
+		t.Fatalf("small client close popup geometry = %#v, want %#v", got, want)
+	}
+
+	if _, err := tuiClosePopupGeometryForClient(tmuxrun.ClientSize{Width: 40, Height: 20}); err == nil {
+		t.Fatal("tuiClosePopupGeometryForClient() succeeded for too-small client")
+	}
+	if _, err := tuiClosePopupGeometryForClient(tmuxrun.ClientSize{Width: 80, Height: 10}); err == nil {
+		t.Fatal("tuiClosePopupGeometryForClient() succeeded without enough close popup height")
+	}
+}
+
 func TestTUINewPanePopupResultRoundTrip(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -291,6 +328,42 @@ func TestTUINewPanePopupResultRoundTrip(t *testing.T) {
 	}
 }
 
+func TestTUIClosePopupRequestAndResultRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	requestPath := filepath.Join(dir, "request.json")
+	request := tuiClosePopupRequest{PaneLabel: "#101", Mode: closeModeName(lifecycle.CloseEverything)}
+	if err := writeTUIClosePopupRequest(requestPath, request); err != nil {
+		t.Fatal(err)
+	}
+	gotRequest, err := readTUIClosePopupRequest(requestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotRequest != request {
+		t.Fatalf("close popup request = %#v, want %#v", gotRequest, request)
+	}
+
+	resultPath := filepath.Join(dir, "result.json")
+	result := tuiClosePopupResult{Mode: closeModeName(lifecycle.CloseWorktree)}
+	if writeErr := writeTUIClosePopupResult(resultPath, result); writeErr != nil {
+		t.Fatal(writeErr)
+	}
+	gotResult, err := readTUIClosePopupResult(resultPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotResult != result {
+		t.Fatalf("close popup result = %#v, want %#v", gotResult, result)
+	}
+	info, err := os.Stat(resultPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("close popup result mode = %o, want 600", got)
+	}
+}
+
 func TestNewPopupResultPathsUsesPrivateDirectory(t *testing.T) {
 	resultPath, donePath, cleanup, err := newPopupResultPaths()
 	if err != nil {
@@ -334,6 +407,23 @@ func TestWaitForTUINewPanePopupResultTreatsDoneWithoutResultAsCancel(t *testing.
 	}
 }
 
+func TestWaitForTUIClosePopupResultTreatsDoneWithoutResultAsCancel(t *testing.T) {
+	dir := t.TempDir()
+	resultPath := filepath.Join(dir, "result.json")
+	donePath := filepath.Join(dir, "result.done")
+	if err := os.WriteFile(donePath, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := waitForTUIClosePopupResult(resultPath, donePath, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.Canceled {
+		t.Fatalf("close popup result = %#v, want canceled", got)
+	}
+}
+
 func TestTUIHelpPopupShellCommandPropagatesPathAndDimensions(t *testing.T) {
 	got := tuiHelpPopupShellCommand("fanout", 80, 18)
 	for _, want := range []string{
@@ -344,6 +434,25 @@ func TestTUIHelpPopupShellCommandPropagatesPathAndDimensions(t *testing.T) {
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("help popup shell command missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestTUIClosePopupShellCommandMarksDoneAndPropagatesPath(t *testing.T) {
+	got := tuiClosePopupShellCommand("fanout", "/tmp/request.json", "/tmp/result.json", "/tmp/result.done", 72, 9)
+	for _, want := range []string{
+		"trap ",
+		"EXIT HUP INT TERM",
+		"/tmp/result.done",
+		tuiClosePopupCommand,
+		"--request-file /tmp/request.json",
+		"--result-file /tmp/result.json",
+		"--width 72",
+		"--height 9",
+		"PATH=" + run.ShellQuote(os.Getenv("PATH")),
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("close popup shell command missing %q:\n%s", want, got)
 		}
 	}
 }

--- a/internal/ui/tui/actions.go
+++ b/internal/ui/tui/actions.go
@@ -130,28 +130,39 @@ func (m model) updatePendingCloseChoice(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "up", "k":
 		m.pendingAction.closeOptionIndex = clampCloseOptionIndex(m.pendingAction.closeOptionIndex - 1)
 		m.pendingAction.closeMode = closeOptions()[m.pendingAction.closeOptionIndex].mode
-		m.actionMessage = closeChoiceMessage(*m.pendingAction)
 		return m, nil
 	case "down", "j":
 		m.pendingAction.closeOptionIndex = clampCloseOptionIndex(m.pendingAction.closeOptionIndex + 1)
 		m.pendingAction.closeMode = closeOptions()[m.pendingAction.closeOptionIndex].mode
-		m.actionMessage = closeChoiceMessage(*m.pendingAction)
 		return m, nil
 	case "1", "2", "3":
 		idx := int(msg.String()[0] - '1')
 		m.pendingAction.closeOptionIndex = clampCloseOptionIndex(idx)
 		m.pendingAction.closeMode = closeOptions()[m.pendingAction.closeOptionIndex].mode
-		m.actionMessage = closeChoiceMessage(*m.pendingAction)
 		return m, nil
 	case "y", "enter":
 		pending := *m.pendingAction
+		if m.closeOnly {
+			m.closeDone = true
+			m.closeResult = pending.closeMode
+			m.pendingAction = nil
+			return m.quit()
+		}
 		m.pendingAction = nil
+		m.mode = modeMonitor
 		m.actionRunning = true
 		m.actionMessage = lifecycleRunningMessage(pending)
 		return m, m.lifecycleCmd(pending)
 	case "n", "esc", "q", "ctrl+c":
+		if m.closeOnly {
+			m.closeDone = true
+			m.closeCanceled = true
+			m.pendingAction = nil
+			return m.quit()
+		}
 		m.actionMessage = "close canceled"
 		m.pendingAction = nil
+		m.mode = modeMonitor
 		return m, nil
 	}
 	return m, nil
@@ -173,8 +184,7 @@ func (m model) startPendingAction(action lifecycleAction) (tea.Model, tea.Cmd) {
 		if !pane.isPaneOnly() {
 			m.pendingAction.closeOptionIndex = 0
 			m.pendingAction.closeMode = closeOptions()[0].mode
-			m.actionMessage = closeChoiceMessage(*m.pendingAction)
-			return m, nil
+			return m.closeChoicePopupCmd()
 		}
 	}
 	m.actionMessage = confirmMessage(action, pane)
@@ -395,20 +405,6 @@ func clampCloseOptionIndex(idx int) int {
 		return len(opts) - 1
 	}
 	return idx
-}
-
-func closeChoiceMessage(pending pendingLifecycleAction) string {
-	var b strings.Builder
-	fmt.Fprintf(&b, "close %s?\n", pending.pane.identityLabel())
-	for i, opt := range closeOptions() {
-		prefix := "  "
-		if i == pending.closeOptionIndex {
-			prefix = "> "
-		}
-		fmt.Fprintf(&b, "%s%d. %s - %s\n", prefix, i+1, opt.label, opt.description)
-	}
-	b.WriteString("up/down or 1-3 select, enter confirm, esc cancel")
-	return b.String()
 }
 
 func closeModeVerb(mode lifecycle.CloseMode) string {

--- a/internal/ui/tui/close_choice.go
+++ b/internal/ui/tui/close_choice.go
@@ -1,0 +1,142 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/butaosuinu/fanout/internal/app/lifecycle"
+)
+
+const closePopupOpeningNotice = "opening close popup..."
+
+// CloseChoiceRequest describes the pane close option prompt shown in an
+// external surface, such as a tmux display-popup.
+type CloseChoiceRequest struct {
+	PaneLabel   string
+	InitialMode lifecycle.CloseMode
+}
+
+// CloseChoicePopupFunc collects the close mode to use. canceled is true when
+// the user dismisses the popup without choosing.
+type CloseChoicePopupFunc func(CloseChoiceRequest) (mode lifecycle.CloseMode, canceled bool, err error)
+
+// CloseChoicePopupOptions configures the standalone close-choice popup program.
+type CloseChoicePopupOptions struct {
+	PaneLabel   string
+	InitialMode lifecycle.CloseMode
+	Width       int
+	Height      int
+}
+
+// RunCloseChoicePopup opens only the close-choice UI and returns the selected
+// close mode.
+func RunCloseChoicePopup(opts CloseChoicePopupOptions) (lifecycle.CloseMode, bool, error) {
+	width := opts.Width
+	if width <= 0 {
+		width = 72
+	}
+	height := opts.Height
+	if height <= 0 {
+		height = 10
+	}
+	m := newModel(Options{})
+	m.closeOnly = true
+	m.mode = modeCloseChoice
+	m.width = width
+	m.height = height
+	label := strings.TrimSpace(opts.PaneLabel)
+	if label == "" {
+		label = "pane"
+	}
+	idx := closeOptionIndexForMode(opts.InitialMode)
+	m.pendingAction = &pendingLifecycleAction{
+		action:           actionClose,
+		pane:             paneView{TaskID: label},
+		closeOptionIndex: idx,
+		closeMode:        closeOptions()[idx].mode,
+	}
+	finalModel, err := tea.NewProgram(m, tea.WithAltScreen()).Run()
+	if err != nil {
+		return lifecycle.ClosePaneOnly, false, err
+	}
+	final, ok := finalModel.(model)
+	if !ok {
+		return lifecycle.ClosePaneOnly, false, fmt.Errorf("unexpected close popup model %T", finalModel)
+	}
+	if !final.closeDone || final.closeCanceled {
+		return lifecycle.ClosePaneOnly, true, nil
+	}
+	return final.closeResult, false, nil
+}
+
+func (m model) closeChoicePopupCmd() (model, tea.Cmd) {
+	popup := m.opts.CloseChoicePopup
+	if popup == nil || m.pendingAction == nil {
+		m.mode = modeCloseChoice
+		m.actionMessage = ""
+		return m, nil
+	}
+	pending := *m.pendingAction
+	m.notice = closePopupOpeningNotice
+	m.actionMessage = ""
+	m.closePopupOpen = true
+	cmd := func() tea.Msg {
+		mode, canceled, err := popup(CloseChoiceRequest{
+			PaneLabel:   pending.pane.identityLabel(),
+			InitialMode: pending.closeMode,
+		})
+		return closeChoicePopupDoneMsg{mode: mode, canceled: canceled, err: err}
+	}
+	return m, cmd
+}
+
+func (m model) closeChoiceView() string {
+	label := "pane"
+	optionIndex := 0
+	if m.pendingAction != nil {
+		label = m.pendingAction.pane.identityLabel()
+		optionIndex = m.pendingAction.closeOptionIndex
+	}
+	lines := make([]string, 0, 6)
+	if !m.closeOnly {
+		lines = append(lines, titleStyle.Render("Close pane"))
+	}
+	lines = append(lines, fmt.Sprintf("Close %s?", label))
+	for i, opt := range closeOptions() {
+		marker := " "
+		style := lipgloss.NewStyle()
+		if i == optionIndex {
+			marker = ">"
+			style = titleStyle
+		}
+		lines = append(lines, style.Render(fmt.Sprintf("%s %d. %s - %s", marker, i+1, opt.label, opt.description)))
+	}
+	lines = append(lines, dimStyle.Render("up/down or 1-3 select, enter confirm, esc cancel"))
+	content := strings.Join(lines, "\n")
+	if m.closeOnly {
+		return popupContentStyle.Width(m.closeChoiceModalWidth()).Render(content)
+	}
+	return modalStyle.Width(m.closeChoiceModalWidth()).Render(content)
+}
+
+func (m model) closeChoiceModalWidth() int {
+	if m.width <= 0 {
+		return 72
+	}
+	if m.closeOnly {
+		return clampInt(m.width, 48, 82)
+	}
+	return clampInt(m.width-4, 48, 76)
+}
+
+func closeOptionIndexForMode(mode lifecycle.CloseMode) int {
+	for i, opt := range closeOptions() {
+		if opt.mode == mode {
+			return i
+		}
+	}
+	return 0
+}

--- a/internal/ui/tui/tui.go
+++ b/internal/ui/tui/tui.go
@@ -10,6 +10,7 @@ import (
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/butaosuinu/fanout/internal/app/lifecycle"
 	"github.com/butaosuinu/fanout/internal/infra/hooks"
 	"github.com/butaosuinu/fanout/internal/infra/tmuxrun"
 	"github.com/butaosuinu/fanout/internal/infra/worktree"
@@ -48,6 +49,7 @@ type Options struct {
 	LaunchPane          LaunchFunc
 	NewPanePrompt       NewPanePromptFunc
 	HelpPopup           HelpPopupFunc
+	CloseChoicePopup    CloseChoicePopupFunc
 	LaunchAttach        AttachLaunchFunc
 	LaunchShell         ShellLaunchFunc
 	RestorePanes        func() (string, error)
@@ -77,6 +79,7 @@ const (
 	modeMonitor viewMode = iota
 	modeNewPane
 	modeHelp
+	modeCloseChoice
 )
 
 type model struct {
@@ -106,6 +109,7 @@ type model struct {
 	newPane          newPaneForm
 	newPanePopupOpen bool
 	helpPopupOpen    bool
+	closePopupOpen   bool
 	repoFiles        []string
 	repoFileIndex    []fileEntry
 	repoFilesLoaded  bool
@@ -123,9 +127,13 @@ type model struct {
 	relayoutGen      int
 	promptOnly       bool
 	helpOnly         bool
+	closeOnly        bool
 	promptDone       bool
 	promptCanceled   bool
 	promptResult     LaunchRequest
+	closeDone        bool
+	closeCanceled    bool
+	closeResult      lifecycle.CloseMode
 }
 
 type keyboardProtocolsEnabledMsg struct{}
@@ -147,6 +155,11 @@ type (
 	}
 	helpPopupDoneMsg struct {
 		err error
+	}
+	closeChoicePopupDoneMsg struct {
+		mode     lifecycle.CloseMode
+		canceled bool
+		err      error
 	}
 	launchShellMsg struct {
 		req ShellLaunchRequest
@@ -275,6 +288,9 @@ func newModel(opts Options) model {
 }
 
 func (m model) Init() tea.Cmd {
+	if m.closeOnly {
+		return nil
+	}
 	if m.helpOnly {
 		return nil
 	}

--- a/internal/ui/tui/tui_test.go
+++ b/internal/ui/tui/tui_test.go
@@ -2183,13 +2183,16 @@ func TestLifecycleClosePopupCancelAndFailure(t *testing.T) {
 	})
 
 	t.Run("failure", func(t *testing.T) {
+		runner := &fakeLifecycleRunner{code: exitcode.OK}
 		m := newModel(Options{
 			ProjectRoot: "/repo",
-			lifecycle:   &fakeLifecycleRunner{code: exitcode.OK},
+			lifecycle:   runner,
 			CloseChoicePopup: func(CloseChoiceRequest) (lifecycle.CloseMode, bool, error) {
 				return lifecycle.ClosePaneOnly, false, errBoom
 			},
 		})
+		m.width = 100
+		m.height = 40
 		m.allPanes = []paneView{{Parent: "84", IssueNum: 101, Name: "child"}}
 		m.refreshRows()
 
@@ -2203,11 +2206,32 @@ func TestLifecycleClosePopupCancelAndFailure(t *testing.T) {
 		if m.closePopupOpen {
 			t.Fatal("closePopupOpen = true after failure")
 		}
-		if m.pendingAction != nil {
-			t.Fatalf("pendingAction = %#v, want nil after failure", m.pendingAction)
+		if m.pendingAction == nil {
+			t.Fatal("pendingAction = nil, want fallback close choice")
+		}
+		if m.mode != modeCloseChoice {
+			t.Fatalf("mode = %v, want close choice fallback", m.mode)
 		}
 		if m.notice != "close popup: boom" {
 			t.Fatalf("notice = %q, want close popup error", m.notice)
+		}
+		if view := m.View(); !strings.Contains(view, "Close #101?") {
+			t.Fatalf("fallback view = %q, want close choice modal", view)
+		}
+
+		updated, next = m.Update(keyRunes("enter"))
+		m = updated.(model)
+		if next == nil {
+			t.Fatal("fallback enter returned nil command, want lifecycle command")
+		}
+		if !m.actionRunning {
+			t.Fatal("actionRunning = false, want true while fallback lifecycle runs")
+		}
+		if _, ok := next().(lifecycleDoneMsg); !ok {
+			t.Fatal("fallback lifecycle command did not return lifecycleDoneMsg")
+		}
+		if runner.closeMode != lifecycle.ClosePaneOnly {
+			t.Fatalf("close mode = %v, want pane only", runner.closeMode)
 		}
 	})
 }

--- a/internal/ui/tui/tui_test.go
+++ b/internal/ui/tui/tui_test.go
@@ -2006,6 +2006,8 @@ func paneByIssue(t *testing.T, panes []paneView, issueNum int) paneView {
 func TestLifecycleCloseKeyConfirmsRunsAndRefreshes(t *testing.T) {
 	runner := &fakeLifecycleRunner{code: exitcode.OK}
 	m := newModel(Options{ProjectRoot: "/repo", WatcherRunningLabel: "fanout:test-running", lifecycle: runner})
+	m.width = 100
+	m.height = 40
 	m.allPanes = []paneView{{Parent: "84", IssueNum: 101, Name: "child"}}
 	m.refreshRows()
 
@@ -2017,8 +2019,12 @@ func TestLifecycleCloseKeyConfirmsRunsAndRefreshes(t *testing.T) {
 	if m.pendingAction == nil || m.pendingAction.action != actionClose {
 		t.Fatalf("pendingAction = %#v, want close", m.pendingAction)
 	}
-	if !strings.Contains(m.actionMessage, "Just close pane") || !strings.Contains(m.actionMessage, "Close and delete everything") {
-		t.Fatalf("actionMessage = %q, want close option menu", m.actionMessage)
+	if m.mode != modeCloseChoice {
+		t.Fatalf("mode = %v, want close choice", m.mode)
+	}
+	view := m.View()
+	if !strings.Contains(view, "Just close pane") || !strings.Contains(view, "Close and delete everything") {
+		t.Fatalf("view = %q, want close option menu", view)
 	}
 
 	updated, cmd = m.Update(keyRunes("y"))
@@ -2059,6 +2065,151 @@ func TestLifecycleCloseKeyConfirmsRunsAndRefreshes(t *testing.T) {
 	if cmd == nil {
 		t.Fatal("done returned nil command, want state/GH reload")
 	}
+}
+
+func TestLifecycleCloseKeyUsesPopupWhenConfigured(t *testing.T) {
+	runner := &fakeLifecycleRunner{code: exitcode.OK}
+	calls := 0
+	var prompted CloseChoiceRequest
+	m := newModel(Options{
+		ProjectRoot: "/repo",
+		lifecycle:   runner,
+		CloseChoicePopup: func(req CloseChoiceRequest) (lifecycle.CloseMode, bool, error) {
+			calls++
+			prompted = req
+			return lifecycle.CloseEverything, false, nil
+		},
+	})
+	m.allPanes = []paneView{{Parent: "84", IssueNum: 101, Name: "child"}}
+	m.refreshRows()
+
+	updated, cmd := m.Update(keyRunes("c"))
+	m = updated.(model)
+	if cmd == nil {
+		t.Fatal("close key returned nil command, want popup command")
+	}
+	if calls != 0 {
+		t.Fatalf("popup calls before command execution = %d, want 0", calls)
+	}
+	if m.mode != modeMonitor {
+		t.Fatalf("mode = %v, want monitor while popup owns input", m.mode)
+	}
+	if !m.closePopupOpen {
+		t.Fatal("closePopupOpen = false, want true")
+	}
+	if m.notice != closePopupOpeningNotice {
+		t.Fatalf("notice = %q, want %q", m.notice, closePopupOpeningNotice)
+	}
+	if m.actionMessage != "" {
+		t.Fatalf("actionMessage = %q, want no footer close menu", m.actionMessage)
+	}
+
+	for _, key := range []tea.KeyMsg{keyRunes("q"), keyRunes("1"), keyRunes("n"), {Type: tea.KeyCtrlC}} {
+		nextModel, blockedCmd := m.Update(key)
+		m = nextModel.(model)
+		if blockedCmd != nil {
+			t.Fatalf("%q returned command while close popup is open", key.String())
+		}
+		if !m.closePopupOpen {
+			t.Fatalf("%q cleared closePopupOpen", key.String())
+		}
+	}
+
+	updated, next := m.Update(cmd())
+	m = updated.(model)
+	if next == nil {
+		t.Fatal("close popup completion returned nil command, want lifecycle command")
+	}
+	if calls != 1 {
+		t.Fatalf("popup calls = %d, want 1", calls)
+	}
+	if prompted.PaneLabel != "#101" || prompted.InitialMode != lifecycle.ClosePaneOnly {
+		t.Fatalf("popup request = %#v, want #101 pane-only", prompted)
+	}
+	if m.closePopupOpen {
+		t.Fatal("closePopupOpen = true after popup completion")
+	}
+	if m.notice != "" {
+		t.Fatalf("notice = %q, want cleared", m.notice)
+	}
+	if !m.actionRunning {
+		t.Fatal("actionRunning = false, want true while command runs")
+	}
+	if !strings.Contains(m.actionMessage, "delete #101") {
+		t.Fatalf("actionMessage = %q, want delete running message", m.actionMessage)
+	}
+
+	rawMsg := next()
+	if _, ok := rawMsg.(lifecycleDoneMsg); !ok {
+		t.Fatalf("lifecycle command returned %T, want lifecycleDoneMsg", rawMsg)
+	}
+	if runner.closeMode != lifecycle.CloseEverything {
+		t.Fatalf("close mode = %v, want delete everything", runner.closeMode)
+	}
+}
+
+func TestLifecycleClosePopupCancelAndFailure(t *testing.T) {
+	t.Run("cancel", func(t *testing.T) {
+		runner := &fakeLifecycleRunner{code: exitcode.OK}
+		m := newModel(Options{
+			ProjectRoot: "/repo",
+			lifecycle:   runner,
+			CloseChoicePopup: func(CloseChoiceRequest) (lifecycle.CloseMode, bool, error) {
+				return lifecycle.ClosePaneOnly, true, nil
+			},
+		})
+		m.allPanes = []paneView{{Parent: "84", IssueNum: 101, Name: "child"}}
+		m.refreshRows()
+
+		updated, cmd := m.Update(keyRunes("c"))
+		m = updated.(model)
+		updated, next := m.Update(cmd())
+		m = updated.(model)
+		if next != nil {
+			t.Fatal("canceled close popup returned command")
+		}
+		if m.closePopupOpen {
+			t.Fatal("closePopupOpen = true after cancel")
+		}
+		if m.pendingAction != nil {
+			t.Fatalf("pendingAction = %#v, want nil after cancel", m.pendingAction)
+		}
+		if m.actionMessage != "close canceled" {
+			t.Fatalf("actionMessage = %q, want close canceled", m.actionMessage)
+		}
+		if runner.closeParent != "" {
+			t.Fatalf("runner closeParent = %q, want not called", runner.closeParent)
+		}
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		m := newModel(Options{
+			ProjectRoot: "/repo",
+			lifecycle:   &fakeLifecycleRunner{code: exitcode.OK},
+			CloseChoicePopup: func(CloseChoiceRequest) (lifecycle.CloseMode, bool, error) {
+				return lifecycle.ClosePaneOnly, false, errBoom
+			},
+		})
+		m.allPanes = []paneView{{Parent: "84", IssueNum: 101, Name: "child"}}
+		m.refreshRows()
+
+		updated, cmd := m.Update(keyRunes("c"))
+		m = updated.(model)
+		updated, next := m.Update(cmd())
+		m = updated.(model)
+		if next != nil {
+			t.Fatal("failed close popup returned command")
+		}
+		if m.closePopupOpen {
+			t.Fatal("closePopupOpen = true after failure")
+		}
+		if m.pendingAction != nil {
+			t.Fatalf("pendingAction = %#v, want nil after failure", m.pendingAction)
+		}
+		if m.notice != "close popup: boom" {
+			t.Fatalf("notice = %q, want close popup error", m.notice)
+		}
+	})
 }
 
 func TestLifecycleCloseChoiceSelectsWorktreeAndBranchModes(t *testing.T) {
@@ -2307,6 +2458,8 @@ func TestLifecycleKeysRoutePlanTaskRows(t *testing.T) {
 		t.Run(tc.key, func(t *testing.T) {
 			runner := &fakeLifecycleRunner{code: exitcode.OK}
 			m := newModel(Options{ProjectRoot: "/repo", lifecycle: runner})
+			m.width = 100
+			m.height = 40
 			m.allPanes = []paneView{{Parent: "plan:launch-plan", IssueNum: 0, TaskID: "api-client", Name: "task"}}
 			m.refreshRows()
 
@@ -2318,12 +2471,21 @@ func TestLifecycleKeysRoutePlanTaskRows(t *testing.T) {
 			if m.pendingAction == nil || m.pendingAction.action != tc.action {
 				t.Fatalf("pendingAction = %#v, want %s", m.pendingAction, tc.action)
 			}
-			wantMessage := "api-client"
-			if tc.action == actionCleanup {
-				wantMessage = "plan:launch-plan"
-			}
-			if !strings.Contains(m.actionMessage, wantMessage) {
-				t.Fatalf("actionMessage = %q, want confirmation containing %q", m.actionMessage, wantMessage)
+			if tc.action == actionClose {
+				if m.mode != modeCloseChoice {
+					t.Fatalf("mode = %v, want close choice", m.mode)
+				}
+				if view := m.View(); !strings.Contains(view, "api-client") {
+					t.Fatalf("close choice view = %q, want task id", view)
+				}
+			} else {
+				wantMessage := "api-client"
+				if tc.action == actionCleanup {
+					wantMessage = "plan:launch-plan"
+				}
+				if !strings.Contains(m.actionMessage, wantMessage) {
+					t.Fatalf("actionMessage = %q, want confirmation containing %q", m.actionMessage, wantMessage)
+				}
 			}
 
 			updated, cmd = m.Update(keyRunes("y"))

--- a/internal/ui/tui/update.go
+++ b/internal/ui/tui/update.go
@@ -288,7 +288,10 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.closePopupOpen = false
 		if msg.err != nil {
 			m.notice = "close popup: " + msg.err.Error()
-			m.pendingAction = nil
+			if m.pendingAction != nil {
+				m.mode = modeCloseChoice
+				m.actionMessage = ""
+			}
 			return m, nil
 		}
 		if msg.canceled {

--- a/internal/ui/tui/update.go
+++ b/internal/ui/tui/update.go
@@ -31,7 +31,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case tea.KeyMsg:
 		m.resumeKeyboardProtocols()
-		if (m.newPanePopupOpen || m.helpPopupOpen || m.newPane.launching) && m.mode != modeNewPane {
+		if (m.newPanePopupOpen || m.helpPopupOpen || m.closePopupOpen || m.newPane.launching) && m.mode != modeNewPane {
 			// An issue launch can run a whole fan-out (seconds per child), so
 			// mirror the lifecycle-action gate: keys stay blocked, but q/ctrl+c
 			// queue a quit instead of appearing hung.
@@ -65,6 +65,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case "ctrl+c":
 				return m.quit()
 			}
+			return m, nil
+		}
+		if m.mode == modeCloseChoice {
 			return m, nil
 		}
 		if m.mode == modeNewPane {
@@ -281,6 +284,37 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.notice = ""
 		}
 		return m, nil
+	case closeChoicePopupDoneMsg:
+		m.closePopupOpen = false
+		if msg.err != nil {
+			m.notice = "close popup: " + msg.err.Error()
+			m.pendingAction = nil
+			return m, nil
+		}
+		if msg.canceled {
+			if m.notice == closePopupOpeningNotice {
+				m.notice = ""
+			}
+			m.actionMessage = "close canceled"
+			m.pendingAction = nil
+			return m, nil
+		}
+		if m.pendingAction == nil {
+			if m.notice == closePopupOpeningNotice {
+				m.notice = ""
+			}
+			return m, nil
+		}
+		pending := *m.pendingAction
+		pending.closeMode = msg.mode
+		pending.closeOptionIndex = closeOptionIndexForMode(msg.mode)
+		m.pendingAction = nil
+		m.actionRunning = true
+		m.actionMessage = lifecycleRunningMessage(pending)
+		if m.notice == closePopupOpeningNotice {
+			m.notice = ""
+		}
+		return m, m.lifecycleCmd(pending)
 	case newPaneIssuesLoadedMsg:
 		p := &m.newPane.issuePicker
 		p.loading = false

--- a/internal/ui/tui/view.go
+++ b/internal/ui/tui/view.go
@@ -60,6 +60,12 @@ func (m model) compactActive() bool {
 }
 
 func (m model) View() string {
+	if m.closeOnly {
+		if m.width == 0 {
+			return "Close pane"
+		}
+		return m.closeChoiceView()
+	}
 	if m.helpOnly {
 		if m.width == 0 {
 			return "Keyboard shortcuts"
@@ -132,6 +138,9 @@ func (m model) View() string {
 	}
 	if m.mode == modeHelp {
 		return overlayCentered(base, m.helpView(), m.width, m.height)
+	}
+	if m.mode == modeCloseChoice {
+		return overlayCentered(base, m.closeChoiceView(), m.width, m.height)
 	}
 	return base
 }


### PR DESCRIPTION
## TL;DR

pane close の3択UIをfooter下のテキスト表示から、helpと同じtmux popup優先のmodal表示へ移しました。

## 変更内容

- 通常paneのclose選択を `Close pane` popupで表示
- popupが使えない場合はTUI内の中央modalへfallback
- close popup用のhidden self-exec commandとresult file受け渡しを追加
- shell / attached-agent の単純close確認は既存動作を維持

## 検証

- `GOCACHE=$PWD/.cache/go-build go test ./internal/ui/tui ./cmd/fanout`
- `make lint`
- `make test`
- post-work-review: `clean=true`, `finding_count=0`

Review effort: 2
