### PR TITLE
docs: add v0.10.0 changelog entry and bump install pin example

### DIFF
--- a/site/content/docs/changelog.ja.md
+++ b/site/content/docs/changelog.ja.md
@@ -9,6 +9,16 @@ yomi: changelog
 
 リリースのハイライトを新しい順に並べています。各タグには [GitHub release](https://github.com/butaosuinu/fanout/releases) があり、完全なコミット一覧とビルド済みバイナリ（darwin / linux × amd64 / arm64）を含みます。バージョンは git タグから ldflags 経由で埋め込まれます。`fanout --check-update` で自分の版を確認できます。
 
+## v0.10.0 (2026-07-09)
+
+- **Agent-state テレメトリ。** `@fanout_agent_state` 契約を 6 値の語彙(`running` / `working` / `plan` / `blocked` / `idle` / `done`)に拡張しました。起動ラッパーと Codex Plan Mode が状態を発行し、TUI / web の glyph とバッジに反映されます。agent がプランを提示・入力待ち・終了したときにコンソールが通知音を鳴らします。[Monitoring]({{< relref "/docs/monitoring" >}}) を参照。
+- **TUI popup アクション。** settings popup とペインクローズの選択 popup を追加し、いずれもアクティブなペインの隣に表示します。[Monitoring]({{< relref "/docs/monitoring" >}}) を参照。
+- **TUI picker の改善。** picker から issue リンクを直接開けるようにし、コンパクト switcher の選択をフォーカス中のペインと同期させました。[Monitoring]({{< relref "/docs/monitoring" >}}) を参照。
+- **PR review-risk の機械判定。** H/M/A 正典から `review:<level>` を判定する `tools/reviewrisk` を新設しました。ローカルでは `make review-risk` で実行できます。`docs/review-risk.ja.md` を参照。
+- **briefing を `/tmp` の外へ。** 子の briefing を `/tmp` から `.fanout/briefings/` へ移設しました。
+
+[リリースノート →](https://github.com/butaosuinu/fanout/releases/tag/v0.10.0)
+
 ## v0.9.0 (2026-07-06)
 
 - **常駐コンソールの刷新。** 引数なしコンソールに、コンパクトな Session switcher(`v` で切り替え)、`1`–`9` の数字ジャンプ、`Z` zoom、AgentState 列、tmux popup のショートカットヘルプを追加し、再起動時にペインを復元するようにしました。任意のペインから `F11` または `prefix T` で復帰できます。[Monitoring]({{< relref "/docs/monitoring" >}}) を参照。

--- a/site/content/docs/changelog.md
+++ b/site/content/docs/changelog.md
@@ -9,6 +9,16 @@ yomi: changelog
 
 Release highlights, newest first. Every tag also has a [GitHub release](https://github.com/butaosuinu/fanout/releases) with the full commit list and prebuilt binaries (darwin / linux × amd64 / arm64). Versions come from git tags via ldflags — check yours with `fanout --check-update`.
 
+## v0.10.0 (2026-07-09)
+
+- **Agent-state telemetry.** The `@fanout_agent_state` contract expanded to a six-value vocabulary (`running` / `working` / `plan` / `blocked` / `idle` / `done`), emitted by the launch wrapper and Codex Plan Mode and surfaced as TUI / web glyphs and badges. The console now sounds a notification when an agent presents a plan, waits for input, or exits. See [Monitoring]({{< relref "/docs/monitoring" >}}).
+- **TUI popup actions.** Added a settings popup and a pane-close chooser popup, both positioned next to the active pane. See [Monitoring]({{< relref "/docs/monitoring" >}}).
+- **TUI picker refinements.** Open issue links straight from the picker, and keep the compact switcher selection synced with the focused pane. See [Monitoring]({{< relref "/docs/monitoring" >}}).
+- **Automated PR review-risk.** New `tools/reviewrisk` derives a `review:<level>` judgment from the H/M/A canon; run it locally with `make review-risk`. See `docs/review-risk.ja.md`.
+- **Briefings out of `/tmp`.** Child briefings moved from `/tmp` to `.fanout/briefings/`.
+
+[Release notes →](https://github.com/butaosuinu/fanout/releases/tag/v0.10.0)
+
 ## v0.9.0 (2026-07-06)
 
 - **Persistent console overhaul.** The no-argument console gained a compact Session switcher (toggle with `v`), `1`–`9` number jumps, `Z` zoom, an AgentState column, and a tmux-popup shortcut help modal, and it restores its panes on restart. Return to it from any pane with `F11` or the `prefix T` binding. See [Monitoring]({{< relref "/docs/monitoring" >}}).

--- a/site/content/docs/installation.ja.md
+++ b/site/content/docs/installation.ja.md
@@ -32,7 +32,7 @@ curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh |
 
 # 配置先や Release tag を指定
 curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh | BIN_DIR=/usr/local/bin sh
-curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh | FANOUT_VERSION=v0.9.0 sh
+curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh | FANOUT_VERSION=v0.10.0 sh
 ```
 
 `install.sh` は OS/arch を自動判定し、最新 Release(または `FANOUT_VERSION` で指定した tag)から `fanout` バイナリと Claude/Codex 連携ファイルを取得して配置します。

--- a/site/content/docs/installation.md
+++ b/site/content/docs/installation.md
@@ -32,7 +32,7 @@ curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh |
 
 # Custom destination or pinned release tag
 curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh | BIN_DIR=/usr/local/bin sh
-curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh | FANOUT_VERSION=v0.9.0 sh
+curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh | FANOUT_VERSION=v0.10.0 sh
 ```
 
 `install.sh` auto-detects your OS/arch, then fetches and installs the `fanout` binary and the Claude/Codex integration files from the latest Release (or the tag given via `FANOUT_VERSION`).


### PR DESCRIPTION
## What

v0.10.0 リリースに向けた docs 更新。過去リリース(#430 v0.9.0 / #333 v0.8.0)と同じく、changelog エントリ追記 + installation のピン止め例更新を行い、このマージ commit を `v0.10.0` タグの対象にする。

## Changes

- `site/content/docs/changelog.md` / `.ja.md` — `## v0.10.0 (2026-07-09)` エントリを新設(EN/JA ペア同期)。ハイライト: agent-state 6値契約(#409/#413/#408/#446)、TUI popup アクション(#443/#433/#434/#435/#449)、TUI picker 改善(#447/#448)、`tools/reviewrisk`(#432)、briefing 移設(#445)。
- `site/content/docs/installation.md` / `.ja.md` — ピン止め例を `FANOUT_VERSION=v0.9.0` → `v0.10.0`。

## Notes

- コード変更なし。version はタグから ldflags 経由で注入されるためソース編集は不要。
- changelog の通知音の記述は monitoring.md の実挙動(plan/blocked/done でのみ通知)に合わせて表現を調整済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0148Me5Uac3EGMZNTeRLcpuP