### PR TITLE
push 前品質ゲートを agent hooks で強制する (PreToolUse deny + Codex stop gate)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -25,6 +25,23 @@
             "type": "command",
             "command": "\"${CLAUDE_PROJECT_DIR}/.claude/hooks/pre-pr-review-gate.sh\"",
             "timeout": 10
+          },
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR}/scripts/agent-push-gate.sh\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash \"${CLAUDE_PROJECT_DIR}/scripts/agent-format-on-edit.sh\"",
+            "timeout": 30
           }
         ]
       }

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,40 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash scripts/agent-push-gate.sh",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash scripts/agent-format-on-edit.sh",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash scripts/agent-stop-gate.sh",
+            "timeout": 900,
+            "statusMessage": "Running make check (quality gate)"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash scripts/agent-push-gate.sh",
+            "command": "bash \"$(git rev-parse --show-toplevel)/scripts/agent-push-gate.sh\"",
             "timeout": 10
           }
         ]
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash scripts/agent-format-on-edit.sh",
+            "command": "bash \"$(git rev-parse --show-toplevel)/scripts/agent-format-on-edit.sh\"",
             "timeout": 30
           }
         ]
@@ -29,7 +29,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash scripts/agent-stop-gate.sh",
+            "command": "bash \"$(git rev-parse --show-toplevel)/scripts/agent-stop-gate.sh\"",
             "timeout": 900,
             "statusMessage": "Running make check (quality gate)"
           }

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .claude/settings.local.json
-.codex/
+# .codex/ holds machine-local Codex state except the tracked repo hooks
+.codex/*
+!.codex/hooks.json
 .dmux/
 .fanout/
 !.fanout/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,7 +230,9 @@ touching only class-A packages can rely on AI review.
   only a successful `make check` on a clean tree writes (`check-marker`). When
   a push is denied, commit the candidate, run `make check`, then push again;
   never bypass with `--no-verify`. Branch deletions and tag pushes stay
-  ungated. Escape hatch: `FANOUT_SKIP_PUSH_CHECK=1`. Codex additionally runs
+  ungated; `gh pr create` (gh pushes an unpushed branch itself) requires the
+  same marker, and untraceable forms (`bash -c '… git push …'`, `--mirror`)
+  fail closed. Escape hatch: `FANOUT_SKIP_PUSH_CHECK=1`. Codex additionally runs
   `scripts/agent-stop-gate.sh` on `Stop` as a backstop (its PreToolUse
   interception is incomplete upstream): at turn end with a clean, unvalidated
   HEAD it runs `make check` and blocks the stop on failure — the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,6 +223,22 @@ touching only class-A packages can rely on AI review.
   driver, invoked per `codex/skills/post-work-review`) against that final HEAD
   before `gh pr create`. The gate owns `make check`, and its marker is tied to
   the exact commit reviewed, so committing anything afterward invalidates it.
+- `git push` to a branch is gated by `scripts/agent-push-gate.sh`, wired as a
+  `PreToolUse` hook for both agents (`.codex/hooks.json` for Codex,
+  `.claude/settings.json` for Claude Code). The pushed tip must equal the
+  per-worktree marker `$(git rev-parse --git-dir)/fanout-check-passed`, which
+  only a successful `make check` on a clean tree writes (`check-marker`). When
+  a push is denied, commit the candidate, run `make check`, then push again;
+  never bypass with `--no-verify`. Branch deletions and tag pushes stay
+  ungated. Escape hatch: `FANOUT_SKIP_PUSH_CHECK=1`. Codex additionally runs
+  `scripts/agent-stop-gate.sh` on `Stop` as a backstop (its PreToolUse
+  interception is incomplete upstream): at turn end with a clean, unvalidated
+  HEAD it runs `make check` and blocks the stop on failure — the
+  marker makes this free when the push flow was followed. Escape hatch:
+  `FANOUT_SKIP_STOP_GATE=1`. Edits are auto-formatted by
+  `scripts/agent-format-on-edit.sh` (`PostToolUse`, per-file fast paths only).
+  Codex prompts once per checkout path to trust these repo hooks; accept the
+  prompt in a new worktree or the hooks are silently skipped.
 
 ## Documentation Writing
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -264,10 +264,12 @@ stdlib-only imports, so repo-support code stays isolated from the product.
   `$(git rev-parse --git-dir)/fanout-check-passed`, which only a successful
   `make check` on a clean tree writes. When denied, commit the candidate, run
   `make check`, then push again — do not reach for `--no-verify` or retry
-  unchanged. Branch deletions and tag pushes stay ungated. Escape hatch:
-  `FANOUT_SKIP_PUSH_CHECK=1`. Edits are auto-formatted by a `PostToolUse`
-  hook (`scripts/agent-format-on-edit.sh`, per-file `golangci-lint fmt` /
-  `oxfmt` fast paths only).
+  unchanged. Branch deletions and tag pushes stay ungated; `gh pr create`
+  (gh pushes an unpushed branch itself) requires the same marker, and forms
+  the gate cannot trace (`bash -c '… git push …'`, `--mirror`) fail closed.
+  Escape hatch: `FANOUT_SKIP_PUSH_CHECK=1`. Edits are auto-formatted by a
+  `PostToolUse` hook (`scripts/agent-format-on-edit.sh`, per-file
+  `golangci-lint fmt` / `oxfmt` fast paths only).
 
 ## Test Conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -258,6 +258,16 @@ stdlib-only imports, so repo-support code stays isolated from the product.
   `cd`/`pushd`/`env --chdir` chained in (any cwd
   inside the target worktree works), and keep the PR base at the default
   branch. `FANOUT_SKIP_PR_REVIEW=1` is only for the documented escape hatch.
+- `git push` to a branch is gated the same way (`scripts/agent-push-gate.sh`,
+  a second `PreToolUse(Bash)` hook; Codex runs it via `.codex/hooks.json`):
+  the pushed tip must equal the per-worktree marker
+  `$(git rev-parse --git-dir)/fanout-check-passed`, which only a successful
+  `make check` on a clean tree writes. When denied, commit the candidate, run
+  `make check`, then push again — do not reach for `--no-verify` or retry
+  unchanged. Branch deletions and tag pushes stay ungated. Escape hatch:
+  `FANOUT_SKIP_PUSH_CHECK=1`. Edits are auto-formatted by a `PostToolUse`
+  hook (`scripts/agent-format-on-edit.sh`, per-file `golangci-lint fmt` /
+  `oxfmt` fast paths only).
 
 ## Test Conventions
 

--- a/Makefile
+++ b/Makefile
@@ -239,10 +239,12 @@ test: build-web go-test test-web test-tier1 test-tier2
 
 # Serialize even when the caller passes -j: go-test must see build-web's fresh
 # go:embed inputs. One submake also de-duplicates the shared phony prerequisites.
-# check-marker runs last (-j1), so the push-gate marker is only written when
-# every gate goal passed.
+# check-marker is a separate recipe line, not a goal of the same submake: a
+# failed gate line stops the recipe even under `make -k`, so the push-gate
+# marker is only written when every gate goal passed.
 check:
-	+$(MAKE) -j1 --no-print-directory test lint lint-web check-marker
+	+$(MAKE) -j1 --no-print-directory test lint lint-web
+	+$(MAKE) --no-print-directory check-marker
 
 # Internal: records the validated HEAD into the per-worktree marker
 # $(git rev-parse --git-dir)/fanout-check-passed, which scripts/agent-push-gate.sh

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ POST_WORK_REVIEW_BATS := tests/bats/tier1_post_work_review.bats
 POST_WORK_REVIEW_SHARDS := 1 2 3 4 5 6 7 8 9 10 11 12
 POST_WORK_REVIEW_SHARD_TARGETS := $(addprefix test-tier1-post-work-review-shard-,$(POST_WORK_REVIEW_SHARDS))
 
-.PHONY: install link uninstall build-go build-web clean-go clean-web install-integrations link-integrations uninstall-integrations go-test test test-web test-tier1 test-tier2 check lint lint-go lint-shell lint-web fmt fmt-web fix vuln check-bats review-risk prepare-dev-cache $(POST_WORK_REVIEW_SHARD_TARGETS)
+.PHONY: install link uninstall build-go build-web clean-go clean-web install-integrations link-integrations uninstall-integrations go-test test test-web test-tier1 test-tier2 check check-marker lint lint-go lint-shell lint-web fmt fmt-web fix vuln check-bats review-risk prepare-dev-cache $(POST_WORK_REVIEW_SHARD_TARGETS)
 
 # The local default lives under predictable /tmp on supported macOS and Linux
 # hosts. Reject a pre-created symlink or a directory owned by another user
@@ -239,11 +239,30 @@ test: build-web go-test test-web test-tier1 test-tier2
 
 # Serialize even when the caller passes -j: go-test must see build-web's fresh
 # go:embed inputs. One submake also de-duplicates the shared phony prerequisites.
+# check-marker runs last (-j1), so the push-gate marker is only written when
+# every gate goal passed.
 check:
-	+$(MAKE) -j1 --no-print-directory test lint lint-web
+	+$(MAKE) -j1 --no-print-directory test lint lint-web check-marker
+
+# Internal: records the validated HEAD into the per-worktree marker
+# $(git rev-parse --git-dir)/fanout-check-passed, which scripts/agent-push-gate.sh
+# compares against the pushed tip. Clean tree only (same dirty test as
+# codex/tools/post-work-review.sh has_dirty_tree): a dirty tree means the
+# validated content is not the commit that would be pushed. Running this
+# target without `check` defeats the push gate — for a deliberate bypass use
+# FANOUT_SKIP_PUSH_CHECK=1 instead.
+check-marker:
+	@set -eu; \
+		git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0; \
+		if [ -n "$$(git status --porcelain -uall)" ]; then \
+			echo "warning: working tree is dirty; push-gate marker not written." >&2; \
+			echo "         commit the candidate and rerun make check to unlock git push." >&2; \
+			exit 0; \
+		fi; \
+		git rev-parse HEAD >"$$(git rev-parse --git-dir)/fanout-check-passed"
 
 test-tier1: build-go check-bats
-	FANOUT_BIN="$(CURDIR)/$(GO_BIN)" $(BATS) tests/bats/tier1_flags.bats tests/bats/tier1_msg.bats tests/bats/tier1_pr_watch.bats
+	FANOUT_BIN="$(CURDIR)/$(GO_BIN)" $(BATS) tests/bats/tier1_flags.bats tests/bats/tier1_msg.bats tests/bats/tier1_pr_watch.bats tests/bats/tier1_agent_hooks.bats
 	@set -eu; \
 		all=$$($(BATS) --count "$(POST_WORK_REVIEW_BATS)"); \
 		assigned=0; \
@@ -298,7 +317,7 @@ lint-go: $(GOLANGCI_LINT_BIN)
 	$(GO_CACHE_ENV) GOLANGCI_LINT_CACHE="$(GOLANGCI_LINT_CACHE)" "$(GOLANGCI_LINT_BIN)" run
 
 lint-shell:
-	shellcheck tests/bin/gh tests/bin/tmux tests/bin/git tests/bats/helpers.bash codex/tools/post-work-review.sh codex/skills/pr-watch/scripts/watch-pr.sh
+	shellcheck tests/bin/gh tests/bin/tmux tests/bin/git tests/bats/helpers.bash codex/tools/post-work-review.sh codex/skills/pr-watch/scripts/watch-pr.sh scripts/agent-hooks-lib.sh scripts/agent-push-gate.sh scripts/agent-stop-gate.sh scripts/agent-format-on-edit.sh
 
 fmt: $(GOLANGCI_LINT_BIN)
 	$(GO_CACHE_ENV) GOLANGCI_LINT_CACHE="$(GOLANGCI_LINT_CACHE)" "$(GOLANGCI_LINT_BIN)" fmt

--- a/Makefile
+++ b/Makefile
@@ -256,7 +256,11 @@ check:
 check-marker:
 	@set -eu; \
 		git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0; \
-		if [ -n "$$(git status --porcelain -uall)" ]; then \
+		status_out="$$(git status --porcelain -uall)" || { \
+			echo "error: git status failed; push-gate marker not written." >&2; \
+			exit 1; \
+		}; \
+		if [ -n "$$status_out" ]; then \
 			echo "warning: working tree is dirty; push-gate marker not written." >&2; \
 			echo "         commit the candidate and rerun make check to unlock git push." >&2; \
 			exit 0; \

--- a/claude/skills/pr-watch/SKILL.md
+++ b/claude/skills/pr-watch/SKILL.md
@@ -337,9 +337,13 @@ git push --force-with-lease="refs/heads/$head:$pr_head_before_work" "<head-remot
 4. `git rebase FETCH_HEAD` で今 fetch した base に rebase する。
 5. import 併合など確信できる hunk だけ自動解決する。意味的判断が必要な衝突は
    `git rebase --abort` して、具体的な hunk と理由を添えてエスカレーションする。
-6. rebase 完了後、push 直前に remote tip が `pr_head_before_work` から動いていないことを
+6. rebase 完了後、リポジトリの canonical full gate を rebase 後の HEAD に対して 1 回
+   通す(プロジェクトが `make check` のような umbrella target を定義していればそれを
+   優先し、無ければ AGENTS.md / CLAUDE.md / build ファイルから解決する)。自動解決した
+   hunk が build を壊すのはこの時点で捕まえる。
+7. push 直前に remote tip が `pr_head_before_work` から動いていないことを
    確認し、保存した SHA を期待値にした `--force-with-lease` で push する。
-7. push したら、その pass では古い CI/log/thread を使わず終了する。必要なら次 pass で
+8. push したら、その pass では古い CI/log/thread を使わず終了する。必要なら次 pass で
    状態を取り直す。
 
 ### E. CI 失敗
@@ -356,7 +360,10 @@ git push --force-with-lease="refs/heads/$head:$pr_head_before_work" "<head-remot
   エスカレーションする。
 - 原因を特定してから修正する。CI を通すためにテスト削除、workflow 緩和、skip 追加を
   してはいけない。
-- 修正後は focused test を実行し、commit して、明示 refspec で push する。
+- 修正中は focused test で解消を確認し、commit する。push の前に、リポジトリの
+  canonical full gate を最終 commit に対して 1 回通す(D と同じ解決方法)。gate が
+  通ってから明示 refspec で push する。CI がローカルで再現する lint / test で落ちて
+  いるとき、focused test だけで push し直すと同じ CI 失敗を繰り返す。
 - flaky やインフラ起因なら 1 回だけ再実行を促す。再現するならコードを無理に触らず
   エスカレーションする。
 
@@ -368,7 +375,8 @@ git push --force-with-lease="refs/heads/$head:$pr_head_before_work" "<head-remot
   skip する。
 - 新しいレビュアー返信があれば、top-level comment ではなく latest comment の要求を読む。
 - 仕様判断や方針確認が必要な指摘は無理に直さず、判断点を整理してユーザーに確認する。
-- 修正したら test、commit、push の順に進める。
+- 修正したら focused test → commit → canonical full gate(E と同じ 1 回)→ push の順に
+  進める。
 - 返信は push 後に行う。インライン返信は top-level comment の `fullDatabaseId` を使う。
 - thread resolve は基本的にレビュアーへ委ねる。自分で resolve するのは確信がある場合のみ。
 
@@ -616,6 +624,9 @@ done
 - 明示指示なしに auto-merge しない。
 - 他者 PR、保護ブランチ、push 権限が曖昧な fork に force push しない。
 - CI を通すためにテストや必須チェックを弱めない。
+- リポジトリの push ゲート(pre-push 系 hook や PreToolUse gate)を `--no-verify` や
+  hooks 設定の書き換えで回避しない。push が deny されたら、指示されたコマンド
+  (canonical full gate)を最終 commit で通してから push し直す。
 - GitHub の古い thread や push 前の CI log を根拠に、push 後も同じ pass で修正を続けない。
 - approval / `:+1:` 待ちだけのために full One Pass を繰り返さない。
 - unchanged cheap snapshot をモデルに何度も読ませない。

--- a/codex/skills/pr-watch/SKILL.md
+++ b/codex/skills/pr-watch/SKILL.md
@@ -128,9 +128,14 @@ changed. Read only the relevant part of the [repair playbook](references/repair-
    top-level comments as needed.
 2. Reconfirm the PR head branch, author, push remote, and saved remote head SHA.
 3. Handle conflict/base drift, failing CI, then actionable review feedback.
-4. Run focused tests. Do not weaken tests, required checks, or workflows.
-5. Commit intentionally and push with an explicit refspec. Use guarded
-   `--force-with-lease=<ref>:<saved-sha>` only for an authorized history rewrite.
+4. Run focused tests while editing. Do not weaken tests, required checks, or
+   workflows.
+5. Commit intentionally. Before each push, run the repository's canonical full
+   gate once against the final commit (prefer an umbrella target such as
+   `make check` when the project defines one; otherwise resolve it from
+   AGENTS.md, CLAUDE.md, or the build files). Then push with an explicit
+   refspec. Use guarded `--force-with-lease=<ref>:<saved-sha>` only for an
+   authorized history rewrite.
 6. Reply to review feedback only after the fix is pushed. In this repository,
    write automatic review comments in Japanese.
 7. After any push, discard old logs/thread state and return to a fresh cheap
@@ -154,6 +159,10 @@ inspected.
 - Never use plain `--force` or an unqualified `--force-with-lease`.
 - Never overwrite another author's PR, a protected branch, or a fork with
   unclear ownership.
+- Never bypass a repository push gate (a pre-push hook or a PreToolUse deny)
+  with `--no-verify` or by rewriting the hooks configuration. A denied push
+  means the pushed tip has not passed the repository gate; run the canonical
+  full gate on the final commit and push again.
 
 ## Limits and stop conditions
 

--- a/codex/skills/pr-watch/references/repair-playbook.md
+++ b/codex/skills/pr-watch/references/repair-playbook.md
@@ -179,7 +179,12 @@ failure is clearly flaky or infrastructure-owned, request one rerun. Stop if it
 recurs. For external CI, follow the check link; if the log is inaccessible,
 report the provider and URL as blocked rather than guessing.
 
-Commit and push a real code fix with an explicit refspec:
+Commit the real code fix first, then run the repository's canonical full gate
+once against that final commit (prefer an umbrella target such as `make check`
+when the project defines one; otherwise resolve it from AGENTS.md, CLAUDE.md,
+or the build files). A CI failure that reproduces locally recurs on the next
+push unless the full gate passed. Repositories may enforce this with a push
+gate; never bypass it with `--no-verify`. Then push with an explicit refspec:
 
 ```bash
 git push "$head_remote" HEAD:"$head"
@@ -198,8 +203,9 @@ For an actionable request:
 
 1. Trace the behavior in the current head and confirm the issue.
 2. Implement the narrow fix.
-3. Run focused tests and the relevant repository gate.
-4. Commit and push.
+3. Run focused tests while editing.
+4. Commit, run the repository's canonical full gate once against the final
+   commit (same resolution as in Repair CI), then push.
 5. Reply after GitHub sees the pushed commit.
 
 Use the top-level inline comment's `fullDatabaseId` to reply in-thread. In this

--- a/codex/skills/pr-watch/references/repair-playbook.md
+++ b/codex/skills/pr-watch/references/repair-playbook.md
@@ -153,8 +153,11 @@ git rebase FETCH_HEAD
 
 Resolve only mechanical conflicts whose intent is clear. For behavioral or
 product ambiguity, `git rebase --abort` and report the file/hunk and decision
-needed. After tests pass, re-fetch the PR head, compare it with the saved SHA,
-and use the qualified lease command above.
+needed. After tests pass, run the repository's canonical full gate once
+against the rebased HEAD (same resolution as in Repair CI) — auto-resolved
+hunks that break the build surface here, not on CI. Then re-fetch the PR
+head, compare it with the saved SHA, and use the qualified lease command
+above.
 
 `BEHIND` alone is not always a repair trigger. If branch protection does not
 require the latest base and GitHub reports mergeable with green checks, avoid a

--- a/docs/review-checklist.ja.md
+++ b/docs/review-checklist.ja.md
@@ -28,6 +28,10 @@ diff へ自問する。
   レビューゲートをバイパスする場合は、PR 作成前に `make check` を直接実行する。
 - `make test`、`make lint`、`make lint-web` は失敗の切り分けに使う。
   同じ最終ゲートで個別に重ねて実行しない。
+- branch への `git push` は agent hook でゲートされる。clean tree での
+  `make check` 成功が marker を書き、push はそのまま通る。deny されたら
+  `make check` を通し直す。`--no-verify` での回避は禁止。緊急回避は
+  `FANOUT_SKIP_PUSH_CHECK=1`。
 - dry-run / status 出力を変えたら `FANOUT_GOLDEN_UPDATE=1 make test-tier2` で
   golden を regen して diff を目視する。
 

--- a/scripts/agent-format-on-edit.sh
+++ b/scripts/agent-format-on-edit.sh
@@ -17,9 +17,11 @@ lib="$(cd "$(dirname "$0")" && pwd)/agent-hooks-lib.sh"
 # shellcheck source=scripts/agent-hooks-lib.sh
 . "$lib"
 
-dir="$(resolve_project_dir "$input")"
+cwd_base="$(resolve_project_dir "$input")"
 # The session may run from a subdirectory; the version pin, web/ tree, and
-# .cache fallback all live at the repository root.
+# .cache fallback all live at the repository root, but relative edit paths
+# resolve against the payload cwd.
+dir="$cwd_base"
 top="$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null)"
 [ -n "$top" ] && dir="$top"
 
@@ -81,7 +83,7 @@ go_bin_resolved=0
 for file in "${files[@]}"; do
   case "$file" in
   /*) ;;
-  *) file="$dir/$file" ;;
+  *) file="$cwd_base/$file" ;;
   esac
   [ -f "$file" ] || continue
   case "$file" in

--- a/scripts/agent-format-on-edit.sh
+++ b/scripts/agent-format-on-edit.sh
@@ -32,7 +32,15 @@ case "$file" in
   [ -f "$dir/.golangci-lint-version" ] || exit 0
   version="$(tr -d '[:space:]' <"$dir/.golangci-lint-version")"
   cache_root="${FANOUT_DEV_CACHE_DIR:-/tmp/fanout-dev-cache-$(id -u)}"
-  bin="$cache_root/tools/golangci-lint-$version"
+  # Same resolution order as the Makefile: explicit override, local shared
+  # cache, then the repo-local .cache the CI branch uses.
+  bin="${GOLANGCI_LINT_BIN:-}"
+  if [ -z "$bin" ] || [ ! -x "$bin" ]; then
+    bin="$cache_root/tools/golangci-lint-$version"
+  fi
+  if [ ! -x "$bin" ]; then
+    bin="$dir/.cache/tools/golangci-lint-$version"
+  fi
   [ -x "$bin" ] || exit 0
   "$bin" fmt "$file" >/dev/null 2>&1 || true
   ;;

--- a/scripts/agent-format-on-edit.sh
+++ b/scripts/agent-format-on-edit.sh
@@ -17,19 +17,30 @@ lib="$(cd "$(dirname "$0")" && pwd)/agent-hooks-lib.sh"
 # shellcheck source=scripts/agent-hooks-lib.sh
 . "$lib"
 
-file="$(json_field "$input" file_path)"
-[ -n "$file" ] || exit 0
-
 dir="$(resolve_project_dir "$input")"
 # The session may run from a subdirectory; the version pin, web/ tree, and
 # .cache fallback all live at the repository root.
 top="$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null)"
 [ -n "$top" ] && dir="$top"
-case "$file" in
-/*) ;;
-*) file="$dir/$file" ;;
-esac
-[ -f "$file" ] || exit 0
+
+# Claude Edit/Write payloads carry tool_input.file_path. Codex apply_patch
+# payloads carry the patch text instead; its `*** Add/Update File:` headers
+# name every touched path.
+files=()
+file="$(json_field "$input" file_path)"
+if [ -n "$file" ]; then
+  files+=("$file")
+else
+  patch="$(json_field "$input" command)"
+  [ -n "$patch" ] || patch="$(json_field "$input" patch)"
+  [ -n "$patch" ] || exit 0
+  while IFS= read -r line; do
+    case "$line" in
+    "*** Add File: "* | "*** Update File: "*) files+=("${line#*File: }") ;;
+    esac
+  done <<<"$patch"
+fi
+[ "${#files[@]}" -gt 0 ] || exit 0
 
 # trusted_cache_root DIR — refuse a symlinked or foreign-owned shared cache
 # before executing a binary out of it (same checks as the Makefile's
@@ -42,12 +53,13 @@ trusted_cache_root() {
   [ "$owner" = "$(id -u)" ]
 }
 
-case "$file" in
-*.go)
-  [ -f "$dir/.golangci-lint-version" ] || exit 0
+# golangci_bin — resolve the pinned formatter once. Same resolution order as
+# the Makefile: explicit override, local shared cache (owner-validated), then
+# the repo-local .cache the CI branch uses. Empty when unavailable.
+golangci_bin() {
+  local version bin cache_root
+  [ -f "$dir/.golangci-lint-version" ] || return 0
   version="$(tr -d '[:space:]' <"$dir/.golangci-lint-version")"
-  # Same resolution order as the Makefile: explicit override, local shared
-  # cache (owner-validated), then the repo-local .cache the CI branch uses.
   bin="${GOLANGCI_LINT_BIN:-}"
   if [ -z "$bin" ] || [ ! -x "$bin" ]; then
     cache_root="${FANOUT_DEV_CACHE_DIR:-/tmp/fanout-dev-cache-$(id -u)}"
@@ -60,15 +72,34 @@ case "$file" in
   if [ -z "$bin" ] || [ ! -x "$bin" ]; then
     bin="$dir/.cache/tools/golangci-lint-$version"
   fi
-  [ -x "$bin" ] || exit 0
-  "$bin" fmt "$file" >/dev/null 2>&1 || true
-  ;;
-"$dir"/web/vite.config.ts | "$dir"/web/src/*.ts | "$dir"/web/src/*.tsx | "$dir"/web/src/*.js | "$dir"/web/src/*.jsx)
-  [ -d "$dir/web/node_modules" ] || exit 0
-  command -v pnpm >/dev/null 2>&1 || exit 0
-  rel="${file#"$dir"/web/}"
-  (cd "$dir/web" && pnpm exec oxfmt "$rel") >/dev/null 2>&1 || true
-  ;;
-esac
+  [ -x "$bin" ] && printf '%s' "$bin"
+}
+
+go_bin=""
+go_bin_resolved=0
+
+for file in "${files[@]}"; do
+  case "$file" in
+  /*) ;;
+  *) file="$dir/$file" ;;
+  esac
+  [ -f "$file" ] || continue
+  case "$file" in
+  *.go)
+    if [ "$go_bin_resolved" = "0" ]; then
+      go_bin="$(golangci_bin)"
+      go_bin_resolved=1
+    fi
+    [ -n "$go_bin" ] || continue
+    "$go_bin" fmt "$file" >/dev/null 2>&1 || true
+    ;;
+  "$dir"/web/vite.config.ts | "$dir"/web/src/*.ts | "$dir"/web/src/*.tsx | "$dir"/web/src/*.js | "$dir"/web/src/*.jsx)
+    [ -d "$dir/web/node_modules" ] || continue
+    command -v pnpm >/dev/null 2>&1 || continue
+    rel="${file#"$dir"/web/}"
+    (cd "$dir/web" && pnpm exec oxfmt "$rel") >/dev/null 2>&1 || true
+    ;;
+  esac
+done
 
 exit 0

--- a/scripts/agent-format-on-edit.sh
+++ b/scripts/agent-format-on-edit.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# fanout format-on-edit — PostToolUse(Edit|Write|MultiEdit) hook for Claude
+# Code and Codex.
+#
+# Formats just the edited file, mirroring `make fmt` (pinned golangci-lint
+# fmt for Go) and `make fmt-web` (oxfmt for web/src + vite.config.ts; CSS and
+# web/-root JSON stay untouched). Fast paths only: the hook never downloads a
+# tool — when the pinned golangci-lint binary or web/node_modules is absent it
+# exits silently and the normal make targets pick the formatting up later.
+# Always exits 0 so an edit is never interrupted by formatting.
+set -u
+
+input="$(cat)"
+
+lib="$(cd "$(dirname "$0")" && pwd)/agent-hooks-lib.sh"
+[ -f "$lib" ] || exit 0
+# shellcheck source=scripts/agent-hooks-lib.sh
+. "$lib"
+
+file="$(json_field "$input" file_path)"
+[ -n "$file" ] || exit 0
+
+dir="$(resolve_project_dir "$input")"
+case "$file" in
+/*) ;;
+*) file="$dir/$file" ;;
+esac
+[ -f "$file" ] || exit 0
+
+case "$file" in
+*.go)
+  [ -f "$dir/.golangci-lint-version" ] || exit 0
+  version="$(tr -d '[:space:]' <"$dir/.golangci-lint-version")"
+  cache_root="${FANOUT_DEV_CACHE_DIR:-/tmp/fanout-dev-cache-$(id -u)}"
+  bin="$cache_root/tools/golangci-lint-$version"
+  [ -x "$bin" ] || exit 0
+  "$bin" fmt "$file" >/dev/null 2>&1 || true
+  ;;
+"$dir"/web/vite.config.ts | "$dir"/web/src/*.ts | "$dir"/web/src/*.tsx | "$dir"/web/src/*.js | "$dir"/web/src/*.jsx)
+  [ -d "$dir/web/node_modules" ] || exit 0
+  command -v pnpm >/dev/null 2>&1 || exit 0
+  rel="${file#"$dir"/web/}"
+  (cd "$dir/web" && pnpm exec oxfmt "$rel") >/dev/null 2>&1 || true
+  ;;
+esac
+
+exit 0

--- a/scripts/agent-format-on-edit.sh
+++ b/scripts/agent-format-on-edit.sh
@@ -21,24 +21,43 @@ file="$(json_field "$input" file_path)"
 [ -n "$file" ] || exit 0
 
 dir="$(resolve_project_dir "$input")"
+# The session may run from a subdirectory; the version pin, web/ tree, and
+# .cache fallback all live at the repository root.
+top="$(git -C "$dir" rev-parse --show-toplevel 2>/dev/null)"
+[ -n "$top" ] && dir="$top"
 case "$file" in
 /*) ;;
 *) file="$dir/$file" ;;
 esac
 [ -f "$file" ] || exit 0
 
+# trusted_cache_root DIR — refuse a symlinked or foreign-owned shared cache
+# before executing a binary out of it (same checks as the Makefile's
+# prepare-dev-cache; the hook runs with the agent user's privileges).
+trusted_cache_root() {
+  local owner
+  [ -L "$1" ] && return 1
+  [ -d "$1" ] || return 1
+  owner="$(stat -f '%u' "$1" 2>/dev/null || stat -c '%u' "$1" 2>/dev/null)" || return 1
+  [ "$owner" = "$(id -u)" ]
+}
+
 case "$file" in
 *.go)
   [ -f "$dir/.golangci-lint-version" ] || exit 0
   version="$(tr -d '[:space:]' <"$dir/.golangci-lint-version")"
-  cache_root="${FANOUT_DEV_CACHE_DIR:-/tmp/fanout-dev-cache-$(id -u)}"
   # Same resolution order as the Makefile: explicit override, local shared
-  # cache, then the repo-local .cache the CI branch uses.
+  # cache (owner-validated), then the repo-local .cache the CI branch uses.
   bin="${GOLANGCI_LINT_BIN:-}"
   if [ -z "$bin" ] || [ ! -x "$bin" ]; then
-    bin="$cache_root/tools/golangci-lint-$version"
+    cache_root="${FANOUT_DEV_CACHE_DIR:-/tmp/fanout-dev-cache-$(id -u)}"
+    if trusted_cache_root "$cache_root"; then
+      bin="$cache_root/tools/golangci-lint-$version"
+    else
+      bin=""
+    fi
   fi
-  if [ ! -x "$bin" ]; then
+  if [ -z "$bin" ] || [ ! -x "$bin" ]; then
     bin="$dir/.cache/tools/golangci-lint-$version"
   fi
   [ -x "$bin" ] || exit 0

--- a/scripts/agent-hooks-lib.sh
+++ b/scripts/agent-hooks-lib.sh
@@ -61,16 +61,20 @@ resolve_project_dir() {
 }
 
 # strip_shell_noise CMD — normalize a shell command string for word scanning:
-# single-/double-quoted spans become spaces (double quotes honor backslash
-# escapes, so an apostrophe inside "..." cannot mis-pair), heredoc bodies are
-# dropped up to their terminator, backslash escapes outside quotes become
-# spaces, and command separators (; | & ( ) { } ` and newlines) become
-# newlines — one simple command per output line. This is a gate heuristic,
-# not a shell: unknown constructs must degrade toward keeping words visible
-# (fail closed), never toward hiding an executable `git push`.
+# heredoc bodies are dropped up to their terminator and command separators
+# (; | & ( ) { } ` and unquoted newlines) become newlines — one simple
+# command per output line. Quoted spans (and backslash-escaped characters)
+# are NOT dropped: their content is kept as part of the surrounding word,
+# with embedded whitespace/newlines replaced by the \001 sentinel, so a
+# quoted path stays one traceable token (`git -C "$repo" push` keeps its -C
+# value) while quoted prose can never form new command words (`"git push"`
+# stays one word). unsentinel() restores the spaces when a word is used as a
+# path. This is a gate heuristic, not a shell: unknown constructs must
+# degrade toward keeping words visible (fail closed), never toward hiding an
+# executable `git push`.
 strip_shell_noise() {
   awk '
-    BEGIN { hd = 0; hdword = "" }
+    BEGIN { hd = 0; hdword = ""; sq = 0; dq = 0; buf = ""; S = sprintf("%c", 1) }
     {
       line = $0
       if (hd) {
@@ -79,27 +83,40 @@ strip_shell_noise() {
         if (stripped == hdword) hd = 0
         next
       }
-      out = ""
       n = length(line)
       i = 1
-      sq = 0
-      dq = 0
       while (i <= n) {
         c = substr(line, i, 1)
         if (sq) {
-          if (c == "\047") sq = 0
+          if (c == "\047") { sq = 0 }
+          else if (c == " " || c == "\t") buf = buf S
+          else buf = buf c
           i++
           continue
         }
         if (dq) {
-          if (c == "\\") { i += 2; continue }
-          if (c == "\"") dq = 0
+          if (c == "\\") {
+            e = substr(line, i + 1, 1)
+            if (e == " " || e == "\t") buf = buf S
+            else buf = buf e
+            i += 2
+            continue
+          }
+          if (c == "\"") { dq = 0 }
+          else if (c == " " || c == "\t") buf = buf S
+          else buf = buf c
           i++
           continue
         }
-        if (c == "\047") { sq = 1; out = out " "; i++; continue }
-        if (c == "\"") { dq = 1; out = out " "; i++; continue }
-        if (c == "\\") { out = out " "; i += 2; continue }
+        if (c == "\047") { sq = 1; i++; continue }
+        if (c == "\"") { dq = 1; i++; continue }
+        if (c == "\\") {
+          e = substr(line, i + 1, 1)
+          if (e == " " || e == "\t") buf = buf S
+          else if (e != "") buf = buf e
+          i += 2
+          continue
+        }
         if (c == "<" && substr(line, i + 1, 1) == "<" && substr(line, i + 2, 1) != "<") {
           j = i + 2
           if (substr(line, j, 1) == "-") j++
@@ -109,18 +126,26 @@ strip_shell_noise() {
             w = w substr(line, j, 1)
             j++
           }
-          if (w != "") { hd = 1; hdword = w; out = out " "; i = j; continue }
-          out = out c
+          if (w != "") { hd = 1; hdword = w; buf = buf " "; i = j; continue }
+          buf = buf c
           i++
           continue
         }
-        if (c ~ /[;|&(){}`]/) { out = out "\n"; i++; continue }
-        out = out c
+        if (c ~ /[;|&(){}`]/) { buf = buf "\n"; i++; continue }
+        buf = buf c
         i++
       }
-      print out
+      # A quoted span continuing past the line end keeps the word joined.
+      if (sq || dq) buf = buf S
+      else buf = buf "\n"
     }
+    END { printf "%s", buf }
   ' <<<"$1"
+}
+
+# unsentinel WORD — restore the whitespace strip_shell_noise encoded as \001.
+unsentinel() {
+  printf '%s' "${1//$'\001'/ }"
 }
 
 # marker_path DIR — the per-worktree `make check` marker. `git rev-parse

--- a/scripts/agent-hooks-lib.sh
+++ b/scripts/agent-hooks-lib.sh
@@ -85,6 +85,7 @@ strip_shell_noise() {
       }
       n = length(line)
       i = 1
+      joinnext = 0
       while (i <= n) {
         c = substr(line, i, 1)
         if (sq) {
@@ -102,6 +103,12 @@ strip_shell_noise() {
             i += 2
             continue
           }
+          # $(…) and `…` inside "…" still execute: break the segment and
+          # rescan the substitution as code (the string is prose, the
+          # substitution is not). The dangling close quote this leaves is an
+          # accepted heuristic imbalance.
+          if (c == "$" && substr(line, i + 1, 1) == "(") { dq = 0; buf = buf "\n"; i += 2; continue }
+          if (c == "`") { dq = 0; buf = buf "\n"; i++; continue }
           if (c == "\"") { dq = 0 }
           else if (c == " " || c == "\t") buf = buf S
           else buf = buf c
@@ -111,21 +118,27 @@ strip_shell_noise() {
         if (c == "\047") { sq = 1; i++; continue }
         if (c == "\"") { dq = 1; i++; continue }
         if (c == "\\") {
+          if (i == n) { joinnext = 1; i++; continue } # line continuation
           e = substr(line, i + 1, 1)
           if (e == " " || e == "\t") buf = buf S
-          else if (e != "") buf = buf e
+          else buf = buf e
           i += 2
           continue
         }
         if (c == "<" && substr(line, i + 1, 1) == "<" && substr(line, i + 2, 1) != "<") {
           j = i + 2
           if (substr(line, j, 1) == "-") j++
-          if (substr(line, j, 1) == "\047" || substr(line, j, 1) == "\"") j++
+          qc = ""
+          if (substr(line, j, 1) == "\047" || substr(line, j, 1) == "\"") {
+            qc = substr(line, j, 1)
+            j++
+          }
           w = ""
           while (j <= n && substr(line, j, 1) ~ /[A-Za-z0-9_]/) {
             w = w substr(line, j, 1)
             j++
           }
+          if (qc != "" && substr(line, j, 1) == qc) j++ # closing quote of <<"EOF"
           if (w != "") { hd = 1; hdword = w; buf = buf " "; i = j; continue }
           buf = buf c
           i++
@@ -135,9 +148,10 @@ strip_shell_noise() {
         buf = buf c
         i++
       }
-      # A quoted span continuing past the line end keeps the word joined.
+      # A quoted span continuing past the line end keeps the word joined; a
+      # backslash continuation splices the next line into this segment.
       if (sq || dq) buf = buf S
-      else buf = buf "\n"
+      else if (!joinnext) buf = buf "\n"
     }
     END { printf "%s", buf }
   ' <<<"$1"

--- a/scripts/agent-hooks-lib.sh
+++ b/scripts/agent-hooks-lib.sh
@@ -1,0 +1,78 @@
+# shellcheck shell=bash
+# fanout agent hooks — shared helpers for the repo-local Claude Code / Codex
+# hook scripts (scripts/agent-*.sh). Sourced, not executed.
+#
+# Pure bash + git + POSIX awk/grep/sed on purpose: no python3 / node / jq, so
+# the hooks run on minimal hosts. The hook payload key names are identical for
+# Claude Code and Codex (verified against Codex CLI 0.144.0: tool_name "Bash",
+# tool_input.command, cwd, stop_hook_active), so one set of helpers serves
+# both agents.
+
+# json_field JSON NAME — print the first "NAME":"..." string value with JSON
+# backslash escapes decoded. Handles double-quoted string values only, which
+# covers every field the hooks read (command / cwd / file_path). First match
+# wins: real keys precede embedded escaped copies (e.g. inside tool_response,
+# where quotes arrive as \" and therefore never match the unescaped pattern).
+json_field() {
+  awk -v name="$2" '
+    { buf = buf $0 "\n" }
+    END {
+      pat = "\"" name "\"[[:space:]]*:[[:space:]]*\""
+      if (!match(buf, pat)) exit
+      rest = substr(buf, RSTART + RLENGTH)
+      out = ""
+      n = length(rest)
+      for (i = 1; i <= n; i++) {
+        c = substr(rest, i, 1)
+        if (c == "\\") {
+          i++
+          e = substr(rest, i, 1)
+          if (e == "n") out = out "\n"
+          else if (e == "t") out = out "\t"
+          else if (e == "r") out = out "\r"
+          else if (e == "b" || e == "f") out = out " "
+          else if (e == "u") i += 4
+          else out = out e
+        } else if (c == "\"") break
+        else out = out c
+      }
+      printf "%s", out
+    }' <<<"$1"
+}
+
+# resolve_project_dir JSON — the directory the gated command runs in:
+# CLAUDE_PROJECT_DIR (Claude sets it), else the payload cwd, else $PWD.
+resolve_project_dir() {
+  local dir="${CLAUDE_PROJECT_DIR:-}"
+  if [ -z "$dir" ]; then
+    dir="$(json_field "$1" cwd)"
+  fi
+  if [ -z "$dir" ] || [ ! -d "$dir" ]; then
+    dir="$PWD"
+  fi
+  printf '%s' "$dir"
+}
+
+# marker_path DIR — the per-worktree `make check` marker. `git rev-parse
+# --git-dir` resolves to .git/worktrees/<name> inside a linked worktree, so
+# parallel fanout panes never share a marker.
+marker_path() {
+  local gitdir
+  gitdir="$(git -C "$1" rev-parse --git-dir 2>/dev/null)" || return 1
+  case "$gitdir" in
+    /*) printf '%s/fanout-check-passed' "$gitdir" ;;
+    *) printf '%s/%s/fanout-check-passed' "$1" "$gitdir" ;;
+  esac
+}
+
+# marker_sha DIR — the recorded validated commit, empty when absent.
+marker_sha() {
+  local marker
+  marker="$(marker_path "$1")" || return 0
+  [ -f "$marker" ] || return 0
+  tr -d '[:space:]' <"$marker"
+}
+
+head_sha() {
+  git -C "$1" rev-parse HEAD 2>/dev/null
+}

--- a/scripts/agent-hooks-lib.sh
+++ b/scripts/agent-hooks-lib.sh
@@ -74,14 +74,44 @@ resolve_project_dir() {
 # executable `git push`.
 strip_shell_noise() {
   awk '
+    # subst_span: consume a $(…) / `…` span starting at `start`; queue the
+    # raw inner text as its own segment (via the global `extra`) and return
+    # the index just past the closer. The outer word gets a placeholder, so
+    # a push whose path/refspec depends on a substitution fails closed.
+    function subst_span(line, start, n, kind,    depth, k, ch, inner) {
+      inner = ""
+      if (kind == "`") {
+        k = start
+        while (k <= n && substr(line, k, 1) != "`") {
+          inner = inner substr(line, k, 1)
+          k++
+        }
+        extra = extra "\n" inner "\n"
+        return k + 1
+      }
+      depth = 1
+      k = start
+      while (k <= n) {
+        ch = substr(line, k, 1)
+        if (ch == "(") depth++
+        else if (ch == ")") {
+          depth--
+          if (depth == 0) break
+        }
+        inner = inner ch
+        k++
+      }
+      extra = extra "\n" inner "\n"
+      return k + 1
+    }
     BEGIN {
       hd = 0; hdword = ""; hdq = 0
       sq = 0; dq = 0
-      pdepth = 0; btres = 0
-      buf = ""; S = sprintf("%c", 1)
+      buf = ""; extra = ""; S = sprintf("%c", 1)
     }
     {
       line = $0
+      prev = ""
       if (hd) {
         stripped = line
         sub(/^\t+/, "", stripped)
@@ -110,18 +140,20 @@ strip_shell_noise() {
             i += 2
             continue
           }
-          # $(…) and `…` inside "…" still execute: break the segment and
-          # rescan the substitution as code, then resume the string state at
-          # the matching closer so the rest of the line keeps its quoting.
+          # $(…) and `…` inside "…" still execute: substitute a placeholder
+          # into the outer word (so its structure survives — an untraceable
+          # placeholder path later fails closed) and queue the inner text as
+          # its own segment for scanning.
           if (c == "$" && substr(line, i + 1, 1) == "(") {
-            pdepth++
-            resume[pdepth] = 1
-            dq = 0
-            buf = buf "\n"
-            i += 2
+            i = subst_span(line, i + 2, n, "(")
+            buf = buf "__FANOUT_SUBST__"
             continue
           }
-          if (c == "`") { btres = 1; dq = 0; buf = buf "\n"; i++; continue }
+          if (c == "`") {
+            i = subst_span(line, i + 1, n, "`")
+            buf = buf "__FANOUT_SUBST__"
+            continue
+          }
           if (c == "\"") { dq = 0 }
           else if (c == " " || c == "\t") buf = buf S
           else buf = buf c
@@ -130,12 +162,21 @@ strip_shell_noise() {
         }
         if (c == "\047") { sq = 1; i++; continue }
         if (c == "\"") { dq = 1; i++; continue }
+        # A word-boundary # starts a comment: the shell ignores the rest of
+        # the line, including any apostrophes in it.
+        if (c == "#" && (prev == "" || prev == " " || prev == "\t")) break
         if (c == "\\") {
           if (i == n) { joinnext = 1; i++; continue } # line continuation
           e = substr(line, i + 1, 1)
           if (e == " " || e == "\t") buf = buf S
           else buf = buf e
           i += 2
+          continue
+        }
+        if (c == "$" && substr(line, i + 1, 1) == "(") {
+          i = subst_span(line, i + 2, n, "(")
+          buf = buf "__FANOUT_SUBST__"
+          prev = "_"
           continue
         }
         if (c == "<" && substr(line, i + 1, 1) == "<" && substr(line, i + 2, 1) != "<") {
@@ -147,7 +188,7 @@ strip_shell_noise() {
             j++
           }
           w = ""
-          while (j <= n && substr(line, j, 1) ~ /[A-Za-z0-9_]/) {
+          while (j <= n && substr(line, j, 1) ~ /[A-Za-z0-9_.-]/) {
             w = w substr(line, j, 1)
             j++
           }
@@ -157,24 +198,15 @@ strip_shell_noise() {
           i++
           continue
         }
-        if (c == "(") { pdepth++; buf = buf "\n"; i++; continue }
-        if (c == ")") {
-          if (pdepth > 0) {
-            if (resume[pdepth]) { dq = 1; delete resume[pdepth] }
-            pdepth--
-          }
-          buf = buf "\n"
-          i++
-          continue
-        }
         if (c == "`") {
-          if (btres) { dq = 1; btres = 0 }
-          buf = buf "\n"
-          i++
+          i = subst_span(line, i + 1, n, "`")
+          buf = buf "__FANOUT_SUBST__"
+          prev = "_"
           continue
         }
-        if (c ~ /[;|&{}]/) { buf = buf "\n"; i++; continue }
+        if (c ~ /[;|&(){}]/) { buf = buf "\n"; prev = "\n"; i++; continue }
         buf = buf c
+        prev = c
         i++
       }
       # A quoted span continuing past the line end keeps the word joined; a
@@ -182,7 +214,7 @@ strip_shell_noise() {
       if (sq || dq) buf = buf S
       else if (!joinnext) buf = buf "\n"
     }
-    END { printf "%s", buf }
+    END { printf "%s%s", buf, extra }
   ' <<<"$1"
 }
 

--- a/scripts/agent-hooks-lib.sh
+++ b/scripts/agent-hooks-lib.sh
@@ -13,6 +13,9 @@
 # covers every field the hooks read (command / cwd / file_path). First match
 # wins: real keys precede embedded escaped copies (e.g. inside tool_response,
 # where quotes arrive as \" and therefore never match the unescaped pattern).
+# \uXXXX escapes decode to a "_" placeholder: the character identity is
+# irrelevant to the gates, but dropping it entirely could merge adjacent
+# tokens into new command words.
 json_field() {
   awk -v name="$2" '
     { buf = buf $0 "\n" }
@@ -31,7 +34,7 @@ json_field() {
           else if (e == "t") out = out "\t"
           else if (e == "r") out = out "\r"
           else if (e == "b" || e == "f") out = out " "
-          else if (e == "u") i += 4
+          else if (e == "u") { i += 4; out = out "_" }
           else out = out e
         } else if (c == "\"") break
         else out = out c
@@ -40,17 +43,84 @@ json_field() {
     }' <<<"$1"
 }
 
-# resolve_project_dir JSON — the directory the gated command runs in:
-# CLAUDE_PROJECT_DIR (Claude sets it), else the payload cwd, else $PWD.
+# resolve_project_dir JSON — the directory the gated command runs in. The
+# payload cwd wins: it is where the tool call actually executes. The session
+# env CLAUDE_PROJECT_DIR is only a fallback — a session rooted in repo A can
+# run commands inside repo B (fanout worktrees), and gating A while pushing B
+# checks the wrong marker.
 resolve_project_dir() {
-  local dir="${CLAUDE_PROJECT_DIR:-}"
-  if [ -z "$dir" ]; then
-    dir="$(json_field "$1" cwd)"
+  local dir
+  dir="$(json_field "$1" cwd)"
+  if [ -z "$dir" ] || [ ! -d "$dir" ]; then
+    dir="${CLAUDE_PROJECT_DIR:-}"
   fi
   if [ -z "$dir" ] || [ ! -d "$dir" ]; then
     dir="$PWD"
   fi
   printf '%s' "$dir"
+}
+
+# strip_shell_noise CMD — normalize a shell command string for word scanning:
+# single-/double-quoted spans become spaces (double quotes honor backslash
+# escapes, so an apostrophe inside "..." cannot mis-pair), heredoc bodies are
+# dropped up to their terminator, backslash escapes outside quotes become
+# spaces, and command separators (; | & ( ) { } ` and newlines) become
+# newlines — one simple command per output line. This is a gate heuristic,
+# not a shell: unknown constructs must degrade toward keeping words visible
+# (fail closed), never toward hiding an executable `git push`.
+strip_shell_noise() {
+  awk '
+    BEGIN { hd = 0; hdword = "" }
+    {
+      line = $0
+      if (hd) {
+        stripped = line
+        sub(/^\t+/, "", stripped)
+        if (stripped == hdword) hd = 0
+        next
+      }
+      out = ""
+      n = length(line)
+      i = 1
+      sq = 0
+      dq = 0
+      while (i <= n) {
+        c = substr(line, i, 1)
+        if (sq) {
+          if (c == "\047") sq = 0
+          i++
+          continue
+        }
+        if (dq) {
+          if (c == "\\") { i += 2; continue }
+          if (c == "\"") dq = 0
+          i++
+          continue
+        }
+        if (c == "\047") { sq = 1; out = out " "; i++; continue }
+        if (c == "\"") { dq = 1; out = out " "; i++; continue }
+        if (c == "\\") { out = out " "; i += 2; continue }
+        if (c == "<" && substr(line, i + 1, 1) == "<" && substr(line, i + 2, 1) != "<") {
+          j = i + 2
+          if (substr(line, j, 1) == "-") j++
+          if (substr(line, j, 1) == "\047" || substr(line, j, 1) == "\"") j++
+          w = ""
+          while (j <= n && substr(line, j, 1) ~ /[A-Za-z0-9_]/) {
+            w = w substr(line, j, 1)
+            j++
+          }
+          if (w != "") { hd = 1; hdword = w; out = out " "; i = j; continue }
+          out = out c
+          i++
+          continue
+        }
+        if (c ~ /[;|&(){}`]/) { out = out "\n"; i++; continue }
+        out = out c
+        i++
+      }
+      print out
+    }
+  ' <<<"$1"
 }
 
 # marker_path DIR — the per-worktree `make check` marker. `git rev-parse

--- a/scripts/agent-hooks-lib.sh
+++ b/scripts/agent-hooks-lib.sh
@@ -74,14 +74,21 @@ resolve_project_dir() {
 # executable `git push`.
 strip_shell_noise() {
   awk '
-    BEGIN { hd = 0; hdword = ""; sq = 0; dq = 0; buf = ""; S = sprintf("%c", 1) }
+    BEGIN {
+      hd = 0; hdword = ""; hdq = 0
+      sq = 0; dq = 0
+      pdepth = 0; btres = 0
+      buf = ""; S = sprintf("%c", 1)
+    }
     {
       line = $0
       if (hd) {
         stripped = line
         sub(/^\t+/, "", stripped)
-        if (stripped == hdword) hd = 0
-        next
+        if (stripped == hdword) { hd = 0; next }
+        # Expansions still run inside an unquoted heredoc body: scan lines
+        # that contain a substitution as code; drop everything else.
+        if (hdq || (index(line, "$(") == 0 && index(line, "`") == 0)) next
       }
       n = length(line)
       i = 1
@@ -104,11 +111,17 @@ strip_shell_noise() {
             continue
           }
           # $(…) and `…` inside "…" still execute: break the segment and
-          # rescan the substitution as code (the string is prose, the
-          # substitution is not). The dangling close quote this leaves is an
-          # accepted heuristic imbalance.
-          if (c == "$" && substr(line, i + 1, 1) == "(") { dq = 0; buf = buf "\n"; i += 2; continue }
-          if (c == "`") { dq = 0; buf = buf "\n"; i++; continue }
+          # rescan the substitution as code, then resume the string state at
+          # the matching closer so the rest of the line keeps its quoting.
+          if (c == "$" && substr(line, i + 1, 1) == "(") {
+            pdepth++
+            resume[pdepth] = 1
+            dq = 0
+            buf = buf "\n"
+            i += 2
+            continue
+          }
+          if (c == "`") { btres = 1; dq = 0; buf = buf "\n"; i++; continue }
           if (c == "\"") { dq = 0 }
           else if (c == " " || c == "\t") buf = buf S
           else buf = buf c
@@ -139,12 +152,28 @@ strip_shell_noise() {
             j++
           }
           if (qc != "" && substr(line, j, 1) == qc) j++ # closing quote of <<"EOF"
-          if (w != "") { hd = 1; hdword = w; buf = buf " "; i = j; continue }
+          if (w != "") { hd = 1; hdword = w; hdq = (qc != ""); buf = buf " "; i = j; continue }
           buf = buf c
           i++
           continue
         }
-        if (c ~ /[;|&(){}`]/) { buf = buf "\n"; i++; continue }
+        if (c == "(") { pdepth++; buf = buf "\n"; i++; continue }
+        if (c == ")") {
+          if (pdepth > 0) {
+            if (resume[pdepth]) { dq = 1; delete resume[pdepth] }
+            pdepth--
+          }
+          buf = buf "\n"
+          i++
+          continue
+        }
+        if (c == "`") {
+          if (btres) { dq = 1; btres = 0 }
+          buf = buf "\n"
+          i++
+          continue
+        }
+        if (c ~ /[;|&{}]/) { buf = buf "\n"; i++; continue }
         buf = buf c
         i++
       }

--- a/scripts/agent-push-gate.sh
+++ b/scripts/agent-push-gate.sh
@@ -23,6 +23,13 @@
 # prefixing the push command itself (a mention elsewhere in the command does
 # not count). If the command cannot be extracted at all but the raw payload
 # mentions `git push` in a Bash call, the gate fails closed.
+#
+# Known accepted limits of the linear scan: subshell scoping and
+# short-circuit control flow are not modeled — `(cd /x); git push` gates
+# against /x, and a bypass behind `false &&` still counts as set. The Codex
+# stop gate and CI remain the backstops for what the heuristic misses; the
+# gate exists to stop forgetting, not a deliberate evader (that is what the
+# sanctioned FANOUT_SKIP_PUSH_CHECK=1 is for).
 set -u
 
 [ "${FANOUT_SKIP_PUSH_CHECK:-}" = "1" ] && exit 0
@@ -58,8 +65,9 @@ deny() {
 # command. Sets SEG_ARGS (words after `push`, newline-separated), SEG_BYPASS
 # (a FANOUT_SKIP_PUSH_CHECK=1 assignment prefixes this command), SEG_GIT_C
 # (newline-separated values of `git -C` in order), and SEG_REPO_SWITCH
-# (--git-dir/--work-tree seen — the gate cannot follow those, so the caller
-# fails closed).
+# (--git-dir/--work-tree, a repo-hopping `env -C`/`-S`, or a push-affecting
+# `git -c` override seen — the gate cannot follow those, so the caller fails
+# closed).
 parse_push_segment() {
   SEG_ARGS=""
   SEG_BYPASS=0
@@ -73,10 +81,17 @@ parse_push_segment() {
     [A-Za-z_]*=*) ;;
     env)
       # Consume env's own options so `env -i git push` is still a push.
+      # env -C hops directories and env -S splices a command string; the
+      # scan cannot follow either, so a push behind them fails closed.
       shift
       while [ $# -gt 0 ]; do
         case "$1" in
-        -u | -S | --split-string | -C | --chdir) shift ;;
+        -C | --chdir | -S | --split-string)
+          SEG_REPO_SWITCH=1
+          shift # the option; its value falls to the shift below
+          ;;
+        -C* | -S*) SEG_REPO_SWITCH=1 ;;
+        -u) shift ;;
         --) shift; break ;;
         -*) ;;
         *) break ;;
@@ -88,11 +103,20 @@ parse_push_segment() {
     command | exec | nohup) ;;
     # Shell control words: `if git push …; then` must still gate the push.
     if | then | elif | else | fi | do | done | while | until | ! | time) ;;
+    # Leading redirections (`>log git push …`) are valid shell.
+    \>* | [0-9]\>* | \<*)
+      case "$1" in
+      *\> | *\<)
+        shift
+        [ $# -gt 0 ] || return 1
+        ;;
+      esac
+      ;;
     *) break ;;
     esac
     shift
   done
-  [ "${1:-}" = "git" ] || return 1
+  [ "${1##*/}" = "git" ] || return 1
   shift
   while [ $# -gt 0 ]; do
     case "$1" in
@@ -109,7 +133,18 @@ parse_push_segment() {
         ;;
       esac
       ;;
-    -c | --namespace | --config-env)
+    -c | --config-env)
+      shift
+      [ $# -gt 0 ] || return 1
+      # An inline config override can redirect what a push sends
+      # (remote.*.push / push.* / mirror / pushRemote); fail closed on those.
+      case "$1" in
+      push.* | *.push=* | *.push | *.pushurl=* | *.mirror=* | *.mirror | *.pushremote=* | *.pushRemote=*)
+        SEG_REPO_SWITCH=1
+        ;;
+      esac
+      ;;
+    --namespace)
       shift
       [ $# -gt 0 ] || return 1
       ;;
@@ -175,6 +210,7 @@ while IFS= read -r seg; do
   deletions=0
   non_flag=0
   skip_next=0
+  repo_val_next=0
   tag_kw=0
   remote_w=""
   refspecs=()
@@ -184,17 +220,31 @@ while IFS= read -r seg; do
       skip_next=0
       continue
     fi
+    if [ "$repo_val_next" = "1" ]; then
+      repo_val_next=0
+      remote_w="$w"
+      continue
+    fi
     case "$w" in
     --delete | -d) gated=0 ;;
     --dry-run | -n) gated=0 ;; # side-effect-free probe push
     --all | --branches | --mirror) all_flag=1 ;;
     --tags) tags_flag=1 ;;
-    -o | --push-option | --receive-pack | --exec | --repo) skip_next=1 ;;
+    -o | --push-option | --receive-pack | --exec) skip_next=1 ;;
+    # --repo supplies the repository, so the next positional is a refspec.
+    --repo)
+      repo_val_next=1
+      non_flag=$((non_flag + 1))
+      ;;
+    --repo=*)
+      remote_w="${w#--repo=}"
+      non_flag=$((non_flag + 1))
+      ;;
     \>* | [0-9]\>* | \<*)
       case "$w" in *\> | *\<) skip_next=1 ;; esac
       ;;
     : | +:) all_flag=1 ;; # bare colon: matching push, every shared branch
-    :*) deletions=$((deletions + 1)) ;;
+    :* | +:*) deletions=$((deletions + 1)) ;;
     -*) ;;
     tag)
       if [ "$non_flag" -ge 1 ]; then
@@ -241,15 +291,25 @@ while IFS= read -r seg; do
       continue # deletion-only push or pure `git push --tags [remote]`
     fi
     # No explicit refspec: git falls back to remote.<name>.push, then
-    # push.default. A configured refspec set or `matching` can push tips
-    # other than HEAD.
+    # push.default. A configured refspec set, a mirror remote, or `matching`
+    # can push tips other than HEAD.
     if [ -z "$remote_w" ]; then
+      # Git resolves the implicit remote as branch.<name>.pushRemote,
+      # remote.pushDefault, branch.<name>.remote, then origin.
       cur_branch="$(git -C "$push_dir" symbolic-ref --short -q HEAD 2>/dev/null)"
-      remote_w="$(git -C "$push_dir" config "branch.${cur_branch:-HEAD}.remote" 2>/dev/null)"
+      remote_w="$(git -C "$push_dir" config "branch.${cur_branch:-HEAD}.pushRemote" 2>/dev/null)"
+      [ -n "$remote_w" ] || remote_w="$(git -C "$push_dir" config remote.pushDefault 2>/dev/null)"
+      [ -n "$remote_w" ] || remote_w="$(git -C "$push_dir" config "branch.${cur_branch:-HEAD}.remote" 2>/dev/null)"
       remote_w="${remote_w:-origin}"
     fi
     cfg_specs="$(git -C "$push_dir" config --get-all "remote.$remote_w.push" 2>/dev/null)"
-    if [ -n "$cfg_specs" ]; then
+    if [ "$(git -C "$push_dir" config --bool "remote.$remote_w.mirror" 2>/dev/null)" = "true" ]; then
+      # remote.<name>.mirror makes a bare `git push` mirror every ref.
+      while IFS= read -r tip; do
+        [ -n "$tip" ] || continue
+        required+=("$tip")
+      done < <(git -C "$push_dir" for-each-ref refs/heads --format='%(objectname)' 2>/dev/null | sort -u)
+    elif [ -n "$cfg_specs" ]; then
       while IFS= read -r spec; do
         [ -n "$spec" ] || continue
         refspecs+=("$spec")

--- a/scripts/agent-push-gate.sh
+++ b/scripts/agent-push-gate.sh
@@ -1,11 +1,13 @@
 #!/usr/bin/env bash
 # fanout push gate — PreToolUse hook for Claude Code and Codex.
 #
-# Denies `git push` to a branch unless the per-worktree marker
-# $(git rev-parse --git-dir)/fanout-check-passed matches HEAD. The marker is
-# written by a successful `make check` on a clean tree (Makefile check-marker),
-# so a denied push means the pushed tip was never validated: run `make check`,
-# then push again. Branch deletions and tag pushes stay ungated.
+# Denies `git push` of a branch tip that `make check` has not validated. Every
+# pushed source ref is resolved to its commit in the repository the push
+# actually targets (payload cwd, adjusted for `cd` segments and `git -C`), and
+# each one must equal the per-worktree marker
+# $(git rev-parse --git-dir)/fanout-check-passed, written by a successful
+# `make check` on a clean tree (Makefile check-marker). Deletions, tag-to-tag
+# pushes, and --dry-run stay ungated.
 #
 # Contract (PreToolUse hook, identical for both agents): stdin is the
 # tool-call JSON ({"tool_name":"Bash","tool_input":{"command":…},"cwd":…}).
@@ -13,11 +15,13 @@
 # back to the agent. Any other exit is a non-blocking error (fail open), which
 # is why this script uses `set -u` without `-e`.
 #
-# Detection is a staged shell heuristic, not a full tokenizer: quoted spans
-# are stripped first so `git push` inside commit messages or --body text does
-# not trigger the gate, then each pipeline segment is word-scanned for a real
-# `git … push` command. Escape hatch: FANOUT_SKIP_PUSH_CHECK=1 (exported or
-# inline). If the command cannot be extracted at all but the raw payload
+# Detection is a staged shell heuristic, not a shell: strip_shell_noise
+# (agent-hooks-lib.sh) removes quoted spans and heredoc bodies and splits on
+# separators, then each simple command is word-scanned for `git … push`.
+# Unknown constructs must degrade toward a false deny, never a false allow.
+# Escape hatch: FANOUT_SKIP_PUSH_CHECK=1 — exported, or as an assignment
+# prefixing the push command itself (a mention elsewhere in the command does
+# not count). If the command cannot be extracted at all but the raw payload
 # mentions `git push` in a Bash call, the gate fails closed.
 set -u
 
@@ -40,105 +44,185 @@ if [ -z "$cmd" ]; then
   exit 0
 fi
 
-case "$cmd" in
-*FANOUT_SKIP_PUSH_CHECK=1*) exit 0 ;;
-esac
+deny() {
+  {
+    echo "fanout push gate: この push は make check 未検証のため拒否しました。"
+    echo "$1"
+    echo "clean tree で make check を成功させてから push し直してください (成功時に marker が書かれます)。"
+    echo "緊急回避: FANOUT_SKIP_PUSH_CHECK=1 git push ..."
+  } >&2
+  exit 2
+}
 
-# Strip quoted spans, then split on pipeline/list separators. Stripping only
-# removes text, so it cannot fabricate a `git push` that was not already a
-# command word (adjacent-token merges collapse into whitespace).
-stripped="$(printf '%s' "$cmd" | sed -e "s/'[^']*'/ /g" -e 's/"[^"]*"/ /g')"
-segments="$(printf '%s' "$stripped" | tr '|;&' '\n')"
-
-# seg_push_args SEGMENT — if SEGMENT is a `git … push` command, print the
-# words after `push` (one per line) and return 0.
-seg_push_args() {
+# parse_push_segment SEGMENT — return 0 when SEGMENT is a `git … push`
+# command. Sets SEG_ARGS (words after `push`, newline-separated), SEG_BYPASS
+# (a FANOUT_SKIP_PUSH_CHECK=1 assignment prefixes this command), and
+# SEG_GIT_C (newline-separated values of `git -C` in order).
+parse_push_segment() {
+  SEG_ARGS=""
+  SEG_BYPASS=0
+  SEG_GIT_C=""
   # shellcheck disable=SC2086 # word splitting is the tokenizer here
   set -- $1
   while [ $# -gt 0 ]; do
     case "$1" in
-    [A-Za-z_]*=*) shift ;; # env assignment prefix
-    env | command | exec | nohup) shift ;;
+    FANOUT_SKIP_PUSH_CHECK=1) SEG_BYPASS=1 ;;
+    [A-Za-z_]*=*) ;;
+    env | command | exec | nohup) ;;
     *) break ;;
     esac
+    shift
   done
   [ "${1:-}" = "git" ] || return 1
   shift
   while [ $# -gt 0 ]; do
     case "$1" in
-    -C | -c | --git-dir | --work-tree | --namespace | --config-env)
+    -C)
       shift
-      [ $# -gt 0 ] && shift
+      [ $# -gt 0 ] || return 1
+      SEG_GIT_C="${SEG_GIT_C}${1}"$'\n'
       ;;
-    -*) shift ;;
+    -c | --git-dir | --work-tree | --namespace | --config-env)
+      shift
+      [ $# -gt 0 ] || return 1
+      ;;
+    -*) ;;
     *) break ;;
     esac
+    shift
   done
   [ "${1:-}" = "push" ] || return 1
   shift
-  printf '%s\n' "$@"
-}
-
-# all_refspecs_are_tags DIR REFSPECS — release flows push existing tags; a
-# push whose every source ref resolves under refs/tags/ stays ungated.
-all_refspecs_are_tags() {
-  local dir="$1" spec src
-  shift
-  [ $# -gt 0 ] || return 1
-  for spec in "$@"; do
-    src="${spec%%:*}"
-    src="${src#+}"
-    git -C "$dir" rev-parse -q --verify "refs/tags/$src" >/dev/null 2>&1 || return 1
-  done
+  SEG_ARGS="$(printf '%s\n' "$@")"
   return 0
 }
 
-needs_marker=0
+# abs_dir BASE PATH — PATH absolutized against BASE (no existence check).
+abs_dir() {
+  case "$2" in
+  /*) printf '%s' "$2" ;;
+  *) printf '%s/%s' "$1" "$2" ;;
+  esac
+}
+
+base_dir="$(resolve_project_dir "$input")"
+segments="$(strip_shell_noise "$cmd")"
+
+cmd_bypass=0
+seg_dir="$base_dir" # follows `cd` segments so later pushes gate the right repo
+
 while IFS= read -r seg; do
-  [ -n "${seg// /}" ] || continue
-  push_args="$(seg_push_args "$seg")" || continue
+  case "$seg" in *[![:space:]]*) ;; *) continue ;; esac
+
+  # shellcheck disable=SC2086
+  set -- $seg
+  if [ "${1:-}" = "export" ] && [ "${2:-}" = "FANOUT_SKIP_PUSH_CHECK=1" ]; then
+    cmd_bypass=1
+    continue
+  fi
+  if [ "${1:-}" = "cd" ] || [ "${1:-}" = "pushd" ]; then
+    if [ -n "${2:-}" ]; then
+      seg_dir="$(abs_dir "$seg_dir" "$2")"
+    else
+      seg_dir="$HOME"
+    fi
+    continue
+  fi
+
+  parse_push_segment "$seg" || continue
+  [ "$SEG_BYPASS" = "1" ] && continue
+  [ "$cmd_bypass" = "1" ] && continue
+
+  push_dir="$seg_dir"
+  while IFS= read -r c_path; do
+    [ -n "$c_path" ] || continue
+    push_dir="$(abs_dir "$push_dir" "$c_path")"
+  done <<<"$SEG_GIT_C"
+
   gated=1
-  non_flag=0
+  tags_flag=0
   deletions=0
+  non_flag=0
+  skip_next=0
+  tag_kw=0
   refspecs=()
   while IFS= read -r w; do
     [ -n "$w" ] || continue
+    if [ "$skip_next" = "1" ]; then
+      skip_next=0
+      continue
+    fi
     case "$w" in
-    --delete | -d | --tags | --follow-tags) gated=0 ;;
-    :*) deletions=$((deletions + 1)) ;; # delete refspec: no source ref
+    --delete | -d) gated=0 ;;
+    --dry-run | -n) gated=0 ;; # side-effect-free probe push
+    --tags) tags_flag=1 ;;
+    -o | --push-option | --receive-pack | --exec | --repo) skip_next=1 ;;
+    \>* | [0-9]\>* | \<*)
+      case "$w" in *\> | *\<) skip_next=1 ;; esac
+      ;;
+    :*) deletions=$((deletions + 1)) ;;
     -*) ;;
+    tag)
+      if [ "$non_flag" -ge 1 ]; then tag_kw=1; else non_flag=$((non_flag + 1)); fi
+      ;;
     *)
       non_flag=$((non_flag + 1))
-      [ "$non_flag" -ge 2 ] && refspecs+=("$w")
+      if [ "$non_flag" -ge 2 ]; then
+        if [ "$tag_kw" = "1" ]; then
+          refspecs+=("refs/tags/$w")
+          tag_kw=0
+        else
+          refspecs+=("$w")
+        fi
+      fi
       ;;
     esac
-  done <<<"$push_args"
+  done <<<"$SEG_ARGS"
   [ "$gated" = "1" ] || continue
-  if [ "${#refspecs[@]}" -gt 0 ]; then
-    dir_for_tags="$(resolve_project_dir "$input")"
-    all_refspecs_are_tags "$dir_for_tags" "${refspecs[@]}" && continue
-  elif [ "$deletions" -gt 0 ]; then
-    continue # deletion-only push (git push origin :branch)
+
+  git -C "$push_dir" rev-parse --is-inside-work-tree >/dev/null 2>&1 || continue
+  recorded="$(marker_sha "$push_dir")"
+
+  required=()
+  if [ "${#refspecs[@]}" -eq 0 ]; then
+    if [ "$deletions" -gt 0 ] || [ "$tags_flag" = "1" ]; then
+      continue # deletion-only push or pure `git push --tags [remote]`
+    fi
+    required+=("HEAD")
+  else
+    for spec in "${refspecs[@]}"; do
+      src="${spec%%:*}"
+      src="${src#+}"
+      dst=""
+      case "$spec" in *:*) dst="${spec#*:}" ;; esac
+      tag_ref=""
+      case "$src" in
+      refs/tags/*) tag_ref="$src" ;;
+      *)
+        if git -C "$push_dir" rev-parse -q --verify "refs/tags/$src" >/dev/null 2>&1; then
+          tag_ref="refs/tags/$src"
+        fi
+        ;;
+      esac
+      if [ -n "$tag_ref" ]; then
+        case "$dst" in
+        "" | refs/tags/*) continue ;; # release flow: tag pushed as a tag
+        esac
+      fi
+      required+=("$src")
+    done
+    [ "${#required[@]}" -eq 0 ] && continue
   fi
-  needs_marker=1
+
+  for src in "${required[@]}"; do
+    sha="$(git -C "$push_dir" rev-parse -q --verify "$src^{commit}" 2>/dev/null)" || sha=""
+    if [ -z "$sha" ]; then
+      deny "push 対象 $src を $push_dir で解決できませんでした (marker 照合不能のため安全側で拒否)。"
+    fi
+    if [ "$sha" != "$recorded" ]; then
+      deny "push 対象 $src ($sha) に対する marker が見つからないか一致しません (marker: ${recorded:-なし}, repo: $push_dir)。"
+    fi
+  done
 done <<<"$segments"
-
-[ "$needs_marker" = "1" ] || exit 0
-
-dir="$(resolve_project_dir "$input")"
-git -C "$dir" rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
-head="$(head_sha "$dir")" || exit 0
-[ -n "$head" ] || exit 0
-recorded="$(marker_sha "$dir")"
-
-if [ "$recorded" != "$head" ]; then
-  {
-    echo "fanout push gate: この push は make check 未検証のため拒否しました。"
-    echo "HEAD $head に対する marker が見つからないか一致しません (marker: ${recorded:-なし})。"
-    echo "clean tree で make check を成功させてから push し直してください (成功時に marker が書かれます)。"
-    echo "緊急回避: FANOUT_SKIP_PUSH_CHECK=1 git push ..."
-  } >&2
-  exit 2
-fi
 
 exit 0

--- a/scripts/agent-push-gate.sh
+++ b/scripts/agent-push-gate.sh
@@ -35,6 +35,14 @@
 # - config that only re-points the REMOTE of a validated tip
 #   (`-c branch.<name>.remote=…`) is not tracked: the pushed commit itself
 #   was validated.
+#
+# Wrapper/option coverage is intentionally broad but not exhaustive: the
+# scanner transparently steps over env (incl. -C/-S/-u/--unset), command,
+# exec, nohup, and timeout (with its DURATION), treats bash/sh/eval/env -S
+# splices and `--git-dir`/`--work-tree`/`--namespace`/GIT_* repo switches as
+# fail-closed, and flags ref-moving git subcommands before a same-call push.
+# A genuinely novel wrapper is a false-allow gap the backstops cover, not a
+# security boundary.
 set -u
 
 [ "${FANOUT_SKIP_PUSH_CHECK:-}" = "1" ] && exit 0
@@ -99,12 +107,27 @@ parse_push_segment() {
           shift # the option; its value falls to the shift below
           ;;
         -C* | -S* | --chdir=* | --split-string=*) SEG_REPO_SWITCH=1 ;;
-        -u) shift ;;
+        -u | --unset) shift ;; # takes a value (the next word)
+        --unset=*) ;;
         --) shift; break ;;
         -*) ;;
         *) break ;;
         esac
         shift
+      done
+      continue
+      ;;
+    timeout | */timeout)
+      # timeout [OPTION]... DURATION COMMAND …: skip options and DURATION so
+      # `timeout 30 git push` is still a push.
+      shift
+      while [ $# -gt 0 ]; do
+        case "$1" in
+        -s | --signal | -k | --kill-after) shift; [ $# -gt 0 ] && shift ;;
+        --) shift; [ $# -gt 0 ] && shift; break ;;
+        -*) shift ;;
+        *) shift; break ;; # DURATION operand
+        esac
       done
       continue
       ;;
@@ -169,9 +192,14 @@ parse_push_segment() {
     --config-env=*)
       if push_affecting_config "${1#--config-env=}"; then SEG_REPO_SWITCH=1; fi
       ;;
-    --namespace)
-      shift
-      [ $# -gt 0 ] || return 1
+    --namespace | --namespace=*)
+      # --namespace re-points refs under refs/namespaces/<name>/: untraceable.
+      SEG_REPO_SWITCH=1
+      case "$1" in --namespace)
+        shift
+        [ $# -gt 0 ] || return 1
+        ;;
+      esac
       ;;
     -*) ;;
     *) break ;;
@@ -216,6 +244,18 @@ seg_inner_shell_push() {
     [A-Za-z_]*=*) ;;
     command | exec | nohup | time | */nohup | */time) ;;
     if | then | elif | else | fi | do | done | while | until | !) ;;
+    timeout | */timeout)
+      shift
+      while [ $# -gt 0 ]; do
+        case "$1" in
+        -s | --signal | -k | --kill-after) shift; [ $# -gt 0 ] && shift ;;
+        --) shift; [ $# -gt 0 ] && shift; break ;;
+        -*) shift ;;
+        *) shift; break ;;
+        esac
+      done
+      continue
+      ;;
     env | */env)
       shift
       while [ $# -gt 0 ]; do
@@ -317,6 +357,18 @@ seg_gh_pr_create() {
       continue
       ;;
     command | exec | nohup | time | */nohup | */time) ;;
+    timeout | */timeout)
+      shift
+      while [ $# -gt 0 ]; do
+        case "$1" in
+        -s | --signal | -k | --kill-after) shift; [ $# -gt 0 ] && shift ;;
+        --) shift; [ $# -gt 0 ] && shift; break ;;
+        -*) shift ;;
+        *) shift; break ;;
+        esac
+      done
+      continue
+      ;;
     if | then | elif | else | fi | do | done | while | until | !) ;;
     *) break ;;
     esac
@@ -360,8 +412,34 @@ seg_ref_mutating() {
   while [ $# -gt 0 ]; do
     case "$1" in
     [A-Za-z_]*=*) ;;
-    env | command | exec | nohup | */env | */nohup) ;;
+    command | exec | nohup | */nohup) ;;
     if | then | elif | else | fi | do | done | while | until | ! | time) ;;
+    env | */env)
+      # Consume env's options so `env -C repo git commit` is still a mutation.
+      shift
+      while [ $# -gt 0 ]; do
+        case "$1" in
+        -C | --chdir | -S | --split-string | -u | --unset) shift; [ $# -gt 0 ] && shift ;;
+        -C* | -S* | --chdir=* | --split-string=* | --unset=*) shift ;;
+        --) shift; break ;;
+        -*) shift ;;
+        *) break ;;
+        esac
+      done
+      continue
+      ;;
+    timeout | */timeout)
+      shift
+      while [ $# -gt 0 ]; do
+        case "$1" in
+        -s | --signal | -k | --kill-after) shift; [ $# -gt 0 ] && shift ;;
+        --) shift; [ $# -gt 0 ] && shift; break ;;
+        -*) shift ;;
+        *) shift; break ;;
+        esac
+      done
+      continue
+      ;;
     *) break ;;
     esac
     shift
@@ -383,9 +461,10 @@ seg_ref_mutating() {
     shift
   done
   case "${1:-}" in
-  # config and tag do not move branch tips, but they change what a later
-  # push in the same call sends (push refspecs / a re-pointed tag source).
-  commit | merge | rebase | cherry-pick | revert | reset | am | pull | switch | checkout | fetch | branch | update-ref | config | tag) return 0 ;;
+  # config, tag, and symbolic-ref do not move branch tips, but they change
+  # what a later push in the same call sends (push refspecs, a re-pointed tag
+  # source, or a switched HEAD symref).
+  commit | merge | rebase | cherry-pick | revert | reset | am | pull | switch | checkout | fetch | branch | update-ref | config | tag | symbolic-ref) return 0 ;;
   esac
   return 1
 }
@@ -632,8 +711,9 @@ while IFS= read -r seg; do
       if [ -n "$tag_ref" ]; then
         case "$dst" in
         "" | refs/tags/*) continue ;; # release flow: tag pushed as a tag
-        refs/*) ;;                    # explicit non-tag destination: gated
-        *) continue ;;                # unqualified dst: git infers refs/tags/ from the tag source
+        # An unqualified <dst> can expand to an existing remote branch, so a
+        # tag source with a non-refs/tags destination stays gated.
+        *) ;;
         esac
       fi
       required+=("$src")

--- a/scripts/agent-push-gate.sh
+++ b/scripts/agent-push-gate.sh
@@ -69,6 +69,8 @@ parse_push_segment() {
     FANOUT_SKIP_PUSH_CHECK=1) SEG_BYPASS=1 ;;
     [A-Za-z_]*=*) ;;
     env | command | exec | nohup) ;;
+    # Shell control words: `if git push …; then` must still gate the push.
+    if | then | elif | else | fi | do | done | while | until | ! | time) ;;
     *) break ;;
     esac
     shift
@@ -122,7 +124,7 @@ while IFS= read -r seg; do
   fi
   if [ "${1:-}" = "cd" ] || [ "${1:-}" = "pushd" ]; then
     if [ -n "${2:-}" ]; then
-      seg_dir="$(abs_dir "$seg_dir" "$2")"
+      seg_dir="$(abs_dir "$seg_dir" "$(unsentinel "$2")")"
     else
       seg_dir="$HOME"
     fi
@@ -136,11 +138,12 @@ while IFS= read -r seg; do
   push_dir="$seg_dir"
   while IFS= read -r c_path; do
     [ -n "$c_path" ] || continue
-    push_dir="$(abs_dir "$push_dir" "$c_path")"
+    push_dir="$(abs_dir "$push_dir" "$(unsentinel "$c_path")")"
   done <<<"$SEG_GIT_C"
 
   gated=1
   tags_flag=0
+  all_flag=0
   deletions=0
   non_flag=0
   skip_next=0
@@ -155,6 +158,7 @@ while IFS= read -r seg; do
     case "$w" in
     --delete | -d) gated=0 ;;
     --dry-run | -n) gated=0 ;; # side-effect-free probe push
+    --all | --branches | --mirror) all_flag=1 ;;
     --tags) tags_flag=1 ;;
     -o | --push-option | --receive-pack | --exec | --repo) skip_next=1 ;;
     \>* | [0-9]\>* | \<*)
@@ -180,11 +184,24 @@ while IFS= read -r seg; do
   done <<<"$SEG_ARGS"
   [ "$gated" = "1" ] || continue
 
-  git -C "$push_dir" rev-parse --is-inside-work-tree >/dev/null 2>&1 || continue
+  # A detected push whose repository cannot be resolved (a `cd` to a missing
+  # path, an unexpanded variable) is unverifiable — fail closed.
+  if ! git -C "$push_dir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    deny "push 先リポジトリを解決できませんでした ($push_dir)。変数や存在しないパスを経由した push は検証できないため安全側で拒否します。"
+  fi
   recorded="$(marker_sha "$push_dir")"
 
   required=()
-  if [ "${#refspecs[@]}" -eq 0 ]; then
+  if [ "$all_flag" = "1" ]; then
+    # --all / --branches / --mirror push every local branch tip.
+    while IFS= read -r tip; do
+      [ -n "$tip" ] || continue
+      required+=("$tip")
+    done < <(git -C "$push_dir" for-each-ref refs/heads --format='%(objectname)' 2>/dev/null | sort -u)
+    if [ "${#required[@]}" -eq 0 ]; then
+      deny "--all/--mirror push の branch tip を列挙できませんでした ($push_dir)。"
+    fi
+  elif [ "${#refspecs[@]}" -eq 0 ]; then
     if [ "$deletions" -gt 0 ] || [ "$tags_flag" = "1" ]; then
       continue # deletion-only push or pure `git push --tags [remote]`
     fi

--- a/scripts/agent-push-gate.sh
+++ b/scripts/agent-push-gate.sh
@@ -131,6 +131,9 @@ parse_push_segment() {
     esac
     shift
   done
+  # bash >= 4.4 with set -u errors on ${1##…} when $1 is unset (bash 3.2
+  # tolerates it); guard the arity first.
+  [ $# -gt 0 ] || return 1
   [ "${1##*/}" = "git" ] || return 1
   shift
   while [ $# -gt 0 ]; do
@@ -210,6 +213,9 @@ seg_ref_mutating() {
     esac
     shift
   done
+  # bash >= 4.4 with set -u errors on ${1##…} when $1 is unset (bash 3.2
+  # tolerates it); guard the arity first.
+  [ $# -gt 0 ] || return 1
   [ "${1##*/}" = "git" ] || return 1
   shift
   while [ $# -gt 0 ]; do

--- a/scripts/agent-push-gate.sh
+++ b/scripts/agent-push-gate.sh
@@ -78,6 +78,9 @@ parse_push_segment() {
   while [ $# -gt 0 ]; do
     case "$1" in
     FANOUT_SKIP_PUSH_CHECK=1) SEG_BYPASS=1 ;;
+    # Environment overrides that re-point git's repository/ref resolution
+    # make the push untraceable: fail closed.
+    GIT_DIR=* | GIT_WORK_TREE=* | GIT_COMMON_DIR=* | GIT_INDEX_FILE=* | GIT_NAMESPACE=* | GIT_OBJECT_DIRECTORY=* | GIT_CONFIG*=*) SEG_REPO_SWITCH=1 ;;
     [A-Za-z_]*=*) ;;
     env)
       # Consume env's own options so `env -i git push` is still a push.
@@ -138,11 +141,13 @@ parse_push_segment() {
       [ $# -gt 0 ] || return 1
       # An inline config override can redirect what a push sends
       # (remote.*.push / push.* / mirror / pushRemote); fail closed on those.
-      case "$1" in
-      push.* | *.push=* | *.push | *.pushurl=* | *.mirror=* | *.mirror | *.pushremote=* | *.pushRemote=*)
-        SEG_REPO_SWITCH=1
-        ;;
-      esac
+      if push_affecting_config "$1"; then SEG_REPO_SWITCH=1; fi
+      ;;
+    -c?*)
+      if push_affecting_config "${1#-c}"; then SEG_REPO_SWITCH=1; fi
+      ;;
+    --config-env=*)
+      if push_affecting_config "${1#--config-env=}"; then SEG_REPO_SWITCH=1; fi
       ;;
     --namespace)
       shift
@@ -167,14 +172,65 @@ abs_dir() {
   esac
 }
 
+# push_affecting_config KEY[=VALUE] — config that changes what a push sends.
+push_affecting_config() {
+  case "$1" in
+  push.* | *.push=* | *.push | *.pushurl=* | *.mirror=* | *.mirror | *.pushremote=* | *.pushRemote=*)
+    return 0
+    ;;
+  esac
+  return 1
+}
+
+# seg_ref_mutating SEGMENT — true when SEGMENT is a git command that can move
+# local refs (or HEAD) before a later push in the same tool call. The gate
+# resolves refs before the call runs, so a push after one of these cannot be
+# validated.
+seg_ref_mutating() {
+  # shellcheck disable=SC2086 # word splitting is the tokenizer here
+  set -- $1
+  while [ $# -gt 0 ]; do
+    case "$1" in
+    [A-Za-z_]*=*) ;;
+    env | command | exec | nohup) ;;
+    if | then | elif | else | fi | do | done | while | until | ! | time) ;;
+    *) break ;;
+    esac
+    shift
+  done
+  [ "${1##*/}" = "git" ] || return 1
+  shift
+  while [ $# -gt 0 ]; do
+    case "$1" in
+    -C | -c | --git-dir | --work-tree | --namespace | --config-env)
+      shift
+      [ $# -gt 0 ] || return 1
+      ;;
+    -*) ;;
+    *) break ;;
+    esac
+    shift
+  done
+  case "${1:-}" in
+  commit | merge | rebase | cherry-pick | revert | reset | am | pull | switch | checkout) return 0 ;;
+  esac
+  return 1
+}
+
 base_dir="$(resolve_project_dir "$input")"
 segments="$(strip_shell_noise "$cmd")"
 
 cmd_bypass=0
+ref_mut=0
 seg_dir="$base_dir" # follows `cd` segments so later pushes gate the right repo
 
 while IFS= read -r seg; do
   case "$seg" in *[![:space:]]*) ;; *) continue ;; esac
+
+  if seg_ref_mutating "$seg"; then
+    ref_mut=1
+    continue
+  fi
 
   # shellcheck disable=SC2086
   set -- $seg
@@ -341,11 +397,19 @@ while IFS= read -r seg; do
       if [ -n "$tag_ref" ]; then
         case "$dst" in
         "" | refs/tags/*) continue ;; # release flow: tag pushed as a tag
+        refs/*) ;;                    # explicit non-tag destination: gated
+        *) continue ;;                # unqualified dst: git infers refs/tags/ from the tag source
         esac
       fi
       required+=("$src")
     done
     [ "${#required[@]}" -eq 0 ] && continue
+  fi
+
+  # Refs are resolved before this tool call runs; a commit/rebase earlier in
+  # the same call would move them afterwards, making the validation stale.
+  if [ "${#required[@]}" -gt 0 ] && [ "$ref_mut" = "1" ]; then
+    deny "同一コマンド内で ref を変更するコマンド (commit / rebase 等) の後に push しています。gate は実行前の状態しか検証できないため拒否します。commit 後に make check を通し、push は単独のコマンドとして実行してください。"
   fi
 
   for src in "${required[@]}"; do

--- a/scripts/agent-push-gate.sh
+++ b/scripts/agent-push-gate.sh
@@ -190,7 +190,7 @@ abs_dir() {
 # push_affecting_config KEY[=VALUE] — config that changes what a push sends.
 push_affecting_config() {
   case "$1" in
-  push.* | *.push=* | *.push | *.pushurl=* | *.mirror=* | *.mirror | *.pushremote=* | *.pushRemote=*)
+  push.* | *.push=* | *.push | *.pushurl=* | *.mirror=* | *.mirror | *.pushremote=* | *.pushRemote=* | remote.pushdefault=* | remote.pushDefault=*)
     return 0
     ;;
   esac
@@ -198,8 +198,9 @@ push_affecting_config() {
 }
 
 # seg_inner_shell_push SEGMENT — true when SEGMENT hands a command string to
-# an inner shell (`bash -c …` / `sh -lc …`) that mentions a git push. The
-# scanner cannot follow the inner shell, so the caller fails closed.
+# an inner shell (`bash -c …` / `sh -lc …`) or to `env -S '…'` that mentions
+# a git push. The scanner cannot follow the spliced string, so the caller
+# fails closed.
 seg_inner_shell_push() {
   local has_c=0 w joined
   # shellcheck disable=SC2086 # word splitting is the tokenizer here
@@ -207,23 +208,52 @@ seg_inner_shell_push() {
   while [ $# -gt 0 ]; do
     case "$1" in
     [A-Za-z_]*=*) ;;
-    env | command | exec | nohup | time) ;;
+    command | exec | nohup | time) ;;
     if | then | elif | else | fi | do | done | while | until | !) ;;
+    env)
+      shift
+      while [ $# -gt 0 ]; do
+        case "$1" in
+        -S | --split-string)
+          has_c=1
+          shift
+          break # the spliced string follows; keep it for the scan below
+          ;;
+        -S* | --split-string=*)
+          has_c=1
+          break # value embedded in the token; keep it for the scan below
+          ;;
+        -u | -C | --chdir)
+          shift
+          [ $# -gt 0 ] && shift
+          ;;
+        --)
+          shift
+          break
+          ;;
+        -*) shift ;;
+        *) break ;;
+        esac
+      done
+      continue
+      ;;
     *) break ;;
     esac
     shift
   done
-  [ $# -gt 0 ] || return 1
-  case "${1##*/}" in
-  bash | sh | zsh | dash | ksh) ;;
-  *) return 1 ;;
-  esac
-  shift
-  for w in "$@"; do
-    case "$w" in
-    -*c*) has_c=1 ;;
+  if [ "$has_c" = "0" ]; then
+    [ $# -gt 0 ] || return 1
+    case "${1##*/}" in
+    bash | sh | zsh | dash | ksh) ;;
+    *) return 1 ;;
     esac
-  done
+    shift
+    for w in "$@"; do
+      case "$w" in
+      -*c*) has_c=1 ;;
+      esac
+    done
+  fi
   [ "$has_c" = "1" ] || return 1
   joined="$(unsentinel "$*")"
   case "$joined" in
@@ -320,11 +350,12 @@ base_dir="$(resolve_project_dir "$input")"
 segments="$(strip_shell_noise "$cmd")"
 
 cmd_bypass=0
+cmd_repo_switch=0
 ref_mut=0
 
 # First pass — command-wide facts. Substitution bodies are queued after the
 # outer segments, so positional scanning would see a `git commit` inside
-# `$(…)` only after the push; ref mutation and an exported bypass are
+# `$(…)` only after the push; ref mutation and exported state are
 # command-wide either way.
 while IFS= read -r seg; do
   case "$seg" in *[![:space:]]*) ;; *) continue ;; esac
@@ -334,12 +365,20 @@ while IFS= read -r seg; do
   fi
   # shellcheck disable=SC2086
   set -- $seg
-  if [ "${1:-}" = "export" ] && [ "${2:-}" = "FANOUT_SKIP_PUSH_CHECK=1" ]; then
-    cmd_bypass=1
+  if [ "${1:-}" = "export" ]; then
+    shift
+    for w in "$@"; do
+      case "$w" in
+      FANOUT_SKIP_PUSH_CHECK=1) cmd_bypass=1 ;;
+      # Exported repo-pointing env vars redirect every later git call.
+      GIT_DIR=* | GIT_WORK_TREE=* | GIT_COMMON_DIR=* | GIT_INDEX_FILE=* | GIT_NAMESPACE=* | GIT_OBJECT_DIRECTORY=* | GIT_CONFIG*=*) cmd_repo_switch=1 ;;
+      esac
+    done
   fi
 done <<<"$segments"
 
 seg_dir="$base_dir" # follows `cd` segments so later pushes gate the right repo
+dir_stack=()        # pushd/popd
 
 while IFS= read -r seg; do
   case "$seg" in *[![:space:]]*) ;; *) continue ;; esac
@@ -361,11 +400,32 @@ while IFS= read -r seg; do
 
   # shellcheck disable=SC2086
   set -- $seg
-  if [ "${1:-}" = "cd" ] || [ "${1:-}" = "pushd" ]; then
+  if [ "${1:-}" = "cd" ]; then
     if [ -n "${2:-}" ]; then
       seg_dir="$(abs_dir "$seg_dir" "$(unsentinel "$2")")"
     else
       seg_dir="$HOME"
+    fi
+    continue
+  fi
+  if [ "${1:-}" = "pushd" ]; then
+    if [ -n "${2:-}" ]; then
+      dir_stack+=("$seg_dir")
+      seg_dir="$(abs_dir "$seg_dir" "$(unsentinel "$2")")"
+    elif [ "${#dir_stack[@]}" -gt 0 ]; then
+      # bare pushd swaps the top two directory-stack entries
+      top_idx=$((${#dir_stack[@]} - 1))
+      swap="${dir_stack[$top_idx]}"
+      dir_stack[top_idx]="$seg_dir"
+      seg_dir="$swap"
+    fi
+    continue
+  fi
+  if [ "${1:-}" = "popd" ]; then
+    if [ "${#dir_stack[@]}" -gt 0 ]; then
+      top_idx=$((${#dir_stack[@]} - 1))
+      seg_dir="${dir_stack[$top_idx]}"
+      unset "dir_stack[$top_idx]"
     fi
     continue
   fi
@@ -538,6 +598,9 @@ while IFS= read -r seg; do
   # the same call would move them afterwards, making the validation stale.
   if [ "${#required[@]}" -gt 0 ] && [ "$ref_mut" = "1" ]; then
     deny "同一コマンド内で ref を変更するコマンド (commit / rebase 等) の後に push しています。gate は実行前の状態しか検証できないため拒否します。commit 後に make check を通し、push は単独のコマンドとして実行してください。"
+  fi
+  if [ "${#required[@]}" -gt 0 ] && [ "$cmd_repo_switch" = "1" ]; then
+    deny "同一コマンド内で GIT_DIR / GIT_WORK_TREE 等が export されており、push 先リポジトリを追跡できません。export せずに対象リポジトリ内から git push を実行してください。"
   fi
 
   for src in "${required[@]}"; do

--- a/scripts/agent-push-gate.sh
+++ b/scripts/agent-push-gate.sh
@@ -24,12 +24,17 @@
 # not count). If the command cannot be extracted at all but the raw payload
 # mentions `git push` in a Bash call, the gate fails closed.
 #
-# Known accepted limits of the linear scan: subshell scoping and
-# short-circuit control flow are not modeled — `(cd /x); git push` gates
-# against /x, and a bypass behind `false &&` still counts as set. The Codex
-# stop gate and CI remain the backstops for what the heuristic misses; the
-# gate exists to stop forgetting, not a deliberate evader (that is what the
-# sanctioned FANOUT_SKIP_PUSH_CHECK=1 is for).
+# Known accepted limits of the linear scan (by design — the gate exists to
+# stop forgetting, not a deliberate evader; that is what the sanctioned
+# FANOUT_SKIP_PUSH_CHECK=1 is for, and the Codex stop gate and CI remain the
+# backstops):
+# - subshell scoping and short-circuit control flow are not modeled —
+#   `(cd /x); git push` gates against /x, and a bypass behind `false &&`
+#   still counts as set (lexical order of exports is likewise ignored).
+# - a script fed to a shell via stdin (`bash <<EOF … EOF`) is not scanned.
+# - config that only re-points the REMOTE of a validated tip
+#   (`-c branch.<name>.remote=…`) is not tracked: the pushed commit itself
+#   was validated.
 set -u
 
 [ "${FANOUT_SKIP_PUSH_CHECK:-}" = "1" ] && exit 0
@@ -244,20 +249,26 @@ seg_inner_shell_push() {
   if [ "$has_c" = "0" ]; then
     [ $# -gt 0 ] || return 1
     case "${1##*/}" in
-    bash | sh | zsh | dash | ksh) ;;
+    bash | sh | zsh | dash | ksh)
+      shift
+      for w in "$@"; do
+        case "$w" in
+        -*c*) has_c=1 ;;
+        esac
+      done
+      ;;
+    eval)
+      # eval executes its (usually quoted) arguments in the current shell.
+      shift
+      has_c=1
+      ;;
     *) return 1 ;;
     esac
-    shift
-    for w in "$@"; do
-      case "$w" in
-      -*c*) has_c=1 ;;
-      esac
-    done
   fi
   [ "$has_c" = "1" ] || return 1
   joined="$(unsentinel "$*")"
   case "$joined" in
-  *git*push*) return 0 ;;
+  *git*push* | *gh*pr*create* | *gh*pr*new*) return 0 ;;
   esac
   return 1
 }
@@ -274,7 +285,25 @@ seg_gh_pr_create() {
   while [ $# -gt 0 ]; do
     case "$1" in
     [A-Za-z_]*=*) ;;
-    env | command | exec | nohup | time) ;;
+    env)
+      shift
+      while [ $# -gt 0 ]; do
+        case "$1" in
+        -u | -C | --chdir)
+          shift
+          [ $# -gt 0 ] && shift
+          ;;
+        --)
+          shift
+          break
+          ;;
+        -*) shift ;;
+        *) break ;;
+        esac
+      done
+      continue
+      ;;
+    command | exec | nohup | time) ;;
     if | then | elif | else | fi | do | done | while | until | !) ;;
     *) break ;;
     esac
@@ -341,7 +370,9 @@ seg_ref_mutating() {
     shift
   done
   case "${1:-}" in
-  commit | merge | rebase | cherry-pick | revert | reset | am | pull | switch | checkout | fetch | branch | update-ref) return 0 ;;
+  # config and tag do not move branch tips, but they change what a later
+  # push in the same call sends (push refspecs / a re-pointed tag source).
+  commit | merge | rebase | cherry-pick | revert | reset | am | pull | switch | checkout | fetch | branch | update-ref | config | tag) return 0 ;;
   esac
   return 1
 }

--- a/scripts/agent-push-gate.sh
+++ b/scripts/agent-push-gate.sh
@@ -56,19 +56,36 @@ deny() {
 
 # parse_push_segment SEGMENT — return 0 when SEGMENT is a `git … push`
 # command. Sets SEG_ARGS (words after `push`, newline-separated), SEG_BYPASS
-# (a FANOUT_SKIP_PUSH_CHECK=1 assignment prefixes this command), and
-# SEG_GIT_C (newline-separated values of `git -C` in order).
+# (a FANOUT_SKIP_PUSH_CHECK=1 assignment prefixes this command), SEG_GIT_C
+# (newline-separated values of `git -C` in order), and SEG_REPO_SWITCH
+# (--git-dir/--work-tree seen — the gate cannot follow those, so the caller
+# fails closed).
 parse_push_segment() {
   SEG_ARGS=""
   SEG_BYPASS=0
   SEG_GIT_C=""
+  SEG_REPO_SWITCH=0
   # shellcheck disable=SC2086 # word splitting is the tokenizer here
   set -- $1
   while [ $# -gt 0 ]; do
     case "$1" in
     FANOUT_SKIP_PUSH_CHECK=1) SEG_BYPASS=1 ;;
     [A-Za-z_]*=*) ;;
-    env | command | exec | nohup) ;;
+    env)
+      # Consume env's own options so `env -i git push` is still a push.
+      shift
+      while [ $# -gt 0 ]; do
+        case "$1" in
+        -u | -S | --split-string | -C | --chdir) shift ;;
+        --) shift; break ;;
+        -*) ;;
+        *) break ;;
+        esac
+        shift
+      done
+      continue
+      ;;
+    command | exec | nohup) ;;
     # Shell control words: `if git push …; then` must still gate the push.
     if | then | elif | else | fi | do | done | while | until | ! | time) ;;
     *) break ;;
@@ -84,7 +101,15 @@ parse_push_segment() {
       [ $# -gt 0 ] || return 1
       SEG_GIT_C="${SEG_GIT_C}${1}"$'\n'
       ;;
-    -c | --git-dir | --work-tree | --namespace | --config-env)
+    --git-dir | --work-tree | --git-dir=* | --work-tree=*)
+      SEG_REPO_SWITCH=1
+      case "$1" in --git-dir | --work-tree)
+        shift
+        [ $# -gt 0 ] || return 1
+        ;;
+      esac
+      ;;
+    -c | --namespace | --config-env)
       shift
       [ $# -gt 0 ] || return 1
       ;;
@@ -134,6 +159,9 @@ while IFS= read -r seg; do
   parse_push_segment "$seg" || continue
   [ "$SEG_BYPASS" = "1" ] && continue
   [ "$cmd_bypass" = "1" ] && continue
+  if [ "$SEG_REPO_SWITCH" = "1" ]; then
+    deny "--git-dir / --work-tree 経由の push はゲートが対象リポジトリを追跡できないため安全側で拒否します。対象リポジトリ内から通常の git push を実行してください。"
+  fi
 
   push_dir="$seg_dir"
   while IFS= read -r c_path; do
@@ -148,6 +176,7 @@ while IFS= read -r seg; do
   non_flag=0
   skip_next=0
   tag_kw=0
+  remote_w=""
   refspecs=()
   while IFS= read -r w; do
     [ -n "$w" ] || continue
@@ -164,20 +193,26 @@ while IFS= read -r seg; do
     \>* | [0-9]\>* | \<*)
       case "$w" in *\> | *\<) skip_next=1 ;; esac
       ;;
+    : | +:) all_flag=1 ;; # bare colon: matching push, every shared branch
     :*) deletions=$((deletions + 1)) ;;
     -*) ;;
     tag)
-      if [ "$non_flag" -ge 1 ]; then tag_kw=1; else non_flag=$((non_flag + 1)); fi
+      if [ "$non_flag" -ge 1 ]; then
+        tag_kw=1
+      else
+        non_flag=$((non_flag + 1))
+        remote_w="$w"
+      fi
       ;;
     *)
       non_flag=$((non_flag + 1))
-      if [ "$non_flag" -ge 2 ]; then
-        if [ "$tag_kw" = "1" ]; then
-          refspecs+=("refs/tags/$w")
-          tag_kw=0
-        else
-          refspecs+=("$w")
-        fi
+      if [ "$non_flag" -eq 1 ]; then
+        remote_w="$w"
+      elif [ "$tag_kw" = "1" ]; then
+        refspecs+=("refs/tags/$w")
+        tag_kw=0
+      else
+        refspecs+=("$w")
       fi
       ;;
     esac
@@ -205,8 +240,30 @@ while IFS= read -r seg; do
     if [ "$deletions" -gt 0 ] || [ "$tags_flag" = "1" ]; then
       continue # deletion-only push or pure `git push --tags [remote]`
     fi
-    required+=("HEAD")
-  else
+    # No explicit refspec: git falls back to remote.<name>.push, then
+    # push.default. A configured refspec set or `matching` can push tips
+    # other than HEAD.
+    if [ -z "$remote_w" ]; then
+      cur_branch="$(git -C "$push_dir" symbolic-ref --short -q HEAD 2>/dev/null)"
+      remote_w="$(git -C "$push_dir" config "branch.${cur_branch:-HEAD}.remote" 2>/dev/null)"
+      remote_w="${remote_w:-origin}"
+    fi
+    cfg_specs="$(git -C "$push_dir" config --get-all "remote.$remote_w.push" 2>/dev/null)"
+    if [ -n "$cfg_specs" ]; then
+      while IFS= read -r spec; do
+        [ -n "$spec" ] || continue
+        refspecs+=("$spec")
+      done <<<"$cfg_specs"
+    elif [ "$(git -C "$push_dir" config push.default 2>/dev/null)" = "matching" ]; then
+      while IFS= read -r tip; do
+        [ -n "$tip" ] || continue
+        required+=("$tip")
+      done < <(git -C "$push_dir" for-each-ref refs/heads --format='%(objectname)' 2>/dev/null | sort -u)
+    else
+      required+=("HEAD")
+    fi
+  fi
+  if [ "${#required[@]}" -eq 0 ] && [ "${#refspecs[@]}" -gt 0 ]; then
     for spec in "${refspecs[@]}"; do
       src="${spec%%:*}"
       src="${src#+}"

--- a/scripts/agent-push-gate.sh
+++ b/scripts/agent-push-gate.sh
@@ -35,6 +35,11 @@
 # - config that only re-points the REMOTE of a validated tip
 #   (`-c branch.<name>.remote=…`) is not tracked: the pushed commit itself
 #   was validated.
+# - a git alias whose expansion contains `push` (`git myalias`, defined in an
+#   out-of-band gitconfig) is not resolved — the scanner cannot read the
+#   alias body. Defining a push alias inline (`git config alias.x '…push…'`)
+#   is caught as a same-call config mutation; an externally-defined alias is
+#   a backstop case.
 #
 # Wrapper/option coverage is intentionally broad but not exhaustive: the
 # scanner transparently steps over env (incl. -C/-S/-u/--unset), command,
@@ -145,7 +150,19 @@ parse_push_segment() {
       continue
       ;;
     # Shell control words: `if git push …; then` must still gate the push.
-    if | then | elif | else | fi | do | done | while | until | ! | time) ;;
+    if | then | elif | else | fi | do | done | while | until | !) ;;
+    time | */time)
+      # `time [-p] git push` runs the push; skip time's options.
+      shift
+      while [ $# -gt 0 ]; do
+        case "$1" in
+        -o | --output | -f | --format) shift; [ $# -gt 0 ] && shift ;;
+        -*) shift ;;
+        *) break ;;
+        esac
+      done
+      continue
+      ;;
     # Leading redirections (`>log git push …`) are valid shell.
     \>* | [0-9]\>* | \<*)
       case "$1" in
@@ -242,7 +259,18 @@ seg_inner_shell_push() {
   while [ $# -gt 0 ]; do
     case "$1" in
     [A-Za-z_]*=*) ;;
-    command | exec | nohup | time | */nohup | */time) ;;
+    command | exec | nohup | */nohup) ;;
+    time | */time)
+      shift
+      while [ $# -gt 0 ]; do
+        case "$1" in
+        -o | --output | -f | --format) shift; [ $# -gt 0 ] && shift ;;
+        -*) shift ;;
+        *) break ;;
+        esac
+      done
+      continue
+      ;;
     if | then | elif | else | fi | do | done | while | until | !) ;;
     timeout | */timeout)
       shift
@@ -269,10 +297,11 @@ seg_inner_shell_push() {
           has_c=1
           break # value embedded in the token; keep it for the scan below
           ;;
-        -u | -C | --chdir)
+        -u | --unset | -C | --chdir)
           shift
           [ $# -gt 0 ] && shift
           ;;
+        --unset=* | -C* | --chdir=*) ;;
         --)
           shift
           break
@@ -356,7 +385,18 @@ seg_gh_pr_create() {
       done
       continue
       ;;
-    command | exec | nohup | time | */nohup | */time) ;;
+    command | exec | nohup | */nohup) ;;
+    time | */time)
+      shift
+      while [ $# -gt 0 ]; do
+        case "$1" in
+        -o | --output | -f | --format) shift; [ $# -gt 0 ] && shift ;;
+        -*) shift ;;
+        *) break ;;
+        esac
+      done
+      continue
+      ;;
     timeout | */timeout)
       shift
       while [ $# -gt 0 ]; do
@@ -413,7 +453,18 @@ seg_ref_mutating() {
     case "$1" in
     [A-Za-z_]*=*) ;;
     command | exec | nohup | */nohup) ;;
-    if | then | elif | else | fi | do | done | while | until | ! | time) ;;
+    if | then | elif | else | fi | do | done | while | until | !) ;;
+    time | */time)
+      shift
+      while [ $# -gt 0 ]; do
+        case "$1" in
+        -o | --output | -f | --format) shift; [ $# -gt 0 ] && shift ;;
+        -*) shift ;;
+        *) break ;;
+        esac
+      done
+      continue
+      ;;
     env | */env)
       # Consume env's options so `env -C repo git commit` is still a mutation.
       shift
@@ -513,6 +564,9 @@ while IFS= read -r seg; do
   if seg_gh_pr_create "$seg"; then
     if [ "$SEG_GH_UNSAFE" = "1" ]; then
       deny "env -C / -S 経由の gh pr create はゲートが対象リポジトリを追跡できないため拒否します。対象リポジトリ内から直接 gh pr create を実行してください。"
+    fi
+    if [ "$ref_mut" = "1" ]; then
+      deny "同一コマンド内で ref を変更するコマンド (commit / rebase 等) の後に gh pr create を実行しています。gh は未 push branch を push するため、ゲートは実行前の状態しか検証できません。commit 後に make check を通し、gh pr create は単独のコマンドとして実行してください。"
     fi
     gh_dir="$seg_dir"
     if git -C "$gh_dir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then

--- a/scripts/agent-push-gate.sh
+++ b/scripts/agent-push-gate.sh
@@ -87,7 +87,7 @@ parse_push_segment() {
     # make the push untraceable: fail closed.
     GIT_DIR=* | GIT_WORK_TREE=* | GIT_COMMON_DIR=* | GIT_INDEX_FILE=* | GIT_NAMESPACE=* | GIT_OBJECT_DIRECTORY=* | GIT_CONFIG*=*) SEG_REPO_SWITCH=1 ;;
     [A-Za-z_]*=*) ;;
-    env)
+    env | */env)
       # Consume env's own options so `env -i git push` is still a push.
       # env -C hops directories and env -S splices a command string; the
       # scan cannot follow either, so a push behind them fails closed.
@@ -108,7 +108,7 @@ parse_push_segment() {
       done
       continue
       ;;
-    command | exec | nohup)
+    command | exec | nohup | */nohup)
       # Consume the wrapper's own options and `--` so `command -- git push`
       # is still a push.
       shift
@@ -193,9 +193,10 @@ abs_dir() {
 }
 
 # push_affecting_config KEY[=VALUE] — config that changes what a push sends.
+# include.path can pull any of the other keys in from a file, so it counts.
 push_affecting_config() {
   case "$1" in
-  push.* | *.push=* | *.push | *.pushurl=* | *.mirror=* | *.mirror | *.pushremote=* | *.pushRemote=* | remote.pushdefault=* | remote.pushDefault=*)
+  push.* | *.push=* | *.push | *.pushurl=* | *.mirror=* | *.mirror | *.pushremote=* | *.pushRemote=* | remote.pushdefault=* | remote.pushDefault=* | include.path=* | includeIf.* | includeif.*)
     return 0
     ;;
   esac
@@ -213,9 +214,9 @@ seg_inner_shell_push() {
   while [ $# -gt 0 ]; do
     case "$1" in
     [A-Za-z_]*=*) ;;
-    command | exec | nohup | time) ;;
+    command | exec | nohup | time | */nohup | */time) ;;
     if | then | elif | else | fi | do | done | while | until | !) ;;
-    env)
+    env | */env)
       shift
       while [ $# -gt 0 ]; do
         case "$1" in
@@ -280,16 +281,28 @@ seg_inner_shell_push() {
 # marker).
 seg_gh_pr_create() {
   local pos1="" pos2=""
+  SEG_GH_UNSAFE=0
   # shellcheck disable=SC2086 # word splitting is the tokenizer here
   set -- $1
   while [ $# -gt 0 ]; do
     case "$1" in
     [A-Za-z_]*=*) ;;
-    env)
+    env | */env)
       shift
       while [ $# -gt 0 ]; do
         case "$1" in
-        -u | -C | --chdir)
+        -C | --chdir | -S | --split-string)
+          # gh would run in a directory (or via a splice) the gate cannot
+          # follow: the caller fails closed.
+          SEG_GH_UNSAFE=1
+          shift
+          [ $# -gt 0 ] && shift
+          ;;
+        -C* | -S* | --chdir=* | --split-string=*)
+          SEG_GH_UNSAFE=1
+          shift
+          ;;
+        -u)
           shift
           [ $# -gt 0 ] && shift
           ;;
@@ -303,7 +316,7 @@ seg_gh_pr_create() {
       done
       continue
       ;;
-    command | exec | nohup | time) ;;
+    command | exec | nohup | time | */nohup | */time) ;;
     if | then | elif | else | fi | do | done | while | until | !) ;;
     *) break ;;
     esac
@@ -347,7 +360,7 @@ seg_ref_mutating() {
   while [ $# -gt 0 ]; do
     case "$1" in
     [A-Za-z_]*=*) ;;
-    env | command | exec | nohup) ;;
+    env | command | exec | nohup | */env | */nohup) ;;
     if | then | elif | else | fi | do | done | while | until | ! | time) ;;
     *) break ;;
     esac
@@ -419,6 +432,9 @@ while IFS= read -r seg; do
   fi
 
   if seg_gh_pr_create "$seg"; then
+    if [ "$SEG_GH_UNSAFE" = "1" ]; then
+      deny "env -C / -S 経由の gh pr create はゲートが対象リポジトリを追跡できないため拒否します。対象リポジトリ内から直接 gh pr create を実行してください。"
+    fi
     gh_dir="$seg_dir"
     if git -C "$gh_dir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
       gh_head="$(head_sha "$gh_dir")"

--- a/scripts/agent-push-gate.sh
+++ b/scripts/agent-push-gate.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# fanout push gate — PreToolUse hook for Claude Code and Codex.
+#
+# Denies `git push` to a branch unless the per-worktree marker
+# $(git rev-parse --git-dir)/fanout-check-passed matches HEAD. The marker is
+# written by a successful `make check` on a clean tree (Makefile check-marker),
+# so a denied push means the pushed tip was never validated: run `make check`,
+# then push again. Branch deletions and tag pushes stay ungated.
+#
+# Contract (PreToolUse hook, identical for both agents): stdin is the
+# tool-call JSON ({"tool_name":"Bash","tool_input":{"command":…},"cwd":…}).
+# Exit 0 allows the command; exit 2 + stderr denies it and feeds the message
+# back to the agent. Any other exit is a non-blocking error (fail open), which
+# is why this script uses `set -u` without `-e`.
+#
+# Detection is a staged shell heuristic, not a full tokenizer: quoted spans
+# are stripped first so `git push` inside commit messages or --body text does
+# not trigger the gate, then each pipeline segment is word-scanned for a real
+# `git … push` command. Escape hatch: FANOUT_SKIP_PUSH_CHECK=1 (exported or
+# inline). If the command cannot be extracted at all but the raw payload
+# mentions `git push` in a Bash call, the gate fails closed.
+set -u
+
+[ "${FANOUT_SKIP_PUSH_CHECK:-}" = "1" ] && exit 0
+
+input="$(cat)"
+
+lib="$(cd "$(dirname "$0")" && pwd)/agent-hooks-lib.sh"
+[ -f "$lib" ] || exit 0
+# shellcheck source=scripts/agent-hooks-lib.sh
+. "$lib"
+
+cmd="$(json_field "$input" command)"
+if [ -z "$cmd" ]; then
+  if grep -Eq '"tool_name"[[:space:]]*:[[:space:]]*"Bash"' <<<"$input" &&
+    grep -q 'git push' <<<"$input"; then
+    echo "fanout push gate: Bash コマンドを解析できませんでしたが git push を含むため拒否します (fail closed)。単純な形の git push コマンドで再実行してください。" >&2
+    exit 2
+  fi
+  exit 0
+fi
+
+case "$cmd" in
+*FANOUT_SKIP_PUSH_CHECK=1*) exit 0 ;;
+esac
+
+# Strip quoted spans, then split on pipeline/list separators. Stripping only
+# removes text, so it cannot fabricate a `git push` that was not already a
+# command word (adjacent-token merges collapse into whitespace).
+stripped="$(printf '%s' "$cmd" | sed -e "s/'[^']*'/ /g" -e 's/"[^"]*"/ /g')"
+segments="$(printf '%s' "$stripped" | tr '|;&' '\n')"
+
+# seg_push_args SEGMENT — if SEGMENT is a `git … push` command, print the
+# words after `push` (one per line) and return 0.
+seg_push_args() {
+  # shellcheck disable=SC2086 # word splitting is the tokenizer here
+  set -- $1
+  while [ $# -gt 0 ]; do
+    case "$1" in
+    [A-Za-z_]*=*) shift ;; # env assignment prefix
+    env | command | exec | nohup) shift ;;
+    *) break ;;
+    esac
+  done
+  [ "${1:-}" = "git" ] || return 1
+  shift
+  while [ $# -gt 0 ]; do
+    case "$1" in
+    -C | -c | --git-dir | --work-tree | --namespace | --config-env)
+      shift
+      [ $# -gt 0 ] && shift
+      ;;
+    -*) shift ;;
+    *) break ;;
+    esac
+  done
+  [ "${1:-}" = "push" ] || return 1
+  shift
+  printf '%s\n' "$@"
+}
+
+# all_refspecs_are_tags DIR REFSPECS — release flows push existing tags; a
+# push whose every source ref resolves under refs/tags/ stays ungated.
+all_refspecs_are_tags() {
+  local dir="$1" spec src
+  shift
+  [ $# -gt 0 ] || return 1
+  for spec in "$@"; do
+    src="${spec%%:*}"
+    src="${src#+}"
+    git -C "$dir" rev-parse -q --verify "refs/tags/$src" >/dev/null 2>&1 || return 1
+  done
+  return 0
+}
+
+needs_marker=0
+while IFS= read -r seg; do
+  [ -n "${seg// /}" ] || continue
+  push_args="$(seg_push_args "$seg")" || continue
+  gated=1
+  non_flag=0
+  deletions=0
+  refspecs=()
+  while IFS= read -r w; do
+    [ -n "$w" ] || continue
+    case "$w" in
+    --delete | -d | --tags | --follow-tags) gated=0 ;;
+    :*) deletions=$((deletions + 1)) ;; # delete refspec: no source ref
+    -*) ;;
+    *)
+      non_flag=$((non_flag + 1))
+      [ "$non_flag" -ge 2 ] && refspecs+=("$w")
+      ;;
+    esac
+  done <<<"$push_args"
+  [ "$gated" = "1" ] || continue
+  if [ "${#refspecs[@]}" -gt 0 ]; then
+    dir_for_tags="$(resolve_project_dir "$input")"
+    all_refspecs_are_tags "$dir_for_tags" "${refspecs[@]}" && continue
+  elif [ "$deletions" -gt 0 ]; then
+    continue # deletion-only push (git push origin :branch)
+  fi
+  needs_marker=1
+done <<<"$segments"
+
+[ "$needs_marker" = "1" ] || exit 0
+
+dir="$(resolve_project_dir "$input")"
+git -C "$dir" rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+head="$(head_sha "$dir")" || exit 0
+[ -n "$head" ] || exit 0
+recorded="$(marker_sha "$dir")"
+
+if [ "$recorded" != "$head" ]; then
+  {
+    echo "fanout push gate: この push は make check 未検証のため拒否しました。"
+    echo "HEAD $head に対する marker が見つからないか一致しません (marker: ${recorded:-なし})。"
+    echo "clean tree で make check を成功させてから push し直してください (成功時に marker が書かれます)。"
+    echo "緊急回避: FANOUT_SKIP_PUSH_CHECK=1 git push ..."
+  } >&2
+  exit 2
+fi
+
+exit 0

--- a/scripts/agent-push-gate.sh
+++ b/scripts/agent-push-gate.sh
@@ -197,6 +197,87 @@ push_affecting_config() {
   return 1
 }
 
+# seg_inner_shell_push SEGMENT — true when SEGMENT hands a command string to
+# an inner shell (`bash -c …` / `sh -lc …`) that mentions a git push. The
+# scanner cannot follow the inner shell, so the caller fails closed.
+seg_inner_shell_push() {
+  local has_c=0 w joined
+  # shellcheck disable=SC2086 # word splitting is the tokenizer here
+  set -- $1
+  while [ $# -gt 0 ]; do
+    case "$1" in
+    [A-Za-z_]*=*) ;;
+    env | command | exec | nohup | time) ;;
+    if | then | elif | else | fi | do | done | while | until | !) ;;
+    *) break ;;
+    esac
+    shift
+  done
+  [ $# -gt 0 ] || return 1
+  case "${1##*/}" in
+  bash | sh | zsh | dash | ksh) ;;
+  *) return 1 ;;
+  esac
+  shift
+  for w in "$@"; do
+    case "$w" in
+    -*c*) has_c=1 ;;
+    esac
+  done
+  [ "$has_c" = "1" ] || return 1
+  joined="$(unsentinel "$*")"
+  case "$joined" in
+  *git*push*) return 0 ;;
+  esac
+  return 1
+}
+
+# seg_gh_pr_create SEGMENT — true when SEGMENT is a `gh pr create|new`. gh
+# pushes the current branch itself when it is not fully pushed, so PR
+# creation is a push path (Codex has no other gate on it; for Claude this
+# runs alongside the pre-pr-review gate, whose flow already produced the
+# marker).
+seg_gh_pr_create() {
+  local pos1="" pos2=""
+  # shellcheck disable=SC2086 # word splitting is the tokenizer here
+  set -- $1
+  while [ $# -gt 0 ]; do
+    case "$1" in
+    [A-Za-z_]*=*) ;;
+    env | command | exec | nohup | time) ;;
+    if | then | elif | else | fi | do | done | while | until | !) ;;
+    *) break ;;
+    esac
+    shift
+  done
+  [ $# -gt 0 ] || return 1
+  [ "${1##*/}" = "gh" ] || return 1
+  shift
+  while [ $# -gt 0 ]; do
+    case "$1" in
+    -R | --repo)
+      shift
+      [ $# -gt 0 ] || return 1
+      ;;
+    -*) ;;
+    *)
+      if [ -z "$pos1" ]; then
+        pos1="$1"
+      elif [ -z "$pos2" ]; then
+        pos2="$1"
+        break
+      fi
+      ;;
+    esac
+    shift
+  done
+  [ "$pos1" = "pr" ] || return 1
+  case "$pos2" in
+  create | new) return 0 ;;
+  esac
+  return 1
+}
+
 # seg_ref_mutating SEGMENT — true when SEGMENT is a git command that can move
 # local refs (or HEAD) before a later push in the same tool call. The gate
 # resolves refs before the call runs, so a push after one of these cannot be
@@ -263,6 +344,21 @@ seg_dir="$base_dir" # follows `cd` segments so later pushes gate the right repo
 while IFS= read -r seg; do
   case "$seg" in *[![:space:]]*) ;; *) continue ;; esac
 
+  if seg_inner_shell_push "$seg"; then
+    deny "インナーシェル (bash -c / sh -c) 経由の push はゲートが検証できないため拒否します。git push を直接実行してください。"
+  fi
+
+  if seg_gh_pr_create "$seg"; then
+    gh_dir="$seg_dir"
+    if git -C "$gh_dir" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+      gh_head="$(head_sha "$gh_dir")"
+      if [ -n "$gh_head" ] && [ "$(marker_sha "$gh_dir")" != "$gh_head" ]; then
+        deny "gh pr create は未 push の branch を自動 push します。HEAD $gh_head は make check 未検証です。"
+      fi
+    fi
+    continue
+  fi
+
   # shellcheck disable=SC2086
   set -- $seg
   if [ "${1:-}" = "cd" ] || [ "${1:-}" = "pushd" ]; then
@@ -290,6 +386,7 @@ while IFS= read -r seg; do
   gated=1
   tags_flag=0
   all_flag=0
+  mirror_flag=0
   deletions=0
   non_flag=0
   skip_next=0
@@ -311,7 +408,8 @@ while IFS= read -r seg; do
     case "$w" in
     --delete | -d) gated=0 ;;
     --dry-run | -n) gated=0 ;; # side-effect-free probe push
-    --all | --branches | --mirror) all_flag=1 ;;
+    --all | --branches) all_flag=1 ;;
+    --mirror) mirror_flag=1 ;;
     --tags) tags_flag=1 ;;
     -o | --push-option | --receive-pack | --exec) skip_next=1 ;;
     # --repo supplies the repository, so the next positional is a refspec.
@@ -359,15 +457,21 @@ while IFS= read -r seg; do
   fi
   recorded="$(marker_sha "$push_dir")"
 
+  # --mirror sends every ref (backups, remotes, notes), which the marker
+  # cannot vouch for: fail closed.
+  if [ "$mirror_flag" = "1" ] && [ "$gated" = "1" ]; then
+    deny "--mirror push は refs/heads 以外の全 ref も送るため gate で検証できません。"
+  fi
+
   required=()
   if [ "$all_flag" = "1" ]; then
-    # --all / --branches / --mirror push every local branch tip.
+    # --all / --branches push every local branch tip.
     while IFS= read -r tip; do
       [ -n "$tip" ] || continue
       required+=("$tip")
     done < <(git -C "$push_dir" for-each-ref refs/heads --format='%(objectname)' 2>/dev/null | sort -u)
     if [ "${#required[@]}" -eq 0 ]; then
-      deny "--all/--mirror push の branch tip を列挙できませんでした ($push_dir)。"
+      deny "--all push の branch tip を列挙できませんでした ($push_dir)。"
     fi
   elif [ "${#refspecs[@]}" -eq 0 ]; then
     if [ "$deletions" -gt 0 ] || [ "$tags_flag" = "1" ]; then
@@ -388,10 +492,7 @@ while IFS= read -r seg; do
     cfg_specs="$(git -C "$push_dir" config --get-all "remote.$remote_w.push" 2>/dev/null)"
     if [ "$(git -C "$push_dir" config --bool "remote.$remote_w.mirror" 2>/dev/null)" = "true" ]; then
       # remote.<name>.mirror makes a bare `git push` mirror every ref.
-      while IFS= read -r tip; do
-        [ -n "$tip" ] || continue
-        required+=("$tip")
-      done < <(git -C "$push_dir" for-each-ref refs/heads --format='%(objectname)' 2>/dev/null | sort -u)
+      deny "remote.$remote_w.mirror=true の push は全 ref を送るため gate で検証できません。"
     elif [ -n "$cfg_specs" ]; then
       while IFS= read -r spec; do
         [ -n "$spec" ] || continue

--- a/scripts/agent-push-gate.sh
+++ b/scripts/agent-push-gate.sh
@@ -93,7 +93,7 @@ parse_push_segment() {
           SEG_REPO_SWITCH=1
           shift # the option; its value falls to the shift below
           ;;
-        -C* | -S*) SEG_REPO_SWITCH=1 ;;
+        -C* | -S* | --chdir=* | --split-string=*) SEG_REPO_SWITCH=1 ;;
         -u) shift ;;
         --) shift; break ;;
         -*) ;;
@@ -103,7 +103,19 @@ parse_push_segment() {
       done
       continue
       ;;
-    command | exec | nohup) ;;
+    command | exec | nohup)
+      # Consume the wrapper's own options and `--` so `command -- git push`
+      # is still a push.
+      shift
+      while [ $# -gt 0 ]; do
+        case "$1" in
+        --) shift; break ;;
+        -*) shift ;;
+        *) break ;;
+        esac
+      done
+      continue
+      ;;
     # Shell control words: `if git push …; then` must still gate the push.
     if | then | elif | else | fi | do | done | while | until | ! | time) ;;
     # Leading redirections (`>log git push …`) are valid shell.
@@ -212,7 +224,7 @@ seg_ref_mutating() {
     shift
   done
   case "${1:-}" in
-  commit | merge | rebase | cherry-pick | revert | reset | am | pull | switch | checkout) return 0 ;;
+  commit | merge | rebase | cherry-pick | revert | reset | am | pull | switch | checkout | fetch | branch | update-ref) return 0 ;;
   esac
   return 1
 }
@@ -222,22 +234,31 @@ segments="$(strip_shell_noise "$cmd")"
 
 cmd_bypass=0
 ref_mut=0
+
+# First pass — command-wide facts. Substitution bodies are queued after the
+# outer segments, so positional scanning would see a `git commit` inside
+# `$(…)` only after the push; ref mutation and an exported bypass are
+# command-wide either way.
+while IFS= read -r seg; do
+  case "$seg" in *[![:space:]]*) ;; *) continue ;; esac
+  if seg_ref_mutating "$seg"; then
+    ref_mut=1
+    continue
+  fi
+  # shellcheck disable=SC2086
+  set -- $seg
+  if [ "${1:-}" = "export" ] && [ "${2:-}" = "FANOUT_SKIP_PUSH_CHECK=1" ]; then
+    cmd_bypass=1
+  fi
+done <<<"$segments"
+
 seg_dir="$base_dir" # follows `cd` segments so later pushes gate the right repo
 
 while IFS= read -r seg; do
   case "$seg" in *[![:space:]]*) ;; *) continue ;; esac
 
-  if seg_ref_mutating "$seg"; then
-    ref_mut=1
-    continue
-  fi
-
   # shellcheck disable=SC2086
   set -- $seg
-  if [ "${1:-}" = "export" ] && [ "${2:-}" = "FANOUT_SKIP_PUSH_CHECK=1" ]; then
-    cmd_bypass=1
-    continue
-  fi
   if [ "${1:-}" = "cd" ] || [ "${1:-}" = "pushd" ]; then
     if [ -n "${2:-}" ]; then
       seg_dir="$(abs_dir "$seg_dir" "$(unsentinel "$2")")"

--- a/scripts/agent-stop-gate.sh
+++ b/scripts/agent-stop-gate.sh
@@ -39,9 +39,6 @@ dir="$top"
 command -v make >/dev/null 2>&1 || exit 0
 [ -f Makefile ] || exit 0
 
-# Uncommitted work cannot be pushed; do not burn minutes on mid-work stops.
-[ -n "$(git status --porcelain -uall 2>/dev/null)" ] && exit 0
-
 head="$(head_sha "$dir")" || exit 0
 [ -n "$head" ] || exit 0
 
@@ -59,6 +56,23 @@ if [ -z "$default_ref" ]; then
   done
 fi
 if [ -n "$default_ref" ] && git merge-base --is-ancestor HEAD "$default_ref" 2>/dev/null; then
+  exit 0
+fi
+
+# Uncommitted work cannot be pushed; do not burn minutes on mid-work stops.
+# Exception: when this unvalidated HEAD is already the pushed upstream tip
+# (a push slipped past the PreToolUse gate), a silent skip would erase the
+# backstop — block with instructions instead of running make check on a
+# dirty tree.
+if [ -n "$(git status --porcelain -uall 2>/dev/null)" ]; then
+  upstream="$(git rev-parse -q --verify '@{upstream}' 2>/dev/null)"
+  if [ -n "$upstream" ] && [ "$upstream" = "$head" ]; then
+    {
+      echo "fanout stop gate: push 済みの HEAD $head は make check 未検証ですが、working tree が dirty なため検証を実行できません。"
+      echo "作業中の変更を commit または stash してから、clean tree で make check を成功させてください。"
+    } >&2
+    exit 2
+  fi
   exit 0
 fi
 

--- a/scripts/agent-stop-gate.sh
+++ b/scripts/agent-stop-gate.sh
@@ -65,8 +65,17 @@ fi
 # backstop — block with instructions instead of running make check on a
 # dirty tree.
 if [ -n "$(git status --porcelain -uall 2>/dev/null)" ]; then
+  # `git push origin HEAD` sets no upstream, so also check whether this exact
+  # commit is any remote-tracking tip — the backstop must fire whenever the
+  # unvalidated HEAD already reached a remote.
+  pushed=0
   upstream="$(git rev-parse -q --verify '@{upstream}' 2>/dev/null)"
   if [ -n "$upstream" ] && [ "$upstream" = "$head" ]; then
+    pushed=1
+  elif git for-each-ref --format='%(objectname)' refs/remotes 2>/dev/null | grep -qxF "$head"; then
+    pushed=1
+  fi
+  if [ "$pushed" = "1" ]; then
     {
       echo "fanout stop gate: push 済みの HEAD $head は make check 未検証ですが、working tree が dirty なため検証を実行できません。"
       echo "作業中の変更を commit または stash してから、clean tree で make check を成功させてください。"

--- a/scripts/agent-stop-gate.sh
+++ b/scripts/agent-stop-gate.sh
@@ -30,6 +30,12 @@ lib="$(cd "$(dirname "$0")" && pwd)/agent-hooks-lib.sh"
 dir="$(resolve_project_dir "$input")"
 cd "$dir" 2>/dev/null || exit 0
 git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+# The session may stop with its cwd in a subdirectory; the gate belongs to
+# the repository root.
+top="$(git rev-parse --show-toplevel 2>/dev/null)"
+[ -n "$top" ] || exit 0
+cd "$top" 2>/dev/null || exit 0
+dir="$top"
 command -v make >/dev/null 2>&1 || exit 0
 [ -f Makefile ] || exit 0
 

--- a/scripts/agent-stop-gate.sh
+++ b/scripts/agent-stop-gate.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# fanout stop gate — Codex-only Stop-hook backstop for the push gate.
+#
+# Codex's PreToolUse interception is documented as incomplete ("only the
+# simple ones"), so a push can slip past scripts/agent-push-gate.sh. This hook
+# runs at turn end: if the committed HEAD was never validated by `make check`,
+# it runs the gate and, on failure, blocks the stop (exit 2) so the agent
+# fixes the findings before finishing. Claude Code does not register this hook
+# — its Bash interception is complete, the push gate alone covers it.
+#
+# Cost control: the gate is skipped when the tree is dirty (uncommitted work
+# cannot reach CI), when the marker already matches HEAD (the normal
+# make-check-before-push flow), and when HEAD is on the origin default branch
+# (read-only sessions). stop_hook_active guards against continuation loops.
+# Escape hatch: FANOUT_SKIP_STOP_GATE=1.
+set -u
+
+input="$(cat)"
+
+if grep -Eq '"stop_hook_active"[[:space:]]*:[[:space:]]*true' <<<"$input"; then
+  exit 0
+fi
+[ "${FANOUT_SKIP_STOP_GATE:-}" = "1" ] && exit 0
+
+lib="$(cd "$(dirname "$0")" && pwd)/agent-hooks-lib.sh"
+[ -f "$lib" ] || exit 0
+# shellcheck source=scripts/agent-hooks-lib.sh
+. "$lib"
+
+dir="$(resolve_project_dir "$input")"
+cd "$dir" 2>/dev/null || exit 0
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || exit 0
+command -v make >/dev/null 2>&1 || exit 0
+[ -f Makefile ] || exit 0
+
+# Uncommitted work cannot be pushed; do not burn minutes on mid-work stops.
+[ -n "$(git status --porcelain -uall 2>/dev/null)" ] && exit 0
+
+head="$(head_sha "$dir")" || exit 0
+[ -n "$head" ] || exit 0
+
+# Already validated: `make check` wrote the marker for this exact commit.
+[ "$(marker_sha "$dir")" = "$head" ] && exit 0
+
+# Read-only sessions on the default branch: CI already validated this commit.
+default_ref="$(git symbolic-ref -q --short refs/remotes/origin/HEAD 2>/dev/null)"
+if [ -z "$default_ref" ]; then
+  for candidate in origin/main origin/master; do
+    if git rev-parse -q --verify "$candidate" >/dev/null 2>&1; then
+      default_ref="$candidate"
+      break
+    fi
+  done
+fi
+if [ -n "$default_ref" ] && git merge-base --is-ancestor HEAD "$default_ref" 2>/dev/null; then
+  exit 0
+fi
+
+gitdir="$(git rev-parse --git-dir)"
+case "$gitdir" in
+/*) log="$gitdir/fanout-check.log" ;;
+*) log="$dir/$gitdir/fanout-check.log" ;;
+esac
+
+if make check >"$log" 2>&1; then
+  exit 0
+fi
+
+{
+  echo "fanout stop gate: HEAD $head は make check に失敗しています。指摘を修正し、commit して、make check が通ってから終了してください。"
+  echo "ログ全文: $log (末尾 150 行を以下に表示)"
+  echo "-----"
+  tail -n 150 "$log"
+} >&2
+exit 2

--- a/tests/bats/tier1_agent_hooks.bats
+++ b/tests/bats/tier1_agent_hooks.bats
@@ -341,6 +341,63 @@ run_push_gate() {
   [ "$status" -eq 2 ]
 }
 
+@test "push gate: wrapper and config evasions stay gated" {
+  local repo="$BATS_TEST_TMPDIR/repo"
+  setup_hook_repo "$repo"
+
+  run_push_gate '/usr/bin/git push origin HEAD' "$repo"
+  [ "$status" -eq 2 ]
+  run_push_gate '>trace.log git push origin HEAD' "$repo"
+  [ "$status" -eq 2 ]
+  run_push_gate 'env -C /elsewhere git push origin HEAD' "$repo"
+  [ "$status" -eq 2 ]
+
+  write_marker "$repo"
+  # An inline config override can change what a push sends: fail closed.
+  run_push_gate 'git -c remote.origin.push=refs/heads/x:refs/heads/x push origin' "$repo"
+  [ "$status" -eq 2 ]
+
+  # Quote state resumes after "$(...)": the chained push is still seen.
+  local payload="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"branch=\\\"\$(echo main)\\\" && git push origin stale-ref\"},\"cwd\":\"$repo\"}"
+  run_hook "$PUSH_GATE" "$payload"
+  [ "$status" -eq 2 ]
+
+  # An unquoted heredoc body runs its substitutions.
+  payload="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"cat <<EOF\\n\$(git push origin stale-ref)\\nEOF\"},\"cwd\":\"$repo\"}"
+  run_hook "$PUSH_GATE" "$payload"
+  [ "$status" -eq 2 ]
+}
+
+@test "push gate: --repo and forced deletion refspecs classify correctly" {
+  local repo="$BATS_TEST_TMPDIR/repo"
+  setup_hook_repo "$repo"
+  git -C "$repo" branch stale-branch
+  printf 'more\n' >>"$repo/tracked.txt"
+  git -C "$repo" commit -aqm "second"
+  write_marker "$repo"
+
+  # After --repo <remote>, the first positional is a refspec, not the remote.
+  run_push_gate 'git push --repo origin stale-branch' "$repo"
+  [ "$status" -eq 2 ]
+
+  # +:branch is a forced deletion and stays ungated.
+  run_push_gate 'git push origin +:old-branch' "$repo"
+  [ "$status" -eq 0 ]
+}
+
+@test "push gate: a mirror remote validates every branch tip" {
+  local repo="$BATS_TEST_TMPDIR/repo"
+  setup_hook_repo "$repo"
+  git -C "$repo" branch stale-branch
+  printf 'more\n' >>"$repo/tracked.txt"
+  git -C "$repo" commit -aqm "second"
+  write_marker "$repo"
+  git -C "$repo" config remote.origin.mirror true
+
+  run_push_gate 'git push origin' "$repo"
+  [ "$status" -eq 2 ]
+}
+
 @test "push gate: fails closed when extraction fails but the payload mentions git push" {
   local repo="$BATS_TEST_TMPDIR/repo"
   setup_hook_repo "$repo"
@@ -518,6 +575,24 @@ format_payload() {
   run_hook "$FORMAT_HOOK" "$(format_payload "$repo/bad.go" "$repo/sub")"
   [ "$status" -eq 0 ]
   [[ "$(cat "$repo/bad.go")" == *'println("y")'* ]]
+}
+
+@test "format-on-edit: formats paths from a Codex apply_patch payload" {
+  local cache_root="${FANOUT_DEV_CACHE_DIR:-/tmp/fanout-dev-cache-$(id -u)}"
+  local version
+  version="$(tr -d '[:space:]' <"$REPO_ROOT/.golangci-lint-version")"
+  [ -x "$cache_root/tools/golangci-lint-$version" ] || skip "pinned golangci-lint not cached locally"
+
+  local repo="$BATS_TEST_TMPDIR/repo"
+  mkdir -p "$repo"
+  git -C "$repo" init -q
+  cp "$REPO_ROOT/.golangci-lint-version" "$REPO_ROOT/.golangci.yml" "$repo/"
+  printf 'package main\n\nfunc main() {\nprintln( "x" )\n}\n' >"$repo/bad.go"
+
+  local payload="{\"tool_name\":\"apply_patch\",\"tool_input\":{\"command\":\"*** Begin Patch\\n*** Update File: bad.go\\n@@\\n-x\\n+y\\n*** End Patch\"},\"cwd\":\"$repo\"}"
+  run_hook "$FORMAT_HOOK" "$payload"
+  [ "$status" -eq 0 ]
+  [[ "$(cat "$repo/bad.go")" == *'println("x")'* ]]
 }
 
 @test "format-on-edit: refuses a foreign or symlinked shared cache" {

--- a/tests/bats/tier1_agent_hooks.bats
+++ b/tests/bats/tier1_agent_hooks.bats
@@ -1,0 +1,304 @@
+#!/usr/bin/env bats
+#
+# Tier 1 — repo-local agent hook scripts (scripts/agent-*.sh) contract.
+#
+# These tests drive the Claude Code / Codex hooks directly over their
+# stdin-JSON + exit-code contract: the push gate (PreToolUse), the Codex stop
+# gate backstop (Stop), the format-on-edit hook (PostToolUse), and the
+# Makefile check-marker writer the gates depend on. No agent runs here; heavy
+# `make check` runs are replaced by stub Makefiles inside sandbox repos.
+
+load helpers
+
+PUSH_GATE="$REPO_ROOT/scripts/agent-push-gate.sh"
+STOP_GATE="$REPO_ROOT/scripts/agent-stop-gate.sh"
+FORMAT_HOOK="$REPO_ROOT/scripts/agent-format-on-edit.sh"
+HOOKS_LIB="$REPO_ROOT/scripts/agent-hooks-lib.sh"
+
+setup_hook_repo() {
+  local repo="$1"
+  mkdir -p "$repo"
+  git -C "$repo" init -q
+  git -C "$repo" config user.email "fanout-test@example.com"
+  git -C "$repo" config user.name "fanout test"
+  printf 'base\n' >"$repo/tracked.txt"
+  git -C "$repo" add tracked.txt
+  git -C "$repo" commit -qm "initial"
+  git -C "$repo" branch -M main
+}
+
+write_marker() {
+  git -C "$1" rev-parse HEAD >"$1/.git/fanout-check-passed"
+}
+
+# Feed a payload to a hook script exactly like the agents do: JSON on stdin,
+# combined output captured, ambient hook env scrubbed so a developer's own
+# Claude session (CLAUDE_PROJECT_DIR) or exported bypasses cannot leak in.
+run_hook() {
+  local script="$1" payload="$2"
+  run bash -c 'printf "%s" "$1" | env -u CLAUDE_PROJECT_DIR -u FANOUT_SKIP_PUSH_CHECK -u FANOUT_SKIP_STOP_GATE bash "$0" 2>&1' "$script" "$payload"
+}
+
+# run_push_gate CMD CWD — CMD must not itself contain JSON-special characters;
+# tests that need embedded quotes build their payload literally instead.
+run_push_gate() {
+  run_hook "$PUSH_GATE" "{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"$1\"},\"cwd\":\"$2\"}"
+}
+
+# --- push gate ---------------------------------------------------------------
+
+@test "push gate: denies git push without a marker" {
+  local repo="$BATS_TEST_TMPDIR/repo"
+  setup_hook_repo "$repo"
+
+  run_push_gate 'git push origin HEAD' "$repo"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"fanout push gate"* ]]
+  [[ "$output" == *"make check"* ]]
+
+  # Composite commands are still scanned segment by segment.
+  run_push_gate 'echo done && git push origin main' "$repo"
+  [ "$status" -eq 2 ]
+}
+
+@test "push gate: allows git push when marker matches HEAD" {
+  local repo="$BATS_TEST_TMPDIR/repo"
+  setup_hook_repo "$repo"
+  write_marker "$repo"
+
+  run_push_gate 'git push origin HEAD' "$repo"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+
+  run_push_gate 'git push -u origin feature-branch' "$repo"
+  [ "$status" -eq 0 ]
+}
+
+@test "push gate: denies a stale marker after a new commit" {
+  local repo="$BATS_TEST_TMPDIR/repo"
+  setup_hook_repo "$repo"
+  write_marker "$repo"
+  printf 'more\n' >>"$repo/tracked.txt"
+  git -C "$repo" commit -aqm "second"
+
+  run_push_gate 'git push origin HEAD' "$repo"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"marker"* ]]
+}
+
+@test "push gate: allows branch deletion and tag pushes without a marker" {
+  local repo="$BATS_TEST_TMPDIR/repo"
+  setup_hook_repo "$repo"
+  git -C "$repo" tag v1.0.0
+
+  run_push_gate 'git push --delete origin old-branch' "$repo"
+  [ "$status" -eq 0 ]
+  run_push_gate 'git push origin :old-branch' "$repo"
+  [ "$status" -eq 0 ]
+  run_push_gate 'git push --tags origin' "$repo"
+  [ "$status" -eq 0 ]
+  run_push_gate 'git push origin v1.0.0' "$repo"
+  [ "$status" -eq 0 ]
+
+  # A branch smuggled next to a deletion still needs the marker.
+  run_push_gate 'git push origin main :old-branch' "$repo"
+  [ "$status" -eq 2 ]
+}
+
+@test "push gate: FANOUT_SKIP_PUSH_CHECK=1 bypasses the gate" {
+  local repo="$BATS_TEST_TMPDIR/repo"
+  setup_hook_repo "$repo"
+
+  local payload="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git push origin HEAD\"},\"cwd\":\"$repo\"}"
+  run bash -c 'printf "%s" "$1" | env -u CLAUDE_PROJECT_DIR FANOUT_SKIP_PUSH_CHECK=1 bash "$0" 2>&1' "$PUSH_GATE" "$payload"
+  [ "$status" -eq 0 ]
+
+  run_push_gate 'FANOUT_SKIP_PUSH_CHECK=1 git push origin HEAD' "$repo"
+  [ "$status" -eq 0 ]
+}
+
+@test "push gate: ignores non-push commands and quoted push-like strings" {
+  local repo="$BATS_TEST_TMPDIR/repo"
+  setup_hook_repo "$repo"
+
+  run_push_gate 'ls -la' "$repo"
+  [ "$status" -eq 0 ]
+
+  # `git push` inside a quoted argument is not a command word.
+  local payload="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m \\\"docs: explain git push flow\\\"\"},\"cwd\":\"$repo\"}"
+  run_hook "$PUSH_GATE" "$payload"
+  [ "$status" -eq 0 ]
+}
+
+@test "push gate: fails closed when extraction fails but the payload mentions git push" {
+  local repo="$BATS_TEST_TMPDIR/repo"
+  setup_hook_repo "$repo"
+
+  run_hook "$PUSH_GATE" "{\"tool_name\":\"Bash\",\"note\":\"git push\",\"tool_input\":{},\"cwd\":\"$repo\"}"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"fail closed"* ]]
+}
+
+# --- stop gate (Codex backstop) ----------------------------------------------
+
+stop_payload() {
+  printf '{"hook_event_name":"Stop","stop_hook_active":false,"cwd":"%s"}' "$1"
+}
+
+write_failing_check_makefile() {
+  printf 'check:\n\t@echo boom from stub check >&2; exit 1\n' >"$1/Makefile"
+}
+
+@test "stop gate: skips when stop_hook_active is true" {
+  local repo="$BATS_TEST_TMPDIR/repo"
+  setup_hook_repo "$repo"
+  write_failing_check_makefile "$repo"
+  git -C "$repo" add Makefile && git -C "$repo" commit -qm makefile
+
+  run_hook "$STOP_GATE" "{\"hook_event_name\":\"Stop\",\"stop_hook_active\":true,\"cwd\":\"$repo\"}"
+  [ "$status" -eq 0 ]
+}
+
+@test "stop gate: skips on a dirty tree" {
+  local repo="$BATS_TEST_TMPDIR/repo"
+  setup_hook_repo "$repo"
+  write_failing_check_makefile "$repo"
+  git -C "$repo" add Makefile && git -C "$repo" commit -qm makefile
+  printf 'wip\n' >>"$repo/tracked.txt"
+
+  run_hook "$STOP_GATE" "$(stop_payload "$repo")"
+  [ "$status" -eq 0 ]
+}
+
+@test "stop gate: skips when marker matches HEAD" {
+  local repo="$BATS_TEST_TMPDIR/repo"
+  setup_hook_repo "$repo"
+  write_failing_check_makefile "$repo"
+  git -C "$repo" add Makefile && git -C "$repo" commit -qm makefile
+  write_marker "$repo"
+
+  run_hook "$STOP_GATE" "$(stop_payload "$repo")"
+  [ "$status" -eq 0 ]
+}
+
+@test "stop gate: skips when HEAD is an ancestor of the origin default branch" {
+  local repo="$BATS_TEST_TMPDIR/repo"
+  setup_hook_repo "$repo"
+  write_failing_check_makefile "$repo"
+  git -C "$repo" add Makefile && git -C "$repo" commit -qm makefile
+  git -C "$repo" update-ref refs/remotes/origin/main HEAD
+
+  run_hook "$STOP_GATE" "$(stop_payload "$repo")"
+  [ "$status" -eq 0 ]
+}
+
+@test "stop gate: blocks on a failing check and reports the log path" {
+  local repo="$BATS_TEST_TMPDIR/repo"
+  setup_hook_repo "$repo"
+  write_failing_check_makefile "$repo"
+  git -C "$repo" add Makefile && git -C "$repo" commit -qm makefile
+
+  run_hook "$STOP_GATE" "$(stop_payload "$repo")"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"fanout stop gate"* ]]
+  [[ "$output" == *"fanout-check.log"* ]]
+  [[ "$output" == *"boom from stub check"* ]]
+  [ -f "$repo/.git/fanout-check.log" ]
+}
+
+@test "stop gate: passes on a green check and honors FANOUT_SKIP_STOP_GATE=1" {
+  local repo="$BATS_TEST_TMPDIR/repo"
+  setup_hook_repo "$repo"
+  printf 'check:\n\t@echo stub check ok\n' >"$repo/Makefile"
+  git -C "$repo" add Makefile && git -C "$repo" commit -qm makefile
+
+  run_hook "$STOP_GATE" "$(stop_payload "$repo")"
+  [ "$status" -eq 0 ]
+
+  write_failing_check_makefile "$repo"
+  git -C "$repo" commit -aqm failing
+  run bash -c 'printf "%s" "$1" | env -u CLAUDE_PROJECT_DIR FANOUT_SKIP_STOP_GATE=1 bash "$0" 2>&1' "$STOP_GATE" "$(stop_payload "$repo")"
+  [ "$status" -eq 0 ]
+}
+
+# --- check-marker (Makefile) ---------------------------------------------------
+
+@test "check-marker: writes HEAD only on a clean tree" {
+  local sandbox="$BATS_TEST_TMPDIR/sandbox"
+  mkdir -p "$sandbox"
+  cp "$REPO_ROOT/Makefile" "$REPO_ROOT/.golangci-lint-version" "$sandbox/"
+  git -C "$sandbox" init -q
+  git -C "$sandbox" config user.email "fanout-test@example.com"
+  git -C "$sandbox" config user.name "fanout test"
+  git -C "$sandbox" add Makefile .golangci-lint-version
+  git -C "$sandbox" commit -qm initial
+
+  # Untracked files count as dirty (git status --porcelain -uall).
+  printf 'scratch\n' >"$sandbox/scratch.txt"
+  run bash -c 'make -C "$0" --no-print-directory check-marker 2>&1' "$sandbox"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"marker not written"* ]]
+  [ ! -f "$sandbox/.git/fanout-check-passed" ]
+
+  rm "$sandbox/scratch.txt"
+  run bash -c 'make -C "$0" --no-print-directory check-marker 2>&1' "$sandbox"
+  [ "$status" -eq 0 ]
+  [ "$(cat "$sandbox/.git/fanout-check-passed")" = "$(git -C "$sandbox" rev-parse HEAD)" ]
+}
+
+# --- format-on-edit ------------------------------------------------------------
+
+format_payload() {
+  printf '{"tool_name":"Edit","tool_input":{"file_path":"%s"},"cwd":"%s"}' "$1" "$2"
+}
+
+@test "format-on-edit: exits 0 and leaves the file untouched when the toolchain is absent" {
+  local repo="$BATS_TEST_TMPDIR/repo"
+  mkdir -p "$repo"
+  printf 'vTEST-does-not-exist\n' >"$repo/.golangci-lint-version"
+  printf 'package main\n\nfunc main() {\nprintln( "x" )\n}\n' >"$repo/bad.go"
+
+  run bash -c 'printf "%s" "$1" | env -u CLAUDE_PROJECT_DIR FANOUT_DEV_CACHE_DIR="$2" bash "$0" 2>&1' \
+    "$FORMAT_HOOK" "$(format_payload "$repo/bad.go" "$repo")" "$BATS_TEST_TMPDIR/empty-cache"
+  [ "$status" -eq 0 ]
+  [[ "$(cat "$repo/bad.go")" == *'println( "x" )'* ]]
+}
+
+@test "format-on-edit: ignores non-target extensions" {
+  local repo="$BATS_TEST_TMPDIR/repo"
+  mkdir -p "$repo"
+  printf '#  messy   markdown\n' >"$repo/README.md"
+
+  run_hook "$FORMAT_HOOK" "$(format_payload "$repo/README.md" "$repo")"
+  [ "$status" -eq 0 ]
+  [[ "$(cat "$repo/README.md")" == '#  messy   markdown' ]]
+}
+
+@test "format-on-edit: formats a .go file when the pinned golangci-lint is cached" {
+  local cache_root="${FANOUT_DEV_CACHE_DIR:-/tmp/fanout-dev-cache-$(id -u)}"
+  local version
+  version="$(tr -d '[:space:]' <"$REPO_ROOT/.golangci-lint-version")"
+  [ -x "$cache_root/tools/golangci-lint-$version" ] || skip "pinned golangci-lint not cached locally"
+
+  local repo="$BATS_TEST_TMPDIR/repo"
+  mkdir -p "$repo"
+  cp "$REPO_ROOT/.golangci-lint-version" "$REPO_ROOT/.golangci.yml" "$repo/"
+  printf 'package main\n\nfunc main() {\nprintln( "x" )\n}\n' >"$repo/bad.go"
+
+  run_hook "$FORMAT_HOOK" "$(format_payload "$repo/bad.go" "$repo")"
+  [ "$status" -eq 0 ]
+  [[ "$(cat "$repo/bad.go")" == *'println("x")'* ]]
+}
+
+# --- hooks lib -----------------------------------------------------------------
+
+@test "hooks lib: json_field decodes escaped command strings" {
+  local payload='{"cwd":"/tmp/x","tool_input":{"command":"git commit -m \"say \\\\ hi\" && ls"}}'
+  run bash -c '. "$0"; json_field "$1" command' "$HOOKS_LIB" "$payload"
+  [ "$status" -eq 0 ]
+  # JSON \\\\ decodes to two literal backslashes.
+  [ "$output" = 'git commit -m "say \\ hi" && ls' ]
+
+  run bash -c '. "$0"; json_field "$1" cwd' "$HOOKS_LIB" "$payload"
+  [ "$output" = "/tmp/x" ]
+}

--- a/tests/bats/tier1_agent_hooks.bats
+++ b/tests/bats/tier1_agent_hooks.bats
@@ -506,6 +506,23 @@ run_push_gate() {
   git -C "$repo" tag rel
   run_push_gate 'git push origin rel:main' "$repo"
   [ "$status" -eq 2 ]
+
+  # time wraps the real push (POSIX -p and GNU value options).
+  run_push_gate 'time git push origin HEAD' "$repo"
+  [ "$status" -eq 2 ]
+  run_push_gate 'time -p git push origin HEAD' "$repo"
+  [ "$status" -eq 2 ]
+
+  # env --unset before an inner shell must still expose the push.
+  local payload="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"env --unset FOO bash -c 'git push origin HEAD'\"},\"cwd\":\"$repo\"}"
+  run_hook "$PUSH_GATE" "$payload"
+  [ "$status" -eq 2 ]
+
+  # A ref mutation before gh pr create in one call is stale.
+  git -C "$repo" checkout -qb pr-branch
+  git -C "$repo" rev-parse HEAD >"$repo/.git/fanout-check-passed"
+  run_push_gate 'git commit --allow-empty -m wip && gh pr create --fill' "$repo"
+  [ "$status" -eq 2 ]
 }
 
 @test "push gate: eval, config-then-push, tag-then-push, and wrapped gh pr create stay gated" {

--- a/tests/bats/tier1_agent_hooks.bats
+++ b/tests/bats/tier1_agent_hooks.bats
@@ -61,17 +61,33 @@ run_push_gate() {
   [ "$status" -eq 2 ]
 }
 
-@test "push gate: allows git push when marker matches HEAD" {
+@test "push gate: allows git push when marker matches the pushed tip" {
   local repo="$BATS_TEST_TMPDIR/repo"
   setup_hook_repo "$repo"
+  git -C "$repo" branch feature-branch
   write_marker "$repo"
 
   run_push_gate 'git push origin HEAD' "$repo"
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 
+  # A named refspec is validated against its own tip, which here equals HEAD.
   run_push_gate 'git push -u origin feature-branch' "$repo"
   [ "$status" -eq 0 ]
+}
+
+@test "push gate: validates the refspec tip, not the checked-out HEAD" {
+  local repo="$BATS_TEST_TMPDIR/repo"
+  setup_hook_repo "$repo"
+  git -C "$repo" branch stale-branch
+  printf 'more\n' >>"$repo/tracked.txt"
+  git -C "$repo" commit -aqm "second"
+  write_marker "$repo" # marker == new HEAD, not stale-branch
+
+  run_push_gate 'git push origin HEAD' "$repo"
+  [ "$status" -eq 0 ]
+  run_push_gate 'git push origin stale-branch' "$repo"
+  [ "$status" -eq 2 ]
 }
 
 @test "push gate: denies a stale marker after a new commit" {
@@ -99,9 +115,63 @@ run_push_gate() {
   [ "$status" -eq 0 ]
   run_push_gate 'git push origin v1.0.0' "$repo"
   [ "$status" -eq 0 ]
+  run_push_gate 'git push origin refs/tags/v1.0.0' "$repo"
+  [ "$status" -eq 0 ]
+  run_push_gate 'git push origin tag v1.0.0' "$repo"
+  [ "$status" -eq 0 ]
+  run_push_gate 'git push -o ci.skip origin v1.0.0' "$repo"
+  [ "$status" -eq 0 ]
+  run_push_gate 'git push --dry-run origin HEAD' "$repo"
+  [ "$status" -eq 0 ]
 
   # A branch smuggled next to a deletion still needs the marker.
   run_push_gate 'git push origin main :old-branch' "$repo"
+  [ "$status" -eq 2 ]
+}
+
+@test "push gate: tag exemptions do not cover branch updates" {
+  local repo="$BATS_TEST_TMPDIR/repo"
+  setup_hook_repo "$repo"
+  git -C "$repo" tag tmp
+
+  # --tags / --follow-tags alongside a branch refspec still gate the branch.
+  run_push_gate 'git push --tags origin main' "$repo"
+  [ "$status" -eq 2 ]
+  run_push_gate 'git push --follow-tags origin main' "$repo"
+  [ "$status" -eq 2 ]
+  # A tag pushed to a branch destination is a branch update.
+  run_push_gate 'git push origin tmp:refs/heads/feature' "$repo"
+  [ "$status" -eq 2 ]
+}
+
+@test "push gate: follows cd and git -C to the pushed repository" {
+  local repo_a="$BATS_TEST_TMPDIR/repo-a"
+  local repo_b="$BATS_TEST_TMPDIR/repo-b"
+  setup_hook_repo "$repo_a"
+  setup_hook_repo "$repo_b"
+  write_marker "$repo_a" # only repo A is validated
+
+  # Payload cwd is the validated repo A, but the push targets repo B.
+  run_push_gate "cd $repo_b && git push origin HEAD" "$repo_a"
+  [ "$status" -eq 2 ]
+  run_push_gate "git -C $repo_b push origin HEAD" "$repo_a"
+  [ "$status" -eq 2 ]
+
+  write_marker "$repo_b"
+  run_push_gate "cd $repo_b && git push origin HEAD" "$repo_a"
+  [ "$status" -eq 0 ]
+}
+
+@test "push gate: payload cwd wins over CLAUDE_PROJECT_DIR" {
+  local repo_a="$BATS_TEST_TMPDIR/repo-a"
+  local repo_b="$BATS_TEST_TMPDIR/repo-b"
+  setup_hook_repo "$repo_a"
+  setup_hook_repo "$repo_b"
+  write_marker "$repo_a" # session root is validated, the pushed repo is not
+
+  local payload="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git push origin HEAD\"},\"cwd\":\"$repo_b\"}"
+  run bash -c 'printf "%s" "$1" | env -u FANOUT_SKIP_PUSH_CHECK CLAUDE_PROJECT_DIR="$2" bash "$0" 2>&1' \
+    "$PUSH_GATE" "$payload" "$repo_a"
   [ "$status" -eq 2 ]
 }
 
@@ -115,6 +185,16 @@ run_push_gate() {
 
   run_push_gate 'FANOUT_SKIP_PUSH_CHECK=1 git push origin HEAD' "$repo"
   [ "$status" -eq 0 ]
+  run_push_gate 'export FANOUT_SKIP_PUSH_CHECK=1 && git push origin HEAD' "$repo"
+  [ "$status" -eq 0 ]
+}
+
+@test "push gate: a mere mention of the escape hatch does not bypass" {
+  local repo="$BATS_TEST_TMPDIR/repo"
+  setup_hook_repo "$repo"
+
+  run_push_gate 'echo FANOUT_SKIP_PUSH_CHECK=1 > note.txt; git push origin HEAD' "$repo"
+  [ "$status" -eq 2 ]
 }
 
 @test "push gate: ignores non-push commands and quoted push-like strings" {
@@ -128,6 +208,24 @@ run_push_gate() {
   local payload="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m \\\"docs: explain git push flow\\\"\"},\"cwd\":\"$repo\"}"
   run_hook "$PUSH_GATE" "$payload"
   [ "$status" -eq 0 ]
+
+  # A heredoc body mentioning git push is content, not a command.
+  payload="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"cat > doc.md <<'EOF'\\ngit push origin main\\nEOF\"},\"cwd\":\"$repo\"}"
+  run_hook "$PUSH_GATE" "$payload"
+  [ "$status" -eq 0 ]
+}
+
+@test "push gate: quote and subshell tricks cannot hide a real push" {
+  local repo="$BATS_TEST_TMPDIR/repo"
+  setup_hook_repo "$repo"
+
+  # Apostrophes inside double quotes must not pair up and swallow the push.
+  local payload="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git commit -m \\\"isn't done\\\" && git push origin main && echo \\\"won't stop\\\"\"},\"cwd\":\"$repo\"}"
+  run_hook "$PUSH_GATE" "$payload"
+  [ "$status" -eq 2 ]
+
+  run_push_gate '(git push origin main)' "$repo"
+  [ "$status" -eq 2 ]
 }
 
 @test "push gate: fails closed when extraction fails but the payload mentions git push" {
@@ -147,6 +245,18 @@ stop_payload() {
 
 write_failing_check_makefile() {
   printf 'check:\n\t@echo boom from stub check >&2; exit 1\n' >"$1/Makefile"
+}
+
+@test "stop gate: runs from a subdirectory by walking to the repo root" {
+  local repo="$BATS_TEST_TMPDIR/repo"
+  setup_hook_repo "$repo"
+  write_failing_check_makefile "$repo"
+  git -C "$repo" add Makefile && git -C "$repo" commit -qm makefile
+  mkdir -p "$repo/web"
+
+  run_hook "$STOP_GATE" "$(stop_payload "$repo/web")"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"boom from stub check"* ]]
 }
 
 @test "stop gate: skips when stop_hook_active is true" {
@@ -301,4 +411,9 @@ format_payload() {
 
   run bash -c '. "$0"; json_field "$1" cwd' "$HOOKS_LIB" "$payload"
   [ "$output" = "/tmp/x" ]
+
+  # \uXXXX decodes to a placeholder so adjacent tokens never merge.
+  local upayload='{"tool_input":{"command":"echo A\u0022B"}}'
+  run bash -c '. "$0"; json_field "$1" command' "$HOOKS_LIB" "$upayload"
+  [ "$output" = "echo A_B" ]
 }

--- a/tests/bats/tier1_agent_hooks.bats
+++ b/tests/bats/tier1_agent_hooks.bats
@@ -474,6 +474,36 @@ run_push_gate() {
   [ "$status" -eq 2 ]
 }
 
+@test "push gate: exported repo vars, env -S, pushDefault, and popd stay gated" {
+  local repo_a="$BATS_TEST_TMPDIR/repo-a"
+  local repo_b="$BATS_TEST_TMPDIR/repo-b"
+  setup_hook_repo "$repo_a"
+  setup_hook_repo "$repo_b"
+  write_marker "$repo_a"
+
+  # Exported GIT_DIR redirects every later git call: fail closed.
+  run_push_gate 'export GIT_DIR=/other/.git GIT_WORK_TREE=/other; git push origin HEAD' "$repo_a"
+  [ "$status" -eq 2 ]
+
+  # env -S splices a command string the scanner cannot follow.
+  local payload="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"env -S 'git push origin HEAD'\"},\"cwd\":\"$repo_a\"}"
+  run_hook "$PUSH_GATE" "$payload"
+  [ "$status" -eq 2 ]
+  payload="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"env -S 'ls -la'\"},\"cwd\":\"$repo_a\"}"
+  run_hook "$PUSH_GATE" "$payload"
+  [ "$status" -eq 0 ]
+
+  # An inline remote.pushDefault override redirects the implicit refspec.
+  run_push_gate 'git -c remote.pushDefault=evil push origin HEAD' "$repo_a"
+  [ "$status" -eq 2 ]
+
+  # popd returns to the original (unvalidated) repo before the push.
+  run_push_gate "pushd $repo_a && popd && git push origin HEAD" "$repo_b"
+  [ "$status" -eq 2 ]
+  run_push_gate "pushd $repo_a && git push origin HEAD && popd" "$repo_b"
+  [ "$status" -eq 0 ]
+}
+
 @test "push gate: fails closed when extraction fails but the payload mentions git push" {
   local repo="$BATS_TEST_TMPDIR/repo"
   setup_hook_repo "$repo"

--- a/tests/bats/tier1_agent_hooks.bats
+++ b/tests/bats/tier1_agent_hooks.bats
@@ -226,6 +226,58 @@ run_push_gate() {
 
   run_push_gate '(git push origin main)' "$repo"
   [ "$status" -eq 2 ]
+
+  run_push_gate 'if git push origin HEAD; then echo pushed; fi' "$repo"
+  [ "$status" -eq 2 ]
+}
+
+@test "push gate: quoted paths keep cd and git -C traceable" {
+  local repo_a="$BATS_TEST_TMPDIR/repo-a"
+  local repo_b="$BATS_TEST_TMPDIR/repo-b"
+  setup_hook_repo "$repo_a"
+  setup_hook_repo "$repo_b"
+  write_marker "$repo_a" # only repo A is validated
+
+  local payload="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git -C \\\"$repo_b\\\" push origin HEAD\"},\"cwd\":\"$repo_a\"}"
+  run_hook "$PUSH_GATE" "$payload"
+  [ "$status" -eq 2 ]
+
+  payload="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"cd \\\"$repo_b\\\" && git push origin HEAD\"},\"cwd\":\"$repo_a\"}"
+  run_hook "$PUSH_GATE" "$payload"
+  [ "$status" -eq 2 ]
+
+  write_marker "$repo_b"
+  run_hook "$PUSH_GATE" "$payload"
+  [ "$status" -eq 0 ]
+}
+
+@test "push gate: fails closed when the pushed repository cannot be resolved" {
+  local repo="$BATS_TEST_TMPDIR/repo"
+  setup_hook_repo "$repo"
+  write_marker "$repo"
+
+  run_push_gate 'cd /nonexistent-fanout-dir && git push origin HEAD' "$repo"
+  [ "$status" -eq 2 ]
+  run_push_gate 'cd $WORKTREE && git push origin HEAD' "$repo"
+  [ "$status" -eq 2 ]
+}
+
+@test "push gate: --all and --mirror validate every branch tip" {
+  local repo="$BATS_TEST_TMPDIR/repo"
+  setup_hook_repo "$repo"
+  git -C "$repo" branch old-branch
+  printf 'more\n' >>"$repo/tracked.txt"
+  git -C "$repo" commit -aqm "second"
+  write_marker "$repo" # old-branch's tip is one commit behind the marker
+
+  run_push_gate 'git push --all origin' "$repo"
+  [ "$status" -eq 2 ]
+  run_push_gate 'git push --mirror origin' "$repo"
+  [ "$status" -eq 2 ]
+
+  git -C "$repo" branch -f old-branch HEAD
+  run_push_gate 'git push --all origin' "$repo"
+  [ "$status" -eq 0 ]
 }
 
 @test "push gate: fails closed when extraction fails but the payload mentions git push" {
@@ -391,13 +443,36 @@ format_payload() {
   [ -x "$cache_root/tools/golangci-lint-$version" ] || skip "pinned golangci-lint not cached locally"
 
   local repo="$BATS_TEST_TMPDIR/repo"
-  mkdir -p "$repo"
+  mkdir -p "$repo/sub"
+  git -C "$repo" init -q
   cp "$REPO_ROOT/.golangci-lint-version" "$REPO_ROOT/.golangci.yml" "$repo/"
   printf 'package main\n\nfunc main() {\nprintln( "x" )\n}\n' >"$repo/bad.go"
 
   run_hook "$FORMAT_HOOK" "$(format_payload "$repo/bad.go" "$repo")"
   [ "$status" -eq 0 ]
   [[ "$(cat "$repo/bad.go")" == *'println("x")'* ]]
+
+  # A subdirectory cwd resolves the repo root for the version pin.
+  printf 'package main\n\nfunc main() {\nprintln( "y" )\n}\n' >"$repo/bad.go"
+  run_hook "$FORMAT_HOOK" "$(format_payload "$repo/bad.go" "$repo/sub")"
+  [ "$status" -eq 0 ]
+  [[ "$(cat "$repo/bad.go")" == *'println("y")'* ]]
+}
+
+@test "format-on-edit: refuses a foreign or symlinked shared cache" {
+  local repo="$BATS_TEST_TMPDIR/repo"
+  mkdir -p "$repo"
+  cp "$REPO_ROOT/.golangci-lint-version" "$repo/"
+  printf 'package main\n\nfunc main() {\nprintln( "x" )\n}\n' >"$repo/bad.go"
+
+  # A symlinked cache root is rejected, so the file stays untouched even if
+  # the link points at a real, populated cache.
+  local real_cache="${FANOUT_DEV_CACHE_DIR:-/tmp/fanout-dev-cache-$(id -u)}"
+  ln -s "$real_cache" "$BATS_TEST_TMPDIR/evil-cache"
+  run bash -c 'printf "%s" "$1" | env -u CLAUDE_PROJECT_DIR -u GOLANGCI_LINT_BIN FANOUT_DEV_CACHE_DIR="$2" bash "$0" 2>&1' \
+    "$FORMAT_HOOK" "$(format_payload "$repo/bad.go" "$repo")" "$BATS_TEST_TMPDIR/evil-cache"
+  [ "$status" -eq 0 ]
+  [[ "$(cat "$repo/bad.go")" == *'println( "x" )'* ]]
 }
 
 # --- hooks lib -----------------------------------------------------------------

--- a/tests/bats/tier1_agent_hooks.bats
+++ b/tests/bats/tier1_agent_hooks.bats
@@ -474,6 +474,39 @@ run_push_gate() {
   [ "$status" -eq 2 ]
 }
 
+@test "push gate: eval, config-then-push, tag-then-push, and wrapped gh pr create stay gated" {
+  local repo="$BATS_TEST_TMPDIR/repo"
+  setup_hook_repo "$repo"
+  write_marker "$repo"
+
+  # eval executes its quoted arguments in the current shell.
+  local payload="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"eval 'git push origin HEAD'\"},\"cwd\":\"$repo\"}"
+  run_hook "$PUSH_GATE" "$payload"
+  [ "$status" -eq 2 ]
+
+  # Mutating config or a tag before a gated push in one call is stale.
+  run_push_gate 'git config remote.origin.push refs/heads/x:refs/heads/x; git push origin' "$repo"
+  [ "$status" -eq 2 ]
+  run_push_gate 'git tag -f moveme HEAD && git push origin moveme:refs/heads/x' "$repo"
+  [ "$status" -eq 2 ]
+  # Same-call tag creation is unverifiable at gate time; split commands work.
+  run_push_gate 'git tag v9.9.9 && git push origin v9.9.9' "$repo"
+  [ "$status" -eq 2 ]
+  git -C "$repo" tag v9.9.9
+  run_push_gate 'git push origin v9.9.9' "$repo"
+  [ "$status" -eq 0 ]
+
+  # gh pr create behind an inner shell or env prefix is still PR creation.
+  git -C "$repo" checkout -qb unpushed
+  printf 'x\n' >>"$repo/tracked.txt"
+  git -C "$repo" commit -aqm second # marker is now stale
+  payload="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"bash -lc 'gh pr create --fill'\"},\"cwd\":\"$repo\"}"
+  run_hook "$PUSH_GATE" "$payload"
+  [ "$status" -eq 2 ]
+  run_push_gate 'env -u FOO gh pr create --fill' "$repo"
+  [ "$status" -eq 2 ]
+}
+
 @test "push gate: exported repo vars, env -S, pushDefault, and popd stay gated" {
   local repo_a="$BATS_TEST_TMPDIR/repo-a"
   local repo_b="$BATS_TEST_TMPDIR/repo-b"

--- a/tests/bats/tier1_agent_hooks.bats
+++ b/tests/bats/tier1_agent_hooks.bats
@@ -119,6 +119,9 @@ run_push_gate() {
   [ "$status" -eq 0 ]
   run_push_gate 'git push origin tag v1.0.0' "$repo"
   [ "$status" -eq 0 ]
+  # An unqualified destination from a tag source infers refs/tags/.
+  run_push_gate 'git push origin v1.0.0:release-tag' "$repo"
+  [ "$status" -eq 0 ]
   run_push_gate 'git push -o ci.skip origin v1.0.0' "$repo"
   [ "$status" -eq 0 ]
   run_push_gate 'git push --dry-run origin HEAD' "$repo"
@@ -395,6 +398,52 @@ run_push_gate() {
   git -C "$repo" config remote.origin.mirror true
 
   run_push_gate 'git push origin' "$repo"
+  [ "$status" -eq 2 ]
+}
+
+@test "push gate: a ref-mutating command before the push in one call is denied" {
+  local repo="$BATS_TEST_TMPDIR/repo"
+  setup_hook_repo "$repo"
+  write_marker "$repo"
+
+  # The gate resolves refs before the call runs; the commit would move HEAD.
+  run_push_gate 'git commit -am wip && git push origin HEAD' "$repo"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"単独のコマンド"* ]]
+  run_push_gate 'git rebase origin/main && git push --force-with-lease origin HEAD' "$repo"
+  [ "$status" -eq 2 ]
+
+  # A push standalone (or after non-mutating commands) still passes.
+  run_push_gate 'git status && git push origin HEAD' "$repo"
+  [ "$status" -eq 0 ]
+}
+
+@test "push gate: substitutions, comments, and odd heredoc delimiters stay safe" {
+  local repo="$BATS_TEST_TMPDIR/repo"
+  setup_hook_repo "$repo"
+  write_marker "$repo"
+
+  # A substituted -C path is untraceable: fail closed even with a marker.
+  local payload="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git -C \\\"\$(git rev-parse --show-toplevel)\\\" push origin HEAD\"},\"cwd\":\"$repo\"}"
+  run_hook "$PUSH_GATE" "$payload"
+  [ "$status" -eq 2 ]
+
+  local repo2="$BATS_TEST_TMPDIR/repo2"
+  setup_hook_repo "$repo2"
+
+  # An apostrophe in a comment must not swallow the next line's push.
+  payload="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"# don't retry\\ngit push origin HEAD\"},\"cwd\":\"$repo2\"}"
+  run_hook "$PUSH_GATE" "$payload"
+  [ "$status" -eq 2 ]
+
+  # A hyphenated heredoc delimiter still terminates the body.
+  payload="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"cat <<'END-JSON'\\n{}\\nEND-JSON\\ngit push origin HEAD\"},\"cwd\":\"$repo2\"}"
+  run_hook "$PUSH_GATE" "$payload"
+  [ "$status" -eq 2 ]
+
+  run_push_gate 'GIT_DIR=/other/.git git push origin HEAD' "$repo2"
+  [ "$status" -eq 2 ]
+  run_push_gate 'git --config-env=remote.origin.push=SPEC push origin' "$repo2"
   [ "$status" -eq 2 ]
 }
 

--- a/tests/bats/tier1_agent_hooks.bats
+++ b/tests/bats/tier1_agent_hooks.bats
@@ -280,6 +280,67 @@ run_push_gate() {
   [ "$status" -eq 0 ]
 }
 
+@test "push gate: shell continuation and substitution forms are still pushes" {
+  local repo="$BATS_TEST_TMPDIR/repo"
+  setup_hook_repo "$repo"
+
+  # Backslash line continuation splices into one command.
+  local payload="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"git push \\\\\\n  origin HEAD\"},\"cwd\":\"$repo\"}"
+  run_hook "$PUSH_GATE" "$payload"
+  [ "$status" -eq 2 ]
+
+  # Command substitution inside double quotes executes the push.
+  payload="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"result=\\\"\$(git push origin HEAD)\\\"\"},\"cwd\":\"$repo\"}"
+  run_hook "$PUSH_GATE" "$payload"
+  [ "$status" -eq 2 ]
+
+  run_push_gate 'env -i git push origin HEAD' "$repo"
+  [ "$status" -eq 2 ]
+
+  # A command chained onto a quoted heredoc opener is not heredoc body.
+  payload="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"cat <<'EOF' && git push origin HEAD\\nbody\\nEOF\"},\"cwd\":\"$repo\"}"
+  run_hook "$PUSH_GATE" "$payload"
+  [ "$status" -eq 2 ]
+}
+
+@test "push gate: repository-switching options fail closed" {
+  local repo="$BATS_TEST_TMPDIR/repo"
+  setup_hook_repo "$repo"
+  write_marker "$repo"
+
+  run_push_gate 'git --git-dir /elsewhere/.git push origin HEAD' "$repo"
+  [ "$status" -eq 2 ]
+  run_push_gate 'git --work-tree=/elsewhere push origin HEAD' "$repo"
+  [ "$status" -eq 2 ]
+}
+
+@test "push gate: implicit refspecs from git config are validated" {
+  local repo="$BATS_TEST_TMPDIR/repo"
+  setup_hook_repo "$repo"
+  git -C "$repo" branch release
+  printf 'more\n' >>"$repo/tracked.txt"
+  git -C "$repo" commit -aqm "second"
+  write_marker "$repo" # release's tip is one commit behind the marker
+
+  # Bare `git push origin` normally validates HEAD only.
+  run_push_gate 'git push origin' "$repo"
+  [ "$status" -eq 0 ]
+
+  # remote.<name>.push redirects the implicit refspec to a stale tip.
+  git -C "$repo" config remote.origin.push refs/heads/release:refs/heads/release
+  run_push_gate 'git push origin' "$repo"
+  [ "$status" -eq 2 ]
+  git -C "$repo" config --unset remote.origin.push
+
+  # push.default=matching pushes every shared branch; so does a bare colon.
+  git -C "$repo" config push.default matching
+  run_push_gate 'git push origin' "$repo"
+  [ "$status" -eq 2 ]
+  git -C "$repo" config --unset push.default
+  run_push_gate 'git push origin :' "$repo"
+  [ "$status" -eq 2 ]
+}
+
 @test "push gate: fails closed when extraction fails but the payload mentions git push" {
   local repo="$BATS_TEST_TMPDIR/repo"
   setup_hook_repo "$repo"

--- a/tests/bats/tier1_agent_hooks.bats
+++ b/tests/bats/tier1_agent_hooks.bats
@@ -265,7 +265,7 @@ run_push_gate() {
   [ "$status" -eq 2 ]
 }
 
-@test "push gate: --all and --mirror validate every branch tip" {
+@test "push gate: --all validates every branch tip and --mirror fails closed" {
   local repo="$BATS_TEST_TMPDIR/repo"
   setup_hook_repo "$repo"
   git -C "$repo" branch old-branch
@@ -275,12 +275,14 @@ run_push_gate() {
 
   run_push_gate 'git push --all origin' "$repo"
   [ "$status" -eq 2 ]
-  run_push_gate 'git push --mirror origin' "$repo"
-  [ "$status" -eq 2 ]
 
   git -C "$repo" branch -f old-branch HEAD
   run_push_gate 'git push --all origin' "$repo"
   [ "$status" -eq 0 ]
+
+  # --mirror sends refs beyond refs/heads: always fail closed.
+  run_push_gate 'git push --mirror origin' "$repo"
+  [ "$status" -eq 2 ]
 }
 
 @test "push gate: shell continuation and substitution forms are still pushes" {
@@ -388,17 +390,42 @@ run_push_gate() {
   [ "$status" -eq 0 ]
 }
 
-@test "push gate: a mirror remote validates every branch tip" {
+@test "push gate: a mirror remote fails closed" {
   local repo="$BATS_TEST_TMPDIR/repo"
   setup_hook_repo "$repo"
-  git -C "$repo" branch stale-branch
-  printf 'more\n' >>"$repo/tracked.txt"
-  git -C "$repo" commit -aqm "second"
   write_marker "$repo"
   git -C "$repo" config remote.origin.mirror true
 
+  # Even a marker-matching HEAD cannot vouch for every mirrored ref.
   run_push_gate 'git push origin' "$repo"
   [ "$status" -eq 2 ]
+}
+
+@test "push gate: inner shells and gh pr create are gated" {
+  local repo="$BATS_TEST_TMPDIR/repo"
+  setup_hook_repo "$repo"
+
+  # A push handed to an inner shell cannot be verified: fail closed.
+  local payload="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"bash -lc 'git push origin HEAD'\"},\"cwd\":\"$repo\"}"
+  run_hook "$PUSH_GATE" "$payload"
+  [ "$status" -eq 2 ]
+  payload="{\"tool_name\":\"Bash\",\"tool_input\":{\"command\":\"sh -c \\\"git push origin main\\\"\"},\"cwd\":\"$repo\"}"
+  run_hook "$PUSH_GATE" "$payload"
+  [ "$status" -eq 2 ]
+  run_push_gate 'bash -c ls' "$repo"
+  [ "$status" -eq 0 ]
+
+  # gh pr create pushes the branch itself when it is not fully pushed.
+  run_push_gate 'gh pr create --fill' "$repo"
+  [ "$status" -eq 2 ]
+  run_push_gate 'gh pr view 12' "$repo"
+  [ "$status" -eq 0 ]
+  run_push_gate 'gh pr comment 12 --body create' "$repo"
+  [ "$status" -eq 0 ]
+
+  write_marker "$repo"
+  run_push_gate 'gh pr create --fill' "$repo"
+  [ "$status" -eq 0 ]
 }
 
 @test "push gate: a ref-mutating command before the push in one call is denied" {
@@ -497,6 +524,23 @@ write_failing_check_makefile() {
 
   run_hook "$STOP_GATE" "$(stop_payload "$repo")"
   [ "$status" -eq 0 ]
+}
+
+@test "stop gate: blocks a dirty stop when the pushed upstream tip is unvalidated" {
+  local repo="$BATS_TEST_TMPDIR/repo"
+  local remote="$BATS_TEST_TMPDIR/remote.git"
+  setup_hook_repo "$repo"
+  write_failing_check_makefile "$repo"
+  git -C "$repo" add Makefile && git -C "$repo" commit -qm makefile
+  git init -q --bare "$remote"
+  git -C "$repo" remote add origin "$remote"
+  git -C "$repo" checkout -qb feature
+  git -C "$repo" push -qu origin feature
+  printf 'wip\n' >>"$repo/tracked.txt" # dirty, but HEAD is already pushed
+
+  run_hook "$STOP_GATE" "$(stop_payload "$repo")"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"push 済みの HEAD"* ]]
 }
 
 @test "stop gate: skips when marker matches HEAD" {

--- a/tests/bats/tier1_agent_hooks.bats
+++ b/tests/bats/tier1_agent_hooks.bats
@@ -119,9 +119,9 @@ run_push_gate() {
   [ "$status" -eq 0 ]
   run_push_gate 'git push origin tag v1.0.0' "$repo"
   [ "$status" -eq 0 ]
-  # An unqualified destination from a tag source infers refs/tags/.
+  # An unqualified dst can expand to an existing remote branch, so it is gated.
   run_push_gate 'git push origin v1.0.0:release-tag' "$repo"
-  [ "$status" -eq 0 ]
+  [ "$status" -eq 2 ]
   run_push_gate 'git push -o ci.skip origin v1.0.0' "$repo"
   [ "$status" -eq 0 ]
   run_push_gate 'git push --dry-run origin HEAD' "$repo"
@@ -474,6 +474,40 @@ run_push_gate() {
   [ "$status" -eq 2 ]
 }
 
+@test "push gate: timeout, env --unset, --namespace, and symbolic-ref stay gated" {
+  local repo="$BATS_TEST_TMPDIR/repo"
+  setup_hook_repo "$repo"
+  # No marker: each form must be seen as an unvalidated push (or a mutation)
+  # and denied, proving the wrapper/option is not silently skipped.
+
+  # timeout wraps the real push.
+  run_push_gate 'timeout 30 git push origin HEAD' "$repo"
+  [ "$status" -eq 2 ]
+  run_push_gate 'timeout -s KILL 5 git push origin HEAD' "$repo"
+  [ "$status" -eq 2 ]
+
+  # env --unset takes a value; the push must still be seen.
+  run_push_gate 'env --unset FOO git push origin HEAD' "$repo"
+  [ "$status" -eq 2 ]
+
+  # --namespace re-points the ref space: fail closed.
+  run_push_gate 'git --namespace foo push origin main' "$repo"
+  [ "$status" -eq 2 ]
+
+  # symbolic-ref before a push changes the source ref.
+  run_push_gate 'git symbolic-ref HEAD refs/heads/stale && git push origin HEAD' "$repo"
+  [ "$status" -eq 2 ]
+
+  # env -C before a commit is still a ref mutation ahead of the push.
+  run_push_gate "env -C $repo git commit -am wip && git push origin HEAD" "$repo"
+  [ "$status" -eq 2 ]
+
+  # A tag pushed to an unqualified (branch-like) destination is gated.
+  git -C "$repo" tag rel
+  run_push_gate 'git push origin rel:main' "$repo"
+  [ "$status" -eq 2 ]
+}
+
 @test "push gate: eval, config-then-push, tag-then-push, and wrapped gh pr create stay gated" {
   local repo="$BATS_TEST_TMPDIR/repo"
   setup_hook_repo "$repo"
@@ -610,6 +644,25 @@ write_failing_check_makefile() {
   git -C "$repo" checkout -qb feature
   git -C "$repo" push -qu origin feature
   printf 'wip\n' >>"$repo/tracked.txt" # dirty, but HEAD is already pushed
+
+  run_hook "$STOP_GATE" "$(stop_payload "$repo")"
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"push 済みの HEAD"* ]]
+}
+
+@test "stop gate: blocks a dirty stop when HEAD is any remote tip without upstream" {
+  local repo="$BATS_TEST_TMPDIR/repo"
+  local remote="$BATS_TEST_TMPDIR/remote.git"
+  setup_hook_repo "$repo"
+  write_failing_check_makefile "$repo"
+  git -C "$repo" add Makefile && git -C "$repo" commit -qm makefile
+  git init -q --bare "$remote"
+  git -C "$repo" remote add origin "$remote"
+  git -C "$repo" checkout -qb feature
+  # Push without -u: no upstream is configured, but the tip reaches origin.
+  git -C "$repo" push -q origin feature
+  git -C "$repo" fetch -q origin
+  printf 'wip\n' >>"$repo/tracked.txt"
 
   run_hook "$STOP_GATE" "$(stop_payload "$repo")"
   [ "$status" -eq 2 ]

--- a/tests/bats/tier1_agent_hooks.bats
+++ b/tests/bats/tier1_agent_hooks.bats
@@ -529,6 +529,16 @@ run_push_gate() {
   # An inline remote.pushDefault override redirects the implicit refspec.
   run_push_gate 'git -c remote.pushDefault=evil push origin HEAD' "$repo_a"
   [ "$status" -eq 2 ]
+  # include.path can pull push-affecting config in from a file.
+  run_push_gate 'git -c include.path=/tmp/evil push origin HEAD' "$repo_a"
+  [ "$status" -eq 2 ]
+
+  # A path-prefixed env wrapper is still env.
+  run_push_gate '/usr/bin/env git push origin HEAD' "$repo_b"
+  [ "$status" -eq 2 ]
+  # env -C before gh pr create leaves the target repo untraceable.
+  run_push_gate 'env -C /elsewhere gh pr create --fill' "$repo_a"
+  [ "$status" -eq 2 ]
 
   # popd returns to the original (unvalidated) repo before the push.
   run_push_gate "pushd $repo_a && popd && git push origin HEAD" "$repo_b"

--- a/tools/reviewrisk/rules.go
+++ b/tools/reviewrisk/rules.go
@@ -174,6 +174,8 @@ var prefixRules = []struct {
 	{".github/workflows/", Rule{ID: "github-workflows", Class: ClassH, Source: SourceExtra, Note: "CI 定義"}},
 	{".github/", Rule{ID: "github-rest", Class: ClassM, Source: SourceExtra, Note: "GitHub 設定"}},
 	{".claude/", Rule{ID: "claude-settings", Class: ClassH, Source: SourceExtra, Note: "PR review gate 等の作業設定"}},
+	{".codex/", Rule{ID: "codex-settings", Class: ClassH, Source: SourceExtra, Note: "Codex hooks 配線 (push gate / stop gate)"}},
+	{"scripts/", Rule{ID: "agent-hooks", Class: ClassH, Source: SourceExtra, Note: "エージェント hook の品質ゲート実体"}},
 	{"codex/tools/", Rule{ID: "codex-tools", Class: ClassH, Source: SourceExtra, Note: "install される実行シェル"}},
 	{"claude/", Rule{ID: "claude-prompts", Class: ClassM, Source: SourceExtra, Note: "配布エージェントプロンプト"}},
 	{"codex/", Rule{ID: "codex-prompts", Class: ClassM, Source: SourceExtra, Note: "配布エージェントプロンプト"}},


### PR DESCRIPTION
## TL;DR

Claude Code / Codex とも編集後に lint / test を回さず push して CI が落ちる事象が多発していたため、**push 時点の PreToolUse hook で強制**する。branch への `git push` は「clean tree での `make check` 成功が書く per-worktree marker と push 対象 tip の一致」を要求し、不一致は deny してエージェントに `make check` を実行させる。Codex は PreToolUse intercept が公式に不完全なため Stop hook をバックストップに持つ。Edit 系 hook には軽量フォーマッタのみ。

Review effort: 4

## 設計 (briefing #32 の指示に基づくユーザー決定)

1. `gh pr create` / `git push` を hook できるエージェントは **その時点で重い品質ゲートを強制**(PreToolUse deny)
2. それができない・不完全なエージェント(Codex)**のみ** Stop hook で重いゲート
3. Write / Edit 系 hook は**フォーマッタ等の軽量処理のみ**
4. git hooks(pre-push)は不採用
5. hook スクリプトは **python 不使用の純シェル**(bash + git + awk/grep/sed)

```
                     Claude Code                       Codex
編集時(軽量):      PostToolUse(Edit|Write|MultiEdit) → agent-format-on-edit.sh(共有)
push 時(強制):     PreToolUse(Bash) ────────────────→ agent-push-gate.sh(共有・exit 2 deny)
turn 終了時:        (なし — 補足完全)                  Stop → agent-stop-gate.sh(バックストップ)
marker 発行:        clean tree で make check 成功 → $(git rev-parse --git-dir)/fanout-check-passed
```

## 変更ファイル

| File | What changed | Why |
|---|---|---|
| `scripts/agent-hooks-lib.sh` | 新規: awk JSON 抽出・シェル正規化(クォート/heredoc/置換/コメント/行継続)・marker ヘルパー | 両エージェント共有の純シェル基盤 |
| `scripts/agent-push-gate.sh` | 新規: push 対象 refspec の実 tip を marker と照合。削除・tag→tag・--dry-run は免除。cd/`git -C` 追跡、暗黙 refspec(remote.*.push / push.default / mirror)解決、追跡不能な形(--git-dir・GIT_DIR=・置換パス・同一呼び出し内 ref 変更後の push 等)は fail closed | push 時点の強制ゲート本体 |
| `scripts/agent-stop-gate.sh` | 新規: Codex 専用。turn 終了時に clean tree かつ未検証 HEAD なら `make check` を実行、失敗で stop をブロック。dirty / marker 一致 / default branch 上は skip(正常フローではコストゼロ) | Codex の intercept 漏れ対策 |
| `scripts/agent-format-on-edit.sh` | 新規: per-file の golangci-lint fmt / oxfmt(高速パスのみ・常に exit 0)。Codex apply_patch の patch ヘッダからも対象抽出。共有キャッシュは symlink 拒否 + 所有 UID 検証 | 編集時の軽量整形 |
| `.claude/settings.json` | PreToolUse 2 本目(push gate)+ PostToolUse(format)追加 | Claude 配線 |
| `.codex/hooks.json` | 新規 track: PreToolUse + PostToolUse + Stop(パスは `$(git rev-parse --show-toplevel)` 基準) | Codex 配線 |
| `.gitignore` | `.codex/` → `.codex/*` + `!.codex/hooks.json` | hooks.json だけ track |
| `Makefile` | `check-marker`(clean tree のみ marker 書込・`make -k` でも失敗時に書かない)、`check` の最終段に接続、lint-shell / test-tier1 配線 | marker 発行と CI 接続 |
| `tests/bats/tier1_agent_hooks.bats` | 新規 38 ケース(hook の stdin/exit code 契約) | 回帰防止 |
| `claude/skills/pr-watch/SKILL.md` ほか codex 側 2 ファイル | CI 修正・レビュー対応・rebase 後の push 前に canonical full gate を 1 回通す手順、`--no-verify` 回避禁止を明記 | 追い push 経路の指示強化 |
| `CLAUDE.md` / `AGENTS.md` / `docs/review-checklist.ja.md` | push gate・escape hatch(`FANOUT_SKIP_PUSH_CHECK=1` / `FANOUT_SKIP_STOP_GATE=1`)・Codex worktree ごとの hooks 承認を記載 | ドキュメント同期 |

## 検証

- `make check` 全 green(Go unit / vitest 106 / Tier1(新規 38 含む)/ Tier2 / golangci-lint / shellcheck / oxlint / oxfmt / tsc)
- Codex 実測 spike: payload 形式は Claude 互換(`tool_name: "Bash"` / `tool_input.command` / `cwd`)、exit 2 で「Blocked by PreToolUse hook: <stderr>」としてモデルに伝達、複合コマンドも intercept されることを `codex exec --dangerously-bypass-hook-trust` で確認
- 本 PR 自体が実地テスト: 最終 HEAD の `make check` が marker を書き、この push がゲートを通過した
- レビュー: code-review workflow(xhigh・55 findings)+ codex review 5 反復で計 33 件修正

> [!WARNING]
> - 純シェルの push 検出はシェルそのものではない(既知の限界はスクリプトヘッダに明記: サブシェルスコープ・短絡制御フローは模倣しない)。取りこぼしは Codex stop gate と CI が拾い、意図的回避は正規の `FANOUT_SKIP_PUSH_CHECK=1` を使う設計
> - `git commit && git push` のような同一呼び出し内の ref 変更後 push は deny される(gate は実行前の ref しか検証できないため)。**push は単独コマンドで実行**する運用になる
> - Codex は worktree パスごとに hooks の trust 承認が必要(未承認は黙って skip)。新しい worktree で初回にプロンプトを承認すること
> - PostToolUse の自動整形は編集直後にファイルを書き換えるため、連続 Edit で "file has been modified" が起こり得る(参照実装 ai-limit-quota-hud と同じ、ユーザー指定アーキテクチャのトレードオフ)

```mermaid
flowchart LR
  subgraph agents["エージェント"]
    C[Claude Code] -->|PreToolUse Bash| G[scripts/agent-push-gate.sh]
    X[Codex] -->|PreToolUse| G
    X -->|Stop| S[scripts/agent-stop-gate.sh]
    C -->|PostToolUse Edit/Write| F[scripts/agent-format-on-edit.sh]
    X -->|PostToolUse| F
  end
  M[make check 成功\nclean tree] -->|check-marker| K[(fanout-check-passed\n= 検証済み HEAD)]
  G -->|push tip == marker ?| K
  S -->|未検証 HEAD なら make check\n失敗で stop ブロック| M