### PR TITLE
agent-state通知音をドキュメント化

### DIFF
--- a/site/content/docs/monitoring.ja.md
+++ b/site/content/docs/monitoring.ja.md
@@ -34,6 +34,18 @@ fanout   # start the persistent tmux console
 
 {{< diagram "console" >}}
 
+### agent-state の通知音
+
+TUI の通知 channel は agent-state の変化も扱います。
+既定の `notifications=bell` では、従来の issue / PR 遷移と同じ terminal bell が、agent が plan を提示したとき、ユーザー入力や承認を待つとき、agent が終了したときにも鳴ります。
+通知先は `notifications` または `FANOUT_NOTIFICATIONS` で変えられます。
+詳細は [Settings]({{< relref "/docs/settings" >}}) を参照してください。
+
+fanout は、ペインの `@fanout_agent_state` tmux option から構造化された agent state を読みます。
+ペイン出力からは推定しません。
+観測する state は `running`、`working`、`plan`、`blocked`、`idle`、`done` ですが、通知を送るのは `plan`(`plan ready`)、`blocked`(`waiting for input`)、`done`(`agent exited`)だけです。
+それ以外の state は表示専用です。
+
 ### キー操作
 
 | キー | 動作 |

--- a/site/content/docs/monitoring.md
+++ b/site/content/docs/monitoring.md
@@ -27,6 +27,12 @@ From a plain shell it creates or attaches to fanout's managed tmux session; from
 
 {{< diagram "console" >}}
 
+### Agent-state notification sounds
+
+The TUI's notification channels also cover agent-state changes. With the default `notifications=bell`, the same terminal bell that already reports issue / PR transitions also sounds when an agent presents a plan, waits for user input or approval, or exits. Change the destination with `notifications` or `FANOUT_NOTIFICATIONS`; see [Settings]({{< relref "/docs/settings" >}}).
+
+fanout reads structured agent state from the pane's `@fanout_agent_state` tmux option. It does not scrape pane output. The observed states are `running`, `working`, `plan`, `blocked`, `idle`, and `done`, but notifications are sent only for `plan` (`plan ready`), `blocked` (`waiting for input`), and `done` (`agent exited`). The other states are display state only.
+
 ### Key bindings
 
 | Key | Action |

--- a/site/content/docs/settings.ja.md
+++ b/site/content/docs/settings.ja.md
@@ -83,9 +83,16 @@ integer の環境変数は 10 進整数を受け付けます。`watcherIntervalS
 
 ## 通知 channel
 
-ターミナルを離れている間に子の状態遷移を知りたいなら、通知先を選びます。`notifications` は comma または空白区切りの selector で、指定できる値は `bell`、`tmux`、`ntfy`、`slack`、`none` です。`ntfy` は `ntfyURL`、`slack` は `slackWebhookURL` が必要です。
+ターミナルを離れている間に子の状態遷移を知りたいなら、通知先を選びます。
+`notifications` は、issue / PR 遷移(merged、CI failed、blocker 待ち)と TUI 由来の agent-state 遷移(plan ready、waiting for input、agent exited)の両方を扱います。
+comma または空白区切りの selector で、指定できる値は `bell`、`tmux`、`ntfy`、`slack`、`none` です。
+`ntfy` は `ntfyURL`、`slack` は `slackWebhookURL` が必要です。
 
 どちらの HTTP channel も outbound POST のみで、inbound socket は開きません。repo の設定だけで外部へ勝手に送信されるのを防ぐため、repo config で選べるのは `bell`、`tmux`、`none` だけです。`ntfy`、`slack`、`ntfyURL`、`slackWebhookURL` は user config か環境変数からだけ有効になります。
+
+agent-state 通知は `@fanout_agent_state` から発火し、ペイン出力からは推定しません。
+通知するのは `plan`、`blocked`、`done` だけです。
+`running`、`working`、`idle` は TUI に表示されますが、通知は送りません。
 
 ## watcher の安全制約
 

--- a/site/content/docs/settings.md
+++ b/site/content/docs/settings.md
@@ -83,9 +83,11 @@ Integer environment values accept base-10 integers. `watcherIntervalSeconds` res
 
 ## Notification channels
 
-When you step away from the terminal and still want to know when a child changes state, pick where the notice goes. `notifications` is a comma- or space-separated selector. Supported values are `bell`, `tmux`, `ntfy`, `slack`, and `none`. `ntfy` requires `ntfyURL`; `slack` requires `slackWebhookURL`.
+When you step away from the terminal and still want to know when a child changes state, pick where the notice goes. The `notifications` setting covers both issue / PR transitions (merged, CI failed, waiting on blockers) and agent-state transitions from the TUI (plan ready, waiting for input, agent exited). It is a comma- or space-separated selector. Supported values are `bell`, `tmux`, `ntfy`, `slack`, and `none`. `ntfy` requires `ntfyURL`; `slack` requires `slackWebhookURL`.
 
 Both HTTP channels only send outbound POST requests and never open inbound sockets. To stop a repo's config from sending anywhere on its own, repo config may only select `bell`, `tmux`, or `none`; `ntfy`, `slack`, `ntfyURL`, and `slackWebhookURL` are honored only from user config or environment variables.
+
+Agent-state notifications come from `@fanout_agent_state`, not from pane output. fanout sends them only for `plan`, `blocked`, and `done`; `running`, `working`, and `idle` are visible in the TUI but do not send notifications.
 
 ## Watcher safety
 


### PR DESCRIPTION
**TL;DR**
agent-state 通知音を `monitoring` / `settings` docs に追記しました。`notifications` / `FANOUT_NOTIFICATIONS` が issue / PR 遷移と agent-state 遷移の両方を扱うことを明記しています。
Review effort: 1

**Why**
`session-notifications` の `docs-notifications` タスクは、新しい agent-state 通知音をユーザーが見つけられ、観測できる範囲を誤解しないようにする意図です。brief は、plan 提示、ユーザー入力または承認待ち、作業完了を docs に載せ、pane 出力 scraping ではなく構造化 agent state を使うことを明記するよう指定していました。

**Changes by file**
<details><summary>Changed files</summary>

| File | What changed | Why |
|---|---|---|
| `site/content/docs/monitoring.md` | TUI の agent-state 通知音、対象イベント、`notifications` / `FANOUT_NOTIFICATIONS` への導線を追加 | Monitoring ページから新しい通知音を見つけられるようにするため |
| `site/content/docs/monitoring.ja.md` | 英語版と同じ agent-state 通知音の説明を追加 | 日本語 docs を英語版と同期するため |
| `site/content/docs/settings.md` | `notifications` が issue / PR 遷移と agent-state 遷移の両方を扱うこと、通知対象 state の範囲を追記 | 設定ページで通知 channel の適用範囲を正確に示すため |
| `site/content/docs/settings.ja.md` | 英語版と同じ `notifications` の適用範囲と agent-state 境界を追記 | 日本語 docs を英語版と同期するため |

</details>

**Risk**
ユーザー向け docs のみの変更です。実装、設定解決、通知配信には触れていません。

**Test plan**
- `git diff --check`
- `make lint`
- `make test`
- `$post-work-review` before commit: `scope=uncommitted`, `clean=true`, `findings=0`, `stop_reason=`
- `$post-work-review` after commit with `POST_WORK_REVIEW_BASE=main`: `scope=branch`, `clean=true`, `findings=0`, `stop_reason=`, marker written for `c7e6732db97f6127be9a4817ad948a6f288aabda`

Plan: session-notifications / Task: docs-notifications
