### PR TITLE
[codex] TUI の選択行をフォーカス中ペインに同期

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -36,7 +36,8 @@ briefing から起動します。再実行しても同じ対象に 2 つ目の�
   スクは codex、のように)。prompt モードのチェックボックスを入れると、
   そのプロンプトを `/fanout plan` で並列タスクに分解します。`s` キーで設定
   popup を開けます。どのペインからでも `F11` または `prefix + T` でコンソールに
-  戻れます。
+  戻れます。マウスや `prefix` のペイン移動でフォーカスしたペインにも、選択行が
+  追従します。
 - **ラベル watcher** — opt-in すると、TUI 常駐中に信頼できる `fanout:auto`
   issue を one-shot fanout session に投入します。
 - **Web ダッシュボード** — localhost で動く read-only のダッシュボード(ライブ

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ English and 日本語.
   in the browser, and per-child agent choices let one task use claude while
   another uses codex. A prompt-mode checkbox instead decomposes the prompt into
   parallel tasks via `/fanout plan`. The `s` key opens the settings popup.
-  Return to the console from any pane with `F11` or `prefix + T`.
+  Return to the console from any pane with `F11` or `prefix + T`; mouse or
+  `prefix` movement keys keep the selected row in sync with the focused pane.
 - **Label watcher** — opt in to a TUI-resident watcher that turns trusted
   `fanout:auto` issues into one-shot fanout sessions.
 - **Web dashboard** — a read-only localhost dashboard with live updates; pop it

--- a/cmd/fanout/tui.go
+++ b/cmd/fanout/tui.go
@@ -105,6 +105,7 @@ func cmdTUI(commandName string, lg *log.Logger) exitcode.Code {
 		LaunchShell:       newTUILaunchShellFunc(projectRoot, session),
 		RestorePanes:      newTUIRestoreFunc(projectRoot, session, commandName),
 		Relayout:          func() error { return panelayout.Apply(tuiLaunchTarget(session), panelayout.Resize) },
+		ActivePane:        newTUIActivePaneFunc(os.Getenv("TMUX_PANE")),
 		Notifier:          notifier,
 	}); err != nil {
 		lg.Err("tui: %v", err)
@@ -148,6 +149,20 @@ func tuiLaunchTarget(session string) string {
 		return pane
 	}
 	return session
+}
+
+func newTUIActivePaneFunc(consolePaneID string) func() (string, error) {
+	consolePaneID = strings.TrimSpace(consolePaneID)
+	return func() (string, error) {
+		paneID, err := tmuxrun.ActivePaneInWindow(consolePaneID)
+		if err != nil {
+			return "", err
+		}
+		if paneID == consolePaneID {
+			return "", nil
+		}
+		return paneID, nil
+	}
 }
 
 func defaultTUIAgent() string {

--- a/cmd/fanout/tui_test.go
+++ b/cmd/fanout/tui_test.go
@@ -95,6 +95,51 @@ func TestCmdTUIRegistersConsoleKeybinds(t *testing.T) {
 	}
 }
 
+func TestCmdTUIWiresActivePaneProvider(t *testing.T) {
+	repo := t.TempDir()
+	initTUITestGitRepo(t, repo)
+	commitTUITestGitRepo(t, repo)
+	writeTUITestStateFile(t, repo)
+	t.Chdir(repo)
+	t.Setenv("TMUX", "tmux-session")
+	t.Setenv("TMUX_PANE", "%tui")
+	installTUIDashboardTmuxShim(t)
+	original := runTUI
+	var opts fanouttui.Options
+	runTUI = func(o fanouttui.Options) error {
+		opts = o
+		return nil
+	}
+	defer func() { runTUI = original }()
+
+	code := cmdTUI("fanout", discardLogger())
+	if code != exitcode.OK {
+		t.Fatalf("cmdTUI() = %d, want OK", code)
+	}
+	if opts.ActivePane == nil {
+		t.Fatal("ActivePane provider is nil, want tmux-backed provider")
+	}
+	got, err := opts.ActivePane()
+	if err != nil {
+		t.Fatalf("ActivePane() failed: %v", err)
+	}
+	if got != "%2" {
+		t.Fatalf("ActivePane() = %q, want %%2", got)
+	}
+}
+
+func TestTUIActivePaneProviderIgnoresConsolePane(t *testing.T) {
+	installTUIActivePaneTmuxShim(t, "%tui")
+
+	got, err := newTUIActivePaneFunc("%tui")()
+	if err != nil {
+		t.Fatalf("ActivePane() failed: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("ActivePane() = %q, want empty for console pane", got)
+	}
+}
+
 func TestCmdTUINoDashboardKeybindHonorsEnv(t *testing.T) {
 	repo := t.TempDir()
 	initTUITestGitRepo(t, repo)
@@ -1534,6 +1579,7 @@ esac
 func installTUIDashboardTmuxShim(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
 	argsPath := filepath.Join(dir, "tmux-args.txt")
 	script := `#!/usr/bin/env bash
 set -euo pipefail
@@ -1557,6 +1603,8 @@ case "${1:-}" in
   list-panes)
     if [[ "$*" == *fanout_role* ]]; then
       printf '%%tui\t0\t1\tconsole\t\n'
+    elif [[ "$*" == *pane_active* ]]; then
+      printf '%%tui:@1:0:0:fanout tui\n%%2:@1:1:1:child\n'
     fi
     ;;
   bind-key|unbind-key|list-keys|set-option|select-pane|select-layout|kill-pane)
@@ -1572,6 +1620,33 @@ esac
 	t.Setenv("TMUX_SHIM_ARGS", argsPath)
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	return argsPath
+}
+
+func installTUIActivePaneTmuxShim(t *testing.T, activePaneID string) {
+	t.Helper()
+	dir := t.TempDir()
+	script := `#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-}" in
+  list-panes)
+    if [[ "$*" == *pane_active* ]]; then
+      if [[ "$TMUX_SHIM_ACTIVE_PANE" == "%tui" ]]; then
+        printf '%%tui:@1:0:1:fanout tui\n%%2:@1:1:0:child\n'
+      else
+        printf '%%tui:@1:0:0:fanout tui\n%%2:@1:1:1:child\n'
+      fi
+    fi
+    ;;
+  *)
+    ;;
+esac
+`
+	path := filepath.Join(dir, "tmux")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TMUX_SHIM_ACTIVE_PANE", activePaneID)
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 }
 
 func installTUISettingsReloadTmuxShim(t *testing.T) string {
@@ -1596,7 +1671,7 @@ case "${1:-}" in
       printf 'bind-key -n F11 run-shell fanout focus-console --from "#{pane_id}"; tmux display-message "fanout: focus-console failed"\n'
     fi
     ;;
-  unbind-key)
+  bind-key|unbind-key|set-option|select-pane|select-layout|kill-pane)
     ;;
   *)
     ;;

--- a/internal/infra/tmuxrun/tmuxrun.go
+++ b/internal/infra/tmuxrun/tmuxrun.go
@@ -950,6 +950,28 @@ func ListAllPanes() ([]PaneInfo, error) {
 	return parseListPanesOutput(string(out))
 }
 
+// ActivePaneInWindow returns the active pane in targetPaneID's tmux window.
+func ActivePaneInWindow(targetPaneID string) (string, error) {
+	targetPaneID = strings.TrimSpace(targetPaneID)
+	if targetPaneID == "" {
+		return "", nil
+	}
+	out, err := exec.Command("tmux", "list-panes", "-t", targetPaneID, "-F", paneListFormat).Output()
+	if err != nil {
+		return "", fmt.Errorf("tmux list-panes: %w", err)
+	}
+	panes, err := parseListPanesOutput(string(out))
+	if err != nil {
+		return "", err
+	}
+	for _, pane := range panes {
+		if pane.Active {
+			return pane.ID, nil
+		}
+	}
+	return "", nil
+}
+
 // NewWindow creates a detached window in session and returns its initial pane.
 func NewWindow(session, name, startDir string) (PaneInfo, error) {
 	session = strings.TrimSpace(session)

--- a/internal/infra/tmuxrun/tmuxrun_test.go
+++ b/internal/infra/tmuxrun/tmuxrun_test.go
@@ -1221,6 +1221,43 @@ printf '%%3:@2:4:1:fanout pane\n'
 	assertTmuxArgs(t, argsPath, []string{"list-panes", "-s", "-t", "=target-session", "-F", paneListFormat})
 }
 
+func TestActivePaneInWindowReturnsActivePaneForTargetWindow(t *testing.T) {
+	argsPath := installTmuxShim(t, `if [ "$1" = "has-session" ]; then
+	exit 1
+fi
+printf '%s\n' "$@" > "$TMUXRUN_ARGS"
+printf '%%1:@2:0:0:fanout tui\n%%2:@2:1:1:child pane\n'
+`)
+
+	got, err := ActivePaneInWindow("%1")
+	if err != nil {
+		t.Fatalf("ActivePaneInWindow() failed: %v", err)
+	}
+	if got != "%2" {
+		t.Fatalf("ActivePaneInWindow() = %q, want %%2", got)
+	}
+	assertTmuxArgs(t, argsPath, []string{"list-panes", "-t", "%1", "-F", paneListFormat})
+}
+
+func TestActivePaneInWindowReturnsEmptyForNoTargetOrNoActivePane(t *testing.T) {
+	if got, err := ActivePaneInWindow(""); err != nil || got != "" {
+		t.Fatalf("ActivePaneInWindow(empty) = %q, %v; want empty nil", got, err)
+	}
+
+	installTmuxShim(t, `if [ "$1" = "has-session" ]; then
+	exit 1
+fi
+printf '%%1:@2:0:0:fanout tui\n%%2:@2:1:0:child pane\n'
+`)
+	got, err := ActivePaneInWindow("%1")
+	if err != nil {
+		t.Fatalf("ActivePaneInWindow() failed: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("ActivePaneInWindow() = %q, want empty when no pane is active", got)
+	}
+}
+
 func TestListPanesPreservesPaneTargetArgs(t *testing.T) {
 	argsPath := installTmuxShim(t, `if [ "$1" = "has-session" ]; then
 	exit 1

--- a/internal/ui/tui/focus.go
+++ b/internal/ui/tui/focus.go
@@ -59,6 +59,25 @@ func (m *model) refreshDetail() {
 	m.detail.SetContent(m.detailContent())
 }
 
+func (m *model) syncCursorToActivePane(paneID string) bool {
+	paneID = strings.TrimSpace(paneID)
+	if paneID == "" {
+		return false
+	}
+	for i, pane := range m.panes {
+		if strings.TrimSpace(pane.PaneID) != paneID || !pane.canFocus() {
+			continue
+		}
+		if i == m.table.Cursor() {
+			return false
+		}
+		m.moveTableCursorTo(i)
+		m.refreshDetail()
+		return true
+	}
+	return false
+}
+
 func (m model) detailContent() string {
 	if len(m.allPanes) == 0 {
 		return emptyStateNoPanes

--- a/internal/ui/tui/issues.go
+++ b/internal/ui/tui/issues.go
@@ -111,6 +111,24 @@ func (m model) loadGHCmd(scheduleNext bool) tea.Cmd {
 	}
 }
 
+func (m model) activePaneTickCmd() tea.Cmd {
+	if m.opts.ActivePane == nil {
+		return nil
+	}
+	return tea.Tick(m.opts.ActivePaneInterval, func(t time.Time) tea.Msg { return activeTickMsg(t) })
+}
+
+func (m model) loadActivePaneCmd(scheduleNext bool) tea.Cmd {
+	activePane := m.opts.ActivePane
+	if activePane == nil {
+		return nil
+	}
+	return func() tea.Msg {
+		paneID, err := activePane()
+		return activePaneMsg{paneID: paneID, err: err, scheduleNext: scheduleNext}
+	}
+}
+
 func loadPaneViews(projectRoot string, issues map[issueKey]issueStatus) ([]paneView, error) {
 	var stateErr error
 	mergedState := sessionview.MergedStateLoader(projectRoot)

--- a/internal/ui/tui/tui.go
+++ b/internal/ui/tui/tui.go
@@ -17,18 +17,19 @@ import (
 )
 
 const (
-	defaultStateInterval = 2 * time.Second
-	defaultGHInterval    = 20 * time.Second
-	defaultWatchInterval = 60 * time.Second
-	minWatchInterval     = 20 * time.Second
-	defaultWatchLabel    = "fanout:auto"
-	detailHeight         = 13
-	peekLines            = 80
-	defaultLaunchAgent   = "claude"
-	sessionSidebarAt     = 120
-	sessionSidebarWidth  = 26
-	sessionTopHeight     = 3
-	compactWidthAt       = 80
+	defaultStateInterval  = 2 * time.Second
+	defaultGHInterval     = 20 * time.Second
+	defaultActiveInterval = 500 * time.Millisecond
+	defaultWatchInterval  = 60 * time.Second
+	minWatchInterval      = 20 * time.Second
+	defaultWatchLabel     = "fanout:auto"
+	detailHeight          = 13
+	peekLines             = 80
+	defaultLaunchAgent    = "claude"
+	sessionSidebarAt      = 120
+	sessionSidebarWidth   = 26
+	sessionTopHeight      = 3
+	compactWidthAt        = 80
 	// relayoutDebounce coalesces the burst of resize events tmux emits while a
 	// terminal window is being dragged into a single relayout.
 	relayoutDebounce = 150 * time.Millisecond
@@ -40,6 +41,7 @@ type Options struct {
 	Session             string
 	StateInterval       time.Duration
 	GHInterval          time.Duration
+	ActivePaneInterval  time.Duration
 	Watcher             WatcherRunner
 	WatchInterval       time.Duration
 	WatchLabel          string
@@ -67,6 +69,7 @@ type Options struct {
 	Relayout          func() error
 	FocusPane         func(string) error
 	ZoomPane          func(string) error
+	ActivePane        func() (string, error)
 	PaneAlive         func(string) bool
 	ShellPaneAlive    func(paneID, shellKey string) bool
 	CapturePaneOutput func(string, int) (string, error)
@@ -152,9 +155,10 @@ type model struct {
 type keyboardProtocolsEnabledMsg struct{}
 
 type (
-	stateTickMsg time.Time
-	ghTickMsg    time.Time
-	watchTickMsg struct {
+	stateTickMsg  time.Time
+	ghTickMsg     time.Time
+	activeTickMsg time.Time
+	watchTickMsg  struct {
 		at  time.Time
 		gen int
 	}
@@ -163,6 +167,11 @@ type (
 		count    int
 		attached bool
 		err      error
+	}
+	activePaneMsg struct {
+		paneID       string
+		err          error
+		scheduleNext bool
 	}
 	newPanePromptMsg struct {
 		req      LaunchRequest
@@ -253,6 +262,9 @@ func normalizeOptions(opts Options) Options {
 	if opts.GHInterval <= 0 {
 		opts.GHInterval = defaultGHInterval
 	}
+	if opts.ActivePaneInterval <= 0 {
+		opts.ActivePaneInterval = defaultActiveInterval
+	}
 	if opts.Watcher != nil {
 		if opts.WatchInterval <= 0 {
 			opts.WatchInterval = defaultWatchInterval
@@ -335,7 +347,7 @@ func (m model) Init() tea.Cmd {
 		}
 		return tea.Sequence(m.enableKeyboardProtocolsCmd(), loadFiles)
 	}
-	loads := tea.Batch(m.loadStateCmd(true), m.loadGHCmd(true))
+	loads := tea.Batch(m.loadStateCmd(true), m.loadGHCmd(true), m.activePaneTickCmd())
 	if m.opts.Watcher == nil {
 		return tea.Sequence(m.enableKeyboardProtocolsCmd(), loads)
 	}

--- a/internal/ui/tui/tui_test.go
+++ b/internal/ui/tui/tui_test.go
@@ -427,6 +427,93 @@ func TestSessionJumpUsesFilteredVisibleRows(t *testing.T) {
 	}
 }
 
+func TestActivePaneMessageSyncsCursorAndPeek(t *testing.T) {
+	var captured string
+	m := newModel(Options{
+		CapturePaneOutput: func(paneID string, _ int) (string, error) {
+			captured = paneID
+			return "latest output", nil
+		},
+	})
+	m.allPanes = []paneView{
+		{Parent: "100", IssueNum: 101, Name: "one", PaneID: "%1", TmuxState: "live"},
+		{Parent: "100", IssueNum: 102, Name: "two", PaneID: "%2", TmuxState: "live"},
+	}
+	m.refreshRows()
+
+	updated, cmd := m.Update(activePaneMsg{paneID: "%2"})
+	m = updated.(model)
+
+	if got := m.table.Cursor(); got != 1 {
+		t.Fatalf("cursor after active pane sync = %d, want 1", got)
+	}
+	if cmd == nil {
+		t.Fatal("active pane sync returned nil command, want peek refresh")
+	}
+	msg, ok := cmd().(panePeekLoadedMsg)
+	if !ok {
+		t.Fatalf("active pane sync command = %T, want panePeekLoadedMsg", msg)
+	}
+	if msg.paneID != "%2" || captured != "%2" {
+		t.Fatalf("peek pane = msg %q captured %q, want %%2", msg.paneID, captured)
+	}
+}
+
+func TestActivePaneMessageIgnoresUnselectableRows(t *testing.T) {
+	tests := []struct {
+		name   string
+		panes  []paneView
+		filter string
+		active string
+	}{
+		{
+			name: "filtered out pane",
+			panes: []paneView{
+				{IssueNum: 1, Name: "visible", PaneID: "%1", TmuxState: "live"},
+				{IssueNum: 2, Name: "hidden", PaneID: "%2", TmuxState: "live"},
+			},
+			filter: "visible",
+			active: "%2",
+		},
+		{
+			name: "stale pane",
+			panes: []paneView{
+				{IssueNum: 1, Name: "live", PaneID: "%1", TmuxState: "live"},
+				{IssueNum: 2, Name: "stale", PaneID: "%2", TmuxState: "stale"},
+			},
+			active: "%2",
+		},
+		{
+			name: "unrecorded pane",
+			panes: []paneView{
+				{IssueNum: 1, Name: "live", PaneID: "%1", TmuxState: "live"},
+			},
+			active: "%9",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := newModel(Options{CapturePaneOutput: func(string, int) (string, error) {
+				t.Fatal("CapturePaneOutput should not run when cursor does not move")
+				return "", nil
+			}})
+			m.allPanes = tt.panes
+			m.filterQuery = tt.filter
+			m.refreshRows()
+
+			updated, cmd := m.Update(activePaneMsg{paneID: tt.active})
+			m = updated.(model)
+
+			if got := m.table.Cursor(); got != 0 {
+				t.Fatalf("cursor after ignored active pane = %d, want 0", got)
+			}
+			if cmd != nil {
+				t.Fatalf("active pane sync command = %T, want nil", cmd)
+			}
+		})
+	}
+}
+
 func TestNarrowShortLayoutCollapsesTopStrip(t *testing.T) {
 	m := newModel(Options{})
 	m.width = 90

--- a/internal/ui/tui/update.go
+++ b/internal/ui/tui/update.go
@@ -245,6 +245,17 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.loadStateCmd(true)
 	case ghTickMsg:
 		return m, m.loadGHCmd(true)
+	case activeTickMsg:
+		return m, m.loadActivePaneCmd(true)
+	case activePaneMsg:
+		var peekCmd tea.Cmd
+		if msg.err == nil && m.syncCursorToActivePane(msg.paneID) {
+			peekCmd = m.peekSelectedCmd(false)
+		}
+		if msg.scheduleNext {
+			return m, tea.Batch(m.activePaneTickCmd(), peekCmd)
+		}
+		return m, peekCmd
 	case watchTickMsg:
 		if msg.gen != m.watchTickGen {
 			return m, nil

--- a/site/content/docs/monitoring.ja.md
+++ b/site/content/docs/monitoring.ja.md
@@ -31,6 +31,7 @@ fanout   # start the persistent tmux console
 素のシェルから起動すると fanout 管理の tmux session を作成または attach し、tmux 内から起動すると現在のペインをそのままコンソールにします。
 コンソールは `.fanout/state.json` を読み、記録済みペインの issue と PR の状態を定期更新し、各行の worktree には変更量を `+X/-Y`、未 commit の作業の有無を `dirty` / `clean` で示します。
 `RUN` 列には agent の実行状態がグリフで出て(起動ラッパー由来の `●` running・`✓` done に加え、agent hooks が報告すると `◐` working・`◇` plan・`◆` blocked・`○` idle)、detail panel には同じ値が `run=` として出ます。
+マウスや tmux の `prefix` ペイン移動で記録済みペインへフォーカスすると、TUI の選択行もそのペインに追従します。
 
 {{< diagram "console" >}}
 

--- a/site/content/docs/monitoring.md
+++ b/site/content/docs/monitoring.md
@@ -23,7 +23,7 @@ To watch every pane from your terminal, run `fanout` with no arguments to start 
 fanout   # start the persistent tmux console
 ```
 
-From a plain shell it creates or attaches to fanout's managed tmux session; from inside tmux it turns the current pane into the console. The console reads `.fanout/state.json`, periodically refreshes the issue and PR state of recorded panes, and shows each row's worktree change size as `+X/-Y` and whether it holds uncommitted work as `dirty` / `clean`. The `RUN` column shows the agent's execution state as a glyph — `●` running, `✓` done from the launch wrapper, plus `◐` working, `◇` plan, `◆` blocked, `○` idle when agent hooks report them — and the detail panel shows the same value as `run=`.
+From a plain shell it creates or attaches to fanout's managed tmux session; from inside tmux it turns the current pane into the console. The console reads `.fanout/state.json`, periodically refreshes the issue and PR state of recorded panes, and shows each row's worktree change size as `+X/-Y` and whether it holds uncommitted work as `dirty` / `clean`. The `RUN` column shows the agent's execution state as a glyph — `●` running, `✓` done from the launch wrapper, plus `◐` working, `◇` plan, `◆` blocked, `○` idle when agent hooks report them — and the detail panel shows the same value as `run=`. When you focus a recorded pane with the mouse or tmux `prefix` movement keys, the selected TUI row follows that pane.
 
 {{< diagram "console" >}}
 


### PR DESCRIPTION
## TL;DR

fanout TUI の選択行を、tmux 側で現在フォーカスされている記録済みペインに追従させます。

## 変更内容

- TUI 起動中の console pane と同じ tmux window から active pane を定期取得する `tmuxrun.ActivePaneInWindow` を追加しました。
- TUI に active pane poll を追加し、記録済み live row と一致したときだけ `table.Cursor()` を移動するようにしました。
- filter 外、stale、未記録 pane、TUI 自身は選択同期の対象外にしました。
- README と monitoring docs に、マウス操作や `prefix` のペイン移動で選択行が追従する旨を追記しました。

## 確認

- `go test ./internal/infra/tmuxrun ./internal/ui/tui ./cmd/fanout`
- `make lint`
- `make test`
- `git diff --check`
- post-work-review: `clean=true`, broad reviewer 1 回、findings 0 件

Review effort: 2