### PR TITLE
fix: Prompt Session の PR/CI を Web ダッシュボードへ反映

### DIFF
--- a/internal/app/sessionview/aggregate.go
+++ b/internal/app/sessionview/aggregate.go
@@ -58,9 +58,10 @@ type Collectors struct {
 	// so id-only matching would falsely revive stale rows.
 	LivePanes func() (map[string]LivePaneInfo, error)
 	IssuePRs  func(num int) (issueState string, prs []ghissue.PRRef, err error)
-	// BranchPRs mirrors IssuePRs for issue-less task rows keyed by head branch:
-	// a nil PR slice with nil error is a cache miss, while a non-nil error marks
-	// GitHub degraded.
+	// BranchPRs mirrors IssuePRs for branch-owning issue-less pane rows (for
+	// example plan tasks and @manual Prompt Sessions), keyed by normalized head
+	// branch. A nil PR slice with nil error is a cache miss, while a non-nil
+	// error marks GitHub degraded.
 	BranchPRs func(branch string) ([]ghissue.PRRef, error)
 	// Waves follows the same three-outcome cache contract as IssuePRs, keyed by
 	// parent instead of issue number (the caller closes over the recorded issue
@@ -77,6 +78,17 @@ type Collectors struct {
 	Waves        func(parent string) (WaveGraph, error)
 	WorktreeStat func(path, baseRef string) (WorktreeStat, error)
 	Now          func() time.Time
+}
+
+// BranchPRLookupKey returns the normalized head branch for an issue-less pane
+// that owns its worktree branch. Shell and attached-agent rows reuse another
+// pane's worktree and must not duplicate its PR lookup.
+func BranchPRLookupKey(p state.Pane) (string, bool) {
+	if p.IssueNum > 0 || p.IsShell() || p.IsAttachedAgent() {
+		return "", false
+	}
+	branch := strings.TrimSpace(p.BranchName)
+	return branch, branch != ""
 }
 
 // Build assembles a Snapshot. It never returns an error: a read-only dashboard
@@ -162,8 +174,8 @@ func Build(repo, projectRoot string, c Collectors) Snapshot {
 		return prs
 	}
 	fetchPanePRs := func(p state.Pane) (string, []ghissue.PRRef) {
-		if p.IssueNum <= 0 && strings.TrimSpace(p.TaskID) != "" && strings.TrimSpace(p.BranchName) != "" {
-			return IssueStateUnknown, fetchBranch(p.BranchName)
+		if branch, ok := BranchPRLookupKey(p); ok {
+			return IssueStateUnknown, fetchBranch(branch)
 		}
 		if p.IssueNum <= 0 {
 			return IssueStateUnknown, []ghissue.PRRef{}

--- a/internal/app/sessionview/aggregate_test.go
+++ b/internal/app/sessionview/aggregate_test.go
@@ -810,6 +810,106 @@ func TestBuildPlanModePassthrough(t *testing.T) {
 	}
 }
 
+func TestBranchPRLookupKey(t *testing.T) {
+	tests := []struct {
+		name       string
+		pane       state.Pane
+		wantBranch string
+		wantOK     bool
+	}{
+		{
+			name:       "manual prompt session",
+			pane:       state.Pane{Parent: "@manual", IssueNum: -1, BranchName: "  fanout/manual  "},
+			wantBranch: "fanout/manual",
+			wantOK:     true,
+		},
+		{
+			name:       "plan task",
+			pane:       state.Pane{Parent: "plan:alpha", IssueNum: 0, TaskID: "task-a", BranchName: "fanout/task-a"},
+			wantBranch: "fanout/task-a",
+			wantOK:     true,
+		},
+		{
+			name: "positive issue",
+			pane: state.Pane{IssueNum: 12, BranchName: "fanout/issue-12"},
+		},
+		{
+			name: "empty branch",
+			pane: state.Pane{Parent: "@manual", IssueNum: -1, BranchName: "  "},
+		},
+		{
+			name: "shell",
+			pane: state.Pane{IssueNum: -1, Kind: state.PaneKindShell, BranchName: "fanout/shell"},
+		},
+		{
+			name: "attached agent",
+			pane: state.Pane{IssueNum: -1, Kind: state.PaneKindAttachedAgent, BranchName: "fanout/source"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotBranch, gotOK := BranchPRLookupKey(tt.pane)
+			if gotBranch != tt.wantBranch || gotOK != tt.wantOK {
+				t.Fatalf("BranchPRLookupKey() = %q, %v, want %q, %v", gotBranch, gotOK, tt.wantBranch, tt.wantOK)
+			}
+		})
+	}
+}
+
+func TestBuildManualPromptSessionsUseBranchPRs(t *testing.T) {
+	planMode := pane("@manual", -2, "%1")
+	planMode.TaskID = ""
+	planMode.BranchName = "  fanout/manual-shared  "
+	planMode.CodexPlanMode = true
+	normalMode := pane("@manual", -1, "%2")
+	normalMode.TaskID = ""
+	normalMode.BranchName = "fanout/manual-shared"
+	normalMode.CodexPlanMode = false
+
+	branchCalls := 0
+	c := Collectors{
+		Now:       fixedNow,
+		LoadState: storeOf(normalMode, planMode),
+		LivePanes: livePanesAt(),
+		IssuePRs: func(num int) (string, []ghissue.PRRef, error) {
+			t.Fatalf("IssuePRs(%d) called for @manual row", num)
+			return "", nil, nil
+		},
+		BranchPRs: func(branch string) ([]ghissue.PRRef, error) {
+			branchCalls++
+			if branch != "fanout/manual-shared" {
+				t.Fatalf("BranchPRs branch = %q, want fanout/manual-shared", branch)
+			}
+			return []ghissue.PRRef{{Number: 702, State: "OPEN", CIStatus: " PASS "}}, nil
+		},
+		Waves: wavesNone,
+	}
+
+	snap := Build("o/n", "/root", c)
+	if branchCalls != 1 {
+		t.Fatalf("BranchPRs calls = %d, want one cached call for normalized shared branch", branchCalls)
+	}
+	panes := snap.Sessions[0].Panes
+	if len(panes) != 2 {
+		t.Fatalf("panes = %+v, want two @manual panes", panes)
+	}
+	for _, pv := range panes {
+		if pv.TaskID != "" || pv.IssueState != IssueStateUnknown || len(pv.PRs) != 1 || pv.PRs[0].Number != 702 {
+			t.Fatalf("manual pane should carry branch PR state: %+v", pv)
+		}
+		if pv.CIStatus != "pass" {
+			t.Fatalf("manual pane CIStatus = %q, want pass", pv.CIStatus)
+		}
+		if pv.Derived.PRSummary != "#702 open" || pv.Derived.PrimaryPRNumber != 702 || pv.Derived.PrimaryPRState != "open" || pv.Derived.CI != "pass" {
+			t.Fatalf("manual pane derived PR/CI = %+v", pv.Derived)
+		}
+	}
+	if !panes[0].PlanMode || panes[1].PlanMode {
+		t.Fatalf("PlanMode passthrough = %v,%v, want true,false", panes[0].PlanMode, panes[1].PlanMode)
+	}
+}
+
 func TestBuildTaskIDPaneUsesBranchPRs(t *testing.T) {
 	first := pane("plan:alpha", 0, "%1")
 	first.TaskID = "task-b"
@@ -865,26 +965,40 @@ func TestBuildTaskIDPaneUsesBranchPRs(t *testing.T) {
 	}
 }
 
-func TestBuildTaskIDBranchPRFailureDegradesGitHub(t *testing.T) {
-	task := pane("plan:alpha", 0, "%1")
-	task.TaskID = "task-a"
-	task.BranchName = "fanout/task-a"
-	c := Collectors{
-		Now:       fixedNow,
-		LoadState: storeOf(task),
-		LivePanes: livePanesAt(),
-		BranchPRs: func(branch string) ([]ghissue.PRRef, error) {
-			return nil, errors.New("gh pr list failed")
-		},
-		Waves: wavesNone,
-	}
-	snap := Build("o/n", "/root", c)
-	if !snap.Degraded.GitHub || !strings.Contains(snap.Degraded.Reason, "gh pr list failed") {
-		t.Fatalf("branch PR failure should degrade GitHub, got %+v", snap.Degraded)
-	}
-	pv := snap.Sessions[0].Panes[0]
-	if pv.IssueState != IssueStateUnknown || pv.PRs == nil || len(pv.PRs) != 0 {
-		t.Fatalf("failed task pane = %+v, want UNKNOWN and non-nil empty PRs", pv)
+func TestBuildIssueLessBranchPRFailureDegradesGitHub(t *testing.T) {
+	planTask := pane("plan:alpha", 0, "%1")
+	planTask.TaskID = "task-a"
+	planTask.BranchName = "fanout/task-a"
+	manual := pane("@manual", -1, "%1")
+	manual.TaskID = ""
+	manual.BranchName = "fanout/manual"
+
+	for _, tt := range []struct {
+		name string
+		pane state.Pane
+	}{
+		{name: "plan task", pane: planTask},
+		{name: "manual prompt session", pane: manual},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			c := Collectors{
+				Now:       fixedNow,
+				LoadState: storeOf(tt.pane),
+				LivePanes: livePanesAt(),
+				BranchPRs: func(branch string) ([]ghissue.PRRef, error) {
+					return nil, errors.New("gh pr list failed")
+				},
+				Waves: wavesNone,
+			}
+			snap := Build("o/n", "/root", c)
+			if !snap.Degraded.GitHub || !strings.Contains(snap.Degraded.Reason, "gh pr list failed") {
+				t.Fatalf("branch PR failure should degrade GitHub, got %+v", snap.Degraded)
+			}
+			pv := snap.Sessions[0].Panes[0]
+			if pv.IssueState != IssueStateUnknown || pv.PRs == nil || len(pv.PRs) != 0 {
+				t.Fatalf("failed issue-less pane = %+v, want UNKNOWN and non-nil empty PRs", pv)
+			}
+		})
 	}
 }
 

--- a/internal/app/sessionview/collect.go
+++ b/internal/app/sessionview/collect.go
@@ -272,7 +272,7 @@ func (g GH) IssuePRs(num int) (string, []ghissue.PRRef, error) {
 	return g.runner.IssueWithPRs(g.owner, g.repo, num)
 }
 
-// BranchPRs fetches PR refs by head branch for issue-less task rows.
+// BranchPRs fetches PR refs by head branch for branch-owning issue-less rows.
 func (g GH) BranchPRs(branch string) ([]ghissue.PRRef, error) {
 	return g.runner.PRsForBranch(branch)
 }

--- a/internal/ui/dashboard/poller.go
+++ b/internal/ui/dashboard/poller.go
@@ -271,7 +271,7 @@ func (p *poller) refreshGH() {
 	// hourly GitHub API budget (the exact failure the wave throttle exists
 	// to prevent).
 	p.refreshIssuePRs(gh, distinctIssueNums(store))
-	p.refreshBranchPRs(gh, distinctTaskBranches(store))
+	p.refreshBranchPRs(gh, distinctIssueLessBranches(store))
 	// Phase 2: one wave-graph fetch per distinct normalized parent. The recorded
 	// issue numbers seed FetchWaveGraph's child set for @manual/Project parents
 	// and backfill unlinked children for numeric ones.
@@ -529,12 +529,12 @@ func distinctIssueNums(store state.Store) []int {
 	return nums
 }
 
-func distinctTaskBranches(store state.Store) []string {
+func distinctIssueLessBranches(store state.Store) []string {
 	seen := map[string]bool{}
 	var branches []string
 	for _, p := range store.Panes {
-		branch := strings.TrimSpace(p.BranchName)
-		if p.IssueNum > 0 || p.TaskID == "" || branch == "" {
+		branch, ok := sessionview.BranchPRLookupKey(p)
+		if !ok {
 			continue
 		}
 		if !seen[branch] {

--- a/internal/ui/dashboard/poller_test.go
+++ b/internal/ui/dashboard/poller_test.go
@@ -44,7 +44,7 @@ func (g *countingGH) BranchPRs(branch string) ([]ghissue.PRRef, error) {
 		g.branchCalls = map[string]int{}
 	}
 	g.branchCalls[branch]++
-	return []ghissue.PRRef{{Number: 700, State: "MERGED"}}, nil
+	return []ghissue.PRRef{{Number: 700, State: "MERGED", CIStatus: "pass"}}, nil
 }
 
 func (g *countingGH) Waves(parent string, recordedNums []int) (sessionview.WaveGraph, error) {
@@ -175,6 +175,41 @@ func TestPollerRefreshGHPopulatesBranchCacheAndBuildReadsIt(t *testing.T) {
 	}
 	if snap.Degraded.GitHub {
 		t.Fatal("GitHub should not be degraded on branch PR success")
+	}
+}
+
+func TestPollerRefreshGHPopulatesManualPromptModePRAndCI(t *testing.T) {
+	root := t.TempDir()
+	writeState(t, root, `{"schemaVersion":1,"panes":[
+	  {"parent":"@manual","issueNum":-1,"branchName":"fanout/prompt-session","slug":"prompt-session","paneId":"%1","agent":"codex","codexPlanMode":true}
+	]}`)
+
+	gh := &countingGH{}
+	p := newPoller("o/n", root, gh, nil, newHub())
+	p.refreshGH()
+	snap := p.build()
+
+	if len(gh.calls) != 0 {
+		t.Fatalf("IssuePRs calls = %v, want none for the manual row", gh.calls)
+	}
+	if gh.branchCalls["fanout/prompt-session"] != 1 {
+		t.Fatalf("BranchPRs(fanout/prompt-session) calls = %d, want 1", gh.branchCalls["fanout/prompt-session"])
+	}
+	if len(snap.Sessions) != 1 || len(snap.Sessions[0].Panes) != 1 {
+		t.Fatalf("unexpected snapshot shape: %+v", snap.Sessions)
+	}
+	got := snap.Sessions[0].Panes[0]
+	if got.IssueNum != -1 || got.TaskID != "" || !got.PlanMode {
+		t.Fatalf("manual prompt-mode identity = issue:%d task:%q plan:%v", got.IssueNum, got.TaskID, got.PlanMode)
+	}
+	if len(got.PRs) != 1 || got.PRs[0].Number != 700 || !got.HasMergedPR {
+		t.Fatalf("manual prompt-mode PR state = %+v", got)
+	}
+	if got.CIStatus != "pass" || got.Derived.CI != "pass" || got.Derived.PrimaryPRNumber != 700 {
+		t.Fatalf("manual prompt-mode derived PR/CI = ci:%q derived:%+v", got.CIStatus, got.Derived)
+	}
+	if snap.Degraded.GitHub {
+		t.Fatal("GitHub should not be degraded on manual branch PR success")
 	}
 }
 
@@ -356,18 +391,21 @@ func TestDistinctIssueNumsSkipsSyntheticManualPanes(t *testing.T) {
 	}
 }
 
-func TestDistinctTaskBranchesUsesIssueLessTaskRows(t *testing.T) {
-	got := distinctTaskBranches(state.Store{Panes: []state.Pane{
+func TestDistinctIssueLessBranchesUsesBranchOwners(t *testing.T) {
+	got := distinctIssueLessBranches(state.Store{Panes: []state.Pane{
 		{Parent: "plan:a", IssueNum: 0, TaskID: "task-a", BranchName: " fanout/task-a "},
 		{Parent: "plan:a", IssueNum: 0, TaskID: "task-b", BranchName: "fanout/task-a"},
-		{Parent: "plan:a", IssueNum: 0, TaskID: "task-c", BranchName: "fanout/task-c"},
-		{Parent: "plan:a", IssueNum: 0, TaskID: "", BranchName: "fanout/no-task"},
+		{Parent: "@manual", IssueNum: -1, BranchName: " fanout/manual ", CodexPlanMode: true},
+		{Parent: "@manual", IssueNum: -2, BranchName: "fanout/manual"}, // duplicate
 		{Parent: "100", IssueNum: 101, TaskID: "task-issue", BranchName: "fanout/issue"},
+		{Parent: "@manual", IssueNum: -3, BranchName: ""},
+		{Parent: "@manual", IssueNum: -4, Kind: state.PaneKindShell, BranchName: "fanout/shell"},
+		{Parent: "@manual", IssueNum: -5, Kind: state.PaneKindAttachedAgent, BranchName: "fanout/attached"},
 	}})
 
-	want := []string{"fanout/task-a", "fanout/task-c"}
+	want := []string{"fanout/manual", "fanout/task-a"}
 	if !slices.Equal(got, want) {
-		t.Fatalf("distinctTaskBranches() = %#v, want %#v", got, want)
+		t.Fatalf("distinctIssueLessBranches() = %#v, want %#v", got, want)
 	}
 }
 

--- a/site/content/docs/monitoring.ja.md
+++ b/site/content/docs/monitoring.ja.md
@@ -142,6 +142,7 @@ fanout dashboard --web [--port N] [--open] [--no-token] [--no-keybind]
 
 サーバは `127.0.0.1` にのみバインドして GET 専用の endpoint だけを公開し、起動毎にランダムトークンを生成して URL に埋め込みます(単一ユーザ端末では `--no-token` で外せます)。
 埋め込みの SPA は、フィルタと詳細ドロワー、直近出力の live peek でライブの Session 一覧を見せます。
+Prompt Session の記録済み branch に PR があると、ダッシュボードに PR リンクと CI 状態も表示します。
 
 ### F12 / prefix + D
 

--- a/site/content/docs/monitoring.md
+++ b/site/content/docs/monitoring.md
@@ -114,6 +114,7 @@ fanout dashboard --web [--port N] [--open] [--no-token] [--no-keybind]
 ```
 
 The server binds only to `127.0.0.1` and exposes GET-only endpoints, generating a random token each start and embedding it in the URL (drop it with `--no-token` on a single-user machine). The embedded SPA shows the live Session list with a filter, a detail drawer, and a live peek of recent output.
+The dashboard also shows the PR link and CI status for a Prompt Session when a PR exists for its recorded branch.
 
 ### F12 / prefix + D
 

--- a/web/src/test/app.test.tsx
+++ b/web/src/test/app.test.tsx
@@ -153,6 +153,48 @@ describe("snapshot 描画", () => {
     expect(screen.queryByText("#0")).not.toBeInTheDocument();
   });
 
+  it("Prompt Session は branch に紐づく PR リンクと CI を表示する", async () => {
+    const user = userEvent.setup();
+    server.use(peekHandler(() => "manual output"));
+    render(<App />);
+    streamSnapshot(
+      makeSnapshot([
+        makeSession("@manual", [
+          makePane({
+            issueNum: -1,
+            sourceKey: "manual-prompt",
+            displayName: "Prompt session",
+            slug: "manual-1-prompt-session-pane",
+            agent: "codex",
+            paneId: "%9",
+            branchName: "fanout/manual-1-prompt-session-pane",
+            issueState: "UNKNOWN",
+            prs: [{ number: 701, state: "OPEN", mergedAt: null, ci: "pass" }],
+            ciStatus: "pass",
+          }),
+        ]),
+      ]),
+    );
+
+    const row = screen.getByText("Prompt session").closest("tr")!;
+    expect(within(row).getByText("#-1")).toBeInTheDocument();
+    expect(within(row).queryByRole("link", { name: "#-1" })).not.toBeInTheDocument();
+    expect(row.querySelector('a[href$="/issues/-1"]')).toBeNull();
+    expect(within(row).getByRole("link", { name: "#701 OPEN" })).toHaveAttribute(
+      "href",
+      "https://github.com/octo/fanout/pull/701",
+    );
+    expect(within(row).getByText("pass", { selector: ".tag" })).toBeInTheDocument();
+
+    await user.click(within(row).getByText("Prompt session"));
+    const drawer = await screen.findByRole("complementary", { name: "ペイン詳細" });
+    expect(within(drawer).getByRole("link", { name: "#701 OPEN" })).toHaveAttribute(
+      "href",
+      "https://github.com/octo/fanout/pull/701",
+    );
+    expect(within(drawer).getByText("ci pass", { selector: ".tag" })).toBeInTheDocument();
+  });
+
   it("degraded フラグで banner を表示し、正常時は隠す", () => {
     render(<App />);
     streamSnapshot(makeSnapshot([], { degraded: { tmux: true, github: true } }));


### PR DESCRIPTION
## TL;DR

Prompt mode で起動した manual Session について、記録済みブランチに紐づく PR と CI 状態を Web ダッシュボードへ表示します。

## 変更内容

- issue-less pane のブランチ PR 取得条件を共通化し、Prompt Session と plan task を対象にしました
- Web poller が manual Session のブランチも取得・重複排除するようにしました
- shell、attached-agent、通常の issue 行は既存経路を維持します
- PR リンク、CI 列、詳細ドロワーの回帰テストを追加しました
- 英日 Monitoring ドキュメントを更新しました

## 原因

ブランチベースの PR 取得が `TaskID` を持つ plan task に限定されていたため、`@manual`・負の `IssueNum`・空の `TaskID`・有効な `BranchName` を持つ Prompt Session が、poller と snapshot 組み立ての両方で除外されていました。

## 影響

公開 CLI、state schema、Web API の JSON 形式は変更しません。既存の `prs` / `ciStatus` 表示を再利用します。

## 検証

- `make test`
- `make lint`
- `make lint-web`
- `git diff --check`
- `post-work-review`: clean=true、findings=0

Review effort: 2