### PR TITLE
[codex] watcher 有効時の running label 確保を修正

### DIFF
--- a/internal/infra/ghissue/ghissue.go
+++ b/internal/infra/ghissue/ghissue.go
@@ -380,8 +380,10 @@ func (r Runner) EnsureLabel(name string) error {
 		return err
 	}
 	var labels []Label
-	if unmarshalErr := json.Unmarshal(out, &labels); unmarshalErr != nil {
-		return fmt.Errorf("parse gh label list --search %q: %w", name, unmarshalErr)
+	if strings.TrimSpace(string(out)) != "" {
+		if unmarshalErr := json.Unmarshal(out, &labels); unmarshalErr != nil {
+			return fmt.Errorf("parse gh label list --search %q: %w", name, unmarshalErr)
+		}
 	}
 	for _, label := range labels {
 		if strings.EqualFold(strings.TrimSpace(label.Name), strings.TrimSpace(name)) {

--- a/internal/infra/ghissue/ghissue_test.go
+++ b/internal/infra/ghissue/ghissue_test.go
@@ -431,6 +431,32 @@ esac
 	})
 }
 
+func TestEnsureLabelCreatesWhenListOutputEmpty(t *testing.T) {
+	argsPath := installFakeGHScript(t, `
+args="$*"
+printf '%s\n' "$args" >> "$GH_FAKE_ARGS"
+case "$args" in
+"label list --search fanout:running --limit 100 --json name")
+  ;;
+"label create fanout:running")
+  ;;
+*)
+  printf 'unexpected gh args: %s\n' "$args" >&2
+  exit 64
+  ;;
+esac
+`)
+
+	if err := (Runner{}).EnsureLabel("fanout:running"); err != nil {
+		t.Fatal(err)
+	}
+
+	assertFakeGHCommandLines(t, argsPath, []string{
+		"label list --search fanout:running --limit 100 --json name",
+		"label create fanout:running",
+	})
+}
+
 func TestEnsureLabelReturnsParseError(t *testing.T) {
 	installFakeGH(t, `not-json`)
 


### PR DESCRIPTION
## 概要

watcher 有効時の TUI 起動前に実行する running label 確保処理で、`gh label list --search ... --json name` が空出力を返した場合も missing label として扱うようにしました。

## 原因

実際の `gh label list --search fanout:running --limit 100 --json name` は、該当 label が無いと exit 0 かつ 0 byte 出力を返すことがあります。`EnsureLabel` はその出力を常に JSON として parse していたため、`unexpected end of JSON input` になり、watcher 初期化で `fanout` が落ちていました。

## 変更内容

- `EnsureLabel` で空白を除いた出力が空なら label 一覧を空配列相当として扱うように変更
- 非空の不正 JSON は従来どおり parse error として扱う挙動を維持
- 空出力時に `gh label create` へ進む regression test を追加

## 確認

- `go test ./internal/infra/ghissue`
- `go test ./cmd/fanout`
- `make build-go`
- `make test`
- `make lint`
- `FANOUT_WATCHER=1 FANOUT_WATCHER_AGENT=codex FANOUT_WATCHER_INTERVAL_SECONDS=999 ./fanout-go`

post-work-review: clean（broad review 1、findings 0）