### PR TITLE
TUI popupをfanout TUI右隣に表示

### DIFF
--- a/cmd/fanout/tui_popup.go
+++ b/cmd/fanout/tui_popup.go
@@ -267,7 +267,7 @@ func newTUIHelpPopupFunc(projectRoot, commandName string) fanouttui.HelpPopupFun
 			StartDir: projectRoot,
 			Title:    "Keyboard shortcuts",
 			Command:  tuiHelpPopupShellCommand(commandName, geometry.ContentWidth, geometry.ContentHeight),
-			Position: tuiPopupPositionForCurrentPane(geometry.PopupWidth),
+			Position: tuiPopupPositionForCurrentPane(geometry.PopupWidth, geometry.PopupHeight),
 		})
 	}
 }
@@ -365,7 +365,7 @@ func newTUINewPanePromptFunc(projectRoot, commandName string) fanouttui.NewPaneP
 			StartDir: projectRoot,
 			Title:    "New agent pane",
 			Command:  command,
-			Position: tuiPopupPositionForCurrentPane(geometry.PopupWidth),
+			Position: tuiPopupPositionForCurrentPane(geometry.PopupWidth, geometry.PopupHeight),
 		})
 		result, readErr := readTUINewPanePopupResult(resultFile)
 		if os.IsNotExist(readErr) && displayErr == nil {
@@ -398,7 +398,7 @@ func newTUINewPanePromptFunc(projectRoot, commandName string) fanouttui.NewPaneP
 	}
 }
 
-func tuiPopupPositionForCurrentPane(popupWidth int) *tmuxrun.PopupPosition {
+func tuiPopupPositionForCurrentPane(popupWidth, popupHeight int) *tmuxrun.PopupPosition {
 	paneID := strings.TrimSpace(os.Getenv("TMUX_PANE"))
 	if paneID == "" {
 		return nil
@@ -407,14 +407,15 @@ func tuiPopupPositionForCurrentPane(popupWidth int) *tmuxrun.PopupPosition {
 	if err != nil {
 		return nil
 	}
-	return tuiPopupPositionAdjacentToPane(geom, popupWidth)
+	return tuiPopupPositionAdjacentToPane(geom, popupWidth, popupHeight)
 }
 
-func tuiPopupPositionAdjacentToPane(geom tmuxrun.PaneGeometry, popupWidth int) *tmuxrun.PopupPosition {
-	if popupWidth <= 0 || geom.ClientWidth <= 0 {
+func tuiPopupPositionAdjacentToPane(geom tmuxrun.PaneGeometry, popupWidth, popupHeight int) *tmuxrun.PopupPosition {
+	if popupWidth <= 0 || popupHeight <= 0 || geom.ClientWidth <= 0 || geom.ClientHeight <= 0 {
 		return nil
 	}
 	maxX := max(geom.ClientWidth-popupWidth, 0)
+	maxY := max(geom.ClientHeight-popupHeight, 0)
 	rightX := geom.Left + geom.Width + 1
 	leftX := geom.Left - popupWidth - 1
 	x := rightX
@@ -427,7 +428,7 @@ func tuiPopupPositionAdjacentToPane(geom tmuxrun.PaneGeometry, popupWidth int) *
 	}
 	return &tmuxrun.PopupPosition{
 		X: min(max(x, 0), maxX),
-		Y: 0,
+		Y: min(max(geom.Top, 0), maxY),
 	}
 }
 

--- a/cmd/fanout/tui_popup.go
+++ b/cmd/fanout/tui_popup.go
@@ -267,6 +267,7 @@ func newTUIHelpPopupFunc(projectRoot, commandName string) fanouttui.HelpPopupFun
 			StartDir: projectRoot,
 			Title:    "Keyboard shortcuts",
 			Command:  tuiHelpPopupShellCommand(commandName, geometry.ContentWidth, geometry.ContentHeight),
+			Position: tuiPopupPositionForCurrentPane(geometry.PopupWidth),
 		})
 	}
 }
@@ -364,6 +365,7 @@ func newTUINewPanePromptFunc(projectRoot, commandName string) fanouttui.NewPaneP
 			StartDir: projectRoot,
 			Title:    "New agent pane",
 			Command:  command,
+			Position: tuiPopupPositionForCurrentPane(geometry.PopupWidth),
 		})
 		result, readErr := readTUINewPanePopupResult(resultFile)
 		if os.IsNotExist(readErr) && displayErr == nil {
@@ -394,6 +396,53 @@ func newTUINewPanePromptFunc(projectRoot, commandName string) fanouttui.NewPaneP
 			AgentOverrides: result.AgentOverrides,
 		}, false, nil
 	}
+}
+
+func tuiPopupPositionForCurrentPane(popupWidth int) *tmuxrun.PopupPosition {
+	paneID := strings.TrimSpace(os.Getenv("TMUX_PANE"))
+	if paneID == "" {
+		return nil
+	}
+	geom, err := tmuxrun.PaneGeometryForPane(paneID)
+	if err != nil {
+		return nil
+	}
+	return tuiPopupPositionAdjacentToPane(geom, popupWidth)
+}
+
+func tuiPopupPositionAdjacentToPane(geom tmuxrun.PaneGeometry, popupWidth int) *tmuxrun.PopupPosition {
+	if popupWidth <= 0 || geom.ClientWidth <= 0 {
+		return nil
+	}
+	maxX := max(geom.ClientWidth-popupWidth, 0)
+	rightX := geom.Left + geom.Width + 1
+	leftX := geom.Left - popupWidth - 1
+	x := rightX
+	switch {
+	case rightX <= maxX:
+	case leftX >= 0:
+		x = leftX
+	default:
+		x = nearestHorizontalPopupEdge(geom, popupWidth)
+	}
+	return &tmuxrun.PopupPosition{
+		X: min(max(x, 0), maxX),
+		Y: 0,
+	}
+}
+
+func nearestHorizontalPopupEdge(geom tmuxrun.PaneGeometry, popupWidth int) int {
+	leftOverlap := overlapWidth(0, popupWidth, geom.Left, geom.Left+geom.Width)
+	rightX := max(geom.ClientWidth-popupWidth, 0)
+	rightOverlap := overlapWidth(rightX, rightX+popupWidth, geom.Left, geom.Left+geom.Width)
+	if leftOverlap <= rightOverlap {
+		return 0
+	}
+	return rightX
+}
+
+func overlapWidth(aStart, aEnd, bStart, bEnd int) int {
+	return max(0, min(aEnd, bEnd)-max(aStart, bStart))
 }
 
 func tuiHelpPopupGeometryForClient(size tmuxrun.ClientSize) (tuiHelpPopupGeometry, error) {

--- a/cmd/fanout/tui_test.go
+++ b/cmd/fanout/tui_test.go
@@ -282,26 +282,26 @@ func TestTUIClosePopupGeometryUsesClientDimensions(t *testing.T) {
 
 func TestTUIPopupPositionAdjacentToPane(t *testing.T) {
 	got := tuiPopupPositionAdjacentToPane(tmuxrun.PaneGeometry{
-		Left: 0, Width: 40, ClientWidth: 160,
-	}, 90)
-	if got == nil || *got != (tmuxrun.PopupPosition{X: 41, Y: 0}) {
-		t.Fatalf("popup position = %#v, want x=41 y=0", got)
+		Left: 0, Top: 3, Width: 40, Height: 20, ClientWidth: 160, ClientHeight: 40,
+	}, 90, 20)
+	if got == nil || *got != (tmuxrun.PopupPosition{X: 41, Y: 3}) {
+		t.Fatalf("popup position = %#v, want x=41 y=3", got)
 	}
 }
 
 func TestTUIPopupPositionClampsToClient(t *testing.T) {
 	got := tuiPopupPositionAdjacentToPane(tmuxrun.PaneGeometry{
-		Left: 0, Width: 40, ClientWidth: 80,
-	}, 76)
-	if got == nil || *got != (tmuxrun.PopupPosition{X: 4, Y: 0}) {
-		t.Fatalf("clamped popup position = %#v, want x=4 y=0", got)
+		Left: 0, Top: 18, Width: 40, Height: 6, ClientWidth: 80, ClientHeight: 24,
+	}, 76, 20)
+	if got == nil || *got != (tmuxrun.PopupPosition{X: 4, Y: 4}) {
+		t.Fatalf("clamped popup position = %#v, want x=4 y=4", got)
 	}
 }
 
 func TestTUIPopupPositionUsesLeftSideForRightPane(t *testing.T) {
 	got := tuiPopupPositionAdjacentToPane(tmuxrun.PaneGeometry{
-		Left: 80, Width: 80, ClientWidth: 160,
-	}, 70)
+		Left: 80, Width: 80, ClientWidth: 160, ClientHeight: 40,
+	}, 70, 20)
 	if got == nil || *got != (tmuxrun.PopupPosition{X: 9, Y: 0}) {
 		t.Fatalf("left-side popup position = %#v, want x=9 y=0", got)
 	}
@@ -309,8 +309,8 @@ func TestTUIPopupPositionUsesLeftSideForRightPane(t *testing.T) {
 
 func TestTUIPopupPositionChoosesLowerOverlapEdge(t *testing.T) {
 	got := tuiPopupPositionAdjacentToPane(tmuxrun.PaneGeometry{
-		Left: 80, Width: 80, ClientWidth: 160,
-	}, 90)
+		Left: 80, Width: 80, ClientWidth: 160, ClientHeight: 40,
+	}, 90, 20)
 	if got == nil || *got != (tmuxrun.PopupPosition{X: 0, Y: 0}) {
 		t.Fatalf("edge popup position = %#v, want x=0 y=0", got)
 	}
@@ -318,12 +318,12 @@ func TestTUIPopupPositionChoosesLowerOverlapEdge(t *testing.T) {
 
 func TestTUIPopupPositionFallsBackWithoutPane(t *testing.T) {
 	t.Setenv("TMUX_PANE", "")
-	if got := tuiPopupPositionForCurrentPane(90); got != nil {
+	if got := tuiPopupPositionForCurrentPane(90, 20); got != nil {
 		t.Fatalf("popup position = %#v, want centered fallback", got)
 	}
 
 	t.Setenv("TMUX_PANE", "%tui")
-	if got := tuiPopupPositionForCurrentPane(90); got != nil {
+	if got := tuiPopupPositionForCurrentPane(90, 20); got != nil {
 		t.Fatalf("popup position with malformed pane id = %#v, want centered fallback", got)
 	}
 }

--- a/cmd/fanout/tui_test.go
+++ b/cmd/fanout/tui_test.go
@@ -280,6 +280,54 @@ func TestTUIClosePopupGeometryUsesClientDimensions(t *testing.T) {
 	}
 }
 
+func TestTUIPopupPositionAdjacentToPane(t *testing.T) {
+	got := tuiPopupPositionAdjacentToPane(tmuxrun.PaneGeometry{
+		Left: 0, Width: 40, ClientWidth: 160,
+	}, 90)
+	if got == nil || *got != (tmuxrun.PopupPosition{X: 41, Y: 0}) {
+		t.Fatalf("popup position = %#v, want x=41 y=0", got)
+	}
+}
+
+func TestTUIPopupPositionClampsToClient(t *testing.T) {
+	got := tuiPopupPositionAdjacentToPane(tmuxrun.PaneGeometry{
+		Left: 0, Width: 40, ClientWidth: 80,
+	}, 76)
+	if got == nil || *got != (tmuxrun.PopupPosition{X: 4, Y: 0}) {
+		t.Fatalf("clamped popup position = %#v, want x=4 y=0", got)
+	}
+}
+
+func TestTUIPopupPositionUsesLeftSideForRightPane(t *testing.T) {
+	got := tuiPopupPositionAdjacentToPane(tmuxrun.PaneGeometry{
+		Left: 80, Width: 80, ClientWidth: 160,
+	}, 70)
+	if got == nil || *got != (tmuxrun.PopupPosition{X: 9, Y: 0}) {
+		t.Fatalf("left-side popup position = %#v, want x=9 y=0", got)
+	}
+}
+
+func TestTUIPopupPositionChoosesLowerOverlapEdge(t *testing.T) {
+	got := tuiPopupPositionAdjacentToPane(tmuxrun.PaneGeometry{
+		Left: 80, Width: 80, ClientWidth: 160,
+	}, 90)
+	if got == nil || *got != (tmuxrun.PopupPosition{X: 0, Y: 0}) {
+		t.Fatalf("edge popup position = %#v, want x=0 y=0", got)
+	}
+}
+
+func TestTUIPopupPositionFallsBackWithoutPane(t *testing.T) {
+	t.Setenv("TMUX_PANE", "")
+	if got := tuiPopupPositionForCurrentPane(90); got != nil {
+		t.Fatalf("popup position = %#v, want centered fallback", got)
+	}
+
+	t.Setenv("TMUX_PANE", "%tui")
+	if got := tuiPopupPositionForCurrentPane(90); got != nil {
+		t.Fatalf("popup position with malformed pane id = %#v, want centered fallback", got)
+	}
+}
+
 func TestTUINewPanePopupResultRoundTrip(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/infra/tmuxrun/tmuxrun.go
+++ b/internal/infra/tmuxrun/tmuxrun.go
@@ -39,6 +39,7 @@ const (
 	livePaneRoleFormat         = "#{pane_id}\t#{" + roleOption + "}"
 	livePaneSessionIDFormat    = "#{pane_id}\t#{session_id}"
 	paneAlternateFormat        = "#{alternate_on}"
+	paneGeometryFormat         = "#{pane_left}\t#{pane_top}\t#{pane_width}\t#{pane_height}\t#{client_width}\t#{client_height}"
 	// paneLabelOption is a tmux pane user option holding the border label fanout
 	// shows on the pane's top border (e.g. "#123 · fix-login-bug-123"). It is set
 	// per pane and referenced from paneBorderFormat. A dedicated user option keeps
@@ -89,13 +90,31 @@ type ClientSize struct {
 	Height int
 }
 
-// PopupOptions describes a centered tmux display-popup invocation.
+// PopupPosition describes an absolute tmux display-popup origin.
+type PopupPosition struct {
+	X int
+	Y int
+}
+
+// PopupOptions describes a tmux display-popup invocation.
 type PopupOptions struct {
 	Width    int
 	Height   int
 	StartDir string
 	Title    string
 	Command  string
+	Position *PopupPosition
+}
+
+// PaneGeometry is the absolute position and size of a tmux pane plus the
+// current client size used to clamp adjacent popups into view.
+type PaneGeometry struct {
+	Left         int
+	Top          int
+	Width        int
+	Height       int
+	ClientWidth  int
+	ClientHeight int
 }
 
 type tmuxVersion struct {
@@ -196,7 +215,53 @@ func parseClientSize(out string) (ClientSize, error) {
 	return ClientSize{Width: width, Height: height}, nil
 }
 
-// DisplayPopup opens command in a centered tmux popup.
+// PaneGeometryForPane returns pane bounds in client coordinates.
+func PaneGeometryForPane(paneID string) (PaneGeometry, error) {
+	paneID = strings.TrimSpace(paneID)
+	if !paneIDPattern.MatchString(paneID) {
+		return PaneGeometry{}, fmt.Errorf("pane id must be a tmux pane id (%%N), got %q", paneID)
+	}
+	out, err := exec.Command("tmux", "display-message", "-p", "-t", paneID, "-F", paneGeometryFormat).Output()
+	if err != nil {
+		return PaneGeometry{}, fmt.Errorf("tmux display-message pane geometry: %w", err)
+	}
+	geom, err := parsePaneGeometry(string(out))
+	if err != nil {
+		return PaneGeometry{}, fmt.Errorf("parse tmux pane geometry: %w", err)
+	}
+	return geom, nil
+}
+
+func parsePaneGeometry(out string) (PaneGeometry, error) {
+	fields := strings.Split(strings.TrimRight(out, "\r\n"), "\t")
+	if len(fields) != 6 {
+		return PaneGeometry{}, fmt.Errorf("expected 6 fields, got %d", len(fields))
+	}
+	values := make([]int, len(fields))
+	for i, field := range fields {
+		value, err := strconv.Atoi(field)
+		if err != nil {
+			return PaneGeometry{}, fmt.Errorf("field %d: %w", i+1, err)
+		}
+		if value < 0 {
+			return PaneGeometry{}, fmt.Errorf("field %d must be non-negative, got %d", i+1, value)
+		}
+		values[i] = value
+	}
+	if values[2] <= 0 || values[3] <= 0 || values[4] <= 0 || values[5] <= 0 {
+		return PaneGeometry{}, fmt.Errorf("pane and client dimensions must be positive")
+	}
+	return PaneGeometry{
+		Left:         values[0],
+		Top:          values[1],
+		Width:        values[2],
+		Height:       values[3],
+		ClientWidth:  values[4],
+		ClientHeight: values[5],
+	}, nil
+}
+
+// DisplayPopup opens command in a tmux popup.
 func DisplayPopup(opts PopupOptions) error {
 	args, err := displayPopupArgs(opts)
 	if err != nil {
@@ -228,7 +293,11 @@ func displayPopupArgs(opts PopupOptions) ([]string, error) {
 	if strings.TrimSpace(opts.StartDir) != "" {
 		args = append(args, "-d", opts.StartDir)
 	}
-	args = append(args, "-x", "C", "-y", "C")
+	if opts.Position != nil {
+		args = append(args, "-x", strconv.Itoa(opts.Position.X), "-y", strconv.Itoa(opts.Position.Y))
+	} else {
+		args = append(args, "-x", "C", "-y", "C")
+	}
 	if strings.TrimSpace(opts.Title) != "" {
 		args = append(args, "-T", opts.Title)
 	}

--- a/internal/infra/tmuxrun/tmuxrun_test.go
+++ b/internal/infra/tmuxrun/tmuxrun_test.go
@@ -80,6 +80,37 @@ printf '132 41\n'
 	assertTmuxArgs(t, argsPath, []string{"display-message", "-p", "#{client_width} #{client_height}"})
 }
 
+func TestPaneGeometryForPane(t *testing.T) {
+	argsPath := installTmuxShim(t, `printf '%s\n' "$@" > "$TMUXRUN_ARGS"
+printf '10\t2\t40\t20\t132\t41\n'
+`)
+
+	got, err := PaneGeometryForPane("%7")
+	if err != nil {
+		t.Fatalf("PaneGeometryForPane() failed: %v", err)
+	}
+	want := PaneGeometry{Left: 10, Top: 2, Width: 40, Height: 20, ClientWidth: 132, ClientHeight: 41}
+	if got != want {
+		t.Fatalf("PaneGeometryForPane() = %#v, want %#v", got, want)
+	}
+	assertTmuxArgs(t, argsPath, []string{"display-message", "-p", "-t", "%7", "-F", paneGeometryFormat})
+}
+
+func TestPaneGeometryForPaneRejectsBadOutput(t *testing.T) {
+	installTmuxShim(t, `printf '10\t2\t40\n'
+`)
+
+	if _, err := PaneGeometryForPane("%7"); err == nil {
+		t.Fatal("PaneGeometryForPane() succeeded for malformed output")
+	}
+}
+
+func TestPaneGeometryForPaneRejectsMalformedPaneID(t *testing.T) {
+	if _, err := PaneGeometryForPane("pane"); err == nil {
+		t.Fatal("PaneGeometryForPane() succeeded for malformed pane id")
+	}
+}
+
 func TestDisplayPopupBuildsCenteredArgs(t *testing.T) {
 	argsPath := installTmuxShim(t, `printf '%s\n' "$@" > "$TMUXRUN_ARGS"
 `)
@@ -105,6 +136,35 @@ func TestDisplayPopupBuildsCenteredArgs(t *testing.T) {
 		"-y", "C",
 		"-T", "New agent pane",
 		"/tmp/fanout __tui-new-pane-popup",
+	})
+}
+
+func TestDisplayPopupBuildsPositionedArgs(t *testing.T) {
+	argsPath := installTmuxShim(t, `printf '%s\n' "$@" > "$TMUXRUN_ARGS"
+`)
+
+	err := DisplayPopup(PopupOptions{
+		Width:    76,
+		Height:   20,
+		StartDir: "/tmp/repo",
+		Title:    "Keyboard shortcuts",
+		Command:  "/tmp/fanout __tui-help-popup",
+		Position: &PopupPosition{X: 41, Y: 0},
+	})
+	if err != nil {
+		t.Fatalf("DisplayPopup() failed: %v", err)
+	}
+	assertTmuxArgs(t, argsPath, []string{
+		"display-popup", "-E",
+		"-b", popupBorderLines,
+		"-S", popupBorderStyle,
+		"-w", "76",
+		"-h", "20",
+		"-d", "/tmp/repo",
+		"-x", "41",
+		"-y", "0",
+		"-T", "Keyboard shortcuts",
+		"/tmp/fanout __tui-help-popup",
 	})
 }
 


### PR DESCRIPTION
## 概要

新規 Session popup と help popup の表示位置を、画面中央から fanout TUI ペインに隣接する右上へ変更しました。

dmux の popup 配置に合わせ、tmux client 全体の中央ではなく TUI ペインの tmux 座標を基準にします。

## 変更内容

- `display-popup` に任意の絶対位置を渡せる `PopupPosition` を追加
- TUI ペインの `pane_left` / `pane_width` / client 幅を読み、右隣上端に popup を配置
- 右側に十分な余白がない場合は左側配置を優先し、それも難しい場合は重なりが少ない端へ寄せる
- 中央表示 fallback と左右配置の回帰テストを追加

## 確認

- `go test ./cmd/fanout ./internal/infra/tmuxrun`
- `make build-go`
- `make test`
- `make lint`
- `git diff --check`
- `post-work-review`: clean=true, marker_written=true

Review effort: 2