### PR TITLE
[codex] pane close popupの位置を新規Session popupに揃える

### DIFF
--- a/cmd/fanout/tui_popup.go
+++ b/cmd/fanout/tui_popup.go
@@ -307,6 +307,7 @@ func newTUICloseChoicePopupFunc(projectRoot, commandName string) fanouttui.Close
 				geometry.ContentWidth,
 				geometry.ContentHeight,
 			),
+			Position: tuiPopupPositionForCurrentPane(geometry.PopupWidth, geometry.PopupHeight),
 		})
 		result, readErr := readTUIClosePopupResult(resultFile)
 		if os.IsNotExist(readErr) && displayErr == nil {

--- a/cmd/fanout/tui_test.go
+++ b/cmd/fanout/tui_test.go
@@ -328,6 +328,62 @@ func TestTUIPopupPositionFallsBackWithoutPane(t *testing.T) {
 	}
 }
 
+func TestTUIClosePopupUsesCurrentPanePosition(t *testing.T) {
+	dir := t.TempDir()
+	argsPath := filepath.Join(dir, "tmux-args.txt")
+	script := `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$@" >> "$TMUX_SHIM_ARGS"
+printf '%s\n' '---' >> "$TMUX_SHIM_ARGS"
+case "${1:-}" in
+  display-message)
+    if [[ "$*" == *pane_left* ]]; then
+      printf '0\t3\t40\t20\t160\t50\n'
+    elif [[ "$*" == *client_width* ]]; then
+      printf '160 50\n'
+    fi
+    ;;
+  display-popup)
+    command="${@: -1}"
+    if [[ "$command" =~ --result-file[[:space:]]([^[:space:]]+) ]]; then
+      printf '{"mode":"pane"}\n' > "${BASH_REMATCH[1]}"
+    fi
+    ;;
+  *)
+    ;;
+esac
+`
+	tmuxPath := filepath.Join(dir, "tmux")
+	if err := os.WriteFile(tmuxPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TMUX_SHIM_ARGS", argsPath)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("TMUX_PANE", "%7")
+
+	popup := newTUICloseChoicePopupFunc("/tmp/repo", "fanout")
+	mode, canceled, err := popup(fanouttui.CloseChoiceRequest{
+		PaneLabel:   "#101",
+		InitialMode: lifecycle.ClosePaneOnly,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if canceled {
+		t.Fatal("close popup canceled, want selection")
+	}
+	if mode != lifecycle.ClosePaneOnly {
+		t.Fatalf("close popup mode = %v, want pane-only", mode)
+	}
+
+	log := readTUITmuxLog(t, argsPath)
+	if !tmuxLogHasCommand(log, "display-popup\n-E\n") ||
+		!tmuxLogHasCommand(log, "\n-x\n41\n-y\n3\n") ||
+		!tmuxLogHasCommand(log, tuiClosePopupCommand) {
+		t.Fatalf("close popup display-popup was not positioned next to the current pane:\n%s", log)
+	}
+}
+
 func TestTUINewPanePopupResultRoundTrip(t *testing.T) {
 	tests := []struct {
 		name   string


### PR DESCRIPTION
## TL;DR
pane close popup でも新規 Session popup と同じ現在ペイン隣接位置を使うようにしました。

## 変更内容
- `Close pane` popup の `tmux display-popup` 呼び出しに、既存の `tuiPopupPositionForCurrentPane(...)` を渡しました。
- close popup のサイズ、内容、fallback 挙動は変更していません。
- tmux shim を使った回帰テストを追加し、close popup の `display-popup` に期待する `-x` / `-y` が渡ることを確認しています。

## 原因
新規 Session popup と help popup は `Position` を明示していましたが、pane close popup だけ `Position` が未指定で、tmux の中央表示 fallback に落ちていました。

## 検証
- `git diff --check`
- `go test ./cmd/fanout ./internal/ui/tui ./internal/infra/tmuxrun`
- `make test`
- `make lint`
- `post-work-review`: clean=true / findings=0 / marker_written=true

Review effort: 2