### PR TITLE
docs: prepare v0.11.0 release

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -179,7 +179,7 @@ flag を生成します。詳しくは
   引数なしの TUI コンソールは素の shell から起動できます。
 - Project モードは `read:project` の gh スコープが必要です
   (`gh auth refresh -s read:project`)。
-- チェックアウトからビルドする場合は、追加で Go 1.26.5+、Node.js 24+、pnpm 10+
+- チェックアウトからビルドする場合は、追加で Go 1.26.5+、Node.js 24+、pnpm 11+
   が必要です(curl インストールはビルド済みバイナリを配るのでどちらも不要)。
 
 ## 開発

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ context. See the
 - Project mode needs the `read:project` gh scope
   (`gh auth refresh -s read:project`).
 - Building from a checkout additionally needs Go 1.26.5+, Node.js 24+, and
-  pnpm 10+ (the curl install ships a prebuilt binary and needs neither).
+  pnpm 11+ (the curl install ships a prebuilt binary and needs neither).
 
 ## Development
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,10 +1,11 @@
 # Releasing fanout
 
-Cutting a release is **CI-driven**: the only manual step is pushing an annotated
-`vX.Y.Z` tag. Pushing the tag triggers `.github/workflows/release.yml`, which
-builds the four platform archives, generates `SHA256SUMS`, and publishes the
-GitHub Release with auto-generated notes. There is no `make release` target and
-no goreleaser config — the workflow is the whole pipeline.
+Publishing a release is **CI-driven**: after the release docs land on `main`,
+the only manual publication step is pushing an annotated `vX.Y.Z` tag. Pushing
+the tag triggers `.github/workflows/release.yml`, which builds the four platform
+archives, generates `SHA256SUMS`, and publishes the GitHub Release with
+auto-generated notes. There is no `make release` target and no goreleaser config
+— the workflow is the whole pipeline.
 
 ## What the tag push does for you
 
@@ -38,16 +39,26 @@ no goreleaser config — the workflow is the whole pipeline.
    Bump per semver (`v0.MINOR.PATCH` while pre-1.0: features bump MINOR, fixes
    bump PATCH).
 
-2. **Preflight.** Release off the latest `origin/main` and make sure it is green:
+2. **Prepare the release docs.** Add the release date and highlights to
+   `site/content/docs/changelog.{md,ja.md}`, then update the pinned
+   `FANOUT_VERSION` example in `site/content/docs/installation.{md,ja.md}`.
+   Merge the docs through a normal PR; its squash commit becomes the intended
+   tag target. No source version edit is needed.
+
+3. **Preflight.** Release off the latest `origin/main` and make sure it is green:
 
    ```bash
+   git fetch origin main --tags
    gh run list --branch main --workflow test.yml --limit 1 \
      --json headSha,conclusion          # conclusion == "success" on main's tip
-   make test && make lint && make vuln   # optional local re-check (vuln needs network)
+   gh run list --branch main --workflow vuln.yml --limit 1 \
+     --json headSha,conclusion          # conclusion == "success" on the same tip
+   make check                            # optional deterministic local re-check
+   make vuln                             # optional; needs the network-backed vuln DB
    git tag -l vX.Y.Z                     # must be empty — tag not yet used
    ```
 
-3. **Tag and push.** Use an **annotated** tag pointing at `origin/main`, matching
+4. **Tag and push.** Use an **annotated** tag pointing at `origin/main`, matching
    how every prior tag was cut:
 
    ```bash
@@ -60,14 +71,15 @@ no goreleaser config — the workflow is the whole pipeline.
    review gate (`.claude/hooks/pre-pr-review-gate.sh`) only intercepts
    `gh pr create`; **a tag push is not gated.**
 
-4. **Watch the build.**
+5. **Watch the build.**
 
    ```bash
-   gh run watch "$(gh run list --workflow release.yml --limit 1 \
-     --json databaseId -q '.[0].databaseId')" --exit-status
+   until run_id="$(gh run list --workflow release.yml --branch vX.Y.Z --limit 1 \
+     --json databaseId -q '.[0].databaseId')" && [ -n "$run_id" ]; do sleep 5; done
+   gh run watch "$run_id" --exit-status
    ```
 
-5. **Verify the Release.**
+6. **Verify the Release.**
 
    ```bash
    gh release view vX.Y.Z

--- a/site/content/docs/changelog.ja.md
+++ b/site/content/docs/changelog.ja.md
@@ -9,6 +9,30 @@ yomi: changelog
 
 リリースのハイライトを新しい順に並べています。各タグには [GitHub release](https://github.com/butaosuinu/fanout/releases) があり、完全なコミット一覧とビルド済みバイナリ（darwin / linux × amd64 / arm64）を含みます。バージョンは git タグから ldflags 経由で埋め込まれます。`fanout --check-update` で自分の版を確認できます。
 
+## v0.11.0 (2026-07-11)
+
+- **Issue mode の plan fan-out。** 新規 Session popup の Issue mode に Prompt mode と同じ plan fan-out を追加し、選択した issue を issue-less な `fanout plan` task に分解できるようにしました。
+  coordinator と task agent は別々に選択でき、選択中の issue に OPEN な子がある場合はチェックボックスを無効化します。
+  [Monitoring]({{< relref "/docs/monitoring" >}}) を参照。
+- **Codex Plan Mode の起動安定化。** fanout は app-server で Plan Mode thread を作成して interactive Codex TUI を接続し、初回 Plan turn が受理されてから launch を記録するようになりました。
+  plan 生成と承認待ちには startup timeout を設けません。
+  [Agent Integrations]({{< relref "/docs/agents" >}}) を参照。
+- **GPT-5.6 向け Codex 連携。** 同梱する 5 個の Codex skill は、主な判断手順を `SKILL.md` に置き、必要なときだけ reference や script を読む構成になりました。
+  `$post-work-review` は固定した read-only の reviewer と verifier を使い、指定モデルを利用できない場合は停止します。
+  `$pr-watch` は同じ状態の再通知を抑える foreground watcher で監視します。
+  [Agent Integrations]({{< relref "/docs/agents" >}}) を参照。
+- **新規 Session 起動後のフォーカス。** `n` popup から Prompt、plan coordinator、Issue Session を起動すると、実際の作成順で先頭の新規ペインへフォーカスするようになりました。
+  agent 追加（`a`）、shell（`A` / `t`）、watcher、通常の CLI 起動では、従来どおりフォーカスを移しません。
+  [Monitoring]({{< relref "/docs/monitoring" >}}) を参照。
+- **Prompt Session の PR 状態。** Prompt Session の記録済み branch に PR がある場合、Web ダッシュボードがそのリンクと CI 状態を表示するようになりました。
+  [Monitoring]({{< relref "/docs/monitoring" >}}) を参照。
+- **貢献者向け品質ゲート。** リポジトリの正典ローカルゲートを `make check` に統一し、`post-work-review` の結果をレビュー対象の base と diff に結び付けました。
+  リポジトリ内の Claude と Codex の hook は、clean な対象 commit がゲートを通過するまで branch push を止め、Codex Stop hook も backstop として検証します。
+  release tag の push は対象外です。
+  `docs/review-checklist.ja.md` を参照。
+
+[リリースノート →](https://github.com/butaosuinu/fanout/releases/tag/v0.11.0)
+
 ## v0.10.0 (2026-07-09)
 
 - **Agent-state テレメトリ。** `@fanout_agent_state` 契約を 6 値の語彙(`running` / `working` / `plan` / `blocked` / `idle` / `done`)に拡張しました。起動ラッパーと Codex Plan Mode が状態を発行し、TUI / web の glyph とバッジに反映されます。agent がプランを提示・入力待ち・終了したときにコンソールが通知音を鳴らします。[Monitoring]({{< relref "/docs/monitoring" >}}) を参照。

--- a/site/content/docs/changelog.md
+++ b/site/content/docs/changelog.md
@@ -9,6 +9,28 @@ yomi: changelog
 
 Release highlights, newest first. Every tag also has a [GitHub release](https://github.com/butaosuinu/fanout/releases) with the full commit list and prebuilt binaries (darwin / linux × amd64 / arm64). Versions come from git tags via ldflags — check yours with `fanout --check-update`.
 
+## v0.11.0 (2026-07-11)
+
+- **Issue-mode plan fan-out.** The new-session popup gained the same plan fan-out control in Issue mode as in Prompt mode, decomposing a selected issue into issue-less `fanout plan` tasks with separate coordinator and task-agent choices.
+  The control is disabled while the selected issue has OPEN children.
+  See [Monitoring]({{< relref "/docs/monitoring" >}}).
+- **Reliable Codex Plan Mode startup.** fanout now creates the Plan Mode thread through app-server, attaches the interactive Codex TUI, and records the launch only after the initial Plan turn is accepted.
+  Plan generation and approval waiting no longer have a startup timeout.
+  See [Agent Integrations]({{< relref "/docs/agents" >}}).
+- **Codex integrations for GPT-5.6.** The five bundled Codex skills now keep their main decision flow in `SKILL.md` and load references or scripts only when needed.
+  `$post-work-review` uses pinned read-only reviewer and verifier models and stops instead of substituting unavailable models, while `$pr-watch` uses a foreground watcher that suppresses unchanged snapshots.
+  See [Agent Integrations]({{< relref "/docs/agents" >}}).
+- **Focus after new-session launch.** Successful Prompt, plan coordinator, and Issue launches from `n` now move focus to the first pane actually created.
+  Agent attach (`a`), shell (`A` / `t`), watcher, and ordinary CLI launches leave focus unchanged.
+  See [Monitoring]({{< relref "/docs/monitoring" >}}).
+- **Prompt Session PR status.** When a Prompt Session's recorded branch has a PR, the web dashboard now shows its link and CI status.
+  See [Monitoring]({{< relref "/docs/monitoring" >}}).
+- **Contributor quality gates.** The repository now uses `make check` as its canonical local gate, binds `post-work-review` results to the reviewed base and diff, and blocks branch pushes unless the exact clean tip has passed the gate.
+  Repo-local Claude and Codex hooks enforce the push check, with a Codex Stop hook as a backstop; release-tag pushes remain exempt.
+  See `docs/review-checklist.ja.md`.
+
+[Release notes →](https://github.com/butaosuinu/fanout/releases/tag/v0.11.0)
+
 ## v0.10.0 (2026-07-09)
 
 - **Agent-state telemetry.** The `@fanout_agent_state` contract expanded to a six-value vocabulary (`running` / `working` / `plan` / `blocked` / `idle` / `done`), emitted by the launch wrapper and Codex Plan Mode and surfaced as TUI / web glyphs and badges. The console now sounds a notification when an agent presents a plan, waits for input, or exits. See [Monitoring]({{< relref "/docs/monitoring" >}}).

--- a/site/content/docs/installation.ja.md
+++ b/site/content/docs/installation.ja.md
@@ -32,7 +32,7 @@ curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh |
 
 # 配置先や Release tag を指定
 curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh | BIN_DIR=/usr/local/bin sh
-curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh | FANOUT_VERSION=v0.10.0 sh
+curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh | FANOUT_VERSION=v0.11.0 sh
 ```
 
 `install.sh` は OS/arch を自動判定し、最新 Release(または `FANOUT_VERSION` で指定した tag)から `fanout` バイナリと Claude/Codex 連携ファイルを取得して配置します。
@@ -85,7 +85,7 @@ make link           # Go 版を $(BINDIR)/fanout として symlink + 連携を s
 make uninstall      # インストール済みのパスを削除
 ```
 
-ビルドには Go ツールチェイン(Go 1.26.5+)に加えて Node.js 24+ と pnpm 10+ が必要です(`make install` はダッシュボード Web UI を先にビルドして embed するため)。
+ビルドには Go ツールチェイン(Go 1.26.5+)に加えて Node.js 24+ と pnpm 11+ が必要です(`make install` はダッシュボード Web UI を先にビルドして embed するため)。
 curl インストールは prebuilt バイナリを配置するので、Go も Node も要りません。
 
 ## 更新を保つ

--- a/site/content/docs/installation.md
+++ b/site/content/docs/installation.md
@@ -32,7 +32,7 @@ curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh |
 
 # Custom destination or pinned release tag
 curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh | BIN_DIR=/usr/local/bin sh
-curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh | FANOUT_VERSION=v0.10.0 sh
+curl -fsSL https://raw.githubusercontent.com/butaosuinu/fanout/main/install.sh | FANOUT_VERSION=v0.11.0 sh
 ```
 
 `install.sh` auto-detects your OS/arch, then fetches and installs the `fanout` binary and the Claude/Codex integration files from the latest Release (or the tag given via `FANOUT_VERSION`).
@@ -84,7 +84,7 @@ make link           # symlinks the Go binary as $(BINDIR)/fanout + symlinks inte
 make uninstall      # removes installed paths
 ```
 
-Building it needs a Go toolchain (Go 1.26.5+) plus Node.js 24+ and pnpm 10+ (`make install` builds the dashboard web UI first and embeds it). The curl install ships a prebuilt binary, so it needs neither Go nor Node.
+Building it needs a Go toolchain (Go 1.26.5+) plus Node.js 24+ and pnpm 11+ (`make install` builds the dashboard web UI first and embeds it). The curl install ships a prebuilt binary, so it needs neither Go nor Node.
 
 ## Keeping it updated
 


### PR DESCRIPTION
## TL;DR

v0.11.0 のリリース文書を準備し、公開手順と必要ツールの記載を現在のリポジトリ構成に合わせます。

## 変更内容

- 日英の changelog に v0.11.0 のリリース日と主要変更を追加
- 日英のインストール例を `FANOUT_VERSION=v0.11.0` に更新
- `RELEASE.md` に文書 PR、マージ後の再取得、`test.yml` / `vuln.yml` の同一 main SHA 確認、対象タグの workflow 監視を明記
- ソースビルド要件を pnpm 11+ に同期

## 検証

- [x] `make check`
- [x] Hugo build
- [x] `git diff --check`
- [x] `post-work-review`: `clean=true`、broad 1 回、verifier 0 回

Review effort: 1