### PR TITLE
[codex] Add TUI settings popup

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -33,8 +33,9 @@ briefing から起動します。再実行しても同じ対象に 2 つ目の�
   自動復元を備えたコンソールを開きます。新規 Session popup は自由記述 prompt
   や一覧から選んだ OPEN issue から開始でき、子ごとに agent を選べます(あるタ
   スクは claude、別のタスクは codex、のように)。prompt モードのチェックボック
-  スを入れると、そのプロンプトを `/fanout plan` で並列タスクに分解します。どの
-  ペインからでも `F11` または `prefix + T` でコンソールに戻れます。
+  スを入れると、そのプロンプトを `/fanout plan` で並列タスクに分解します。
+  `s` キーで設定 popup を開けます。どのペインからでも `F11` または `prefix + T`
+  でコンソールに戻れます。
 - **ラベル watcher** — opt-in すると、TUI 常駐中に信頼できる `fanout:auto`
   issue を one-shot fanout session に投入します。
 - **Web ダッシュボード** — localhost で動く read-only のダッシュボード(ライブ
@@ -139,7 +140,7 @@ watcher は repo 全体から label 付き issue を探し、one-shot session �
 | `fanout 123 --unblocked-only` | ブロッカーが closed の子だけをファンアウト — 次の wave |
 | `fanout 123 --dry-run` | git / tmux / state / briefing file を変更せず計画だけ表示 |
 | `fanout plan spec.json --agent claude` | GitHub の子 issue でなくローカル plan spec をファンアウト |
-| `fanout` | 常駐 TUI コンソールを起動(Session ジャンプ・数字ジャンプ 1-9・focus・zoom・peek・幅 80 桁未満のコンパクト switcher(`v`)・terminal・prompt / issue からの Session 起動・同一 worktree への追加・復元・lifecycle キー) |
+| `fanout` | 常駐 TUI コンソールを起動(Session ジャンプ・数字ジャンプ 1-9・focus・zoom・peek・幅 80 桁未満のコンパクト switcher(`v`)・terminal・prompt / issue からの Session 起動・設定 popup (`s`)・同一 worktree への追加・復元・lifecycle キー) |
 | `fanout 123 --status` | ペイン・PR review・CI 状態を JSON または table で |
 | `fanout dashboard --web` | localhost で read-only Web ダッシュボードを配信 |
 | `fanout 123 --merge 4` | 子 branch を fast-forward merge(`--close` / `--cleanup` でペインを畳む) |

--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ English and 日本語.
   of missing worktree panes. The new-session popup starts work from a free
   prompt or an OPEN issue picked from a list, with a per-child agent choice
   (claude for one task, codex for another). A prompt-mode checkbox instead
-  decomposes the prompt into parallel tasks via `/fanout plan`. Return to the
-  console from any pane with `F11` or `prefix + T`.
+  decomposes the prompt into parallel tasks via `/fanout plan`. The `s` key
+  opens the settings popup. Return to the console from any pane with `F11` or
+  `prefix + T`.
 - **Label watcher** — opt in to a TUI-resident watcher that turns trusted
   `fanout:auto` issues into one-shot fanout sessions.
 - **Web dashboard** — a read-only localhost dashboard with live updates; pop it
@@ -137,7 +138,7 @@ it discovers labeled issues across the repository and starts one-shot sessions.
 | `fanout 123 --unblocked-only` | Fan out only children whose blockers are closed — the next wave |
 | `fanout 123 --dry-run` | Print the plan without modifying git, tmux, state, or briefing files |
 | `fanout plan spec.json --agent claude` | Fan out a local plan spec instead of GitHub child issues |
-| `fanout` | Start the persistent TUI console (Session jump, numeric jump 1-9, focus, zoom, peek, compact switcher below 80 columns (`v`), terminal, prompt / issue session launch, same-worktree attach, restore, lifecycle keys) |
+| `fanout` | Start the persistent TUI console (Session jump, numeric jump 1-9, focus, zoom, peek, compact switcher below 80 columns (`v`), terminal, prompt / issue session launch, settings popup (`s`), same-worktree attach, restore, lifecycle keys) |
 | `fanout 123 --status` | Pane, PR review, and CI state as JSON or a table |
 | `fanout dashboard --web` | Serve the read-only web dashboard on localhost |
 | `fanout 123 --merge 4` | Fast-forward merge a child branch (`--close` / `--cleanup` fold panes away) |

--- a/cmd/fanout/dashboard.go
+++ b/cmd/fanout/dashboard.go
@@ -267,6 +267,21 @@ func bindDashboardKey(lg *log.Logger, enabled bool) {
 	if !enabled {
 		return
 	}
+	syncDashboardKey(lg, enabled, false)
+}
+
+func syncDashboardKey(lg *log.Logger, enabled bool, cleanupDisabled bool) {
+	if !enabled {
+		if cleanupDisabled {
+			if err := tmuxrun.UnbindDashboardKeys(defaultDashboardKey, defaultDashboardDirectKey); err != nil {
+				lg.Debug("dashboard keybind cleanup: %v (not in tmux?)", err)
+			}
+			if err := tmuxrun.UnbindWorktreeActionKey(defaultWorktreeActionKey); err != nil {
+				lg.Debug("worktree action keybind cleanup: %v (not in tmux?)", err)
+			}
+		}
+		return
+	}
 	bin, err := os.Executable()
 	if err != nil {
 		lg.Debug("dashboard keybind: cannot resolve fanout binary path: %v", err)

--- a/cmd/fanout/focusconsole.go
+++ b/cmd/fanout/focusconsole.go
@@ -185,6 +185,18 @@ func bindConsoleKey(lg *log.Logger, enabled bool) {
 	if !enabled {
 		return
 	}
+	syncConsoleKey(lg, enabled, false)
+}
+
+func syncConsoleKey(lg *log.Logger, enabled bool, cleanupDisabled bool) {
+	if !enabled {
+		if cleanupDisabled {
+			if err := tmuxrun.UnbindConsoleKeys(defaultConsoleKey, defaultConsoleDirectKey); err != nil {
+				lg.Debug("console keybind cleanup: %v (not in tmux?)", err)
+			}
+		}
+		return
+	}
 	bin, err := os.Executable()
 	if err != nil {
 		lg.Debug("console keybind: cannot resolve fanout binary path: %v", err)

--- a/cmd/fanout/main.go
+++ b/cmd/fanout/main.go
@@ -41,6 +41,7 @@ func main() {
 		{isTUINewPanePopupRequest, func() exitcode.Code { return cmdTUINewPanePopup(os.Args[2:], lg) }},
 		{isTUIHelpPopupRequest, func() exitcode.Code { return cmdTUIHelpPopup(os.Args[2:], lg) }},
 		{isTUIClosePopupRequest, func() exitcode.Code { return cmdTUIClosePopup(os.Args[2:], lg) }},
+		{isTUISettingsPopupRequest, func() exitcode.Code { return cmdTUISettingsPopup(os.Args[2:], lg) }},
 		{isCodexPlanTUIRequest, func() exitcode.Code { return cmdCodexPlanTUI(os.Args[2:], lg) }},
 		{isPlanRequest, func() exitcode.Code { return cmdPlan(os.Args[2:], lg, commandName) }},
 		{isDashboardRequest, func() exitcode.Code { return cmdDashboard(os.Args[2:], lg) }},

--- a/cmd/fanout/tui.go
+++ b/cmd/fanout/tui.go
@@ -93,6 +93,8 @@ func cmdTUI(commandName string, lg *log.Logger) exitcode.Code {
 		NewPanePrompt:       newTUINewPanePromptFunc(projectRoot, commandName),
 		HelpPopup:           newTUIHelpPopupFunc(projectRoot, commandName),
 		CloseChoicePopup:    newTUICloseChoicePopupFunc(projectRoot, commandName),
+		SettingsPopup:       newTUISettingsPopupFunc(projectRoot, commandName),
+		ReloadSettings:      newTUISettingsReloadFunc(projectRoot, session, commandName, hookConfig, lg),
 		LaunchAttach:        newTUIAttachAgentFunc(projectRoot, session, commandName, hookConfig),
 		// List providers also feed the in-process fallback form (NewPanePrompt
 		// unavailable); the popup process wires its own copies.
@@ -108,6 +110,36 @@ func cmdTUI(commandName string, lg *log.Logger) exitcode.Code {
 		return exitcode.Env
 	}
 	return exitcode.OK
+}
+
+func newTUISettingsReloadFunc(projectRoot, session, commandName string, hookConfig hooks.Config, lg *log.Logger) fanouttui.SettingsReloadFunc {
+	return func() (fanouttui.SettingsRuntime, error) {
+		resolvedSettings := settings.Resolve(projectRoot, settings.CLIOverrides{}, lg.Warn)
+		watcher, watchInterval, watchLabel, err := newTUIWatcher(projectRoot, session, commandName, resolvedSettings, hookConfig)
+		if err != nil {
+			return fanouttui.SettingsRuntime{}, fmt.Errorf("watcher: %w", err)
+		}
+		notifier, err := fanoutnotify.New(fanoutnotify.Config{
+			Channels:        resolvedSettings.Notifications,
+			TmuxTarget:      session,
+			NtfyURL:         resolvedSettings.NtfyURL,
+			SlackWebhookURL: resolvedSettings.SlackWebhookURL,
+			BellWriter:      os.Stdout,
+		})
+		if err != nil {
+			return fanouttui.SettingsRuntime{}, fmt.Errorf("notifications: %w", err)
+		}
+		syncDashboardKey(lg, resolvedSettings.DashboardKeybind, true)
+		syncConsoleKey(lg, resolvedSettings.ConsoleKeybind, true)
+		return fanouttui.SettingsRuntime{
+			Watcher:             watcher,
+			WatchInterval:       watchInterval,
+			WatchLabel:          watchLabel,
+			WatcherRunningLabel: resolvedSettings.WatcherRunningLabel,
+			Notifier:            notifier,
+			LaunchIssue:         newTUIIssueLaunchFunc(projectRoot, session, commandName, resolvedSettings, hookConfig),
+		}, nil
+	}
 }
 
 func tuiLaunchTarget(session string) string {

--- a/cmd/fanout/tui_popup.go
+++ b/cmd/fanout/tui_popup.go
@@ -14,6 +14,7 @@ import (
 	"github.com/butaosuinu/fanout/internal/app/run"
 	"github.com/butaosuinu/fanout/internal/core/exitcode"
 	"github.com/butaosuinu/fanout/internal/infra/log"
+	fanoutsettings "github.com/butaosuinu/fanout/internal/infra/settings"
 	"github.com/butaosuinu/fanout/internal/infra/tmuxrun"
 	"github.com/butaosuinu/fanout/internal/infra/worktree"
 	fanouttui "github.com/butaosuinu/fanout/internal/ui/tui"
@@ -26,6 +27,7 @@ const (
 	tuiHelpPopupMinHeight      = 18
 	tuiNewPanePopupCommand     = "__tui-new-pane-popup"
 	tuiNewPanePopupMinHeight   = 18
+	tuiSettingsPopupCommand    = "__tui-settings-popup"
 	tuiNewPanePopupBorderInset = 2
 	tuiNewPanePopupResultPoll  = 50 * time.Millisecond
 	tuiNewPanePopupResultWait  = 24 * time.Hour
@@ -75,6 +77,14 @@ type tuiClosePopupResult struct {
 	Error    string `json:"error,omitempty"`
 }
 
+type tuiSettingsPopupResult struct {
+	Canceled bool   `json:"canceled,omitempty"`
+	Saved    bool   `json:"saved,omitempty"`
+	Scope    string `json:"scope,omitempty"`
+	Path     string `json:"path,omitempty"`
+	Error    string `json:"error,omitempty"`
+}
+
 func isTUINewPanePopupRequest(args []string) bool {
 	return len(args) > 0 && args[0] == tuiNewPanePopupCommand
 }
@@ -85,6 +95,10 @@ func isTUIHelpPopupRequest(args []string) bool {
 
 func isTUIClosePopupRequest(args []string) bool {
 	return len(args) > 0 && args[0] == tuiClosePopupCommand
+}
+
+func isTUISettingsPopupRequest(args []string) bool {
+	return len(args) > 0 && args[0] == tuiSettingsPopupCommand
 }
 
 func cmdTUIHelpPopup(args []string, lg *log.Logger) exitcode.Code {
@@ -201,6 +215,43 @@ func cmdTUINewPanePopup(args []string, lg *log.Logger) exitcode.Code {
 	return code
 }
 
+func cmdTUISettingsPopup(args []string, lg *log.Logger) exitcode.Code {
+	fs := flag.NewFlagSet(tuiSettingsPopupCommand, flag.ContinueOnError)
+	fs.SetOutput(lg.Stderr())
+	projectRoot := fs.String("project-root", "", "project root")
+	resultFile := fs.String("result-file", "", "result file")
+	width := fs.Int("width", 90, "popup width")
+	height := fs.Int("height", 24, "popup height")
+	if err := fs.Parse(args); err != nil {
+		return exitcode.Invocation
+	}
+	if strings.TrimSpace(*projectRoot) == "" || strings.TrimSpace(*resultFile) == "" {
+		lg.Err("--project-root and --result-file are required")
+		return exitcode.Invocation
+	}
+	result, canceled, err := fanouttui.RunSettingsPopup(fanouttui.SettingsPopupOptions{
+		ProjectRoot: *projectRoot,
+		Width:       *width,
+		Height:      *height,
+	})
+	out := tuiSettingsPopupResult{
+		Canceled: canceled,
+		Saved:    result.Saved,
+		Scope:    result.Scope,
+		Path:     result.Path,
+	}
+	code := exitcode.OK
+	if err != nil {
+		out = tuiSettingsPopupResult{Error: err.Error()}
+		code = exitcode.Env
+	}
+	if writeErr := writeTUISettingsPopupResult(*resultFile, out); writeErr != nil {
+		lg.Err("write settings popup result: %v", writeErr)
+		return exitcode.Env
+	}
+	return code
+}
+
 func writeTUINewPanePopupResult(path string, result tuiNewPanePopupResult) error {
 	return writePopupJSON(path, result)
 }
@@ -210,6 +261,10 @@ func writeTUIClosePopupRequest(path string, request tuiClosePopupRequest) error 
 }
 
 func writeTUIClosePopupResult(path string, result tuiClosePopupResult) error {
+	return writePopupJSON(path, result)
+}
+
+func writeTUISettingsPopupResult(path string, result tuiSettingsPopupResult) error {
 	return writePopupJSON(path, result)
 }
 
@@ -399,6 +454,64 @@ func newTUINewPanePromptFunc(projectRoot, commandName string) fanouttui.NewPaneP
 	}
 }
 
+func newTUISettingsPopupFunc(projectRoot, commandName string) fanouttui.SettingsPopupFunc {
+	return func(fanouttui.SettingsPopupRequest) (fanouttui.SettingsPopupResult, bool, error) {
+		size, err := tmuxrun.CurrentClientSize()
+		if err != nil {
+			return fanouttui.SettingsPopupResult{}, false, err
+		}
+		geometry, err := tuiNewPanePopupGeometryForClient(size)
+		if err != nil {
+			return fanouttui.SettingsPopupResult{}, false, err
+		}
+		resultFile, doneFile, cleanupPopupResult, err := newPopupResultPaths()
+		if err != nil {
+			return fanouttui.SettingsPopupResult{}, false, err
+		}
+		defer cleanupPopupResult()
+		command := tuiSettingsPopupShellCommand(
+			commandName,
+			projectRoot,
+			resultFile,
+			doneFile,
+			geometry.PromptWidth,
+			geometry.PromptHeight,
+		)
+		displayErr := tmuxrun.DisplayPopup(tmuxrun.PopupOptions{
+			Width:    geometry.PopupWidth,
+			Height:   geometry.PopupHeight,
+			StartDir: projectRoot,
+			Title:    "Settings",
+			Command:  command,
+			Position: tuiPopupPositionForCurrentPane(geometry.PopupWidth, geometry.PopupHeight),
+		})
+		result, readErr := readTUISettingsPopupResult(resultFile)
+		if os.IsNotExist(readErr) && displayErr == nil {
+			result, readErr = waitForTUISettingsPopupResult(resultFile, doneFile, tuiNewPanePopupResultWait)
+		}
+		if readErr != nil {
+			if displayErr != nil {
+				return fanouttui.SettingsPopupResult{}, false, displayErr
+			}
+			return fanouttui.SettingsPopupResult{}, false, readErr
+		}
+		if result.Error != "" {
+			return fanouttui.SettingsPopupResult{}, false, fmt.Errorf("%s", result.Error)
+		}
+		if result.Canceled {
+			return fanouttui.SettingsPopupResult{}, true, nil
+		}
+		if displayErr != nil {
+			return fanouttui.SettingsPopupResult{}, false, displayErr
+		}
+		return fanouttui.SettingsPopupResult{
+			Saved: result.Saved,
+			Scope: result.Scope,
+			Path:  result.Path,
+		}, false, nil
+	}
+}
+
 func tuiPopupPositionForCurrentPane(popupWidth, popupHeight int) *tmuxrun.PopupPosition {
 	paneID := strings.TrimSpace(os.Getenv("TMUX_PANE"))
 	if paneID == "" {
@@ -563,21 +676,60 @@ func tuiNewPanePopupShellCommand(commandName, projectRoot, resultFile, doneFile,
 		"--width", fmt.Sprintf("%d", width),
 		"--height", fmt.Sprintf("%d", height),
 	}
-	// Enhanced keyboard input is on by default. Always forward the current value,
-	// including opt-out values, so the helper mirrors the parent TUI.
-	prefix := fanouttui.EnhancedKeysEnv + "=" + run.ShellQuote(os.Getenv(fanouttui.EnhancedKeysEnv))
 	// display-popup runs under the tmux server's environment, not the parent
-	// fanout process's. Forward PATH so the issue picker finds `gh` (and git)
-	// wherever the parent did. Secrets (GH_TOKEN etc.) are deliberately
-	// not inlined: the command line is visible via ps; token-less setups rely
-	// on gh's config-file auth, which needs only HOME.
-	if path := os.Getenv("PATH"); path != "" {
-		prefix = "PATH=" + run.ShellQuote(path) + " " + prefix
-	}
+	// fanout process's. Forward non-secret path environment so helper commands
+	// resolve tools and config files the same way as the parent process.
+	prefix := tuiPopupShellEnvPrefix()
 	parts = append([]string{prefix}, parts...)
 	command := strings.Join(parts, " ")
 	markDone := "printf '' > " + run.ShellQuote(doneFile)
 	return "trap " + run.ShellQuote(markDone) + " EXIT HUP INT TERM; " + command
+}
+
+func tuiSettingsPopupShellCommand(commandName, projectRoot, resultFile, doneFile string, width, height int) string {
+	exe, err := os.Executable()
+	if err != nil || strings.TrimSpace(exe) == "" {
+		exe = commandName
+	}
+	parts := []string{
+		run.ShellQuote(exe),
+		tuiSettingsPopupCommand,
+		"--project-root", run.ShellQuote(projectRoot),
+		"--result-file", run.ShellQuote(resultFile),
+		"--width", fmt.Sprintf("%d", width),
+		"--height", fmt.Sprintf("%d", height),
+	}
+	prefix := tuiPopupShellEnvPrefix()
+	parts = append([]string{prefix}, parts...)
+	command := strings.Join(parts, " ")
+	markDone := "printf '' > " + run.ShellQuote(doneFile)
+	return "trap " + run.ShellQuote(markDone) + " EXIT HUP INT TERM; " + command
+}
+
+func tuiPopupShellEnvPrefix() string {
+	parts := []string{
+		fanouttui.SettingsEnvOverridesEnv + "=" + run.ShellQuote(settingsEnvOverrideNames()),
+		fanouttui.EnhancedKeysEnv + "=" + run.ShellQuote(os.Getenv(fanouttui.EnhancedKeysEnv)),
+	}
+	for _, key := range []string{"XDG_CONFIG_HOME", "HOME", "PATH"} {
+		if value, ok := os.LookupEnv(key); ok || key != "PATH" {
+			parts = append([]string{key + "=" + run.ShellQuote(value)}, parts...)
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
+func settingsEnvOverrideNames() string {
+	names := []string{}
+	for _, spec := range fanoutsettings.ConfigKeys() {
+		if spec.Env == "" {
+			continue
+		}
+		if _, ok := os.LookupEnv(spec.Env); ok {
+			names = append(names, spec.Env)
+		}
+	}
+	return strings.Join(names, ",")
 }
 
 func waitForTUINewPanePopupResult(resultFile, doneFile string, timeout time.Duration) (tuiNewPanePopupResult, error) {
@@ -624,6 +776,28 @@ func waitForTUIClosePopupResult(resultFile, doneFile string, timeout time.Durati
 	}
 }
 
+func waitForTUISettingsPopupResult(resultFile, doneFile string, timeout time.Duration) (tuiSettingsPopupResult, error) {
+	deadline := time.Now().Add(timeout)
+	for {
+		result, err := readTUISettingsPopupResult(resultFile)
+		if err == nil {
+			return result, nil
+		}
+		if !os.IsNotExist(err) {
+			return tuiSettingsPopupResult{}, err
+		}
+		if _, err := os.Stat(doneFile); err == nil {
+			return tuiSettingsPopupResult{Canceled: true}, nil
+		} else if !os.IsNotExist(err) {
+			return tuiSettingsPopupResult{}, err
+		}
+		if timeout > 0 && time.Now().After(deadline) {
+			return tuiSettingsPopupResult{}, fmt.Errorf("timed out waiting for settings popup result after %s", timeout)
+		}
+		time.Sleep(tuiNewPanePopupResultPoll)
+	}
+}
+
 func readTUINewPanePopupResult(path string) (tuiNewPanePopupResult, error) {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -632,6 +806,18 @@ func readTUINewPanePopupResult(path string) (tuiNewPanePopupResult, error) {
 	var result tuiNewPanePopupResult
 	if err := json.Unmarshal(data, &result); err != nil {
 		return tuiNewPanePopupResult{}, err
+	}
+	return result, nil
+}
+
+func readTUISettingsPopupResult(path string) (tuiSettingsPopupResult, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return tuiSettingsPopupResult{}, err
+	}
+	var result tuiSettingsPopupResult
+	if err := json.Unmarshal(data, &result); err != nil {
+		return tuiSettingsPopupResult{}, err
 	}
 	return result, nil
 }

--- a/cmd/fanout/tui_test.go
+++ b/cmd/fanout/tui_test.go
@@ -115,8 +115,11 @@ func TestCmdTUINoDashboardKeybindHonorsEnv(t *testing.T) {
 	}
 
 	log := readTUITmuxLog(t, argsPath)
-	if strings.Contains(log, "bind-key\n") {
-		t.Fatalf("tmux log should not contain keybinds when both are disabled:\n%s", log)
+	if tmuxLogHasCommand(log, "run-shell") || tmuxLogHasCommand(log, "display-popup") {
+		t.Fatalf("tmux log should not register keybind commands when both are disabled:\n%s", log)
+	}
+	if tmuxLogHasCommand(log, "list-keys") || tmuxLogHasCommand(log, "unbind-key") {
+		t.Fatalf("startup opt-out should not cleanup existing key commands:\n%s", log)
 	}
 }
 
@@ -178,6 +181,43 @@ func TestCmdTUINoConsoleKeybindHonorsEnv(t *testing.T) {
 	}
 	if !tmuxLogHasCommand(log, "bind-key\nD\nrun-shell") {
 		t.Fatalf("tmux log missing dashboard keybind (must stay registered):\n%s", log)
+	}
+}
+
+func TestTUISettingsReloadCleansDisabledKeybinds(t *testing.T) {
+	repo := t.TempDir()
+	initTUITestGitRepo(t, repo)
+	commitTUITestGitRepo(t, repo)
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	configPath := filepath.Join(xdg, "fanout", "config.json")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, []byte(`{"dashboardKeybind": false, "consoleKeybind": false}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	argsPath := installTUISettingsReloadTmuxShim(t)
+
+	reload := newTUISettingsReloadFunc(repo, "fanout-test", "fanout", hooks.Config{}, discardLogger())
+	if _, err := reload(); err != nil {
+		t.Fatal(err)
+	}
+
+	log := readTUITmuxLog(t, argsPath)
+	for _, want := range []string{
+		"unbind-key\n-q\nD",
+		"unbind-key\n-q\n-n\nF12",
+		"unbind-key\n-q\nM",
+		"unbind-key\n-q\nT",
+		"unbind-key\n-q\n-n\nF11",
+	} {
+		if !tmuxLogHasCommand(log, want) {
+			t.Fatalf("tmux log missing settings cleanup %q:\n%s", want, log)
+		}
+	}
+	if tmuxLogHasCommand(log, "run-shell") || tmuxLogHasCommand(log, "display-popup") {
+		t.Fatalf("tmux log should not bind disabled key commands:\n%s", log)
 	}
 }
 
@@ -468,6 +508,29 @@ func TestTUIClosePopupRequestAndResultRoundTrip(t *testing.T) {
 	}
 }
 
+func TestTUISettingsPopupResultRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	resultPath := filepath.Join(dir, "result.json")
+	result := tuiSettingsPopupResult{Saved: true, Scope: "user", Path: "/tmp/fanout/config.json"}
+	if writeErr := writeTUISettingsPopupResult(resultPath, result); writeErr != nil {
+		t.Fatal(writeErr)
+	}
+	got, err := readTUISettingsPopupResult(resultPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != result {
+		t.Fatalf("settings popup result = %#v, want %#v", got, result)
+	}
+	info, err := os.Stat(resultPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("settings popup result mode = %o, want 600", got)
+	}
+}
+
 func TestNewPopupResultPathsUsesPrivateDirectory(t *testing.T) {
 	resultPath, donePath, cleanup, err := newPopupResultPaths()
 	if err != nil {
@@ -528,6 +591,23 @@ func TestWaitForTUIClosePopupResultTreatsDoneWithoutResultAsCancel(t *testing.T)
 	}
 }
 
+func TestWaitForTUISettingsPopupResultTreatsDoneWithoutResultAsCancel(t *testing.T) {
+	dir := t.TempDir()
+	resultPath := filepath.Join(dir, "result.json")
+	donePath := filepath.Join(dir, "result.done")
+	if err := os.WriteFile(donePath, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := waitForTUISettingsPopupResult(resultPath, donePath, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.Canceled {
+		t.Fatalf("settings popup result = %#v, want canceled", got)
+	}
+}
+
 func TestTUIHelpPopupShellCommandPropagatesPathAndDimensions(t *testing.T) {
 	got := tuiHelpPopupShellCommand("fanout", 80, 18)
 	for _, want := range []string{
@@ -562,6 +642,8 @@ func TestTUIClosePopupShellCommandMarksDoneAndPropagatesPath(t *testing.T) {
 }
 
 func TestTUINewPanePopupShellCommandMarksDoneAndPropagatesEnhancedKeys(t *testing.T) {
+	t.Setenv("HOME", "/tmp/fanout-home")
+	t.Setenv("XDG_CONFIG_HOME", "/tmp/fanout-xdg")
 	for _, value := range []string{"", "0", "1"} {
 		t.Setenv(fanouttui.EnhancedKeysEnv, value)
 		got := tuiNewPanePopupShellCommand("fanout", "/tmp/repo", "/tmp/result.json", "/tmp/result.done", "codex", 80, 18)
@@ -580,10 +662,49 @@ func TestTUINewPanePopupShellCommandMarksDoneAndPropagatesEnhancedKeys(t *testin
 		// The popup runs under the tmux server env; PATH must come from the
 		// parent so the issue/plan pickers can exec gh.
 		"PATH=" + run.ShellQuote(os.Getenv("PATH")),
+		"HOME=/tmp/fanout-home",
+		"XDG_CONFIG_HOME=/tmp/fanout-xdg",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("popup shell command missing %q:\n%s", want, got)
 		}
+	}
+}
+
+func TestTUISettingsPopupShellCommandMarksDoneAndPropagatesEnhancedKeys(t *testing.T) {
+	t.Setenv("HOME", "/tmp/fanout-home")
+	t.Setenv("XDG_CONFIG_HOME", "/tmp/fanout-xdg")
+	t.Setenv("FANOUT_WATCHER", "1")
+	t.Setenv("FANOUT_SLACK_WEBHOOK_URL", "https://hooks.slack.com/services/secret")
+	for _, value := range []string{"", "0", "1"} {
+		t.Setenv(fanouttui.EnhancedKeysEnv, value)
+		got := tuiSettingsPopupShellCommand("fanout", "/tmp/repo", "/tmp/result.json", "/tmp/result.done", 80, 18)
+		if !strings.Contains(got, fanouttui.EnhancedKeysEnv+"="+run.ShellQuote(value)+" ") {
+			t.Fatalf("settings popup shell command = %q with %s=%q, want forwarded env prefix", got, fanouttui.EnhancedKeysEnv, value)
+		}
+	}
+
+	got := tuiSettingsPopupShellCommand("fanout", "/tmp/repo", "/tmp/result.json", "/tmp/result.done", 80, 18)
+	for _, want := range []string{
+		"trap ",
+		"EXIT HUP INT TERM",
+		"/tmp/result.done",
+		tuiSettingsPopupCommand,
+		"--project-root /tmp/repo",
+		"--result-file /tmp/result.json",
+		"PATH=" + run.ShellQuote(os.Getenv("PATH")),
+		"HOME=/tmp/fanout-home",
+		"XDG_CONFIG_HOME=/tmp/fanout-xdg",
+		fanouttui.SettingsEnvOverridesEnv + "=",
+		"FANOUT_WATCHER",
+		"FANOUT_SLACK_WEBHOOK_URL",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("settings popup shell command missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "hooks.slack.com") || strings.Contains(got, "secret") {
+		t.Fatalf("settings popup shell command leaked sensitive env value:\n%s", got)
 	}
 }
 
@@ -1438,7 +1559,44 @@ case "${1:-}" in
       printf '%%tui\t0\t1\tconsole\t\n'
     fi
     ;;
-  bind-key|set-option|select-pane|select-layout|kill-pane)
+  bind-key|unbind-key|list-keys|set-option|select-pane|select-layout|kill-pane)
+    ;;
+  *)
+    ;;
+esac
+`
+	path := filepath.Join(dir, "tmux")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TMUX_SHIM_ARGS", argsPath)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return argsPath
+}
+
+func installTUISettingsReloadTmuxShim(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	argsPath := filepath.Join(dir, "tmux-args.txt")
+	script := `#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$@" >> "$TMUX_SHIM_ARGS"
+printf '%s\n' '---' >> "$TMUX_SHIM_ARGS"
+case "${1:-}" in
+  list-keys)
+    if [[ "$*" == *" -T prefix D"* ]]; then
+      printf 'bind-key D run-shell -b fanout dashboard --web --open; tmux new-window -n fanout-dashboard\n'
+    elif [[ "$*" == *" -T root F12"* ]]; then
+      printf 'bind-key -n F12 run-shell -b fanout dashboard --web --open; tmux new-window -n fanout-dashboard\n'
+    elif [[ "$*" == *" -T prefix M"* ]]; then
+      printf 'bind-key M display-popup -E fanout __worktree-action --pane #{pane_id}\n'
+    elif [[ "$*" == *" -T prefix T"* ]]; then
+      printf 'bind-key T run-shell fanout focus-console --from "#{pane_id}"; tmux display-message "fanout: focus-console failed"\n'
+    elif [[ "$*" == *" -T root F11"* ]]; then
+      printf 'bind-key -n F11 run-shell fanout focus-console --from "#{pane_id}"; tmux display-message "fanout: focus-console failed"\n'
+    fi
+    ;;
+  unbind-key)
     ;;
   *)
     ;;

--- a/internal/infra/settings/settings.go
+++ b/internal/infra/settings/settings.go
@@ -4,10 +4,13 @@ package settings
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+
+	"github.com/butaosuinu/fanout/internal/infra/atomicfs"
 )
 
 const (
@@ -33,6 +36,49 @@ type Settings struct {
 	Notifications          string
 	NtfyURL                string
 	SlackWebhookURL        string
+}
+
+// ConfigScope selects which JSON config file is edited.
+type ConfigScope string
+
+const (
+	ConfigScopeUser ConfigScope = "user"
+	ConfigScopeRepo ConfigScope = "repo"
+)
+
+// ValueKind is the JSON scalar kind for one settings key.
+type ValueKind string
+
+const (
+	ValueBool   ValueKind = "bool"
+	ValueString ValueKind = "string"
+	ValueInt    ValueKind = "int"
+)
+
+// ConfigKey describes one key accepted by fanout config.json files.
+type ConfigKey struct {
+	Key          string
+	Group        string
+	Label        string
+	Kind         ValueKind
+	Env          string
+	Default      string
+	RepoEditable bool
+	Sensitive    bool
+}
+
+// ConfigValue is one nullable config.json value. A zero ConfigValue means the
+// key is inherited from lower-priority settings.
+type ConfigValue struct {
+	Bool   *bool
+	String *string
+	Int    *int
+}
+
+// EditableConfig is a parsed config file ready for a UI editor.
+type EditableConfig struct {
+	Path   string
+	Values map[string]ConfigValue
 }
 
 // CLIOverrides holds tri-state command-line overrides. nil means the flag was
@@ -63,6 +109,25 @@ type overrides struct {
 	Notifications          *string
 	NtfyURL                *string
 	SlackWebhookURL        *string
+}
+
+var configKeys = []ConfigKey{
+	{Key: "autoPullRequest", Group: "Briefing", Label: "PR auto-create", Kind: ValueBool, Env: "FANOUT_AUTO_PR", Default: "true", RepoEditable: true},
+	{Key: "prReviewGate", Group: "Briefing", Label: "PR review gate", Kind: ValueBool, Env: "FANOUT_PR_REVIEW_GATE", Default: "true", RepoEditable: true},
+	{Key: "briefingCodeReview", Group: "Briefing", Label: "Claude code review", Kind: ValueBool, Env: "FANOUT_BRIEFING_CODE_REVIEW", Default: "true", RepoEditable: true},
+	{Key: "agentTeamsHint", Group: "Briefing", Label: "Agent Teams hint", Kind: ValueBool, Env: "FANOUT_AGENT_TEAMS_HINT", Default: "true", RepoEditable: true},
+	{Key: "prVisualization", Group: "Briefing", Label: "PR visualization", Kind: ValueBool, Env: "FANOUT_PR_VISUALIZATION", Default: "true", RepoEditable: true},
+	{Key: "dashboardKeybind", Group: "TUI", Label: "Dashboard keybind", Kind: ValueBool, Env: "FANOUT_DASHBOARD_KEYBIND", Default: "true", RepoEditable: true},
+	{Key: "consoleKeybind", Group: "TUI", Label: "Console keybind", Kind: ValueBool, Env: "FANOUT_CONSOLE_KEYBIND", Default: "true", RepoEditable: true},
+	{Key: "watcher", Group: "Watcher", Label: "Watcher", Kind: ValueBool, Env: "FANOUT_WATCHER", Default: "false", RepoEditable: false},
+	{Key: "watcherTriggerLabel", Group: "Watcher", Label: "Trigger label", Kind: ValueString, Env: "FANOUT_WATCHER_TRIGGER_LABEL", Default: "fanout:auto", RepoEditable: true},
+	{Key: "watcherRunningLabel", Group: "Watcher", Label: "Running label", Kind: ValueString, Env: "FANOUT_WATCHER_RUNNING_LABEL", Default: "fanout:running", RepoEditable: true},
+	{Key: "watcherIntervalSeconds", Group: "Watcher", Label: "Interval seconds", Kind: ValueInt, Env: "FANOUT_WATCHER_INTERVAL_SECONDS", Default: "60", RepoEditable: true},
+	{Key: "watcherAgent", Group: "Watcher", Label: "Child agent", Kind: ValueString, Env: "FANOUT_WATCHER_AGENT", Default: "", RepoEditable: true},
+	{Key: "watcherMaxSessions", Group: "Watcher", Label: "Max sessions", Kind: ValueInt, Env: "FANOUT_WATCHER_MAX_SESSIONS", Default: "4", RepoEditable: true},
+	{Key: "notifications", Group: "Notifications", Label: "Channels", Kind: ValueString, Env: "FANOUT_NOTIFICATIONS", Default: "bell", RepoEditable: true},
+	{Key: "ntfyURL", Group: "Notifications", Label: "ntfy URL", Kind: ValueString, Env: "FANOUT_NTFY_URL", Default: "", RepoEditable: false, Sensitive: true},
+	{Key: "slackWebhookURL", Group: "Notifications", Label: "Slack webhook", Kind: ValueString, Env: "FANOUT_SLACK_WEBHOOK_URL", Default: "", RepoEditable: false, Sensitive: true},
 }
 
 // WarnFunc receives tolerant-parse diagnostics. Nil suppresses warnings.
@@ -115,6 +180,100 @@ func UserConfigPath() string {
 // RepoConfigPath returns the repository-scoped fanout config path.
 func RepoConfigPath(projectRoot string) string {
 	return filepath.Join(projectRoot, repoConfigRelPath)
+}
+
+// ConfigKeys returns the config.json keys in UI display order.
+func ConfigKeys() []ConfigKey {
+	out := make([]ConfigKey, len(configKeys))
+	copy(out, configKeys)
+	return out
+}
+
+// Path returns the config file path for the scope.
+func (s ConfigScope) Path(projectRoot string) string {
+	if s == ConfigScopeRepo {
+		return RepoConfigPath(projectRoot)
+	}
+	return UserConfigPath()
+}
+
+// LoadEditable loads the selected config file. Missing files are treated as an
+// empty config.
+func LoadEditable(projectRoot string, scope ConfigScope) (EditableConfig, error) {
+	path := scope.Path(projectRoot)
+	raw, err := readConfigRaw(path)
+	if err != nil {
+		return EditableConfig{}, err
+	}
+	values := make(map[string]ConfigValue, len(configKeys))
+	for _, spec := range configKeys {
+		value, ok := parseConfigValue(spec, raw[spec.Key])
+		if ok {
+			values[spec.Key] = value
+		}
+	}
+	return EditableConfig{Path: path, Values: values}, nil
+}
+
+// SaveEditable writes the selected config file, preserving unknown keys.
+// Values absent from the map are left untouched; present zero values delete the
+// corresponding known key so it inherits from lower-priority layers.
+func SaveEditable(projectRoot string, scope ConfigScope, values map[string]ConfigValue) (string, error) {
+	path := scope.Path(projectRoot)
+	raw, err := readConfigRaw(path)
+	if err != nil {
+		return path, err
+	}
+	if raw == nil {
+		raw = map[string]json.RawMessage{}
+	}
+	specs := configKeyMap()
+	for key, value := range values {
+		spec, ok := specs[key]
+		if !ok {
+			return path, fmt.Errorf("unknown settings key %q", key)
+		}
+		if err := validateEditableValue(scope, spec, value); err != nil {
+			return path, err
+		}
+		if value.Empty() {
+			delete(raw, key)
+			continue
+		}
+		encoded, err := encodeConfigValue(spec, value)
+		if err != nil {
+			return path, err
+		}
+		raw[key] = encoded
+	}
+	return path, atomicfs.WriteJSON(path, raw, configFileMode(scope))
+}
+
+// Empty reports whether the key should be inherited.
+func (v ConfigValue) Empty() bool {
+	return v.Bool == nil && v.String == nil && v.Int == nil
+}
+
+// BoolValue returns a bool config value.
+func BoolValue(v bool) ConfigValue {
+	return ConfigValue{Bool: &v}
+}
+
+// StringValue returns a string config value.
+func StringValue(v string) ConfigValue {
+	return ConfigValue{String: &v}
+}
+
+// IntValue returns an int config value.
+func IntValue(v int) ConfigValue {
+	return ConfigValue{Int: &v}
+}
+
+func configFileMode(scope ConfigScope) os.FileMode {
+	if scope == ConfigScopeRepo {
+		return 0o644
+	}
+	return 0o600
 }
 
 func apply(s *Settings, o overrides) {
@@ -200,28 +359,20 @@ func repoOverrides(path string, warnf WarnFunc) overrides {
 }
 
 func repoSafeNotifications(path, raw string, warnf WarnFunc) *string {
-	parts := strings.FieldsFunc(raw, func(r rune) bool {
-		return r == ',' || r == ' ' || r == '\t' || r == '\n'
-	})
+	parts := notificationChannelParts(raw)
 	if len(parts) == 0 {
 		return nil
 	}
 	safe := make([]string, 0, len(parts))
-	seen := map[string]bool{}
-	for _, part := range parts {
-		ch := strings.ToLower(strings.TrimSpace(part))
-		if ch == "" || seen[ch] {
-			continue
-		}
+	for _, ch := range parts {
 		switch ch {
-		case "ntfy", "slack":
-			warn(warnf, "settings %s: notification channel %q is ignored in repo config; use user config or FANOUT_NOTIFICATIONS", path, ch)
 		case "none":
 			none := "none"
 			return &none
 		case "bell", "tmux":
-			seen[ch] = true
 			safe = append(safe, ch)
+		case "ntfy", "slack":
+			warn(warnf, "settings %s: notification channel %q is ignored in repo config; use user config or FANOUT_NOTIFICATIONS", path, ch)
 		default:
 			warn(warnf, "settings %s: notification channel %q is ignored in repo config; allowed repo channels are bell, tmux, none", path, ch)
 		}
@@ -231,6 +382,161 @@ func repoSafeNotifications(path, raw string, warnf WarnFunc) *string {
 	}
 	value := strings.Join(safe, ",")
 	return &value
+}
+
+func notificationChannelParts(raw string) []string {
+	parts := strings.FieldsFunc(raw, func(r rune) bool {
+		return r == ',' || r == ' ' || r == '\t' || r == '\n'
+	})
+	out := make([]string, 0, len(parts))
+	seen := map[string]bool{}
+	for _, part := range parts {
+		ch := strings.ToLower(strings.TrimSpace(part))
+		if ch == "" || seen[ch] {
+			continue
+		}
+		seen[ch] = true
+		out = append(out, ch)
+	}
+	return out
+}
+
+func normalizeNotificationChannels(raw string, repo bool) (string, error) {
+	parts := notificationChannelParts(raw)
+	if len(parts) == 0 {
+		return "", nil
+	}
+	out := make([]string, 0, len(parts))
+	for _, ch := range parts {
+		switch ch {
+		case "none":
+			return "none", nil
+		case "bell", "tmux":
+			out = append(out, ch)
+		case "ntfy", "slack":
+			if repo {
+				return "", fmt.Errorf("notification channel %q is not allowed in repo config", ch)
+			}
+			out = append(out, ch)
+		default:
+			return "", fmt.Errorf("unknown notification channel %q", ch)
+		}
+	}
+	return strings.Join(out, ","), nil
+}
+
+func readConfigRaw(path string) (map[string]json.RawMessage, error) {
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return map[string]json.RawMessage{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	var root map[string]json.RawMessage
+	if err := json.Unmarshal(data, &root); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if root == nil {
+		return nil, fmt.Errorf("parse %s: top-level JSON must be an object", path)
+	}
+	return root, nil
+}
+
+func parseConfigValue(spec ConfigKey, raw json.RawMessage) (ConfigValue, bool) {
+	if len(raw) == 0 || strings.TrimSpace(string(raw)) == "null" {
+		return ConfigValue{}, false
+	}
+	switch spec.Kind {
+	case ValueBool:
+		var v bool
+		if err := json.Unmarshal(raw, &v); err != nil {
+			return ConfigValue{}, false
+		}
+		return BoolValue(v), true
+	case ValueString:
+		var v string
+		if err := json.Unmarshal(raw, &v); err != nil {
+			return ConfigValue{}, false
+		}
+		return StringValue(v), true
+	case ValueInt:
+		var v int
+		if err := json.Unmarshal(raw, &v); err != nil {
+			return ConfigValue{}, false
+		}
+		return IntValue(v), true
+	default:
+		return ConfigValue{}, false
+	}
+}
+
+func configKeyMap() map[string]ConfigKey {
+	out := make(map[string]ConfigKey, len(configKeys))
+	for _, spec := range configKeys {
+		out[spec.Key] = spec
+	}
+	return out
+}
+
+func validateEditableValue(scope ConfigScope, spec ConfigKey, value ConfigValue) error {
+	if value.Empty() {
+		return nil
+	}
+	if scope == ConfigScopeRepo && !spec.RepoEditable {
+		return fmt.Errorf("%s cannot be set in repo config", spec.Key)
+	}
+	switch spec.Kind {
+	case ValueBool:
+		if value.Bool == nil || value.String != nil || value.Int != nil {
+			return fmt.Errorf("%s must be a boolean", spec.Key)
+		}
+	case ValueString:
+		if value.String == nil || value.Bool != nil || value.Int != nil {
+			return fmt.Errorf("%s must be a string", spec.Key)
+		}
+	case ValueInt:
+		if value.Int == nil || value.Bool != nil || value.String != nil {
+			return fmt.Errorf("%s must be an integer", spec.Key)
+		}
+	default:
+		return fmt.Errorf("%s has unknown value kind %q", spec.Key, spec.Kind)
+	}
+	if spec.Key == "notifications" && value.String != nil {
+		normalized, err := normalizeNotificationChannels(*value.String, scope == ConfigScopeRepo)
+		if err != nil {
+			return err
+		}
+		*value.String = normalized
+	}
+	if spec.Key == "watcherIntervalSeconds" && value.Int != nil && *value.Int < 20 {
+		return fmt.Errorf("watcherIntervalSeconds must be at least 20")
+	}
+	if spec.Key == "watcherMaxSessions" && value.Int != nil && *value.Int < 0 {
+		return fmt.Errorf("watcherMaxSessions must be 0 or greater")
+	}
+	return nil
+}
+
+func encodeConfigValue(spec ConfigKey, value ConfigValue) (json.RawMessage, error) {
+	var (
+		data []byte
+		err  error
+	)
+	switch spec.Kind {
+	case ValueBool:
+		data, err = json.Marshal(*value.Bool)
+	case ValueString:
+		data, err = json.Marshal(*value.String)
+	case ValueInt:
+		data, err = json.Marshal(*value.Int)
+	default:
+		err = fmt.Errorf("unknown value kind %q", spec.Kind)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return json.RawMessage(data), nil
 }
 
 func loadFile(path string, warnf WarnFunc) overrides {

--- a/internal/infra/settings/settings_test.go
+++ b/internal/infra/settings/settings_test.go
@@ -1,6 +1,7 @@
 package settings
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -338,6 +339,116 @@ func TestUserConfigPathHonorsXDGConfigHome(t *testing.T) {
 	want := "/tmp/fanout-xdg/fanout/config.json"
 	if got != want {
 		t.Fatalf("UserConfigPath() = %q, want %q", got, want)
+	}
+}
+
+func TestSaveEditablePreservesUnknownKeysAndDeletesInheritedValues(t *testing.T) {
+	repo := t.TempDir()
+	xdg := setEmptyUserConfig(t)
+	clearEnv(t)
+	path := filepath.Join(xdg, "fanout", "config.json")
+	writeConfig(t, path, `{
+  "custom": "keep",
+  "autoPullRequest": false,
+  "notifications": "ntfy",
+  "ntfyURL": "https://ntfy.example/topic"
+}`)
+
+	gotPath, err := SaveEditable(repo, ConfigScopeUser, map[string]ConfigValue{
+		"autoPullRequest":        {},
+		"prReviewGate":           BoolValue(false),
+		"watcherIntervalSeconds": IntValue(20),
+		"notifications":          StringValue("tmux bell"),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotPath != path {
+		t.Fatalf("SaveEditable path = %q, want %q", gotPath, path)
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var root map[string]any
+	if unmarshalErr := json.Unmarshal(body, &root); unmarshalErr != nil {
+		t.Fatal(unmarshalErr)
+	}
+	if root["custom"] != "keep" {
+		t.Fatalf("custom key = %#v, want preserved", root["custom"])
+	}
+	if _, ok := root["autoPullRequest"]; ok {
+		t.Fatalf("autoPullRequest should have been deleted for inherit:\n%s", body)
+	}
+	if root["prReviewGate"] != false {
+		t.Fatalf("prReviewGate = %#v, want false", root["prReviewGate"])
+	}
+	if root["notifications"] != "tmux,bell" {
+		t.Fatalf("notifications = %#v, want normalized tmux,bell", root["notifications"])
+	}
+	if root["ntfyURL"] != "https://ntfy.example/topic" {
+		t.Fatalf("ntfyURL = %#v, want preserved untouched", root["ntfyURL"])
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o600 {
+		t.Fatalf("user config mode = %o, want 600", got)
+	}
+}
+
+func TestSaveEditableWritesRepoConfigWorldReadable(t *testing.T) {
+	repo := t.TempDir()
+	setEmptyUserConfig(t)
+	clearEnv(t)
+	path := RepoConfigPath(repo)
+
+	gotPath, err := SaveEditable(repo, ConfigScopeRepo, map[string]ConfigValue{
+		"autoPullRequest": BoolValue(false),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotPath != path {
+		t.Fatalf("SaveEditable path = %q, want %q", gotPath, path)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := info.Mode().Perm(); got != 0o644 {
+		t.Fatalf("repo config mode = %o, want 644", got)
+	}
+}
+
+func TestSaveEditableRejectsUnsafeRepoSettingsWithoutChangingFile(t *testing.T) {
+	repo := t.TempDir()
+	setEmptyUserConfig(t)
+	clearEnv(t)
+	path := RepoConfigPath(repo)
+	original := "{\n  \"custom\": \"keep\"\n}\n"
+	writeConfig(t, path, original)
+
+	_, err := SaveEditable(repo, ConfigScopeRepo, map[string]ConfigValue{
+		"watcher": BoolValue(true),
+	})
+	if err == nil {
+		t.Fatal("SaveEditable(repo watcher) = nil, want error")
+	}
+	body, readErr := os.ReadFile(path)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	if string(body) != original {
+		t.Fatalf("repo config changed after rejected save:\nwant %q\ngot  %q", original, body)
+	}
+
+	_, err = SaveEditable(repo, ConfigScopeRepo, map[string]ConfigValue{
+		"notifications": StringValue("bell,slack"),
+	})
+	if err == nil {
+		t.Fatal("SaveEditable(repo slack notifications) = nil, want error")
 	}
 }
 

--- a/internal/infra/tmuxrun/tmuxrun.go
+++ b/internal/infra/tmuxrun/tmuxrun.go
@@ -649,6 +649,14 @@ func BindDashboardKeys(prefixKey, directKey, fanoutBin string) error {
 	return nil
 }
 
+func UnbindDashboardKeys(prefixKey, directKey string) error {
+	markers := []string{"dashboard --web --open", "fanout-dashboard"}
+	if err := unbindPrefixKeyIfFanoutOwned(prefixKey, markers); err != nil {
+		return err
+	}
+	return unbindDirectKeyIfFanoutOwned(directKey, markers)
+}
+
 func dashboardNewWindowShellCommand(fanoutBin, startDir string) string {
 	launch := tmuxLiteral(shellQuote(fanoutBin)) + " dashboard --web --open"
 	notifyClientEnv := DashboardNotifyClientEnv + "=#{client_tty}"
@@ -699,6 +707,14 @@ func BindConsoleKeys(prefixKey, directKey, fanoutBin string) error {
 	return nil
 }
 
+func UnbindConsoleKeys(prefixKey, directKey string) error {
+	markers := []string{"focus-console --from", "fanout: focus-console failed"}
+	if err := unbindPrefixKeyIfFanoutOwned(prefixKey, markers); err != nil {
+		return err
+	}
+	return unbindDirectKeyIfFanoutOwned(directKey, markers)
+}
+
 // BindWorktreeActionKey registers a tmux prefix-table keybinding that opens a
 // small popup for actions against the currently focused fanout pane's recorded
 // worktree.
@@ -719,6 +735,61 @@ func BindWorktreeActionKey(key, fanoutBin string) error {
 		return fmt.Errorf("tmux bind-key %s: %w", key, err)
 	}
 	return nil
+}
+
+func UnbindWorktreeActionKey(key string) error {
+	return unbindPrefixKeyIfFanoutOwned(key, []string{"__worktree-action --pane"})
+}
+
+func unbindPrefixKeyIfFanoutOwned(key string, markers []string) error {
+	if strings.TrimSpace(key) == "" {
+		return fmt.Errorf("tmux unbind-key: key is required")
+	}
+	owned, err := keyBindingIsFanoutOwned("prefix", key, markers)
+	if err != nil {
+		return err
+	}
+	if !owned {
+		return nil
+	}
+	if err := exec.Command("tmux", "unbind-key", "-q", key).Run(); err != nil {
+		return fmt.Errorf("tmux unbind-key %s: %w", key, err)
+	}
+	return nil
+}
+
+func unbindDirectKeyIfFanoutOwned(key string, markers []string) error {
+	if strings.TrimSpace(key) == "" {
+		return fmt.Errorf("tmux unbind-key: key is required")
+	}
+	owned, err := keyBindingIsFanoutOwned("root", key, markers)
+	if err != nil {
+		return err
+	}
+	if !owned {
+		return nil
+	}
+	if err := exec.Command("tmux", "unbind-key", "-q", "-n", key).Run(); err != nil {
+		return fmt.Errorf("tmux unbind-key -n %s: %w", key, err)
+	}
+	return nil
+}
+
+func keyBindingIsFanoutOwned(table, key string, markers []string) (bool, error) {
+	out, err := exec.Command("tmux", "list-keys", "-T", table, key).CombinedOutput()
+	if err != nil {
+		if strings.Contains(string(out), "no key binding") {
+			return false, nil
+		}
+		return false, fmt.Errorf("tmux list-keys -T %s %s: %w", table, key, err)
+	}
+	binding := string(out)
+	for _, marker := range markers {
+		if !strings.Contains(binding, marker) {
+			return false, nil
+		}
+	}
+	return true, nil
 }
 
 // SetPaneProjectRoot records the fanout state owner on a pane. The dashboard

--- a/internal/infra/tmuxrun/tmuxrun_test.go
+++ b/internal/infra/tmuxrun/tmuxrun_test.go
@@ -634,6 +634,83 @@ func TestBindDashboardKeysRejectsEmptyArgs(t *testing.T) {
 	}
 }
 
+func TestUnbindDashboardKeysRemovesPrefixAndDirectBindings(t *testing.T) {
+	dir := t.TempDir()
+	argsPath := filepath.Join(dir, "args.txt")
+	tmuxPath := filepath.Join(dir, "tmux")
+	script := `#!/bin/sh
+printf '%s\n' "$@" >> "$TMUXRUN_ARGS"
+printf '%s\n' '---' >> "$TMUXRUN_ARGS"
+if [ "$1" = list-keys ] && [ "$3" = prefix ] && [ "$4" = D ]; then
+  printf 'bind-key D run-shell -b /abs/fanout dashboard --web --open; tmux new-window -n fanout-dashboard\n'
+fi
+if [ "$1" = list-keys ] && [ "$3" = root ] && [ "$4" = F12 ]; then
+  printf 'bind-key -n F12 run-shell -b /abs/fanout dashboard --web --open; tmux new-window -n fanout-dashboard\n'
+fi
+`
+	if err := os.WriteFile(tmuxPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TMUXRUN_ARGS", argsPath)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if err := UnbindDashboardKeys("D", "F12"); err != nil {
+		t.Fatalf("UnbindDashboardKeys() failed: %v", err)
+	}
+	body, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	commands := strings.Split(strings.TrimSuffix(string(body), "\n---\n"), "\n---\n")
+	if len(commands) != 4 {
+		t.Fatalf("tmux command count = %d, want 4\n%s", len(commands), body)
+	}
+	if got := strings.Split(commands[0], "\n"); strings.Join(got, "\x00") != strings.Join([]string{"list-keys", "-T", "prefix", "D"}, "\x00") {
+		t.Fatalf("prefix list tmux args = %#v", got)
+	}
+	if got := strings.Split(commands[1], "\n"); strings.Join(got, "\x00") != strings.Join([]string{"unbind-key", "-q", "D"}, "\x00") {
+		t.Fatalf("prefix unbind tmux args = %#v", got)
+	}
+	if got := strings.Split(commands[2], "\n"); strings.Join(got, "\x00") != strings.Join([]string{"list-keys", "-T", "root", "F12"}, "\x00") {
+		t.Fatalf("direct list tmux args = %#v", got)
+	}
+	if got := strings.Split(commands[3], "\n"); strings.Join(got, "\x00") != strings.Join([]string{"unbind-key", "-q", "-n", "F12"}, "\x00") {
+		t.Fatalf("direct unbind tmux args = %#v", got)
+	}
+}
+
+func TestUnbindDashboardKeysKeepsNonFanoutBindings(t *testing.T) {
+	dir := t.TempDir()
+	argsPath := filepath.Join(dir, "args.txt")
+	tmuxPath := filepath.Join(dir, "tmux")
+	script := `#!/bin/sh
+printf '%s\n' "$@" >> "$TMUXRUN_ARGS"
+printf '%s\n' '---' >> "$TMUXRUN_ARGS"
+if [ "$1" = list-keys ] && [ "$3" = prefix ] && [ "$4" = D ]; then
+  printf 'bind-key D send-prefix\n'
+fi
+if [ "$1" = list-keys ] && [ "$3" = root ] && [ "$4" = F12 ]; then
+  printf 'bind-key -n F12 display-message user-binding\n'
+fi
+`
+	if err := os.WriteFile(tmuxPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TMUXRUN_ARGS", argsPath)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if err := UnbindDashboardKeys("D", "F12"); err != nil {
+		t.Fatalf("UnbindDashboardKeys() failed: %v", err)
+	}
+	body, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(body), "unbind-key") {
+		t.Fatalf("tmux log unbound non-fanout bindings:\n%s", body)
+	}
+}
+
 func TestBindConsoleKeysRegistersRunShellBindings(t *testing.T) {
 	dir := t.TempDir()
 	argsPath := filepath.Join(dir, "args.txt")
@@ -748,6 +825,51 @@ func TestBindConsoleKeysRejectsEmptyArgs(t *testing.T) {
 	}
 }
 
+func TestUnbindConsoleKeysRemovesPrefixAndDirectBindings(t *testing.T) {
+	dir := t.TempDir()
+	argsPath := filepath.Join(dir, "args.txt")
+	tmuxPath := filepath.Join(dir, "tmux")
+	script := `#!/bin/sh
+printf '%s\n' "$@" >> "$TMUXRUN_ARGS"
+printf '%s\n' '---' >> "$TMUXRUN_ARGS"
+if [ "$1" = list-keys ] && [ "$3" = prefix ] && [ "$4" = T ]; then
+  printf 'bind-key T run-shell /abs/fanout focus-console --from "#{pane_id}"; tmux display-message "fanout: focus-console failed"\n'
+fi
+if [ "$1" = list-keys ] && [ "$3" = root ] && [ "$4" = F11 ]; then
+  printf 'bind-key -n F11 run-shell /abs/fanout focus-console --from "#{pane_id}"; tmux display-message "fanout: focus-console failed"\n'
+fi
+`
+	if err := os.WriteFile(tmuxPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TMUXRUN_ARGS", argsPath)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if err := UnbindConsoleKeys("T", "F11"); err != nil {
+		t.Fatalf("UnbindConsoleKeys() failed: %v", err)
+	}
+	body, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	commands := strings.Split(strings.TrimSuffix(string(body), "\n---\n"), "\n---\n")
+	if len(commands) != 4 {
+		t.Fatalf("tmux command count = %d, want 4\n%s", len(commands), body)
+	}
+	if got := strings.Split(commands[0], "\n"); strings.Join(got, "\x00") != strings.Join([]string{"list-keys", "-T", "prefix", "T"}, "\x00") {
+		t.Fatalf("prefix list tmux args = %#v", got)
+	}
+	if got := strings.Split(commands[1], "\n"); strings.Join(got, "\x00") != strings.Join([]string{"unbind-key", "-q", "T"}, "\x00") {
+		t.Fatalf("prefix unbind tmux args = %#v", got)
+	}
+	if got := strings.Split(commands[2], "\n"); strings.Join(got, "\x00") != strings.Join([]string{"list-keys", "-T", "root", "F11"}, "\x00") {
+		t.Fatalf("direct list tmux args = %#v", got)
+	}
+	if got := strings.Split(commands[3], "\n"); strings.Join(got, "\x00") != strings.Join([]string{"unbind-key", "-q", "-n", "F11"}, "\x00") {
+		t.Fatalf("direct unbind tmux args = %#v", got)
+	}
+}
+
 func TestBindWorktreeActionKeyRegistersPopup(t *testing.T) {
 	dir := t.TempDir()
 	argsPath := filepath.Join(dir, "args.txt")
@@ -787,6 +909,36 @@ func TestBindWorktreeActionKeyRejectsEmptyArgs(t *testing.T) {
 	}
 	if err := BindWorktreeActionKey("M", ""); err == nil {
 		t.Fatal("BindWorktreeActionKey(empty bin) should error")
+	}
+}
+
+func TestUnbindWorktreeActionKeyRemovesPrefixBinding(t *testing.T) {
+	dir := t.TempDir()
+	argsPath := filepath.Join(dir, "args.txt")
+	tmuxPath := filepath.Join(dir, "tmux")
+	script := `#!/bin/sh
+printf '%s\n' "$@" > "$TMUXRUN_ARGS"
+if [ "$1" = list-keys ] && [ "$3" = prefix ] && [ "$4" = M ]; then
+  printf 'bind-key M display-popup -E /abs/fanout __worktree-action --pane #{pane_id}\n'
+fi
+`
+	if err := os.WriteFile(tmuxPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TMUXRUN_ARGS", argsPath)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	if err := UnbindWorktreeActionKey("M"); err != nil {
+		t.Fatalf("UnbindWorktreeActionKey() failed: %v", err)
+	}
+	body, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := strings.Split(strings.TrimRight(string(body), "\n"), "\n")
+	want := []string{"unbind-key", "-q", "M"}
+	if strings.Join(got, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("tmux args = %#v, want %#v", got, want)
 	}
 }
 

--- a/internal/ui/tui/help.go
+++ b/internal/ui/tui/help.go
@@ -60,6 +60,7 @@ func (m *model) openHelpPopupCmd() tea.Cmd {
 func (m model) helpView() string {
 	monitor := []helpEntry{
 		{"n", "New agent pane"},
+		{"s", "Settings"},
 		{"a", "Attach agent to worktree"},
 		{"A", "Worktree terminal"},
 		{"t", "Project root terminal"},
@@ -74,7 +75,6 @@ func (m model) helpView() string {
 		{"c/x", "Close pane"},
 		{"m", "Merge branch"},
 		{"X", "Cleanup parent"},
-		{"q", "Quit TUI"},
 	}
 	newPane := []helpEntry{
 		{"Ctrl+J", "Prompt newline"},
@@ -87,10 +87,8 @@ func (m model) helpView() string {
 		{"Esc", "Cancel / back"},
 	}
 	columnWidth := m.helpColumnWidth()
-	// No blank lines around the columns: with the v entry the monitor column
-	// is 18 rows (16 entries + title + one wrapped description), and the
-	// in-TUI modal fallback must stay within a standard 24-row terminal
-	// (content 20 + border/padding 4).
+	// No blank lines around the columns: the in-TUI modal fallback must stay
+	// within a standard 24-row terminal (content 20 + border/padding 4).
 	lines := make([]string, 0, 4)
 	if !m.helpOnly {
 		lines = append(lines, titleStyle.Render("Keyboard shortcuts"))

--- a/internal/ui/tui/paneview.go
+++ b/internal/ui/tui/paneview.go
@@ -180,7 +180,7 @@ func columnsForWidth(width int) []table.Column {
 }
 
 func (m model) footerText() string {
-	parts := []string{"? help"}
+	parts := []string{"? help", "s settings"}
 	if m.filterEditing {
 		parts = append(parts, "typing")
 	}

--- a/internal/ui/tui/settings.go
+++ b/internal/ui/tui/settings.go
@@ -1,0 +1,623 @@
+package tui
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	tea "github.com/charmbracelet/bubbletea"
+
+	fanoutsettings "github.com/butaosuinu/fanout/internal/infra/settings"
+)
+
+const settingsPopupOpeningNotice = "opening settings popup..."
+
+const SettingsEnvOverridesEnv = "FANOUT_TUI_SETTINGS_ENV_OVERRIDES"
+
+// SettingsPopupRequest describes a TUI settings popup launch.
+type SettingsPopupRequest struct {
+	ProjectRoot string
+}
+
+// SettingsPopupResult reports what the popup saved.
+type SettingsPopupResult struct {
+	Saved bool   `json:"saved,omitempty"`
+	Scope string `json:"scope,omitempty"`
+	Path  string `json:"path,omitempty"`
+}
+
+// SettingsPopupFunc opens settings in an external surface such as tmux popup.
+type SettingsPopupFunc func(SettingsPopupRequest) (result SettingsPopupResult, canceled bool, err error)
+
+// SettingsRuntime is the live TUI runtime derived from resolved settings.
+type SettingsRuntime struct {
+	Watcher             WatcherRunner
+	WatchInterval       time.Duration
+	WatchLabel          string
+	WatcherRunningLabel string
+	Notifier            transitionNotifier
+	LaunchIssue         IssueLaunchFunc
+}
+
+// SettingsReloadFunc refreshes TUI runtime pieces after config changes.
+type SettingsReloadFunc func() (SettingsRuntime, error)
+
+// SettingsPopupOptions configures the standalone settings popup program.
+type SettingsPopupOptions struct {
+	ProjectRoot string
+	Width       int
+	Height      int
+}
+
+type settingsForm struct {
+	scope      fanoutsettings.ConfigScope
+	path       string
+	rows       []settingsRow
+	cursor     int // 0 is target; rows start at 1.
+	top        int
+	editing    bool
+	editText   string
+	err        string
+	loadErr    bool
+	loadErrMsg string
+}
+
+type settingsRow struct {
+	spec        fanoutsettings.ConfigKey
+	value       fanoutsettings.ConfigValue
+	disabled    bool
+	envOverride bool
+}
+
+// RunSettingsPopup opens only the settings UI and returns after save/cancel.
+func RunSettingsPopup(opts SettingsPopupOptions) (SettingsPopupResult, bool, error) {
+	width := opts.Width
+	if width <= 0 {
+		width = 90
+	}
+	height := opts.Height
+	if height <= 0 {
+		height = 24
+	}
+	m := newModel(Options{ProjectRoot: opts.ProjectRoot})
+	m.settingsOnly = true
+	m.mode = modeSettings
+	m.width = width
+	m.height = height
+	m.openSettingsForm(fanoutsettings.ConfigScopeUser)
+	finalModel, err := tea.NewProgram(m, tea.WithAltScreen()).Run()
+	if err != nil {
+		return SettingsPopupResult{}, false, err
+	}
+	final, ok := finalModel.(model)
+	if !ok {
+		return SettingsPopupResult{}, false, fmt.Errorf("unexpected settings popup model %T", finalModel)
+	}
+	if !final.settingsDone || final.settingsCanceled {
+		return SettingsPopupResult{}, true, nil
+	}
+	return final.settingsResult, false, nil
+}
+
+func (m *model) openSettingsForm(scope fanoutsettings.ConfigScope) {
+	m.mode = modeSettings
+	m.notice = ""
+	m.settings = newSettingsForm(m.opts.ProjectRoot, scope)
+}
+
+func newSettingsForm(projectRoot string, scope fanoutsettings.ConfigScope) settingsForm {
+	if scope != fanoutsettings.ConfigScopeRepo {
+		scope = fanoutsettings.ConfigScopeUser
+	}
+	form := settingsForm{scope: scope}
+	cfg, err := fanoutsettings.LoadEditable(projectRoot, scope)
+	form.path = cfg.Path
+	if form.path == "" {
+		form.path = scope.Path(projectRoot)
+	}
+	specs := fanoutsettings.ConfigKeys()
+	form.rows = make([]settingsRow, 0, len(specs))
+	for _, spec := range specs {
+		value := cfg.Values[spec.Key]
+		row := settingsRow{
+			spec:        spec,
+			value:       value,
+			disabled:    scope == fanoutsettings.ConfigScopeRepo && !spec.RepoEditable,
+			envOverride: settingsEnvOverridePresent(spec),
+		}
+		if row.disabled {
+			row.value = fanoutsettings.ConfigValue{}
+		}
+		form.rows = append(form.rows, row)
+	}
+	if err != nil {
+		form.err = err.Error()
+		form.loadErr = true
+		form.loadErrMsg = err.Error()
+	}
+	return form
+}
+
+func (m *model) openSettingsPopupCmd() tea.Cmd {
+	popup := m.opts.SettingsPopup
+	if popup == nil {
+		m.openSettingsForm(fanoutsettings.ConfigScopeUser)
+		return nil
+	}
+	m.notice = settingsPopupOpeningNotice
+	m.settingsPopupOpen = true
+	req := SettingsPopupRequest{ProjectRoot: m.opts.ProjectRoot}
+	return func() tea.Msg {
+		result, canceled, err := popup(req)
+		return settingsPopupDoneMsg{result: result, canceled: canceled, err: err}
+	}
+}
+
+func (m model) updateSettings(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if m.settings.editing {
+		return m.updateSettingsEdit(msg)
+	}
+	switch msg.String() {
+	case "ctrl+c":
+		if m.settingsOnly {
+			m.settingsCanceled = true
+			return m.quit()
+		}
+		return m.quit()
+	case "esc", "q":
+		if m.settingsOnly {
+			m.settingsCanceled = true
+			return m.quit()
+		}
+		m.mode = modeMonitor
+		m.settings = settingsForm{}
+		return m, nil
+	case "ctrl+s":
+		return m.saveSettings()
+	case "up", "k":
+		m.moveSettingsCursor(-1)
+		return m, nil
+	case "down", "j", "tab":
+		m.moveSettingsCursor(1)
+		return m, nil
+	case "shift+tab":
+		m.moveSettingsCursor(-1)
+		return m, nil
+	case "left", "right", " ":
+		if m.settings.cursor == 0 {
+			m.switchSettingsScope()
+			return m, nil
+		}
+		m.adjustSettingsRow(msg.String())
+		return m, nil
+	case "enter":
+		if m.settings.cursor == 0 {
+			m.switchSettingsScope()
+			return m, nil
+		}
+		m.beginSettingsEdit()
+		return m, nil
+	}
+	return m, nil
+}
+
+func (m model) updateSettingsEdit(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "ctrl+c":
+		if m.settingsOnly {
+			m.settingsCanceled = true
+			return m.quit()
+		}
+		return m.quit()
+	case "esc":
+		m.settings.editing = false
+		m.settings.editText = ""
+		return m, nil
+	case "enter":
+		m.commitSettingsEdit()
+		return m, nil
+	case "backspace", "ctrl+h":
+		if len(m.settings.editText) > 0 {
+			runes := []rune(m.settings.editText)
+			m.settings.editText = string(runes[:len(runes)-1])
+		}
+		return m, nil
+	case "ctrl+u":
+		m.settings.editText = ""
+		return m, nil
+	}
+	if msg.Type == tea.KeyRunes {
+		m.settings.editText += string(msg.Runes)
+	}
+	return m, nil
+}
+
+func (m *model) moveSettingsCursor(delta int) {
+	maxCursor := len(m.settings.rows)
+	m.settings.cursor = clampInt(m.settings.cursor+delta, 0, maxCursor)
+	visible := m.settingsVisibleRows()
+	if visible <= 0 || m.settings.cursor == 0 {
+		if m.settings.cursor == 0 {
+			m.settings.top = 0
+		}
+		return
+	}
+	row := m.settings.cursor - 1
+	if row < m.settings.top {
+		m.settings.top = row
+	}
+	if row >= m.settings.top+visible {
+		m.settings.top = row - visible + 1
+	}
+}
+
+func (m *model) switchSettingsScope() {
+	next := fanoutsettings.ConfigScopeRepo
+	if m.settings.scope == fanoutsettings.ConfigScopeRepo {
+		next = fanoutsettings.ConfigScopeUser
+	}
+	oldCursor := m.settings.cursor
+	oldTop := m.settings.top
+	m.settings = newSettingsForm(m.opts.ProjectRoot, next)
+	m.settings.cursor = clampInt(oldCursor, 0, len(m.settings.rows))
+	m.settings.top = clampInt(oldTop, 0, max(len(m.settings.rows)-1, 0))
+}
+
+func (m *model) adjustSettingsRow(key string) {
+	row := m.currentSettingsRow()
+	if row == nil || row.disabled {
+		return
+	}
+	switch row.spec.Kind {
+	case fanoutsettings.ValueBool:
+		row.value = nextSettingsBoolValue(row.value, key)
+	case fanoutsettings.ValueString, fanoutsettings.ValueInt:
+		if row.value.Empty() {
+			row.value = defaultSettingsValue(row.spec)
+		} else if key == " " {
+			row.value = fanoutsettings.ConfigValue{}
+		}
+	}
+	m.settings.err = ""
+}
+
+func nextSettingsBoolValue(value fanoutsettings.ConfigValue, key string) fanoutsettings.ConfigValue {
+	state := 0 // inherit
+	if value.Bool != nil {
+		if *value.Bool {
+			state = 1
+		} else {
+			state = 2
+		}
+	}
+	switch key {
+	case "left":
+		state = (state + 2) % 3
+	default:
+		state = (state + 1) % 3
+	}
+	switch state {
+	case 1:
+		return fanoutsettings.BoolValue(true)
+	case 2:
+		return fanoutsettings.BoolValue(false)
+	default:
+		return fanoutsettings.ConfigValue{}
+	}
+}
+
+func (m *model) beginSettingsEdit() {
+	row := m.currentSettingsRow()
+	if row == nil || row.disabled {
+		return
+	}
+	switch row.spec.Kind {
+	case fanoutsettings.ValueBool:
+		return
+	case fanoutsettings.ValueString, fanoutsettings.ValueInt:
+		if row.value.Empty() {
+			row.value = defaultSettingsValue(row.spec)
+		}
+		m.settings.editing = true
+		m.settings.editText = settingsValueText(row.value)
+		m.settings.err = ""
+	}
+}
+
+func (m *model) commitSettingsEdit() {
+	row := m.currentSettingsRow()
+	if row == nil {
+		m.settings.editing = false
+		return
+	}
+	text := strings.TrimSpace(m.settings.editText)
+	switch row.spec.Kind {
+	case fanoutsettings.ValueBool:
+		// Boolean rows cycle directly and never enter text editing.
+	case fanoutsettings.ValueString:
+		row.value = fanoutsettings.StringValue(text)
+	case fanoutsettings.ValueInt:
+		v, err := strconv.Atoi(text)
+		if err != nil {
+			m.settings.err = fmt.Sprintf("%s must be an integer", row.spec.Key)
+			return
+		}
+		row.value = fanoutsettings.IntValue(v)
+	}
+	m.settings.editing = false
+	m.settings.editText = ""
+	m.settings.err = ""
+}
+
+func (m model) saveSettings() (tea.Model, tea.Cmd) {
+	if m.settings.loadErr {
+		m.settings.err = "fix or remove the invalid config before saving: " + m.settings.loadErrMsg
+		return m, nil
+	}
+	values := map[string]fanoutsettings.ConfigValue{}
+	for _, row := range m.settings.rows {
+		if row.disabled {
+			if m.settings.scope == fanoutsettings.ConfigScopeRepo {
+				values[row.spec.Key] = fanoutsettings.ConfigValue{}
+			}
+			continue
+		}
+		if m.settings.scope == fanoutsettings.ConfigScopeRepo && row.spec.Key == "notifications" {
+			row.value = safeRepoNotificationsValue(row.value)
+		}
+		values[row.spec.Key] = row.value
+	}
+	path, err := fanoutsettings.SaveEditable(m.opts.ProjectRoot, m.settings.scope, values)
+	if err != nil {
+		m.settings.err = err.Error()
+		return m, nil
+	}
+	result := SettingsPopupResult{Saved: true, Scope: string(m.settings.scope), Path: path}
+	if m.settingsOnly {
+		m.settingsDone = true
+		m.settingsResult = result
+		return m.quit()
+	}
+	m.mode = modeMonitor
+	m.settings = settingsForm{}
+	m.notice = "settings saved: " + displayConfigPath(path)
+	return m, m.reloadSettingsCmd(result)
+}
+
+func safeRepoNotificationsValue(value fanoutsettings.ConfigValue) fanoutsettings.ConfigValue {
+	if value.String == nil {
+		return value
+	}
+	allowed := []string{}
+	seen := map[string]bool{}
+	for token := range strings.FieldsFuncSeq(*value.String, func(r rune) bool {
+		return r == ',' || r == ' ' || r == '\t' || r == '\n'
+	}) {
+		token = strings.ToLower(strings.TrimSpace(token))
+		if token == "" || seen[token] {
+			continue
+		}
+		seen[token] = true
+		switch token {
+		case "none":
+			return fanoutsettings.StringValue("none")
+		case "bell", "tmux":
+			allowed = append(allowed, token)
+		}
+	}
+	if len(allowed) == 0 {
+		return fanoutsettings.ConfigValue{}
+	}
+	return fanoutsettings.StringValue(strings.Join(allowed, " "))
+}
+
+func (m model) reloadSettingsCmd(result SettingsPopupResult) tea.Cmd {
+	reload := m.opts.ReloadSettings
+	if reload == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		runtime, err := reload()
+		return settingsReloadedMsg{result: result, runtime: runtime, err: err}
+	}
+}
+
+func (m *model) currentSettingsRow() *settingsRow {
+	if m.settings.cursor <= 0 || m.settings.cursor > len(m.settings.rows) {
+		return nil
+	}
+	return &m.settings.rows[m.settings.cursor-1]
+}
+
+func defaultSettingsValue(spec fanoutsettings.ConfigKey) fanoutsettings.ConfigValue {
+	switch spec.Kind {
+	case fanoutsettings.ValueBool:
+		return fanoutsettings.BoolValue(spec.Default == "true")
+	case fanoutsettings.ValueInt:
+		v, _ := strconv.Atoi(spec.Default)
+		return fanoutsettings.IntValue(v)
+	default:
+		return fanoutsettings.StringValue(spec.Default)
+	}
+}
+
+func settingsValueText(value fanoutsettings.ConfigValue) string {
+	switch {
+	case value.Bool != nil:
+		if *value.Bool {
+			return "on"
+		}
+		return "off"
+	case value.String != nil:
+		return *value.String
+	case value.Int != nil:
+		return strconv.Itoa(*value.Int)
+	default:
+		return "inherit"
+	}
+}
+
+func (m model) settingsView() string {
+	lines := make([]string, 0, 24)
+	if !m.settingsOnly {
+		lines = append(lines, titleStyle.Render("Settings"))
+	}
+	lines = append(lines, m.settingsTargetView())
+	rows := m.settingsVisibleRows()
+	start := clampInt(m.settings.top, 0, max(len(m.settings.rows)-1, 0))
+	end := min(start+rows, len(m.settings.rows))
+	lastGroup := ""
+	for i := start; i < end; i++ {
+		row := m.settings.rows[i]
+		if row.spec.Group != lastGroup {
+			lines = append(lines, dimStyle.Render(row.spec.Group))
+			lastGroup = row.spec.Group
+		}
+		lines = append(lines, m.settingsRowView(i+1, row))
+	}
+	if end < len(m.settings.rows) {
+		lines = append(lines, dimStyle.Render(fmt.Sprintf("... %d more", len(m.settings.rows)-end)))
+	}
+	if m.settings.err != "" {
+		lines = append(lines, errStyle.Render("error: "+m.settings.err))
+	}
+	lines = append(lines, dimStyle.Render(m.settingsHint()))
+	content := strings.Join(lines, "\n")
+	if m.settingsOnly {
+		return popupContentStyle.Width(m.settingsModalWidth()).Render(content)
+	}
+	return modalStyle.Width(m.settingsModalWidth()).Render(content)
+}
+
+func (m model) settingsTargetView() string {
+	marker := "  "
+	if m.settings.cursor == 0 {
+		marker = "> "
+	}
+	scope := "User config"
+	if m.settings.scope == fanoutsettings.ConfigScopeRepo {
+		scope = "Repo config"
+	}
+	return marker + titleStyle.Render(scope) + "  " + dimStyle.Render(displayConfigPath(m.settings.path))
+}
+
+func (m model) settingsRowView(cursor int, row settingsRow) string {
+	marker := "  "
+	if m.settings.cursor == cursor {
+		marker = "> "
+	}
+	value := settingsDisplayValue(row)
+	if m.settings.editing && m.settings.cursor == cursor {
+		value = "[" + settingsEditDisplayValue(row, m.settings.editText) + "]"
+	}
+	if row.disabled {
+		value = "repo-disabled"
+	}
+	env := ""
+	if row.envOverride {
+		env = " env"
+	}
+	text := fmt.Sprintf("%-24s %-16s %s", row.spec.Key, value, env)
+	if row.disabled {
+		return marker + dimStyle.Render(text)
+	}
+	if m.settings.cursor == cursor {
+		return marker + titleStyle.Render(text)
+	}
+	return marker + text
+}
+
+func settingsEnvOverridePresent(spec fanoutsettings.ConfigKey) bool {
+	if spec.Env == "" {
+		return false
+	}
+	if _, ok := os.LookupEnv(spec.Env); ok {
+		return true
+	}
+	for env := range strings.SplitSeq(os.Getenv(SettingsEnvOverridesEnv), ",") {
+		if strings.TrimSpace(env) == spec.Env {
+			return true
+		}
+	}
+	return false
+}
+
+func settingsDisplayValue(row settingsRow) string {
+	if row.spec.Sensitive && !row.value.Empty() {
+		if row.value.String != nil && *row.value.String == "" {
+			return "empty"
+		}
+		return "set"
+	}
+	return settingsValueText(row.value)
+}
+
+func settingsEditDisplayValue(row settingsRow, text string) string {
+	if !row.spec.Sensitive {
+		return text
+	}
+	if text == "" {
+		return ""
+	}
+	return strings.Repeat("*", min(len([]rune(text)), 16))
+}
+
+func (m model) settingsHint() string {
+	if m.settings.editing {
+		return "enter apply  esc cancel edit  ctrl+u clear"
+	}
+	return "up/down row  left/right/space change  enter edit  ctrl+s save  esc cancel"
+}
+
+func (m model) settingsModalWidth() int {
+	if m.width <= 0 {
+		return 90
+	}
+	if m.settingsOnly {
+		return clampInt(m.width, 54, 106)
+	}
+	return clampInt(m.width-12, 54, 104)
+}
+
+func (m model) settingsVisibleRows() int {
+	if m.height <= 0 {
+		return len(m.settings.rows)
+	}
+	overhead := 7
+	if !m.settingsOnly {
+		overhead++
+	}
+	return clampInt(m.height-overhead, 4, len(m.settings.rows))
+}
+
+func displayConfigPath(path string) string {
+	home, err := os.UserHomeDir()
+	if err == nil && home != "" {
+		if rel, relErr := filepath.Rel(home, path); relErr == nil && !strings.HasPrefix(rel, "..") {
+			return "~/" + rel
+		}
+	}
+	return path
+}
+
+func applySettingsRuntime(m *model, runtime SettingsRuntime) tea.Cmd {
+	m.watchTickGen++
+	m.opts.Watcher = runtime.Watcher
+	m.opts.WatchInterval = runtime.WatchInterval
+	m.opts.WatchLabel = runtime.WatchLabel
+	m.opts.WatcherRunningLabel = runtime.WatcherRunningLabel
+	m.opts.Notifier = runtime.Notifier
+	if runtime.LaunchIssue != nil {
+		m.opts.LaunchIssue = runtime.LaunchIssue
+	}
+	m.watchErr = ""
+	m.notifyErr = ""
+	m.watchDisabled = false
+	if m.opts.Watcher != nil {
+		return m.watchTickCmd()
+	}
+	return nil
+}

--- a/internal/ui/tui/tui.go
+++ b/internal/ui/tui/tui.go
@@ -50,6 +50,8 @@ type Options struct {
 	NewPanePrompt       NewPanePromptFunc
 	HelpPopup           HelpPopupFunc
 	CloseChoicePopup    CloseChoicePopupFunc
+	SettingsPopup       SettingsPopupFunc
+	ReloadSettings      SettingsReloadFunc
 	LaunchAttach        AttachLaunchFunc
 	LaunchShell         ShellLaunchFunc
 	RestorePanes        func() (string, error)
@@ -80,70 +82,81 @@ const (
 	modeNewPane
 	modeHelp
 	modeCloseChoice
+	modeSettings
 )
 
 type model struct {
-	opts             Options
-	mode             viewMode
-	table            table.Model
-	detail           viewport.Model
-	width            int
-	height           int
-	allPanes         []paneView
-	panes            []paneView
-	filterQuery      string
-	filterEditing    bool
-	viewOverride     viewOverride
-	issues           map[issueKey]issueStatus
-	lastState        time.Time
-	lastGH           time.Time
-	stateErr         string
-	ghErr            string
-	notifyErr        string
-	watchRunning     bool
-	lastWatch        time.Time
-	watchLaunched    int
-	watchErr         string
-	watchDisabled    bool
-	notice           string
-	newPane          newPaneForm
-	newPanePopupOpen bool
-	helpPopupOpen    bool
-	closePopupOpen   bool
-	repoFiles        []string
-	repoFileIndex    []fileEntry
-	repoFilesLoaded  bool
-	repoFilesLoading bool
-	repoFilesErr     string
-	peek             panePeek
-	pendingAction    *pendingLifecycleAction
-	actionRunning    bool
-	quitAfterAction  bool
-	actionMessage    string
-	notifications    map[issueKey]issueTransitionSnapshot
-	notifyPrimed     bool
-	keyboardPaused   bool
-	quitAfterLaunch  bool
-	relayoutGen      int
-	promptOnly       bool
-	helpOnly         bool
-	closeOnly        bool
-	promptDone       bool
-	promptCanceled   bool
-	promptResult     LaunchRequest
-	agentStates      map[string]agentTransitionSnapshot
-	agentPrimed      bool
-	closeDone        bool
-	closeCanceled    bool
-	closeResult      lifecycle.CloseMode
+	opts              Options
+	mode              viewMode
+	table             table.Model
+	detail            viewport.Model
+	width             int
+	height            int
+	allPanes          []paneView
+	panes             []paneView
+	filterQuery       string
+	filterEditing     bool
+	viewOverride      viewOverride
+	issues            map[issueKey]issueStatus
+	lastState         time.Time
+	lastGH            time.Time
+	stateErr          string
+	ghErr             string
+	notifyErr         string
+	watchRunning      bool
+	lastWatch         time.Time
+	watchLaunched     int
+	watchErr          string
+	watchDisabled     bool
+	watchTickGen      int
+	notice            string
+	newPane           newPaneForm
+	settings          settingsForm
+	newPanePopupOpen  bool
+	helpPopupOpen     bool
+	closePopupOpen    bool
+	settingsPopupOpen bool
+	repoFiles         []string
+	repoFileIndex     []fileEntry
+	repoFilesLoaded   bool
+	repoFilesLoading  bool
+	repoFilesErr      string
+	peek              panePeek
+	pendingAction     *pendingLifecycleAction
+	actionRunning     bool
+	quitAfterAction   bool
+	actionMessage     string
+	notifications     map[issueKey]issueTransitionSnapshot
+	notifyPrimed      bool
+	keyboardPaused    bool
+	quitAfterLaunch   bool
+	relayoutGen       int
+	promptOnly        bool
+	helpOnly          bool
+	closeOnly         bool
+	promptDone        bool
+	promptCanceled    bool
+	promptResult      LaunchRequest
+	agentStates       map[string]agentTransitionSnapshot
+	agentPrimed       bool
+	closeDone         bool
+	closeCanceled     bool
+	closeResult       lifecycle.CloseMode
+	settingsOnly      bool
+	settingsDone      bool
+	settingsCanceled  bool
+	settingsResult    SettingsPopupResult
 }
 
 type keyboardProtocolsEnabledMsg struct{}
 
 type (
-	stateTickMsg  time.Time
-	ghTickMsg     time.Time
-	watchTickMsg  time.Time
+	stateTickMsg time.Time
+	ghTickMsg    time.Time
+	watchTickMsg struct {
+		at  time.Time
+		gen int
+	}
 	launchPaneMsg struct {
 		notice   string
 		count    int
@@ -162,6 +175,16 @@ type (
 		mode     lifecycle.CloseMode
 		canceled bool
 		err      error
+	}
+	settingsPopupDoneMsg struct {
+		result   SettingsPopupResult
+		canceled bool
+		err      error
+	}
+	settingsReloadedMsg struct {
+		result  SettingsPopupResult
+		runtime SettingsRuntime
+		err     error
 	}
 	launchShellMsg struct {
 		req ShellLaunchRequest
@@ -292,6 +315,9 @@ func newModel(opts Options) model {
 
 func (m model) Init() tea.Cmd {
 	if m.closeOnly {
+		return nil
+	}
+	if m.settingsOnly {
 		return nil
 	}
 	if m.helpOnly {

--- a/internal/ui/tui/tui_test.go
+++ b/internal/ui/tui/tui_test.go
@@ -1,6 +1,7 @@
 package tui
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -21,6 +22,7 @@ import (
 	"github.com/butaosuinu/fanout/internal/core/exitcode"
 	"github.com/butaosuinu/fanout/internal/infra/ghissue"
 	fanoutnotify "github.com/butaosuinu/fanout/internal/infra/notify"
+	fanoutsettings "github.com/butaosuinu/fanout/internal/infra/settings"
 	"github.com/butaosuinu/fanout/internal/infra/state"
 	"github.com/butaosuinu/fanout/internal/infra/tmuxrun"
 )
@@ -1279,7 +1281,7 @@ func TestWatchTickRunsCycleAndRefreshesStateAndGH(t *testing.T) {
 		ShellPaneAlive: func(string, string) bool { return true },
 	})
 
-	updated, cmd := m.Update(watchTickMsg(time.Unix(1, 0)))
+	updated, cmd := m.Update(watchTickMsg{at: time.Unix(1, 0)})
 	m = updated.(model)
 	if !m.watchRunning {
 		t.Fatal("watchRunning = false, want true while RunCycle command is outstanding")
@@ -1351,12 +1353,33 @@ func TestWatchLaunchFailureRendersFooter(t *testing.T) {
 func TestWatchTickIgnoredWhenWatcherDisabled(t *testing.T) {
 	m := newModel(Options{})
 
-	updated, cmd := m.Update(watchTickMsg(time.Unix(1, 0)))
+	updated, cmd := m.Update(watchTickMsg{at: time.Unix(1, 0)})
 	if cmd != nil {
 		t.Fatal("watch tick without watcher returned command, want nil")
 	}
 	if updated.(model).watchRunning {
 		t.Fatal("watchRunning = true without watcher, want false")
+	}
+}
+
+func TestWatchTickIgnoresStaleGeneration(t *testing.T) {
+	runner := &fakeWatcherRunner{}
+	m := newModel(Options{
+		Watcher:       runner,
+		WatchInterval: time.Minute,
+	})
+	m.watchTickGen = 2
+
+	updated, cmd := m.Update(watchTickMsg{at: time.Unix(1, 0), gen: 1})
+	m = updated.(model)
+	if cmd != nil {
+		t.Fatal("stale watch tick returned command")
+	}
+	if m.watchRunning {
+		t.Fatal("watchRunning = true after stale watch tick")
+	}
+	if runner.calls != 0 {
+		t.Fatalf("RunCycle calls = %d, want 0", runner.calls)
 	}
 }
 
@@ -3652,6 +3675,359 @@ func TestHelpPopupFailureSurfacesNotice(t *testing.T) {
 	}
 	if m.notice != "help popup: boom" {
 		t.Fatalf("notice = %q, want help popup error", m.notice)
+	}
+}
+
+func TestSettingsKeyUsesPopupAndReloadsRuntime(t *testing.T) {
+	popupCalls := 0
+	reloadCalls := 0
+	issueLaunchCalls := 0
+	m := newModel(Options{
+		SettingsPopup: func(req SettingsPopupRequest) (SettingsPopupResult, bool, error) {
+			popupCalls++
+			if req.ProjectRoot != "/repo" {
+				t.Fatalf("settings popup project root = %q, want /repo", req.ProjectRoot)
+			}
+			return SettingsPopupResult{Saved: true, Scope: "user", Path: "/tmp/fanout-config.json"}, false, nil
+		},
+		ReloadSettings: func() (SettingsRuntime, error) {
+			reloadCalls++
+			return SettingsRuntime{
+				WatchLabel:    "fanout:test",
+				WatchInterval: time.Minute,
+				LaunchIssue: func(int, string, map[string]string) (string, error) {
+					issueLaunchCalls++
+					return "launched with reloaded settings", nil
+				},
+			}, nil
+		},
+		ProjectRoot: "/repo",
+	})
+
+	updated, cmd := m.Update(keyRunes("s"))
+	m = updated.(model)
+	if cmd == nil {
+		t.Fatal("s returned nil command, want settings popup command")
+	}
+	if popupCalls != 0 {
+		t.Fatalf("popup calls before command execution = %d, want 0", popupCalls)
+	}
+	if m.mode != modeMonitor {
+		t.Fatalf("mode = %v, want monitor while popup owns input", m.mode)
+	}
+	if !m.settingsPopupOpen {
+		t.Fatal("settingsPopupOpen = false, want true")
+	}
+	if m.notice != settingsPopupOpeningNotice {
+		t.Fatalf("notice = %q, want %q", m.notice, settingsPopupOpeningNotice)
+	}
+
+	updated, reloadCmd := m.Update(cmd())
+	m = updated.(model)
+	if reloadCmd == nil {
+		t.Fatal("settings popup save returned nil command, want reload command")
+	}
+	if popupCalls != 1 {
+		t.Fatalf("popup calls = %d, want 1", popupCalls)
+	}
+	if m.settingsPopupOpen {
+		t.Fatal("settingsPopupOpen = true after popup completion")
+	}
+
+	updated, next := m.Update(reloadCmd())
+	m = updated.(model)
+	if next != nil {
+		t.Fatal("settings reload returned command with nil watcher")
+	}
+	if reloadCalls != 1 {
+		t.Fatalf("reload calls = %d, want 1", reloadCalls)
+	}
+	if m.opts.WatchLabel != "fanout:test" || m.opts.WatchInterval != time.Minute {
+		t.Fatalf("runtime = label %q interval %s, want reloaded", m.opts.WatchLabel, m.opts.WatchInterval)
+	}
+	if m.opts.LaunchIssue == nil {
+		t.Fatal("LaunchIssue = nil, want reloaded launcher")
+	}
+	notice, err := m.opts.LaunchIssue(123, "codex", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if issueLaunchCalls != 1 || notice != "launched with reloaded settings" {
+		t.Fatalf("LaunchIssue calls=%d notice=%q, want reloaded launcher", issueLaunchCalls, notice)
+	}
+	if m.notice != "settings saved: /tmp/fanout-config.json" {
+		t.Fatalf("notice = %q, want settings saved", m.notice)
+	}
+}
+
+func TestSettingsPopupOpenBlocksMonitorKeys(t *testing.T) {
+	m := newModel(Options{
+		SettingsPopup: func(SettingsPopupRequest) (SettingsPopupResult, bool, error) {
+			return SettingsPopupResult{}, true, nil
+		},
+	})
+
+	updated, popupCmd := m.Update(keyRunes("s"))
+	m = updated.(model)
+	if popupCmd == nil {
+		t.Fatal("s returned nil command, want settings popup command")
+	}
+	if !m.settingsPopupOpen {
+		t.Fatal("settingsPopupOpen = false, want true")
+	}
+
+	for _, key := range []tea.KeyMsg{keyRunes("q"), keyRunes("s"), {Type: tea.KeyCtrlC}} {
+		updated, cmd := m.Update(key)
+		m = updated.(model)
+		if cmd != nil {
+			t.Fatalf("%q returned command while settings popup is open", key.String())
+		}
+		if m.mode != modeMonitor {
+			t.Fatalf("%q changed mode = %v, want monitor", key.String(), m.mode)
+		}
+		if !m.settingsPopupOpen {
+			t.Fatalf("%q cleared settingsPopupOpen", key.String())
+		}
+	}
+}
+
+func TestSettingsReloadPreservesRunningWatcher(t *testing.T) {
+	m := newModel(Options{
+		Watcher:       &fakeWatcherRunner{},
+		WatchInterval: time.Minute,
+	})
+	m.watchRunning = true
+
+	updated, cmd := m.Update(settingsReloadedMsg{
+		result: SettingsPopupResult{Saved: true, Path: "/tmp/fanout-config.json"},
+		runtime: SettingsRuntime{
+			Watcher:       &fakeWatcherRunner{},
+			WatchInterval: 2 * time.Minute,
+			WatchLabel:    "fanout:test",
+		},
+	})
+	m = updated.(model)
+	if !m.watchRunning {
+		t.Fatal("watchRunning = false after settings reload, want in-flight cycle preserved")
+	}
+	if cmd == nil {
+		t.Fatal("settings reload with watcher returned nil command, want next watch tick")
+	}
+	if m.opts.WatchInterval != 2*time.Minute || m.opts.WatchLabel != "fanout:test" {
+		t.Fatalf("runtime not applied: interval=%s label=%q", m.opts.WatchInterval, m.opts.WatchLabel)
+	}
+}
+
+func TestSettingsReloadInvalidatesOlderWatchTicks(t *testing.T) {
+	m := newModel(Options{
+		Watcher:       &fakeWatcherRunner{},
+		WatchInterval: time.Minute,
+	})
+	m.notifyErr = "old notifier failure"
+	before := m.watchTickGen
+
+	updated, cmd := m.Update(settingsReloadedMsg{
+		result: SettingsPopupResult{Saved: true, Path: "/tmp/fanout-config.json"},
+		runtime: SettingsRuntime{
+			Watcher:       &fakeWatcherRunner{},
+			WatchInterval: 2 * time.Minute,
+		},
+	})
+	m = updated.(model)
+	if m.watchTickGen != before+1 {
+		t.Fatalf("watchTickGen = %d, want %d", m.watchTickGen, before+1)
+	}
+	if m.notifyErr != "" {
+		t.Fatalf("notifyErr = %q, want cleared after settings reload", m.notifyErr)
+	}
+	if cmd == nil {
+		t.Fatal("settings reload with watcher returned nil command, want replacement tick")
+	}
+
+	updated, staleCmd := m.Update(watchTickMsg{at: time.Unix(1, 0), gen: before})
+	m = updated.(model)
+	if staleCmd != nil {
+		t.Fatal("stale pre-reload watch tick returned command")
+	}
+	if m.watchRunning {
+		t.Fatal("watchRunning = true after stale pre-reload watch tick")
+	}
+}
+
+func TestSettingsRowMasksSensitiveValues(t *testing.T) {
+	row := settingsRow{
+		spec:  fanoutsettings.ConfigKey{Key: "slackWebhookURL", Kind: fanoutsettings.ValueString, Sensitive: true},
+		value: fanoutsettings.StringValue("https://hooks.slack.com/services/secret"),
+	}
+	m := newModel(Options{})
+	m.settings = settingsForm{rows: []settingsRow{row}, cursor: 1}
+
+	view := m.settingsRowView(1, row)
+	if strings.Contains(view, "hooks.slack.com") || strings.Contains(view, "secret") {
+		t.Fatalf("sensitive row leaked URL:\n%s", view)
+	}
+	if !strings.Contains(view, "set") {
+		t.Fatalf("sensitive row = %q, want masked persisted value", view)
+	}
+
+	m.settings.editing = true
+	m.settings.editText = "https://hooks.slack.com/services/typed-secret"
+	editView := m.settingsRowView(1, row)
+	if strings.Contains(editView, "hooks.slack.com") || strings.Contains(editView, "secret") {
+		t.Fatalf("sensitive edit row leaked URL:\n%s", editView)
+	}
+	if !strings.Contains(editView, "****************") {
+		t.Fatalf("sensitive edit row = %q, want masked edit value", editView)
+	}
+}
+
+func TestSettingsRowMarksForwardedEnvOverride(t *testing.T) {
+	spec := fanoutsettings.ConfigKey{
+		Key:  "watcher",
+		Kind: fanoutsettings.ValueBool,
+		Env:  "FANOUT_TEST_ONLY_SETTINGS_ENV_OVERRIDE_9D0A4F0E",
+	}
+	t.Setenv(SettingsEnvOverridesEnv, spec.Env)
+	row := settingsRow{
+		spec:        spec,
+		value:       fanoutsettings.BoolValue(false),
+		envOverride: settingsEnvOverridePresent(spec),
+	}
+	m := newModel(Options{})
+	m.settings = settingsForm{rows: []settingsRow{row}, cursor: 1}
+
+	view := m.settingsRowView(1, row)
+	if !strings.Contains(view, " env") {
+		t.Fatalf("settings row = %q, want forwarded env marker", view)
+	}
+}
+
+func TestSettingsSaveBlocksInvalidConfig(t *testing.T) {
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	configPath := filepath.Join(xdg, "fanout", "config.json")
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	original := "{broken"
+	if err := os.WriteFile(configPath, []byte(original), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := newModel(Options{ProjectRoot: t.TempDir()})
+	m.openSettingsForm(fanoutsettings.ConfigScopeUser)
+	if !m.settings.loadErr {
+		t.Fatal("settings loadErr = false, want true for invalid JSON")
+	}
+
+	updated, cmd := m.saveSettings()
+	m = updated.(model)
+	if cmd != nil {
+		t.Fatal("save invalid settings returned command")
+	}
+	if !strings.Contains(m.settings.err, "fix or remove the invalid config before saving") {
+		t.Fatalf("settings err = %q, want save-blocking error", m.settings.err)
+	}
+	body, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(body) != original {
+		t.Fatalf("invalid config changed after blocked save:\nwant %q\ngot  %q", original, body)
+	}
+}
+
+func TestSettingsRepoSaveDeletesDisabledUnsafeKeys(t *testing.T) {
+	repo := t.TempDir()
+	configPath := fanoutsettings.RepoConfigPath(repo)
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(configPath, []byte(`{
+  "watcher": true,
+  "watcherLabel": "fanout:ready",
+  "notifications": "slack ntfy bell",
+  "ntfyURL": "https://ntfy.example/topic",
+  "slackWebhookURL": "https://hooks.slack.com/services/secret"
+}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := newModel(Options{ProjectRoot: repo})
+	m.openSettingsForm(fanoutsettings.ConfigScopeRepo)
+	updated, cmd := m.saveSettings()
+	m = updated.(model)
+	if cmd != nil {
+		t.Fatal("repo settings save returned reload command")
+	}
+	if m.settings.err != "" {
+		t.Fatalf("settings err = %q", m.settings.err)
+	}
+
+	body, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var root map[string]any
+	if err := json.Unmarshal(body, &root); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{"watcher", "ntfyURL", "slackWebhookURL"} {
+		if _, ok := root[key]; ok {
+			t.Fatalf("%s should be deleted from repo config:\n%s", key, body)
+		}
+	}
+	if root["notifications"] != "bell" {
+		t.Fatalf("notifications = %#v, want safe selector preserved", root["notifications"])
+	}
+	if root["watcherLabel"] != "fanout:ready" {
+		t.Fatalf("watcherLabel = %#v, want preserved", root["watcherLabel"])
+	}
+}
+
+func TestSettingsRepoSavePreservesSafeNotificationValues(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "none", raw: "none", want: "none"},
+		{name: "comma-safe", raw: "bell,tmux", want: "bell,tmux"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := t.TempDir()
+			configPath := fanoutsettings.RepoConfigPath(repo)
+			if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			body := fmt.Appendf(nil, `{"notifications": %q, "watcherLabel": "fanout:ready"}`, tc.raw)
+			if err := os.WriteFile(configPath, body, 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			m := newModel(Options{ProjectRoot: repo})
+			m.openSettingsForm(fanoutsettings.ConfigScopeRepo)
+			updated, cmd := m.saveSettings()
+			m = updated.(model)
+			if cmd != nil {
+				t.Fatal("repo settings save returned reload command")
+			}
+			if m.settings.err != "" {
+				t.Fatalf("settings err = %q", m.settings.err)
+			}
+
+			body, err := os.ReadFile(configPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var root map[string]any
+			if err := json.Unmarshal(body, &root); err != nil {
+				t.Fatal(err)
+			}
+			if root["notifications"] != tc.want {
+				t.Fatalf("notifications = %#v, want %q\n%s", root["notifications"], tc.want, body)
+			}
+		})
 	}
 }
 

--- a/internal/ui/tui/update.go
+++ b/internal/ui/tui/update.go
@@ -33,7 +33,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case tea.KeyMsg:
 		m.resumeKeyboardProtocols()
-		if (m.newPanePopupOpen || m.helpPopupOpen || m.closePopupOpen || m.newPane.launching) && m.mode != modeNewPane {
+		if (m.newPanePopupOpen || m.helpPopupOpen || m.closePopupOpen || m.settingsPopupOpen || m.newPane.launching) && m.mode != modeNewPane {
 			// An issue launch can run a whole fan-out (seconds per child), so
 			// mirror the lifecycle-action gate: keys stay blocked, but q/ctrl+c
 			// queue a quit instead of appearing hung.
@@ -72,6 +72,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if m.mode == modeCloseChoice {
 			return m, nil
 		}
+		if m.mode == modeSettings {
+			return m.updateSettings(msg)
+		}
 		if m.mode == modeNewPane {
 			return m.updateNewPane(msg)
 		}
@@ -100,6 +103,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m.jumpSession(1)
 		case "n":
 			return m, m.openNewPanePopupCmd()
+		case "s":
+			return m, m.openSettingsPopupCmd()
 		case "a":
 			return m, m.openAttachAgentForm()
 		case "A":
@@ -241,6 +246,9 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case ghTickMsg:
 		return m, m.loadGHCmd(true)
 	case watchTickMsg:
+		if msg.gen != m.watchTickGen {
+			return m, nil
+		}
 		if m.opts.Watcher == nil {
 			return m, nil
 		}
@@ -341,6 +349,36 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.notice = ""
 		}
 		return m, m.lifecycleCmd(pending)
+	case settingsPopupDoneMsg:
+		m.settingsPopupOpen = false
+		if msg.err != nil {
+			m.notice = "settings popup: " + msg.err.Error()
+			return m, nil
+		}
+		if msg.canceled {
+			if m.notice == settingsPopupOpeningNotice {
+				m.notice = ""
+			}
+			return m, nil
+		}
+		if msg.result.Saved {
+			m.notice = "settings saved: " + displayConfigPath(msg.result.Path)
+			return m, m.reloadSettingsCmd(msg.result)
+		}
+		if m.notice == settingsPopupOpeningNotice {
+			m.notice = ""
+		}
+		return m, nil
+	case settingsReloadedMsg:
+		if msg.err != nil {
+			m.notice = "settings saved; reload failed: " + msg.err.Error()
+			return m, nil
+		}
+		cmd := applySettingsRuntime(&m, msg.runtime)
+		if msg.result.Path != "" {
+			m.notice = "settings saved: " + displayConfigPath(msg.result.Path)
+		}
+		return m, cmd
 	case newPaneIssuesLoadedMsg:
 		p := &m.newPane.issuePicker
 		p.loading = false

--- a/internal/ui/tui/view.go
+++ b/internal/ui/tui/view.go
@@ -72,6 +72,12 @@ func (m model) View() string {
 		}
 		return m.helpView()
 	}
+	if m.settingsOnly {
+		if m.width == 0 {
+			return "Settings"
+		}
+		return m.settingsView()
+	}
 	if m.width == 0 {
 		return "fanout TUI"
 	}
@@ -103,7 +109,11 @@ func (m model) View() string {
 		header += " " + dimStyle.Render(formatHUD(summarizeHUD(m.panes)))
 	}
 
-	footer := dimStyle.Render(m.footerText())
+	footerText := m.footerText()
+	if layout.Compact {
+		footerText = truncateCells(footerText, layout.MainWidth)
+	}
+	footer := dimStyle.Render(footerText)
 	if m.notice != "" {
 		footer += "\n" + warnStyle.Render(m.notice)
 	}
@@ -141,6 +151,9 @@ func (m model) View() string {
 	}
 	if m.mode == modeCloseChoice {
 		return overlayCentered(base, m.closeChoiceView(), m.width, m.height)
+	}
+	if m.mode == modeSettings {
+		return overlayCentered(base, m.settingsView(), m.width, m.height)
 	}
 	return base
 }

--- a/internal/ui/tui/watch.go
+++ b/internal/ui/tui/watch.go
@@ -27,7 +27,8 @@ func (m model) watchTickCmd() tea.Cmd {
 		return nil
 	}
 	interval := m.opts.WatchInterval
-	return tea.Tick(interval, func(t time.Time) tea.Msg { return watchTickMsg(t) })
+	gen := m.watchTickGen
+	return tea.Tick(interval, func(t time.Time) tea.Msg { return watchTickMsg{at: t, gen: gen} })
 }
 
 func (m model) runWatchCmd() tea.Cmd {

--- a/site/content/docs/monitoring.ja.md
+++ b/site/content/docs/monitoring.ja.md
@@ -43,6 +43,7 @@ fanout   # start the persistent tmux console
 | `[` / `]` | 前 / 次の Session グループへジャンプする。 |
 | `/` | ロード済みの行を絞り込む(フリーテキストか `state:open` のような述語)。`Esc` は入力を抜けるだけで、一覧からもう一度 `Esc` を押すとフィルタを解除する。 |
 | `n` | 新規 Session の tmux popup を開く。Mode 行で Prompt / Issue を切り替える。詳細は[新規 Session のモード](#新規-session-のモード)を参照。 |
+| `s` | 設定の tmux popup を開く。user config / repo config を選び、`config.json` と同じキーを編集し、`Ctrl+S` で保存する。 |
 | `a` | 選択中の行に記録された worktree に、agent ペインを 1 つ以上追加する。git worktree は作らない。追加行は選択元の worktree と branch を共有し、focus と peek はできるが merge 進捗には数えない。`codex` は Codex Plan Mode で起動する。 |
 | `A` | 選択中の行に記録された worktree で shell terminal を開く。shell 行は `@manual` entry として記録され、focus と peek はできるが merge 進捗には数えない。 |
 | `t` | project root で shell terminal を開く。close は tmux ペインと state 行だけを消し、git worktree は削除しない。 |
@@ -59,6 +60,14 @@ fanout   # start the persistent tmux console
 ### コンパクト表示
 
 幅 80 桁未満では、テーブル + detail panel が 1 ペイン 1 行の switcher に切り替わり、選択中の行だけが branch や PR、ci / wave / blockers / dirty などの詳細に展開されます。
+
+### 設定 popup
+
+`s` で、コンソールを離れずに fanout の JSON 設定を編集できます。
+Target 行で user config と repo config を切り替えます。
+各設定は値を指定するか `inherit` に戻せます。`inherit` は選択中のファイルからそのキーを削除します。
+CLI flag と `FANOUT_*` 環境変数は、保存済みファイルより引き続き優先されます。
+repo config の安全ルールも `config.json` と同じです。repo config から watcher や HTTP 通知 endpoint は有効化できず、通知 channel は `bell`、`tmux`、`none` だけです。
 
 ### F11 / prefix + T
 

--- a/site/content/docs/monitoring.md
+++ b/site/content/docs/monitoring.md
@@ -36,6 +36,7 @@ From a plain shell it creates or attaches to fanout's managed tmux session; from
 | `[` / `]` | Jump to the previous / next Session group. |
 | `/` | Filter the loaded rows (free text or a predicate such as `state:open`). `Esc` only leaves the input; pressing `Esc` again from the list clears the filter. |
 | `n` | Open the new-session tmux popup. Its Mode row switches between Prompt and Issue; see [New session modes](#new-session-modes). |
+| `s` | Open the settings tmux popup. Choose user or repo config, edit the same keys as `config.json`, and save with `Ctrl+S`. |
 | `a` | Attach one or more agent panes to the selected row's recorded worktree. No git worktree is created. The attached rows share the selected worktree and branch, can be focused and peeked, and do not count toward merge progress. `codex` starts in Codex Plan Mode. |
 | `A` | Open a shell terminal in the selected row's recorded worktree. Shell rows are recorded as `@manual` entries, can be focused and peeked, and do not count toward merge progress. |
 | `t` | Open a shell terminal at the project root. Closing it removes only the tmux pane and the state row; it never deletes the git worktree. |
@@ -52,6 +53,10 @@ From a plain shell it creates or attaches to fanout's managed tmux session; from
 ### Compact view
 
 Below 80 columns, the table and detail panel become a one-line-per-pane switcher, and only the selected row expands into details such as branch, PR, and ci / wave / blockers / dirty.
+
+### Settings popup
+
+Press `s` to edit fanout's JSON settings without leaving the console. The Target row switches between user config and repo config; each setting can be set or returned to `inherit`, which removes that key from the selected file. CLI flags and `FANOUT_*` environment variables still win over saved files. Repo config keeps the same safety rules as `config.json`: it cannot enable the watcher or HTTP notification endpoints, and its notification channels are limited to `bell`, `tmux`, and `none`.
 
 ### F11 / prefix + T
 

--- a/site/content/docs/settings.ja.md
+++ b/site/content/docs/settings.ja.md
@@ -16,6 +16,16 @@ fanout の挙動はチームの好みで変えたくなる箇所がいくつか�
 - リポジトリ設定: `<project_root>/.fanout/config.json`。この `project_root` は親リポジトリルートで、子 worktree ではありません。
 - ユーザー設定: `$XDG_CONFIG_HOME/fanout/config.json`、`XDG_CONFIG_HOME` が無い場合は `~/.config/fanout/config.json`。
 
+## TUI から設定を編集する
+
+常駐 TUI コンソールで `s` を押すと、どちらの config ファイルも popup で編集できます。
+Target 行で user config と repo config を切り替えます。
+各キーは値を指定するか `inherit` に戻せます。`inherit` は選択中の JSON ファイルからそのキーを削除します。
+
+popup が編集するのは config ファイルだけです。
+CLI flag と `FANOUT_*` 環境変数は、保存した値より引き続き優先されます。
+repo config の安全制限も後述のとおりです。repo config から watcher は有効化できず、HTTP 通知 URL も設定できません。`notifications` に指定できるのは `bell`、`tmux`、`none` だけです。
+
 ## 各トグルの目的
 
 挙動トグルは「既定で入っているが、チームの事情で外したくなる」指示の集合です。各キーの目的を 1 行ずつ示します。

--- a/site/content/docs/settings.md
+++ b/site/content/docs/settings.md
@@ -16,6 +16,12 @@ When the same setting is given on both the CLI and a config file, which one wins
 - Repo config: `<project_root>/.fanout/config.json`, where `project_root` is the parent repository root, not the child worktree.
 - User config: `$XDG_CONFIG_HOME/fanout/config.json`, or `~/.config/fanout/config.json` when `XDG_CONFIG_HOME` is unset.
 
+## Edit settings from the TUI
+
+Press `s` in the persistent TUI console to edit either config file in a popup. The Target row switches between user config and repo config. Each key can be set to a value or returned to `inherit`, which removes that key from the selected JSON file.
+
+The popup edits only config files. CLI flags and `FANOUT_*` environment variables still override what you save. Repo config keeps the same safety restrictions described below: it cannot enable the watcher, cannot set HTTP notification URLs, and can only choose `bell`, `tmux`, or `none` for `notifications`.
+
 ## What each toggle is for
 
 The behavior toggles are instructions that ship on by default but a team may want off. Here is the purpose of each key, one line apiece.


### PR DESCRIPTION
## 概要

- TUI の `s` キーから設定 popup を開けるようにした
- popup から user config / repo config を切り替え、既存 `config.json` と同じキーを編集・保存できるようにした
- 保存後に TUI の watcher / notifier / tmux keybind runtime を再読込するようにした
- settings docs と monitoring docs の英日両方を更新した

## 検証

- `go test ./internal/infra/settings ./internal/ui/tui ./cmd/fanout`
- `make build-go`
- `make test`
- `make lint`
- post-work-review: clean=true, broad_review_calls=1, marker_written=true
