### PR TITLE
popup modal の余白と選択記号を改善

### DIFF
--- a/.github/workflows/vuln.yml
+++ b/.github/workflows/vuln.yml
@@ -24,5 +24,6 @@ jobs:
       - uses: actions/setup-go@v6.5.0
         with:
           go-version-file: go.mod
+          check-latest: true
 
       - run: make vuln

--- a/cmd/fanout/tui_popup.go
+++ b/cmd/fanout/tui_popup.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	tuiClosePopupCommand       = "__tui-close-popup"
-	tuiClosePopupMinHeight     = 9
+	tuiClosePopupMinHeight     = 10
 	tuiHelpPopupCommand        = "__tui-help-popup"
 	tuiHelpPopupMinHeight      = 21
 	tuiNewPanePopupCommand     = "__tui-new-pane-popup"

--- a/cmd/fanout/tui_popup.go
+++ b/cmd/fanout/tui_popup.go
@@ -24,9 +24,10 @@ const (
 	tuiClosePopupCommand       = "__tui-close-popup"
 	tuiClosePopupMinHeight     = 9
 	tuiHelpPopupCommand        = "__tui-help-popup"
-	tuiHelpPopupMinHeight      = 20
+	tuiHelpPopupMinHeight      = 21
 	tuiNewPanePopupCommand     = "__tui-new-pane-popup"
 	tuiNewPanePopupMinHeight   = 20
+	tuiNewPanePopupMinWidth    = 54
 	tuiSettingsPopupCommand    = "__tui-settings-popup"
 	tuiSettingsPopupMinHeight  = 18
 	tuiSettingsPopupMinWidth   = 54
@@ -598,7 +599,8 @@ func tuiClosePopupGeometryForClient(size tmuxrun.ClientSize) (tuiClosePopupGeome
 
 func tuiNewPanePopupGeometryForClient(size tmuxrun.ClientSize) (tuiNewPanePopupGeometry, error) {
 	minPopupHeight := tuiNewPanePopupMinHeight + tuiNewPanePopupBorderInset
-	if size.Width < 54 || size.Height < minPopupHeight {
+	minClientWidth := tuiNewPanePopupMinWidth + tuiNewPanePopupBorderInset + 4
+	if size.Width < minClientWidth || size.Height < minPopupHeight {
 		return tuiNewPanePopupGeometry{}, fmt.Errorf("tmux client is too small for the new pane popup: %dx%d", size.Width, size.Height)
 	}
 	popupWidth := min(90, size.Width-4)

--- a/cmd/fanout/tui_popup.go
+++ b/cmd/fanout/tui_popup.go
@@ -24,9 +24,9 @@ const (
 	tuiClosePopupCommand       = "__tui-close-popup"
 	tuiClosePopupMinHeight     = 9
 	tuiHelpPopupCommand        = "__tui-help-popup"
-	tuiHelpPopupMinHeight      = 18
+	tuiHelpPopupMinHeight      = 20
 	tuiNewPanePopupCommand     = "__tui-new-pane-popup"
-	tuiNewPanePopupMinHeight   = 18
+	tuiNewPanePopupMinHeight   = 20
 	tuiSettingsPopupCommand    = "__tui-settings-popup"
 	tuiNewPanePopupBorderInset = 2
 	tuiNewPanePopupResultPoll  = 50 * time.Millisecond
@@ -105,7 +105,7 @@ func cmdTUIHelpPopup(args []string, lg *log.Logger) exitcode.Code {
 	fs := flag.NewFlagSet(tuiHelpPopupCommand, flag.ContinueOnError)
 	fs.SetOutput(lg.Stderr())
 	width := fs.Int("width", 76, "help width")
-	height := fs.Int("height", 18, "help height")
+	height := fs.Int("height", tuiHelpPopupMinHeight, "help height")
 	if err := fs.Parse(args); err != nil {
 		return exitcode.Invocation
 	}

--- a/cmd/fanout/tui_popup.go
+++ b/cmd/fanout/tui_popup.go
@@ -29,6 +29,7 @@ const (
 	tuiNewPanePopupMinHeight   = 20
 	tuiSettingsPopupCommand    = "__tui-settings-popup"
 	tuiSettingsPopupMinHeight  = 18
+	tuiSettingsPopupMinWidth   = 54
 	tuiNewPanePopupBorderInset = 2
 	tuiNewPanePopupResultPoll  = 50 * time.Millisecond
 	tuiNewPanePopupResultWait  = 24 * time.Hour
@@ -614,7 +615,8 @@ func tuiNewPanePopupGeometryForClient(size tmuxrun.ClientSize) (tuiNewPanePopupG
 
 func tuiSettingsPopupGeometryForClient(size tmuxrun.ClientSize) (tuiNewPanePopupGeometry, error) {
 	minPopupHeight := tuiSettingsPopupMinHeight + tuiNewPanePopupBorderInset
-	if size.Width < 54 || size.Height < minPopupHeight {
+	minClientWidth := tuiSettingsPopupMinWidth + tuiNewPanePopupBorderInset + 4
+	if size.Width < minClientWidth || size.Height < minPopupHeight {
 		return tuiNewPanePopupGeometry{}, fmt.Errorf("tmux client is too small for the settings popup: %dx%d", size.Width, size.Height)
 	}
 	popupWidth := min(90, size.Width-4)

--- a/cmd/fanout/tui_popup.go
+++ b/cmd/fanout/tui_popup.go
@@ -28,6 +28,7 @@ const (
 	tuiNewPanePopupCommand     = "__tui-new-pane-popup"
 	tuiNewPanePopupMinHeight   = 20
 	tuiSettingsPopupCommand    = "__tui-settings-popup"
+	tuiSettingsPopupMinHeight  = 18
 	tuiNewPanePopupBorderInset = 2
 	tuiNewPanePopupResultPoll  = 50 * time.Millisecond
 	tuiNewPanePopupResultWait  = 24 * time.Hour
@@ -461,7 +462,7 @@ func newTUISettingsPopupFunc(projectRoot, commandName string) fanouttui.Settings
 		if err != nil {
 			return fanouttui.SettingsPopupResult{}, false, err
 		}
-		geometry, err := tuiNewPanePopupGeometryForClient(size)
+		geometry, err := tuiSettingsPopupGeometryForClient(size)
 		if err != nil {
 			return fanouttui.SettingsPopupResult{}, false, err
 		}
@@ -603,6 +604,22 @@ func tuiNewPanePopupGeometryForClient(size tmuxrun.ClientSize) (tuiNewPanePopupG
 	targetPopupHeight := min(int(math.Floor(float64(size.Height)*0.8)), size.Height-2)
 	popupHeight := max(targetPopupHeight, minPopupHeight)
 	// Bordered tmux display-popup subtracts the frame from the child pty.
+	return tuiNewPanePopupGeometry{
+		PopupWidth:   popupWidth,
+		PopupHeight:  popupHeight,
+		PromptWidth:  popupWidth - tuiNewPanePopupBorderInset,
+		PromptHeight: popupHeight - tuiNewPanePopupBorderInset,
+	}, nil
+}
+
+func tuiSettingsPopupGeometryForClient(size tmuxrun.ClientSize) (tuiNewPanePopupGeometry, error) {
+	minPopupHeight := tuiSettingsPopupMinHeight + tuiNewPanePopupBorderInset
+	if size.Width < 54 || size.Height < minPopupHeight {
+		return tuiNewPanePopupGeometry{}, fmt.Errorf("tmux client is too small for the settings popup: %dx%d", size.Width, size.Height)
+	}
+	popupWidth := min(90, size.Width-4)
+	targetPopupHeight := min(int(math.Floor(float64(size.Height)*0.8)), size.Height-2)
+	popupHeight := max(targetPopupHeight, minPopupHeight)
 	return tuiNewPanePopupGeometry{
 		PopupWidth:   popupWidth,
 		PopupHeight:  popupHeight,

--- a/cmd/fanout/tui_test.go
+++ b/cmd/fanout/tui_test.go
@@ -252,6 +252,21 @@ func TestTUINewPanePopupGeometryUsesClientDimensions(t *testing.T) {
 	}
 }
 
+func TestTUISettingsPopupGeometryUsesSettingsMinimumHeight(t *testing.T) {
+	got, err := tuiSettingsPopupGeometryForClient(tmuxrun.ClientSize{Width: 80, Height: 20})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := tuiNewPanePopupGeometry{PopupWidth: 76, PopupHeight: 20, PromptWidth: 74, PromptHeight: 18}
+	if got != want {
+		t.Fatalf("80x20 settings popup geometry = %#v, want %#v", got, want)
+	}
+
+	if _, err := tuiSettingsPopupGeometryForClient(tmuxrun.ClientSize{Width: 80, Height: 19}); err == nil {
+		t.Fatal("tuiSettingsPopupGeometryForClient() succeeded without enough settings height")
+	}
+}
+
 func TestTUIHelpPopupGeometryUsesClientDimensions(t *testing.T) {
 	got, err := tuiHelpPopupGeometryForClient(tmuxrun.ClientSize{Width: 160, Height: 50})
 	if err != nil {

--- a/cmd/fanout/tui_test.go
+++ b/cmd/fanout/tui_test.go
@@ -335,16 +335,16 @@ func TestTUIClosePopupGeometryUsesClientDimensions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want = tuiClosePopupGeometry{PopupWidth: 76, PopupHeight: 11, ContentWidth: 74, ContentHeight: 9}
+	want = tuiClosePopupGeometry{PopupWidth: 76, PopupHeight: 12, ContentWidth: 74, ContentHeight: 10}
 	if got != want {
 		t.Fatalf("80x24 close popup geometry = %#v, want %#v", got, want)
 	}
 
-	got, err = tuiClosePopupGeometryForClient(tmuxrun.ClientSize{Width: 80, Height: 11})
+	got, err = tuiClosePopupGeometryForClient(tmuxrun.ClientSize{Width: 80, Height: 12})
 	if err != nil {
 		t.Fatal(err)
 	}
-	want = tuiClosePopupGeometry{PopupWidth: 76, PopupHeight: 11, ContentWidth: 74, ContentHeight: 9}
+	want = tuiClosePopupGeometry{PopupWidth: 76, PopupHeight: 12, ContentWidth: 74, ContentHeight: 10}
 	if got != want {
 		t.Fatalf("small client close popup geometry = %#v, want %#v", got, want)
 	}
@@ -352,7 +352,7 @@ func TestTUIClosePopupGeometryUsesClientDimensions(t *testing.T) {
 	if _, err := tuiClosePopupGeometryForClient(tmuxrun.ClientSize{Width: 40, Height: 20}); err == nil {
 		t.Fatal("tuiClosePopupGeometryForClient() succeeded for too-small client")
 	}
-	if _, err := tuiClosePopupGeometryForClient(tmuxrun.ClientSize{Width: 80, Height: 10}); err == nil {
+	if _, err := tuiClosePopupGeometryForClient(tmuxrun.ClientSize{Width: 80, Height: 11}); err == nil {
 		t.Fatal("tuiClosePopupGeometryForClient() succeeded without enough close popup height")
 	}
 }

--- a/cmd/fanout/tui_test.go
+++ b/cmd/fanout/tui_test.go
@@ -240,6 +240,18 @@ func TestTUINewPanePopupGeometryUsesClientDimensions(t *testing.T) {
 		t.Fatalf("80x24 popup geometry = %#v, want %#v", got, want)
 	}
 
+	got, err = tuiNewPanePopupGeometryForClient(tmuxrun.ClientSize{Width: 60, Height: 22})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want = tuiNewPanePopupGeometry{PopupWidth: 56, PopupHeight: 22, PromptWidth: 54, PromptHeight: 20}
+	if got != want {
+		t.Fatalf("60x22 popup geometry = %#v, want %#v", got, want)
+	}
+	if _, widthErr := tuiNewPanePopupGeometryForClient(tmuxrun.ClientSize{Width: 59, Height: 22}); widthErr == nil {
+		t.Fatal("tuiNewPanePopupGeometryForClient() succeeded without enough prompt width")
+	}
+
 	if _, err := tuiNewPanePopupGeometryForClient(tmuxrun.ClientSize{Width: 80, Height: 20}); err == nil {
 		t.Fatal("tuiNewPanePopupGeometryForClient() succeeded without enough prompt height")
 	}
@@ -293,11 +305,14 @@ func TestTUIHelpPopupGeometryUsesClientDimensions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want = tuiHelpPopupGeometry{PopupWidth: 76, PopupHeight: 22, ContentWidth: 74, ContentHeight: 20}
+	want = tuiHelpPopupGeometry{PopupWidth: 76, PopupHeight: 23, ContentWidth: 74, ContentHeight: 21}
 	if got != want {
 		t.Fatalf("80x24 help popup geometry = %#v, want %#v", got, want)
 	}
 
+	if _, heightErr := tuiHelpPopupGeometryForClient(tmuxrun.ClientSize{Width: 80, Height: 22}); heightErr == nil {
+		t.Fatal("tuiHelpPopupGeometryForClient() succeeded without enough help height")
+	}
 	if _, err := tuiHelpPopupGeometryForClient(tmuxrun.ClientSize{Width: 40, Height: 20}); err == nil {
 		t.Fatal("tuiHelpPopupGeometryForClient() succeeded for too-small client")
 	}

--- a/cmd/fanout/tui_test.go
+++ b/cmd/fanout/tui_test.go
@@ -262,8 +262,20 @@ func TestTUISettingsPopupGeometryUsesSettingsMinimumHeight(t *testing.T) {
 		t.Fatalf("80x20 settings popup geometry = %#v, want %#v", got, want)
 	}
 
-	if _, err := tuiSettingsPopupGeometryForClient(tmuxrun.ClientSize{Width: 80, Height: 19}); err == nil {
+	if _, heightErr := tuiSettingsPopupGeometryForClient(tmuxrun.ClientSize{Width: 80, Height: 19}); heightErr == nil {
 		t.Fatal("tuiSettingsPopupGeometryForClient() succeeded without enough settings height")
+	}
+
+	got, err = tuiSettingsPopupGeometryForClient(tmuxrun.ClientSize{Width: 60, Height: 20})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want = tuiNewPanePopupGeometry{PopupWidth: 56, PopupHeight: 20, PromptWidth: 54, PromptHeight: 18}
+	if got != want {
+		t.Fatalf("60x20 settings popup geometry = %#v, want %#v", got, want)
+	}
+	if _, widthErr := tuiSettingsPopupGeometryForClient(tmuxrun.ClientSize{Width: 59, Height: 20}); widthErr == nil {
+		t.Fatal("tuiSettingsPopupGeometryForClient() succeeded without enough settings width")
 	}
 }
 

--- a/cmd/fanout/tui_test.go
+++ b/cmd/fanout/tui_test.go
@@ -235,18 +235,13 @@ func TestTUINewPanePopupGeometryUsesClientDimensions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want = tuiNewPanePopupGeometry{PopupWidth: 76, PopupHeight: 20, PromptWidth: 74, PromptHeight: 18}
+	want = tuiNewPanePopupGeometry{PopupWidth: 76, PopupHeight: 22, PromptWidth: 74, PromptHeight: 20}
 	if got != want {
 		t.Fatalf("80x24 popup geometry = %#v, want %#v", got, want)
 	}
 
-	got, err = tuiNewPanePopupGeometryForClient(tmuxrun.ClientSize{Width: 80, Height: 20})
-	if err != nil {
-		t.Fatal(err)
-	}
-	want = tuiNewPanePopupGeometry{PopupWidth: 76, PopupHeight: 20, PromptWidth: 74, PromptHeight: 18}
-	if got != want {
-		t.Fatalf("small client popup geometry = %#v, want %#v", got, want)
+	if _, err := tuiNewPanePopupGeometryForClient(tmuxrun.ClientSize{Width: 80, Height: 20}); err == nil {
+		t.Fatal("tuiNewPanePopupGeometryForClient() succeeded without enough prompt height")
 	}
 
 	if _, err := tuiNewPanePopupGeometryForClient(tmuxrun.ClientSize{Width: 40, Height: 20}); err == nil {
@@ -271,7 +266,7 @@ func TestTUIHelpPopupGeometryUsesClientDimensions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	want = tuiHelpPopupGeometry{PopupWidth: 76, PopupHeight: 20, ContentWidth: 74, ContentHeight: 18}
+	want = tuiHelpPopupGeometry{PopupWidth: 76, PopupHeight: 22, ContentWidth: 74, ContentHeight: 20}
 	if got != want {
 		t.Fatalf("80x24 help popup geometry = %#v, want %#v", got, want)
 	}

--- a/internal/ui/tui/close_choice.go
+++ b/internal/ui/tui/close_choice.go
@@ -106,13 +106,13 @@ func (m model) closeChoiceView() string {
 	}
 	lines = append(lines, fmt.Sprintf("Close %s?", label))
 	for i, opt := range closeOptions() {
-		marker := " "
+		marker := plainItemMarker
 		style := lipgloss.NewStyle()
 		if i == optionIndex {
-			marker = ">"
+			marker = selectedItemMarker
 			style = titleStyle
 		}
-		lines = append(lines, style.Render(fmt.Sprintf("%s %d. %s - %s", marker, i+1, opt.label, opt.description)))
+		lines = append(lines, style.Render(fmt.Sprintf("%s%d. %s - %s", marker, i+1, opt.label, opt.description)))
 	}
 	lines = append(lines, dimStyle.Render("up/down or 1-3 select, enter confirm, esc cancel"))
 	content := strings.Join(lines, "\n")

--- a/internal/ui/tui/help.go
+++ b/internal/ui/tui/help.go
@@ -33,7 +33,7 @@ func RunHelpPopup(opts HelpPopupOptions) error {
 	}
 	height := opts.Height
 	if height <= 0 {
-		height = 20
+		height = 21
 	}
 	m := newModel(Options{})
 	m.helpOnly = true

--- a/internal/ui/tui/help.go
+++ b/internal/ui/tui/help.go
@@ -33,7 +33,7 @@ func RunHelpPopup(opts HelpPopupOptions) error {
 	}
 	height := opts.Height
 	if height <= 0 {
-		height = 18
+		height = 20
 	}
 	m := newModel(Options{})
 	m.helpOnly = true

--- a/internal/ui/tui/newpane.go
+++ b/internal/ui/tui/newpane.go
@@ -354,16 +354,32 @@ func newNewPaneForm(defaultAgent string, width int) newPaneForm {
 }
 
 func (m *model) fitNewPanePromptHeight() {
-	if !m.promptOnly || m.height <= 0 || m.newPane.mode != newPaneModePrompt {
+	if m.height <= 0 || m.newPane.mode != newPaneModePrompt {
 		return
 	}
-	available := popupContentAvailableHeight(m.height)
+	available := m.newPaneContentAvailableHeight()
 	overhead := m.newPanePromptFixedOverhead() + m.newPaneCompletionPopupHeight()
 	m.newPane.prompt.SetHeight(clampInt(available-overhead, newPanePromptMinRows, newPanePromptDefaultRows))
 }
 
+func (m model) newPaneContentAvailableHeight() int {
+	if m.height <= 0 {
+		return m.height
+	}
+	if m.promptOnly {
+		return popupContentAvailableHeight(m.height)
+	}
+	// modalStyle adds one-cell padding plus a border on the top and bottom.
+	return max(m.height-4, 0)
+}
+
 func (m model) newPanePromptFixedOverhead() int {
 	overhead := 10
+	if !m.promptOnly {
+		// The in-process fallback keeps the title as its own section, followed
+		// by the blank section separator.
+		overhead += 2
+	}
 	if len(m.availableNewPaneModes()) > 1 {
 		overhead += 3
 	}

--- a/internal/ui/tui/newpane.go
+++ b/internal/ui/tui/newpane.go
@@ -374,6 +374,11 @@ func (m *model) fitNewPanePromptHeight() {
 	m.newPane.prompt.SetHeight(clampInt(available-overhead, newPanePromptMinRows, newPanePromptDefaultRows))
 }
 
+func (m *model) setNewPaneErr(err string) {
+	m.newPane.err = err
+	m.fitNewPanePromptHeight()
+}
+
 func (m model) updateNewPane(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if m.newPane.launching {
 		if msg.String() == "ctrl+c" {
@@ -630,24 +635,25 @@ func (m *model) submitNewPane() tea.Cmd {
 	}
 	prompt := strings.TrimSpace(m.newPane.prompt.Value())
 	if prompt == "" {
-		m.newPane.err = "prompt is required"
+		m.setNewPaneErr("prompt is required")
 		return nil
 	}
 	agents := m.selectedNewPaneAgents()
 	if len(agents) == 0 {
-		m.newPane.err = "select at least one agent"
+		m.setNewPaneErr("select at least one agent")
 		return nil
 	}
 	if m.newPane.planFanout && len(agents) != 1 {
-		m.newPane.err = "plan fan-out launches one coordinator agent; select exactly one"
+		m.setNewPaneErr("plan fan-out launches one coordinator agent; select exactly one")
 		return nil
 	}
-	m.newPane.err = ""
+	m.setNewPaneErr("")
 	m.newPane.launching = true
+	m.fitNewPanePromptHeight()
 	if m.newPane.attach != nil {
 		if m.opts.LaunchAttach == nil {
-			m.newPane.err = "attach launcher is not configured"
 			m.newPane.launching = false
+			m.setNewPaneErr("attach launcher is not configured")
 			return nil
 		}
 		req := AttachLaunchRequest{
@@ -672,8 +678,8 @@ func (m *model) submitNewPane() tea.Cmd {
 		return tea.Quit
 	}
 	if m.opts.LaunchPane == nil {
-		m.newPane.err = "new pane launcher is not configured"
 		m.newPane.launching = false
+		m.setNewPaneErr("new pane launcher is not configured")
 		return nil
 	}
 	launch := m.opts.LaunchPane

--- a/internal/ui/tui/newpane.go
+++ b/internal/ui/tui/newpane.go
@@ -774,7 +774,7 @@ func (m model) newPaneView() string {
 		footers = append(footers, dimStyle.Render("creating pane..."))
 	}
 	if m.newPane.notice != "" {
-		lines = append(lines, dimStyle.Render(m.newPane.notice))
+		footers = append(footers, dimStyle.Render(m.newPane.notice))
 	}
 	if m.newPane.err != "" {
 		footers = append(footers, errStyle.Render("error: "+m.newPane.err))

--- a/internal/ui/tui/newpane.go
+++ b/internal/ui/tui/newpane.go
@@ -324,7 +324,7 @@ func attachSourceIdentity(pane paneView) (parent string, issueNum int, taskID, l
 func newNewPaneForm(defaultAgent string, width int) newPaneForm {
 	prompt := textarea.New()
 	prompt.Placeholder = "Prompt"
-	prompt.Prompt = "> "
+	prompt.Prompt = ""
 	prompt.ShowLineNumbers = false
 	prompt.CharLimit = 1000
 	prompt.SetWidth(width)
@@ -717,45 +717,54 @@ func (m model) newPaneView() string {
 	}
 	// In the tmux popup the -T frame already shows the title, so drop the
 	// duplicate in-content heading; the in-process fallback keeps it.
-	var lines []string
+	var sections []string
 	if !m.promptOnly {
-		lines = append(lines, titleStyle.Render(title))
+		sections = append(sections, titleStyle.Render(title))
 	}
 	if len(m.availableNewPaneModes()) > 1 {
-		lines = append(lines, m.newPaneFieldView(newPaneFieldMode, "Mode", m.newPaneModeTabsView(), false))
+		sections = append(sections, m.newPaneFieldView(newPaneFieldMode, "Mode", m.newPaneModeTabsView(), false))
 	}
 	switch m.newPane.mode {
 	case newPaneModeIssue:
-		lines = append(lines,
+		sections = append(sections,
 			m.newPaneFieldView(newPaneFieldMain, "Issue", m.pickerView(m.newPane.issuePicker, "no open issues"), true),
 			m.newPaneFieldView(newPaneFieldAgent, "Agent", m.agentSelectorView(), false),
 		)
 	default:
-		lines = append(lines, m.newPaneFieldView(newPaneFieldMain, "Prompt", m.newPane.prompt.View(), true))
+		promptSection := m.newPaneFieldView(newPaneFieldMain, "Prompt", m.newPane.prompt.View(), true)
 		if m.newPane.focus == newPaneFieldMain && m.newPane.completing {
-			lines = append(lines, m.completionPopupView())
+			promptSection += "\n" + m.completionPopupView()
 		}
+		sections = append(sections, promptSection)
 		if m.newPane.attach == nil {
-			lines = append(lines, m.planFanoutCheckboxView())
+			sections = append(sections, m.planFanoutCheckboxView())
 		}
-		lines = append(lines, m.newPaneFieldView(newPaneFieldAgent, "Agent", m.agentSelectorView(), false))
+		sections = append(sections, m.newPaneFieldView(newPaneFieldAgent, "Agent", m.agentSelectorView(), false))
 	}
+	footers := make([]string, 0, 3)
 	if m.newPane.launching {
-		lines = append(lines, dimStyle.Render("creating pane..."))
+		footers = append(footers, dimStyle.Render("creating pane..."))
 	}
 	if m.newPane.notice != "" {
 		lines = append(lines, dimStyle.Render(m.newPane.notice))
 	}
 	if m.newPane.err != "" {
-		lines = append(lines, errStyle.Render("error: "+m.newPane.err))
+		footers = append(footers, errStyle.Render("error: "+m.newPane.err))
 	}
-	lines = append(lines, dimStyle.Render(m.newPaneHint()))
-	return m.renderNewPaneModal(strings.Join(lines, "\n"))
+	footers = append(footers, dimStyle.Render(m.newPaneHint()))
+	content := strings.Join(sections, "\n\n")
+	if len(footers) > 0 {
+		if content != "" {
+			content += "\n"
+		}
+		content += strings.Join(footers, "\n")
+	}
+	return m.renderNewPaneModal(content)
 }
 
 // renderNewPaneModal frames the new-pane content. The tmux popup already draws
-// a border, so promptOnly renders borderless (popupContentStyle) to avoid a
-// double frame; the in-process overlay keeps the modal border.
+// a border, so promptOnly renders borderless with a one-cell content gutter;
+// the in-process overlay keeps the modal border.
 func (m model) renderNewPaneModal(content string) string {
 	if m.promptOnly {
 		return popupContentStyle.Width(m.modalWidth()).Render(content)
@@ -782,9 +791,9 @@ func (m model) newPaneHint() string {
 
 func (m model) newPaneFieldView(field newPaneField, label, value string, boxed bool) string {
 	focused := m.newPane.focus == field
-	marker := "  "
+	marker := plainItemMarker
 	if focused {
-		marker = "> "
+		marker = selectedItemMarker
 	}
 	if boxed {
 		style := inputBoxStyle
@@ -800,9 +809,9 @@ func (m model) newPaneFieldView(field newPaneField, label, value string, boxed b
 // the launch hands the prompt to the fanout-plan skill instead of starting a
 // plain agent pane.
 func (m model) planFanoutCheckboxView() string {
-	marker := "  "
+	marker := plainItemMarker
 	if m.newPane.focus == newPaneFieldPlan {
-		marker = "> "
+		marker = selectedItemMarker
 	}
 	box := "[ ]"
 	if m.newPane.planFanout {
@@ -821,9 +830,9 @@ func (m model) agentSelectorView() string {
 	lines := make([]string, 0, len(launchAgents))
 	for i, agentName := range launchAgents {
 		count := m.newPane.agentCount[agentName]
-		marker := "  "
+		marker := plainItemMarker
 		if m.newPane.focus == newPaneFieldAgent && m.newPane.agentIndex == i {
-			marker = "> "
+			marker = selectedItemMarker
 		}
 		token := fmt.Sprintf("[%d] %s", count, agentName)
 		if count > 0 {
@@ -903,8 +912,8 @@ func (m model) modalWidth() int {
 		return 80
 	}
 	if m.promptOnly {
-		// No modal border in the popup, so the content may use the full pty width
-		// (lipgloss Width excludes the border the popup frame already draws).
+		// No modal border in the popup; popupContentStyle owns the one-cell
+		// gutter inside the pty that tmux display-popup provides.
 		return clampInt(m.width, 40, 106)
 	}
 	return clampInt(m.width-12, 40, 104)

--- a/internal/ui/tui/newpane.go
+++ b/internal/ui/tui/newpane.go
@@ -383,6 +383,7 @@ func (m model) newPanePromptFixedOverhead() int {
 	if len(m.availableNewPaneModes()) > 1 {
 		overhead += 3
 	}
+	overhead += m.newPaneHintRows() - 1
 	if m.newPane.attach != nil {
 		overhead -= 2
 	}
@@ -396,6 +397,23 @@ func (m model) newPanePromptFixedOverhead() int {
 		overhead++
 	}
 	return overhead
+}
+
+func (m model) newPaneHintRows() int {
+	width := m.newPaneHintWrapWidth()
+	if width <= 0 {
+		return 1
+	}
+	return max(lipgloss.Height(lipgloss.NewStyle().Width(width).Render(m.newPaneHint())), 1)
+}
+
+func (m model) newPaneHintWrapWidth() int {
+	width := m.modalWidth()
+	if m.promptOnly {
+		return max(width-2*popupContentPadding, 1)
+	}
+	// modalStyle adds one-cell padding and one border cell on each side.
+	return max(width-4, 1)
 }
 
 func (m *model) setNewPaneNotice(notice string) {

--- a/internal/ui/tui/newpane.go
+++ b/internal/ui/tui/newpane.go
@@ -78,6 +78,11 @@ type NewPanePromptOptions struct {
 
 const newPanePopupOpeningNotice = "opening new pane popup..."
 
+const (
+	newPanePromptDefaultRows = 6
+	newPanePromptMinRows     = 3
+)
+
 // AttachTarget describes the recorded pane/worktree a new agent should share.
 type AttachTarget struct {
 	TargetPath        string
@@ -174,6 +179,7 @@ func (m *model) openNewPaneForm() {
 	m.mode = modeNewPane
 	m.notice = ""
 	m.newPane = newNewPaneForm(m.opts.DefaultAgent, m.inputContentWidth())
+	m.fitNewPanePromptHeight()
 }
 
 // RunNewPanePrompt opens only the new-pane prompt UI and returns the submitted
@@ -295,6 +301,7 @@ func (m *model) openAttachAgentForm() tea.Cmd {
 	m.notice = ""
 	m.newPane = newNewPaneForm(m.opts.DefaultAgent, m.inputContentWidth())
 	m.newPane.attach = &target
+	m.fitNewPanePromptHeight()
 	return m.reloadRepoFilesCmd()
 }
 
@@ -328,7 +335,7 @@ func newNewPaneForm(defaultAgent string, width int) newPaneForm {
 	prompt.ShowLineNumbers = false
 	prompt.CharLimit = 1000
 	prompt.SetWidth(width)
-	prompt.SetHeight(6)
+	prompt.SetHeight(newPanePromptDefaultRows)
 	prompt.KeyMap.InsertNewline = key.NewBinding(
 		key.WithKeys("ctrl+j"),
 		key.WithHelp("ctrl+j", "newline"),
@@ -344,6 +351,27 @@ func newNewPaneForm(defaultAgent string, width int) newPaneForm {
 		agentIndex: defaultAgentIndex(defaultAgent),
 		focus:      newPaneFieldMain,
 	}
+}
+
+func (m *model) fitNewPanePromptHeight() {
+	if !m.promptOnly || m.height <= 0 || m.newPane.mode != newPaneModePrompt {
+		return
+	}
+	available := popupContentAvailableHeight(m.height)
+	overhead := 10
+	if len(m.availableNewPaneModes()) > 1 {
+		overhead += 3
+	}
+	if m.newPane.attach != nil {
+		overhead -= 2
+	}
+	if m.newPane.launching {
+		overhead++
+	}
+	if m.newPane.err != "" {
+		overhead++
+	}
+	m.newPane.prompt.SetHeight(clampInt(available-overhead, newPanePromptMinRows, newPanePromptDefaultRows))
 }
 
 func (m model) updateNewPane(msg tea.KeyMsg) (tea.Model, tea.Cmd) {

--- a/internal/ui/tui/newpane.go
+++ b/internal/ui/tui/newpane.go
@@ -358,6 +358,11 @@ func (m *model) fitNewPanePromptHeight() {
 		return
 	}
 	available := popupContentAvailableHeight(m.height)
+	overhead := m.newPanePromptFixedOverhead() + m.newPaneCompletionPopupHeight()
+	m.newPane.prompt.SetHeight(clampInt(available-overhead, newPanePromptMinRows, newPanePromptDefaultRows))
+}
+
+func (m model) newPanePromptFixedOverhead() int {
 	overhead := 10
 	if len(m.availableNewPaneModes()) > 1 {
 		overhead += 3
@@ -371,7 +376,7 @@ func (m *model) fitNewPanePromptHeight() {
 	if m.newPane.err != "" {
 		overhead++
 	}
-	m.newPane.prompt.SetHeight(clampInt(available-overhead, newPanePromptMinRows, newPanePromptDefaultRows))
+	return overhead
 }
 
 func (m *model) setNewPaneErr(err string) {
@@ -767,7 +772,9 @@ func (m model) newPaneView() string {
 	default:
 		promptSection := m.newPaneFieldView(newPaneFieldMain, "Prompt", m.newPane.prompt.View(), true)
 		if m.newPane.focus == newPaneFieldMain && m.newPane.completing {
-			promptSection += "\n" + m.completionPopupView()
+			if popup := m.completionPopupView(); popup != "" {
+				promptSection += "\n" + popup
+			}
 		}
 		sections = append(sections, promptSection)
 		if m.newPane.attach == nil {

--- a/internal/ui/tui/newpane.go
+++ b/internal/ui/tui/newpane.go
@@ -389,10 +389,18 @@ func (m model) newPanePromptFixedOverhead() int {
 	if m.newPane.launching {
 		overhead++
 	}
+	if m.newPane.notice != "" {
+		overhead++
+	}
 	if m.newPane.err != "" {
 		overhead++
 	}
 	return overhead
+}
+
+func (m *model) setNewPaneNotice(notice string) {
+	m.newPane.notice = notice
+	m.fitNewPanePromptHeight()
 }
 
 func (m *model) setNewPaneErr(err string) {

--- a/internal/ui/tui/newpane_assign.go
+++ b/internal/ui/tui/newpane_assign.go
@@ -250,7 +250,11 @@ func (m model) assignRowWindow() (start, end int) {
 	rows := len(m.newPane.assign.rows)
 	visible := pickerMaxRows
 	if m.height > 0 {
-		visible = clampInt(m.height-assignViewOverhead, 3, pickerMaxRows)
+		height := m.height
+		if m.promptOnly {
+			height = popupContentAvailableHeight(height)
+		}
+		visible = clampInt(height-assignViewOverhead, 3, pickerMaxRows)
 	}
 	if rows <= visible {
 		return 0, rows
@@ -280,9 +284,9 @@ func (m model) newPaneAssignView() string {
 		}
 		for i := start; i < end; i++ {
 			row := a.rows[i]
-			marker := "  "
+			marker := plainItemMarker
 			if i == a.index {
-				marker = "> "
+				marker = selectedItemMarker
 			}
 			agentName := launchAgents[clampInt(row.agentIdx, 0, len(launchAgents)-1)]
 			token := "[" + agentName + "]"

--- a/internal/ui/tui/newpane_complete.go
+++ b/internal/ui/tui/newpane_complete.go
@@ -89,6 +89,7 @@ func (m *model) endCompletion() {
 	m.newPane.compResults = nil
 	m.newPane.compIndex = 0
 	m.newPane.compTotal = 0
+	m.fitNewPanePromptHeight()
 }
 
 // recomputeCompletion re-ranks results for the current query and resets the
@@ -99,6 +100,7 @@ func (m *model) recomputeCompletion() {
 	m.newPane.compResults = results
 	m.newPane.compTotal = total
 	m.newPane.compIndex = 0
+	m.fitNewPanePromptHeight()
 }
 
 func (m *model) moveCompletion(delta int) {
@@ -319,6 +321,10 @@ func entryMatchRank(e fileEntry, q string) int {
 }
 
 func (m model) completionPopupView() string {
+	maxRows := m.newPaneCompletionPopupMaxRows()
+	if maxRows <= 0 {
+		return ""
+	}
 	if !m.repoFilesLoaded {
 		if m.repoFilesErr != "" {
 			return warnStyle.Render("  file list unavailable: " + m.repoFilesErr)
@@ -329,20 +335,70 @@ func (m model) completionPopupView() string {
 		return dimStyle.Render("  no match")
 	}
 	width := m.inputContentWidth()
-	lines := make([]string, 0, len(m.newPane.compResults)+1)
-	for i, p := range m.newPane.compResults {
+	results, start, hidden := m.visibleCompletionResults(maxRows)
+	lines := make([]string, 0, len(results)+1)
+	for i, p := range results {
 		text := truncatePathTail(p, width-2)
-		if i == m.newPane.compIndex {
+		if start+i == m.newPane.compIndex {
 			lines = append(lines, selectedItemMarker+titleStyle.Render(text))
 		} else {
 			lines = append(lines, plainItemMarker+dimStyle.Render(text))
 		}
 	}
-	if m.newPane.compTotal > len(m.newPane.compResults) {
-		more := m.newPane.compTotal - len(m.newPane.compResults)
+	if hidden && len(lines) < maxRows {
+		more := max(m.newPane.compTotal-len(results), 1)
 		lines = append(lines, dimStyle.Render(fmt.Sprintf("  +%d more (type to narrow)", more)))
 	}
 	return strings.Join(lines, "\n")
+}
+
+func (m model) visibleCompletionResults(maxRows int) (results []string, start int, hidden bool) {
+	n := len(m.newPane.compResults)
+	if n == 0 || maxRows <= 0 {
+		return nil, 0, false
+	}
+	slots := min(maxRows, n)
+	if maxRows > 1 && m.newPane.compTotal > maxRows {
+		slots = maxRows - 1
+	}
+	if slots <= 0 {
+		slots = 1
+	}
+	if m.newPane.compIndex >= slots {
+		start = m.newPane.compIndex - slots + 1
+	}
+	if start+slots > n {
+		start = n - slots
+	}
+	if start < 0 {
+		start = 0
+	}
+	end := min(start+slots, n)
+	hidden = start > 0 || end < m.newPane.compTotal
+	return m.newPane.compResults[start:end], start, hidden
+}
+
+func (m model) newPaneCompletionPopupHeight() int {
+	if !m.newPaneCompletionPopupVisible() {
+		return 0
+	}
+	popup := m.completionPopupView()
+	if popup == "" {
+		return 0
+	}
+	return lipgloss.Height(popup)
+}
+
+func (m model) newPaneCompletionPopupMaxRows() int {
+	if !m.newPaneCompletionPopupVisible() || !m.promptOnly || m.height <= 0 {
+		return completionMax + 1
+	}
+	available := popupContentAvailableHeight(m.height)
+	return max(available-m.newPanePromptFixedOverhead()-newPanePromptMinRows, 0)
+}
+
+func (m model) newPaneCompletionPopupVisible() bool {
+	return m.newPane.focus == newPaneFieldMain && m.newPane.mode == newPaneModePrompt && m.newPane.completing
 }
 
 // truncatePathTail keeps the tail (basename side) of a path visible, eliding the

--- a/internal/ui/tui/newpane_complete.go
+++ b/internal/ui/tui/newpane_complete.go
@@ -390,10 +390,10 @@ func (m model) newPaneCompletionPopupHeight() int {
 }
 
 func (m model) newPaneCompletionPopupMaxRows() int {
-	if !m.newPaneCompletionPopupVisible() || !m.promptOnly || m.height <= 0 {
+	if !m.newPaneCompletionPopupVisible() || m.height <= 0 {
 		return completionMax + 1
 	}
-	available := popupContentAvailableHeight(m.height)
+	available := m.newPaneContentAvailableHeight()
 	return max(available-m.newPanePromptFixedOverhead()-newPanePromptMinRows, 0)
 }
 

--- a/internal/ui/tui/newpane_complete.go
+++ b/internal/ui/tui/newpane_complete.go
@@ -333,9 +333,9 @@ func (m model) completionPopupView() string {
 	for i, p := range m.newPane.compResults {
 		text := truncatePathTail(p, width-2)
 		if i == m.newPane.compIndex {
-			lines = append(lines, "> "+titleStyle.Render(text))
+			lines = append(lines, selectedItemMarker+titleStyle.Render(text))
 		} else {
-			lines = append(lines, "  "+dimStyle.Render(text))
+			lines = append(lines, plainItemMarker+dimStyle.Render(text))
 		}
 	}
 	if m.newPane.compTotal > len(m.newPane.compResults) {

--- a/internal/ui/tui/newpane_complete.go
+++ b/internal/ui/tui/newpane_complete.go
@@ -128,11 +128,11 @@ func (m *model) acceptCompletion() {
 	if limit := m.newPane.prompt.CharLimit; limit > 0 {
 		newLength := m.newPane.prompt.Length() - tokenWidth + lipgloss.Width(insertion)
 		if newLength > limit {
-			m.newPane.err = "prompt too long to insert that path"
+			m.setNewPaneErr("prompt too long to insert that path")
 			return
 		}
 	}
-	m.newPane.err = ""
+	m.setNewPaneErr("")
 	for range tokenRunes {
 		m.newPane.prompt, _ = m.newPane.prompt.Update(tea.KeyMsg{Type: tea.KeyBackspace})
 	}

--- a/internal/ui/tui/newpane_complete_test.go
+++ b/internal/ui/tui/newpane_complete_test.go
@@ -479,6 +479,41 @@ func TestPromptCompletionFitsStandardPopupWithModeRow(t *testing.T) {
 	}
 }
 
+func TestPromptCompletionFallbackFitsStandardModalWithModeRow(t *testing.T) {
+	m := newModel(Options{
+		ListOpenIssues: func() ([]IssueListItem, error) {
+			return nil, nil
+		},
+	})
+	m.width = 80
+	m.height = 24
+	m.openNewPaneForm()
+	m.repoFiles = []string{
+		"cmd/main.go",
+		"docs/readme.md",
+		"internal/ui/tui/newpane.go",
+		"internal/ui/tui/newpane_complete.go",
+	}
+	m.repoFileIndex = buildFileIndex(m.repoFiles)
+	m.repoFilesLoaded = true
+
+	m = applyMsg(m, keyRunes("@"))
+
+	if !m.newPane.completing {
+		t.Fatal("expected completion to stay open")
+	}
+	if got := m.newPaneCompletionPopupHeight(); got > 2 {
+		t.Fatalf("completion popup height = %d, want <= 2", got)
+	}
+	view := m.View()
+	if !strings.Contains(view, "+3 more") {
+		t.Fatalf("completion popup should summarize hidden matches:\n%s", view)
+	}
+	if got := lipgloss.Height(view); got > m.height {
+		t.Fatalf("fallback modal height = %d, want <= %d:\n%s", got, m.height, view)
+	}
+}
+
 func TestRepoFilesReloadOnEachFormOpen(t *testing.T) {
 	calls := 0
 	m := newModel(Options{

--- a/internal/ui/tui/newpane_complete_test.go
+++ b/internal/ui/tui/newpane_complete_test.go
@@ -443,6 +443,42 @@ func TestNewPaneViewRendersCompletionPopup(t *testing.T) {
 	}
 }
 
+func TestPromptCompletionFitsStandardPopupWithModeRow(t *testing.T) {
+	m := newModel(Options{
+		ListOpenIssues: func() ([]IssueListItem, error) {
+			return nil, nil
+		},
+	})
+	m.promptOnly = true
+	m.width = 74
+	m.height = 20
+	m.openNewPaneForm()
+	m.repoFiles = []string{
+		"cmd/main.go",
+		"docs/readme.md",
+		"internal/ui/tui/newpane.go",
+		"internal/ui/tui/newpane_complete.go",
+	}
+	m.repoFileIndex = buildFileIndex(m.repoFiles)
+	m.repoFilesLoaded = true
+
+	m = applyMsg(m, keyRunes("@"))
+
+	if !m.newPane.completing {
+		t.Fatal("expected completion to stay open")
+	}
+	if got := m.newPaneCompletionPopupHeight(); got > 2 {
+		t.Fatalf("completion popup height = %d, want <= 2", got)
+	}
+	view := m.View()
+	if !strings.Contains(view, "+3 more") {
+		t.Fatalf("completion popup should summarize hidden matches:\n%s", view)
+	}
+	if got := lipgloss.Height(view); got > m.height {
+		t.Fatalf("popup view height = %d, want <= %d:\n%s", got, m.height, view)
+	}
+}
+
 func TestRepoFilesReloadOnEachFormOpen(t *testing.T) {
 	calls := 0
 	m := newModel(Options{

--- a/internal/ui/tui/newpane_picker.go
+++ b/internal/ui/tui/newpane_picker.go
@@ -92,6 +92,7 @@ func (m *model) cycleNewPaneMode(key string) tea.Cmd {
 	}
 	m.newPane.mode = modes[idx]
 	m.newPane.err = ""
+	m.fitNewPanePromptHeight()
 	return m.ensureModeListLoaded()
 }
 

--- a/internal/ui/tui/newpane_picker.go
+++ b/internal/ui/tui/newpane_picker.go
@@ -145,7 +145,20 @@ func (m model) pickerVisibleRows() int {
 	if m.promptOnly {
 		height = popupContentAvailableHeight(height)
 	}
-	return clampInt(height-pickerFormOverhead, 3, pickerMaxRows)
+	overhead := pickerFormOverhead
+	if !m.promptOnly {
+		// The rendered in-process fallback separates sections with blank lines,
+		// and the standard-width issue hint wraps to two lines, so it needs
+		// less room for issue rows than the borderless tmux popup.
+		overhead += 3
+	}
+	if m.newPane.notice != "" {
+		overhead++
+	}
+	if m.newPane.err != "" {
+		overhead++
+	}
+	return clampInt(height-overhead, 1, pickerMaxRows)
 }
 
 func (m *model) moveActivePicker(delta int) {

--- a/internal/ui/tui/newpane_picker.go
+++ b/internal/ui/tui/newpane_picker.go
@@ -141,7 +141,11 @@ func (m model) pickerVisibleRows() int {
 	if m.height <= 0 {
 		return pickerMaxRows
 	}
-	return clampInt(m.height-pickerFormOverhead, 3, pickerMaxRows)
+	height := m.height
+	if m.promptOnly {
+		height = popupContentAvailableHeight(height)
+	}
+	return clampInt(height-pickerFormOverhead, 3, pickerMaxRows)
 }
 
 func (m *model) moveActivePicker(delta int) {
@@ -424,11 +428,11 @@ func (m model) pickerView(p pickerState, emptyText string) string {
 		text = truncateToWidth(text, width-2)
 		switch {
 		case i == p.index:
-			lines = append(lines, "> "+titleStyle.Render(text))
+			lines = append(lines, selectedItemMarker+titleStyle.Render(text))
 		case item.note != "":
-			lines = append(lines, "  "+dimStyle.Render(text))
+			lines = append(lines, plainItemMarker+dimStyle.Render(text))
 		default:
-			lines = append(lines, "  "+text)
+			lines = append(lines, plainItemMarker+text)
 		}
 	}
 	if end < len(p.results) {

--- a/internal/ui/tui/newpane_picker.go
+++ b/internal/ui/tui/newpane_picker.go
@@ -159,6 +159,9 @@ func (m model) pickerVisibleRows() int {
 	if m.newPane.err != "" {
 		overhead++
 	}
+	if m.newPane.launching {
+		overhead++
+	}
 	return clampInt(height-overhead, 1, pickerMaxRows)
 }
 

--- a/internal/ui/tui/newpane_picker_test.go
+++ b/internal/ui/tui/newpane_picker_test.go
@@ -678,7 +678,7 @@ func TestPickerRowWindowFollowsSelection(t *testing.T) {
 	})
 	m.openNewPaneForm()
 	m.newPane.mode = newPaneModeIssue
-	m.height = 26 // 26-18 overhead = 8 visible rows
+	m.height = 26 // 26-21 overhead = 5 visible rows
 
 	items := make([]IssueListItem, 15)
 	for i := range items {
@@ -692,8 +692,8 @@ func TestPickerRowWindowFollowsSelection(t *testing.T) {
 	if len(p.results) != 15 {
 		t.Fatalf("uncapped results = %d, want all 15", len(p.results))
 	}
-	if start, end := m.pickerRowWindow(*p); start != 0 || end != 8 {
-		t.Fatalf("window at top = [%d,%d), want [0,8)", start, end)
+	if start, end := m.pickerRowWindow(*p); start != 0 || end != 5 {
+		t.Fatalf("window at top = [%d,%d), want [0,5)", start, end)
 	}
 
 	p.index = 12

--- a/internal/ui/tui/newpane_picker_test.go
+++ b/internal/ui/tui/newpane_picker_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 )
 
 func TestRankPickerItems(t *testing.T) {
@@ -830,6 +831,35 @@ func TestIssueModeNormalizesCarriedOverAgentCounts(t *testing.T) {
 	}
 	if got := m.selectedDefaultAgent(); got != "claude" {
 		t.Fatalf("selectedDefaultAgent() = %q, want claude", got)
+	}
+}
+
+func TestPromptModeReturnAfterIssueResizeRefitsPromptHeight(t *testing.T) {
+	m := newModel(Options{
+		ListOpenIssues: func() ([]IssueListItem, error) { return nil, nil },
+	})
+	m.width = 120
+	m.height = 40
+	m.openNewPaneForm()
+	m.newPane.focus = newPaneFieldMode
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRight}) // prompt -> issue
+	m = updated.(model)
+	if m.newPane.mode != newPaneModeIssue {
+		t.Fatalf("mode after first switch = %v, want issue", m.newPane.mode)
+	}
+
+	m.width = 80
+	m.height = 24
+	m.resize()
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRight}) // issue -> prompt
+	m = updated.(model)
+	if m.newPane.mode != newPaneModePrompt {
+		t.Fatalf("mode after return = %v, want prompt", m.newPane.mode)
+	}
+	if got := lipgloss.Height(m.View()); got > m.height {
+		t.Fatalf("prompt return view height = %d, want <= %d:\n%s", got, m.height, m.View())
 	}
 }
 

--- a/internal/ui/tui/settings.go
+++ b/internal/ui/tui/settings.go
@@ -493,9 +493,9 @@ func (m model) settingsView() string {
 }
 
 func (m model) settingsTargetView() string {
-	marker := "  "
+	marker := plainItemMarker
 	if m.settings.cursor == 0 {
-		marker = "> "
+		marker = selectedItemMarker
 	}
 	scope := "User config"
 	if m.settings.scope == fanoutsettings.ConfigScopeRepo {
@@ -505,9 +505,9 @@ func (m model) settingsTargetView() string {
 }
 
 func (m model) settingsRowView(cursor int, row settingsRow) string {
-	marker := "  "
+	marker := plainItemMarker
 	if m.settings.cursor == cursor {
-		marker = "> "
+		marker = selectedItemMarker
 	}
 	value := settingsDisplayValue(row)
 	if m.settings.editing && m.settings.cursor == cursor {
@@ -586,11 +586,15 @@ func (m model) settingsVisibleRows() int {
 	if m.height <= 0 {
 		return len(m.settings.rows)
 	}
+	height := m.height
+	if m.settingsOnly {
+		height = popupContentAvailableHeight(height)
+	}
 	overhead := 7
 	if !m.settingsOnly {
 		overhead++
 	}
-	return clampInt(m.height-overhead, 4, len(m.settings.rows))
+	return clampInt(height-overhead, 4, len(m.settings.rows))
 }
 
 func displayConfigPath(path string) string {

--- a/internal/ui/tui/styles.go
+++ b/internal/ui/tui/styles.go
@@ -26,13 +26,19 @@ var (
 	warnStyle            = lipgloss.NewStyle().Foreground(colorTsuchi)
 	errStyle             = lipgloss.NewStyle().Foreground(colorBeni)
 	panelStyle           = lipgloss.NewStyle().Border(lipgloss.NormalBorder(), true, false, false, false).BorderForeground(colorSuna)
-	modalStyle           = lipgloss.NewStyle().Border(lipgloss.DoubleBorder()).Padding(1, 2).BorderForeground(colorAsagi)
+	modalStyle           = lipgloss.NewStyle().Border(lipgloss.DoubleBorder()).Padding(1, 1).BorderForeground(colorAsagi)
 	// popupContentStyle drops the modal border when the popup runs inside a tmux
-	// display-popup: the popup frame is the only border, so the content only
-	// keeps a 1-column left/right gutter.
-	popupContentStyle = lipgloss.NewStyle().Padding(0, 1)
+	// display-popup: the popup frame is the only border, so the content keeps a
+	// one-cell gutter on every side.
+	popupContentStyle = lipgloss.NewStyle().Padding(popupContentPadding, popupContentPadding)
 	// inputBoxStyle / inputBoxFocusStyle frame the modal's text inputs so the
 	// field bounds are visible; the border color also doubles as a focus cue.
 	inputBoxStyle      = lipgloss.NewStyle().Border(lipgloss.NormalBorder()).BorderForeground(colorSuna)
 	inputBoxFocusStyle = lipgloss.NewStyle().Border(lipgloss.NormalBorder()).BorderForeground(colorAsagi)
+)
+
+const (
+	popupContentPadding = 1
+	selectedItemMarker  = "▶ "
+	plainItemMarker     = "  "
 )

--- a/internal/ui/tui/tui_test.go
+++ b/internal/ui/tui/tui_test.go
@@ -4945,6 +4945,83 @@ func TestNewPanePromptOnlyErrorViewFitsStandardPopupWithModeRow(t *testing.T) {
 	}
 }
 
+func TestNewPaneFallbackPromptViewFitsStandardHeightWithModeRow(t *testing.T) {
+	m := newModel(Options{
+		ListOpenIssues: func() ([]IssueListItem, error) {
+			return nil, nil
+		},
+	})
+	m.width = 80
+	m.height = 24
+	m.openNewPaneForm()
+
+	view := m.newPaneView()
+	if !strings.Contains(view, "New agent pane") {
+		t.Fatalf("fallback view should keep the in-modal title:\n%s", view)
+	}
+	if got := lipgloss.Height(view); got > m.height {
+		t.Fatalf("fallback prompt view height = %d, want <= %d:\n%s", got, m.height, view)
+	}
+}
+
+func TestNewPaneFallbackIssueViewFitsStandardHeightWithModeRow(t *testing.T) {
+	m := newModel(Options{
+		ListOpenIssues: func() ([]IssueListItem, error) {
+			return nil, nil
+		},
+	})
+	m.width = 80
+	m.height = 24
+	m.openNewPaneForm()
+	m.newPane.mode = newPaneModeIssue
+	items := make([]IssueListItem, 12)
+	for i := range items {
+		items[i] = IssueListItem{Number: i + 1, Title: "issue row", HasOpenChildren: true}
+	}
+	p := &m.newPane.issuePicker
+	p.loaded = true
+	p.items = issuePickerItems(items)
+	m.recomputePicker(p)
+
+	view := m.newPaneView()
+	if !strings.Contains(view, "more") {
+		t.Fatalf("fallback issue view should window overflowing rows:\n%s", view)
+	}
+	if got := lipgloss.Height(view); got > m.height {
+		t.Fatalf("fallback issue view height = %d, want <= %d:\n%s", got, m.height, view)
+	}
+}
+
+func TestNewPanePromptOnlyIssueNoticeViewFitsStandardPopup(t *testing.T) {
+	m := newModel(Options{
+		ListOpenIssues: func() ([]IssueListItem, error) {
+			return nil, nil
+		},
+	})
+	m.promptOnly = true
+	m.width = 74
+	m.height = 20
+	m.openNewPaneForm()
+	m.newPane.mode = newPaneModeIssue
+	m.newPane.notice = "opened https://example.test/issues/1"
+	items := make([]IssueListItem, 12)
+	for i := range items {
+		items[i] = IssueListItem{Number: i + 1, Title: "issue row", HasOpenChildren: true}
+	}
+	p := &m.newPane.issuePicker
+	p.loaded = true
+	p.items = issuePickerItems(items)
+	m.recomputePicker(p)
+
+	view := m.View()
+	if !strings.Contains(view, m.newPane.notice) {
+		t.Fatalf("issue popup view missing notice:\n%s", view)
+	}
+	if got := lipgloss.Height(view); got > m.height {
+		t.Fatalf("issue popup notice view height = %d, want <= %d:\n%s", got, m.height, view)
+	}
+}
+
 func TestPopupContentStyleUsesOneCellPadding(t *testing.T) {
 	view := popupContentStyle.Width(8).Render("x")
 	lines := strings.Split(view, "\n")

--- a/internal/ui/tui/tui_test.go
+++ b/internal/ui/tui/tui_test.go
@@ -4992,6 +4992,56 @@ func TestNewPaneFallbackIssueViewFitsStandardHeightWithModeRow(t *testing.T) {
 	}
 }
 
+func TestNewPaneFallbackIssueLaunchingViewFitsStandardHeightWithModeRow(t *testing.T) {
+	m := newModel(Options{
+		ListOpenIssues: func() ([]IssueListItem, error) {
+			return nil, nil
+		},
+	})
+	m.width = 80
+	m.height = 24
+	m.openNewPaneForm()
+	m.newPane.mode = newPaneModeIssue
+	m.newPane.launching = true
+	items := make([]IssueListItem, 12)
+	for i := range items {
+		items[i] = IssueListItem{Number: i + 1, Title: "issue row", HasOpenChildren: true}
+	}
+	p := &m.newPane.issuePicker
+	p.loaded = true
+	p.items = issuePickerItems(items)
+	m.recomputePicker(p)
+
+	view := m.newPaneView()
+	if !strings.Contains(view, "creating pane...") {
+		t.Fatalf("fallback issue launching view missing footer:\n%s", view)
+	}
+	if got := lipgloss.Height(view); got > m.height {
+		t.Fatalf("fallback issue launching view height = %d, want <= %d:\n%s", got, m.height, view)
+	}
+}
+
+func TestNewPanePromptOnlyPromptNoticeViewFitsStandardPopup(t *testing.T) {
+	m := newModel(Options{
+		ListOpenIssues: func() ([]IssueListItem, error) {
+			return nil, nil
+		},
+	})
+	m.promptOnly = true
+	m.width = 74
+	m.height = 20
+	m.openNewPaneForm()
+	m.setNewPaneNotice("opened #42 in browser")
+
+	view := m.View()
+	if !strings.Contains(view, m.newPane.notice) {
+		t.Fatalf("prompt popup view missing notice:\n%s", view)
+	}
+	if got := lipgloss.Height(view); got > m.height {
+		t.Fatalf("prompt popup notice view height = %d, want <= %d:\n%s", got, m.height, view)
+	}
+}
+
 func TestNewPanePromptOnlyIssueNoticeViewFitsStandardPopup(t *testing.T) {
 	m := newModel(Options{
 		ListOpenIssues: func() ([]IssueListItem, error) {

--- a/internal/ui/tui/tui_test.go
+++ b/internal/ui/tui/tui_test.go
@@ -4922,6 +4922,29 @@ func TestNewPanePromptOnlyViewFitsStandardPopupWithModeRow(t *testing.T) {
 	}
 }
 
+func TestNewPanePromptOnlyErrorViewFitsStandardPopupWithModeRow(t *testing.T) {
+	m := newModel(Options{
+		ListOpenIssues: func() ([]IssueListItem, error) {
+			return nil, nil
+		},
+	})
+	m.promptOnly = true
+	m.width = 74
+	m.height = 20
+	m.openNewPaneForm()
+
+	if cmd := m.submitNewPane(); cmd != nil {
+		t.Fatal("submitNewPane returned a command without a prompt")
+	}
+	view := m.View()
+	if !strings.Contains(view, "error: prompt is required") {
+		t.Fatalf("popup view missing prompt error:\n%s", view)
+	}
+	if got := lipgloss.Height(view); got > m.height {
+		t.Fatalf("popup error view height = %d, want <= %d:\n%s", got, m.height, view)
+	}
+}
+
 func TestPopupContentStyleUsesOneCellPadding(t *testing.T) {
 	view := popupContentStyle.Width(8).Render("x")
 	lines := strings.Split(view, "\n")

--- a/internal/ui/tui/tui_test.go
+++ b/internal/ui/tui/tui_test.go
@@ -4902,6 +4902,26 @@ func TestNewPanePromptOnlyViewFillsPopupWithoutModalFrame(t *testing.T) {
 	}
 }
 
+func TestNewPanePromptOnlyViewFitsStandardPopupWithModeRow(t *testing.T) {
+	m := newModel(Options{
+		ListOpenIssues: func() ([]IssueListItem, error) {
+			return nil, nil
+		},
+	})
+	m.promptOnly = true
+	m.width = 74
+	m.height = 20
+	m.openNewPaneForm()
+
+	view := m.View()
+	if !strings.Contains(view, "Mode") {
+		t.Fatalf("popup view should render the mode selector when issue mode is wired:\n%s", view)
+	}
+	if got := lipgloss.Height(view); got > m.height {
+		t.Fatalf("popup view height = %d, want <= %d:\n%s", got, m.height, view)
+	}
+}
+
 func TestPopupContentStyleUsesOneCellPadding(t *testing.T) {
 	view := popupContentStyle.Width(8).Render("x")
 	lines := strings.Split(view, "\n")

--- a/internal/ui/tui/tui_test.go
+++ b/internal/ui/tui/tui_test.go
@@ -5042,6 +5042,27 @@ func TestNewPanePromptOnlyPromptNoticeViewFitsStandardPopup(t *testing.T) {
 	}
 }
 
+func TestNewPanePromptOnlyPromptEnhancedHintFitsMinimumPopup(t *testing.T) {
+	t.Setenv(EnhancedKeysEnv, "")
+	m := newModel(Options{
+		ListOpenIssues: func() ([]IssueListItem, error) {
+			return nil, nil
+		},
+	})
+	m.promptOnly = true
+	m.width = 54
+	m.height = 20
+	m.openNewPaneForm()
+
+	view := m.View()
+	if !strings.Contains(view, "shift+enter/ctrl+j newline") {
+		t.Fatalf("prompt popup view missing enhanced-key hint:\n%s", view)
+	}
+	if got := lipgloss.Height(view); got > m.height {
+		t.Fatalf("prompt popup enhanced hint view height = %d, want <= %d:\n%s", got, m.height, view)
+	}
+}
+
 func TestNewPanePromptOnlyIssueNoticeViewFitsStandardPopup(t *testing.T) {
 	m := newModel(Options{
 		ListOpenIssues: func() ([]IssueListItem, error) {

--- a/internal/ui/tui/tui_test.go
+++ b/internal/ui/tui/tui_test.go
@@ -2743,6 +2743,25 @@ func TestLifecycleClosePopupCancelAndFailure(t *testing.T) {
 	})
 }
 
+func TestCloseChoiceViewUsesTriangleSelectionMarker(t *testing.T) {
+	m := newModel(Options{})
+	m.mode = modeCloseChoice
+	m.pendingAction = &pendingLifecycleAction{
+		action:           actionClose,
+		pane:             paneView{Parent: "84", IssueNum: 101},
+		closeOptionIndex: 0,
+		closeMode:        lifecycle.ClosePaneOnly,
+	}
+
+	view := m.closeChoiceView()
+	if !strings.Contains(view, "▶ 1. Just close pane") {
+		t.Fatalf("close choice view missing selected triangle marker:\n%s", view)
+	}
+	if strings.Contains(view, "> 1.") {
+		t.Fatalf("close choice view should not render the old > marker:\n%s", view)
+	}
+}
+
 func TestLifecycleCloseChoiceSelectsWorktreeAndBranchModes(t *testing.T) {
 	tests := []struct {
 		key  string
@@ -3902,6 +3921,20 @@ func TestSettingsRowMarksForwardedEnvOverride(t *testing.T) {
 	}
 }
 
+func TestSettingsRowUsesTriangleSelectionMarker(t *testing.T) {
+	row := settingsRow{
+		spec:  fanoutsettings.ConfigKey{Key: "watcher", Kind: fanoutsettings.ValueBool},
+		value: fanoutsettings.BoolValue(true),
+	}
+	m := newModel(Options{})
+	m.settings = settingsForm{rows: []settingsRow{row}, cursor: 1}
+
+	view := m.settingsRowView(1, row)
+	if !strings.HasPrefix(view, selectedItemMarker) || strings.HasPrefix(view, "> ") {
+		t.Fatalf("settings selected row marker = %q, want %q", view, selectedItemMarker)
+	}
+}
+
 func TestSettingsSaveBlocksInvalidConfig(t *testing.T) {
 	xdg := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", xdg)
@@ -4710,6 +4743,78 @@ func TestNewPaneViewFramesTextInputs(t *testing.T) {
 	}
 }
 
+func TestNewPaneViewUsesOneCellModalPadding(t *testing.T) {
+	m := newModel(Options{})
+	m.width = 100
+	m.height = 30
+	m.openNewPaneForm()
+
+	view := m.newPaneView()
+	lines := strings.Split(view, "\n")
+	if len(lines) < 3 {
+		t.Fatalf("modal view too short:\n%s", view)
+	}
+	if strings.Trim(strings.Trim(lines[1], "║"), " ") != "" {
+		t.Fatalf("modal should have one blank top padding line:\n%s", view)
+	}
+	for _, line := range lines {
+		if strings.Contains(line, selectedItemMarker+"Prompt") {
+			if !strings.HasPrefix(line, "║ "+selectedItemMarker) || strings.HasPrefix(line, "║  "+selectedItemMarker) {
+				t.Fatalf("modal content should start after one cell of padding:\n%s", view)
+			}
+			return
+		}
+	}
+	t.Fatalf("modal view missing selected prompt line:\n%s", view)
+}
+
+func TestNewPanePromptRemovesTextareaPromptMarker(t *testing.T) {
+	m := newModel(Options{})
+	m.width = 100
+	m.height = 30
+	m.openNewPaneForm()
+
+	view := m.newPaneView()
+	if strings.Contains(view, "> Prompt") || strings.Contains(view, "> ") {
+		t.Fatalf("new pane prompt view should not render the old > marker:\n%s", view)
+	}
+	if !strings.Contains(view, selectedItemMarker+"Prompt") {
+		t.Fatalf("new pane prompt view missing selected marker %q:\n%s", selectedItemMarker, view)
+	}
+}
+
+func TestNewPaneViewSeparatesFormSections(t *testing.T) {
+	m := newModel(Options{})
+	m.width = 100
+	m.height = 30
+	m.openNewPaneForm()
+
+	view := m.newPaneView()
+	lines := strings.Split(view, "\n")
+	promptBoxEnd := -1
+	planLine := -1
+	agentLine := -1
+	for i, line := range lines {
+		switch {
+		case strings.Contains(line, "┘"):
+			promptBoxEnd = i
+		case strings.Contains(line, "decompose via /fanout plan"):
+			planLine = i
+		case strings.Contains(line, "Agent"):
+			agentLine = i
+		}
+	}
+	if promptBoxEnd < 0 || planLine < 0 || agentLine < 0 {
+		t.Fatalf("new pane view missing prompt/plan/agent sections:\n%s", view)
+	}
+	if promptBoxEnd+2 != planLine || strings.Trim(strings.Trim(lines[promptBoxEnd+1], "║"), " ") != "" {
+		t.Fatalf("new pane view should leave one blank line between prompt and plan sections:\n%s", view)
+	}
+	if planLine+2 != agentLine || strings.Trim(strings.Trim(lines[planLine+1], "║"), " ") != "" {
+		t.Fatalf("new pane view should leave one blank line between plan and agent sections:\n%s", view)
+	}
+}
+
 func TestNewPaneLaunchSuccessReturnsToMonitorAndReloadsState(t *testing.T) {
 	m := newModel(Options{})
 	m.openNewPaneForm()
@@ -4775,8 +4880,8 @@ func TestMergeDegradedIssueStatusKeepsWaveOfUnblockedPrevious(t *testing.T) {
 }
 
 // The tmux display-popup already frames the prompt-only popup, so its content
-// must drop the modal border and the duplicate "New agent pane" heading and use
-// the full pty width.
+// must drop the modal border and the duplicate "New agent pane" heading while
+// keeping the popup pty width stable.
 func TestNewPanePromptOnlyViewFillsPopupWithoutModalFrame(t *testing.T) {
 	m := newModel(Options{})
 	m.promptOnly = true
@@ -4794,6 +4899,23 @@ func TestNewPanePromptOnlyViewFillsPopupWithoutModalFrame(t *testing.T) {
 	}
 	if got := lipgloss.Width(view); got != 88 {
 		t.Fatalf("lipgloss.Width(view) = %d, want 88:\n%s", got, view)
+	}
+}
+
+func TestPopupContentStyleUsesOneCellPadding(t *testing.T) {
+	view := popupContentStyle.Width(8).Render("x")
+	lines := strings.Split(view, "\n")
+	if len(lines) != 3 {
+		t.Fatalf("popup content height = %d, want 3:\n%s", len(lines), view)
+	}
+	if strings.TrimSpace(lines[0]) != "" || strings.TrimSpace(lines[2]) != "" {
+		t.Fatalf("popup content should have blank top/bottom padding:\n%s", view)
+	}
+	if !strings.HasPrefix(lines[1], " x") || strings.HasPrefix(lines[1], "  x") {
+		t.Fatalf("popup content should have one leading cell of padding:\n%s", view)
+	}
+	if got := lipgloss.Width(view); got != 8 {
+		t.Fatalf("popup content width = %d, want 8:\n%s", got, view)
 	}
 }
 

--- a/internal/ui/tui/update.go
+++ b/internal/ui/tui/update.go
@@ -308,8 +308,8 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case newPaneIssueOpenedMsg:
 		if msg.err != nil {
 			if m.mode == modeNewPane {
-				m.newPane.notice = ""
-				m.newPane.err = msg.err.Error()
+				m.setNewPaneNotice("")
+				m.setNewPaneErr(msg.err.Error())
 			} else {
 				m.notice = fmt.Sprintf("open issue #%d: %v", msg.issue, msg.err)
 			}
@@ -317,7 +317,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if m.mode == modeNewPane {
 			m.newPane.err = ""
-			m.newPane.notice = fmt.Sprintf("opened #%d in browser", msg.issue)
+			m.setNewPaneNotice(fmt.Sprintf("opened #%d in browser", msg.issue))
 		} else {
 			m.notice = fmt.Sprintf("opened #%d in browser", msg.issue)
 		}

--- a/internal/ui/tui/util.go
+++ b/internal/ui/tui/util.go
@@ -101,3 +101,10 @@ func clampInt(v, low, high int) int {
 	}
 	return v
 }
+
+func popupContentAvailableHeight(height int) int {
+	if height <= 0 {
+		return height
+	}
+	return max(height-2*popupContentPadding, 0)
+}

--- a/internal/ui/tui/view.go
+++ b/internal/ui/tui/view.go
@@ -164,6 +164,7 @@ func (m *model) resize() {
 	}
 	if m.mode == modeNewPane {
 		m.newPane.prompt.SetWidth(m.inputContentWidth())
+		m.fitNewPanePromptHeight()
 	}
 	layout := m.monitorLayout()
 	m.table.SetWidth(layout.MainWidth)


### PR DESCRIPTION
## 概要

- popup/modal の内側余白を 1 文字分に統一
- 新規 Session モーダルの項目間に 1 行分の余白を追加
- prompt mode の textarea 先頭に出ていた `>` を削除
- popup/modal の選択中マーカーを `>` から `▶` に変更
- 標準 80x24 の新規 Session popup で mode 行ありでも収まるよう、prompt 欄の高さを調整

## 確認

- `go test ./internal/ui/tui ./cmd/fanout`
- `XDG_CONFIG_HOME=/private/tmp/fanout-empty-config make test`
- `make lint`
- post-work-review: broad 1 件、verify 1 件、clean
