### PR TITLE
[codex] Renovate設定を追加

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,104 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":configMigration",
+    "security:minimumReleaseAgeNpm",
+    "schedule:weekly"
+  ],
+  "timezone": "Asia/Tokyo",
+  "enabledManagers": ["gomod", "npm", "nvm", "github-actions", "custom.regex"],
+  "ignoreScripts": true,
+  "prConcurrentLimit": 3,
+  "prHourlyLimit": 1,
+  "dependencyDashboard": true,
+  "dependencyDashboardTitle": "Dependency Dashboard",
+  "osvVulnerabilityAlerts": true,
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "vulnerabilityFixStrategy": "lowest"
+  },
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 8am on monday"]
+  },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update the pinned golangci-lint version",
+      "managerFilePatterns": ["/^\\.golangci-lint-version$/"],
+      "matchStrings": ["(?<currentValue>v\\d+\\.\\d+\\.\\d+)\\s*"],
+      "depNameTemplate": "golangci/golangci-lint",
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "description": "Update the docs-site Hugo version",
+      "managerFilePatterns": ["/^\\.github/workflows/pages\\.yml$/"],
+      "matchStrings": ["HUGO_VERSION: (?<currentValue>\\d+\\.\\d+\\.\\d+)"],
+      "depNameTemplate": "gohugoio/hugo",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.*)$",
+      "versioningTemplate": "semver"
+    },
+    {
+      "customType": "regex",
+      "description": "Update the docs-site Pagefind version",
+      "managerFilePatterns": ["/^\\.github/workflows/pages\\.yml$/"],
+      "matchStrings": ["PAGEFIND_VERSION: (?<currentValue>\\d+\\.\\d+\\.\\d+)"],
+      "depNameTemplate": "Pagefind/pagefind",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.*)$",
+      "versioningTemplate": "semver"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Apply cooldown to public non-npm release datasources",
+      "matchDatasources": ["go", "github-releases", "github-tags", "node-version"],
+      "minimumReleaseAge": "3 days",
+      "minimumReleaseAgeBehaviour": "timestamp-required",
+      "internalChecksFilter": "strict"
+    },
+    {
+      "description": "Keep pnpm/action-setup on v5 until the v6 package_json_file regression is resolved",
+      "matchPackageNames": ["pnpm/action-setup"],
+      "allowedVersions": "/^v?5\\./"
+    },
+    {
+      "description": "Run go mod tidy for Go module updates",
+      "matchManagers": ["gomod"],
+      "postUpdateOptions": ["gomodTidy"]
+    },
+    {
+      "description": "Group non-major Go module updates",
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "Go modules"
+    },
+    {
+      "description": "Group non-major web dependency updates",
+      "matchManagers": ["npm", "nvm"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "web dependencies"
+    },
+    {
+      "description": "Group non-major GitHub Actions updates",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "GitHub Actions"
+    },
+    {
+      "description": "Group non-major docs-site tool updates",
+      "matchPackageNames": ["gohugoio/hugo", "Pagefind/pagefind"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "groupName": "docs-site tools"
+    },
+    {
+      "description": "Require dashboard approval for major updates",
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true
+    }
+  ]
+}

--- a/README.ja.md
+++ b/README.ja.md
@@ -176,7 +176,7 @@ flag を生成します。詳しくは
   引数なしの TUI コンソールは素の shell から起動できます。
 - Project モードは `read:project` の gh スコープが必要です
   (`gh auth refresh -s read:project`)。
-- チェックアウトからビルドする場合は、追加で Go 1.26+、Node.js 24+、pnpm 10+
+- チェックアウトからビルドする場合は、追加で Go 1.26.5+、Node.js 24+、pnpm 10+
   が必要です(curl インストールはビルド済みバイナリを配るのでどちらも不要)。
 
 ## 開発

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ context. See the
   TUI console can start from a plain shell.
 - Project mode needs the `read:project` gh scope
   (`gh auth refresh -s read:project`).
-- Building from a checkout additionally needs Go 1.26+, Node.js 24+, and
+- Building from a checkout additionally needs Go 1.26.5+, Node.js 24+, and
   pnpm 10+ (the curl install ships a prebuilt binary and needs neither).
 
 ## Development

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/butaosuinu/fanout
 
-go 1.26
+go 1.26.5
 
 require (
 	github.com/charmbracelet/bubbles v0.20.0

--- a/site/content/docs/installation.ja.md
+++ b/site/content/docs/installation.ja.md
@@ -85,7 +85,7 @@ make link           # Go 版を $(BINDIR)/fanout として symlink + 連携を s
 make uninstall      # インストール済みのパスを削除
 ```
 
-ビルドには Go ツールチェイン(Go 1.26+)に加えて Node.js 24+ と pnpm 10+ が必要です(`make install` はダッシュボード Web UI を先にビルドして embed するため)。
+ビルドには Go ツールチェイン(Go 1.26.5+)に加えて Node.js 24+ と pnpm 10+ が必要です(`make install` はダッシュボード Web UI を先にビルドして embed するため)。
 curl インストールは prebuilt バイナリを配置するので、Go も Node も要りません。
 
 ## 更新を保つ

--- a/site/content/docs/installation.md
+++ b/site/content/docs/installation.md
@@ -84,7 +84,7 @@ make link           # symlinks the Go binary as $(BINDIR)/fanout + symlinks inte
 make uninstall      # removes installed paths
 ```
 
-Building it needs a Go toolchain (Go 1.26+) plus Node.js 24+ and pnpm 10+ (`make install` builds the dashboard web UI first and embeds it). The curl install ships a prebuilt binary, so it needs neither Go nor Node.
+Building it needs a Go toolchain (Go 1.26.5+) plus Node.js 24+ and pnpm 10+ (`make install` builds the dashboard web UI first and embeds it). The curl install ships a prebuilt binary, so it needs neither Go nor Node.
 
 ## Keeping it updated
 

--- a/tools/reviewrisk/rules.go
+++ b/tools/reviewrisk/rules.go
@@ -7,7 +7,7 @@ var (
 	ruleCmdH       = Rule{ID: "cmd-h-files", Class: ClassH, Source: SourceDocTable, Note: "dispatch・self-exec・launch 配線・state 書き換えを伴う cmd エントリ"}
 	ruleDashboardM = Rule{ID: "dashboard-m-files", Class: ClassM, Source: SourceDocTable, Note: "state/tmux ポーリング・SSE・embed"}
 	ruleTuiA       = Rule{ID: "tui-a-files", Class: ClassA, Source: SourceDocTable, Note: "TUI の View 層(描画・整形)"}
-	ruleWebBundle  = Rule{ID: "extra-web-bundle", Class: ClassH, Source: SourceExtra, Note: "token を扱う埋め込みバンドルの生成系"}
+	ruleWebBundle  = Rule{ID: "extra-web-bundle", Class: ClassH, Source: SourceExtra, Note: "web 依存・埋め込みバンドルの生成系"}
 	ruleWebConfig  = Rule{ID: "extra-web-config", Class: ClassM, Source: SourceExtra, Note: "web ビルド設定"}
 	ruleLintConfig = Rule{ID: "extra-lint-config", Class: ClassM, Source: SourceExtra, Note: "Go lint 設定"}
 	ruleAgentGuide = Rule{ID: "extra-agent-guide", Class: ClassM, Source: SourceExtra, Note: "エージェント作業規約"}
@@ -54,9 +54,10 @@ var fileRules = map[string]Rule{
 	"install.sh": {ID: "extra-install-sh", Class: ClassH, Source: SourceExtra, Note: "curl|sh 配布経路"},
 	"Makefile":   {ID: "extra-makefile", Class: ClassH, Source: SourceExtra, Note: "test・install 定義"},
 
-	"web/package.json":   ruleWebBundle,
-	"web/pnpm-lock.yaml": ruleWebBundle,
-	"web/vite.config.ts": ruleWebBundle,
+	"web/package.json":        ruleWebBundle,
+	"web/pnpm-lock.yaml":      ruleWebBundle,
+	"web/pnpm-workspace.yaml": ruleWebBundle,
+	"web/vite.config.ts":      ruleWebBundle,
 
 	"web/tsconfig.json":  ruleWebConfig,
 	"web/.nvmrc":         ruleWebConfig,

--- a/tools/reviewrisk/rules_test.go
+++ b/tools/reviewrisk/rules_test.go
@@ -66,6 +66,7 @@ func TestClassifyPath(t *testing.T) {
 
 		// --- web ---
 		{name: "web index.html is H", path: "web/index.html", want: ClassH, found: true},
+		{name: "web pnpm workspace config is H", path: "web/pnpm-workspace.yaml", want: ClassH, found: true},
 		{name: "web hooks transport is M", path: "web/src/hooks/useSnapshot.ts", want: ClassM, found: true},
 		{name: "web lib transport is M", path: "web/src/lib/api.ts", want: ClassM, found: true},
 		{name: "web components are A", path: "web/src/components/App.tsx", want: ClassA, found: true},

--- a/web/pnpm-workspace.yaml
+++ b/web/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+packages:
+  - "."
+
+minimumReleaseAge: 4320


### PR DESCRIPTION
## TL;DR

Renovate App 用の repo 設定を追加し、Go / pnpm web / GitHub Actions / docs-site tool / golangci-lint の自動アップデート対象を定義しました。

## 変更内容

- `.github/renovate.json5` を追加し、週次更新、Dependency Dashboard、OSV/GitHub vulnerability fix PR、3日 cooldown、major update の Dashboard 承認を設定しました。
- `pnpm/action-setup` はこの repo で v6 系の回帰が確認されているため、v5 系に制限しました。
- `web/pnpm-workspace.yaml` を追加し、pnpm 側でも新規公開直後の package install を 4320 分抑止します。
- `web/pnpm-workspace.yaml` を review-risk 分類対象へ追加しました。
- CI の govulncheck が検出した Go 標準ライブラリ脆弱性に対応するため、Go directive を `1.26.5` へ更新しました。
- Go 要件のドキュメントを `Go 1.26.5+` に同期しました。

## 確認

- `npx --yes --package renovate -- renovate-config-validator --strict`
- `cd web && pnpm install --frozen-lockfile`
- `make lint-web`
- `make vuln`
- `make lint`
- `make test`
- post-work-review: clean (`fe46199`)
- GitHub Actions: 9 checks passed, docs deploy skipped for PR

Review effort: 2