### PR TITLE
feat(panelaunch): issue オーケストレーター用ヘルパーを追加

### DIFF
--- a/internal/app/panelaunch/panelaunch.go
+++ b/internal/app/panelaunch/panelaunch.go
@@ -527,6 +527,12 @@ func rollbackState(recorder StateRecorder, req Request, lg *log.Logger) {
 	}
 }
 
+// KillAttachedPane silently tears down a pane created by AttachWithResult and
+// reconciles its window layout. An empty paneID is a no-op.
+func KillAttachedPane(target, paneID string) {
+	failCleanup("", target, paneID, nil, nil)
+}
+
 // failCleanup tears down a partially created launch: it kills the pane (when
 // one exists), reconciles the window layout, and removes a created worktree
 // (when prepared is non-nil). A nil lg makes every step silent best-effort

--- a/internal/app/panelaunch/panelaunch.go
+++ b/internal/app/panelaunch/panelaunch.go
@@ -527,8 +527,10 @@ func rollbackState(recorder StateRecorder, req Request, lg *log.Logger) {
 	}
 }
 
-// KillAttachedPane silently tears down a pane created by AttachWithResult and
-// reconciles its window layout. An empty paneID is a no-op.
+// KillAttachedPane silently tears down the tmux pane created by
+// AttachWithResult and reconciles its window layout. It does not remove the
+// recorded state row; callers must roll that back separately using the
+// original request identity. An empty paneID is a no-op.
 func KillAttachedPane(target, paneID string) {
 	failCleanup("", target, paneID, nil, nil)
 }

--- a/internal/app/panelaunch/panelaunch_test.go
+++ b/internal/app/panelaunch/panelaunch_test.go
@@ -1012,6 +1012,9 @@ func TestOrchestratorPaneIssueNum(t *testing.T) {
 		{name: "plan slug is distinct", pane: state.Pane{Parent: ManualParentRef, Slug: "plan-issue-123-1"}, ok: false, planParser: true},
 		{name: "longer issue number does not alias", pane: state.Pane{Parent: ManualParentRef, Slug: "orchestrator-issue-1234-1"}, want: 1234, ok: true},
 		{name: "non-numeric issue segment is rejected", pane: state.Pane{Parent: ManualParentRef, Slug: "orchestrator-issue-abc-1"}, ok: false},
+		{name: "non-numeric pane segment is rejected", pane: state.Pane{Parent: ManualParentRef, Slug: "orchestrator-issue-123-codex-a1"}, ok: false},
+		{name: "empty pane segment is rejected", pane: state.Pane{Parent: ManualParentRef, Slug: "orchestrator-issue-123-"}, ok: false},
+		{name: "extra pane segment is rejected", pane: state.Pane{Parent: ManualParentRef, Slug: "orchestrator-issue-123-1-extra"}, ok: false},
 	}
 
 	for _, tt := range tests {

--- a/internal/app/panelaunch/panelaunch_test.go
+++ b/internal/app/panelaunch/panelaunch_test.go
@@ -978,6 +978,75 @@ func TestPlanPaneIssueNum(t *testing.T) {
 	}
 }
 
+func TestOrchestratorIssueSlug(t *testing.T) {
+	tests := []struct {
+		name     string
+		issueNum int
+		number   int
+		want     string
+	}{
+		{name: "formats positive pane number", issueNum: 123, number: 4, want: "orchestrator-issue-123-4"},
+		{name: "normalizes negative pane number", issueNum: 123, number: -4, want: "orchestrator-issue-123-4"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := OrchestratorIssueSlug(tt.issueNum, tt.number); got != tt.want {
+				t.Fatalf("OrchestratorIssueSlug(%d, %d) = %q, want %q", tt.issueNum, tt.number, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOrchestratorPaneIssueNum(t *testing.T) {
+	tests := []struct {
+		name       string
+		pane       state.Pane
+		want       int
+		ok         bool
+		planParser bool
+	}{
+		{name: "orchestrator slug parses", pane: state.Pane{Parent: ManualParentRef, Slug: OrchestratorIssueSlug(123, -1)}, want: 123, ok: true},
+		{name: "numeric parent is rejected", pane: state.Pane{Parent: "500", Slug: "orchestrator-issue-123-1"}, ok: false},
+		{name: "watch parent is rejected", pane: state.Pane{Parent: "@watch", Slug: "orchestrator-issue-123-1"}, ok: false},
+		{name: "plan slug is distinct", pane: state.Pane{Parent: ManualParentRef, Slug: "plan-issue-123-1"}, ok: false, planParser: true},
+		{name: "longer issue number does not alias", pane: state.Pane{Parent: ManualParentRef, Slug: "orchestrator-issue-1234-1"}, want: 1234, ok: true},
+		{name: "non-numeric issue segment is rejected", pane: state.Pane{Parent: ManualParentRef, Slug: "orchestrator-issue-abc-1"}, ok: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := OrchestratorPaneIssueNum(tt.pane)
+			if got != tt.want || ok != tt.ok {
+				t.Fatalf("OrchestratorPaneIssueNum(%+v) = %d, %v, want %d, %v", tt.pane, got, ok, tt.want, tt.ok)
+			}
+
+			_, planOK := PlanPaneIssueNum(tt.pane)
+			if planOK != tt.planParser {
+				t.Fatalf("PlanPaneIssueNum(%+v) ok = %v, want %v", tt.pane, planOK, tt.planParser)
+			}
+		})
+	}
+}
+
+func TestKillAttachedPaneIgnoresEmptyPaneID(t *testing.T) {
+	binDir := t.TempDir()
+	marker := filepath.Join(t.TempDir(), "tmux-called")
+	tmuxPath := filepath.Join(binDir, "tmux")
+	script := "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$TMUX_CALLS\"\n"
+	if err := os.WriteFile(tmuxPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("TMUX_CALLS", marker)
+
+	KillAttachedPane("%caller", "")
+
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("tmux was called for an empty pane ID: %v", err)
+	}
+}
+
 // TestPlanLinkedIssueNums pins the fanned-set contribution: coordinator rows
 // link through their slug, plan task rows only through a saved spec whose
 // plan.source declares the issue — an issue-like plan slug alone never links,

--- a/internal/app/panelaunch/request.go
+++ b/internal/app/panelaunch/request.go
@@ -478,6 +478,31 @@ func PlanPaneIssueNum(pane state.Pane) (int, bool) {
 	return parseLeadingIssueNum(rest)
 }
 
+// OrchestratorIssueSlug keys a TUI issue orchestrator lane's attached-agent
+// row by issue number and the synthetic pane number for uniqueness across
+// relaunches: "orchestrator-issue-<issue>-<n>". Only that lane creates these
+// rows, so the slug is explicit provenance. Its "orchestrator-issue-" prefix
+// is disjoint from "plan-issue-", and neither parser accepts the other lane.
+func OrchestratorIssueSlug(issueNum, number int) string {
+	if number < 0 {
+		number = -number
+	}
+	return fmt.Sprintf("orchestrator-issue-%d-%d", issueNum, number)
+}
+
+// OrchestratorPaneIssueNum returns the GitHub issue linked to a TUI issue
+// orchestrator row, parsed from its provenance slug under the manual parent.
+func OrchestratorPaneIssueNum(pane state.Pane) (int, bool) {
+	if pane.Parent != ManualParentRef {
+		return 0, false
+	}
+	rest, found := strings.CutPrefix(pane.Slug, "orchestrator-issue-")
+	if !found {
+		return 0, false
+	}
+	return parseLeadingIssueNum(rest)
+}
+
 // PlanLinkedIssueNums collects the issues owned by plan-lane rows so the issue
 // fan-out lanes can treat them as already fanned: coordinator rows through
 // PlanPaneIssueNum, and plan task rows through the saved spec's declared

--- a/internal/app/panelaunch/request.go
+++ b/internal/app/panelaunch/request.go
@@ -492,6 +492,7 @@ func OrchestratorIssueSlug(issueNum, number int) string {
 
 // OrchestratorPaneIssueNum returns the GitHub issue linked to a TUI issue
 // orchestrator row, parsed from its provenance slug under the manual parent.
+// Only the complete "orchestrator-issue-<issue>-<numeric pane>" form matches.
 func OrchestratorPaneIssueNum(pane state.Pane) (int, bool) {
 	if pane.Parent != ManualParentRef {
 		return 0, false
@@ -500,7 +501,15 @@ func OrchestratorPaneIssueNum(pane state.Pane) (int, bool) {
 	if !found {
 		return 0, false
 	}
-	return parseLeadingIssueNum(rest)
+	issueNum, ok := parseLeadingIssueNum(rest)
+	if !ok {
+		return 0, false
+	}
+	_, paneNum, found := strings.Cut(rest, "-")
+	if !found || !naming.AllDigits(paneNum) {
+		return 0, false
+	}
+	return issueNum, true
 }
 
 // PlanLinkedIssueNums collects the issues owned by plan-lane rows so the issue


### PR DESCRIPTION
## TL;DR

TUI issue オーケストレーターレーンが使う state row の slug 生成・解析と、attached pane の失敗時 cleanup を `panelaunch` に追加します。

Review effort: 2

## Why

後続タスクが、親オーケストレーターペインを `@manual` の attached-agent row として識別し、後段の失敗時に安全に破棄するための共通部品を必要としています。`orchestrator-issue-` を provenance として `plan-issue-` から分離し、既存 cleanup を再利用します（`internal/app/panelaunch/request.go:486`、`internal/app/panelaunch/panelaunch.go:534`）。

```mermaid
flowchart LR
    A[OrchestratorIssueSlug] --> B[state.Pane.Slug]
    B --> C[OrchestratorPaneIssueNum]
    D[KillAttachedPane] --> E[failCleanup]
    E --> F[tmuxrun.KillPane]
    E --> G[panelayout.Apply]
```

## Changes by file

<details><summary>Changed files</summary>

| File | What changed | Why |
| --- | --- | --- |
| `internal/app/panelaunch/request.go` | `OrchestratorIssueSlug` と `OrchestratorPaneIssueNum` を追加（`:486`） | TUI issue オーケストレーター行を plan coordinator 行や nonnumeric suffix と衝突せず識別するため |
| `internal/app/panelaunch/panelaunch.go` | `KillAttachedPane` を追加（`:534`） | `AttachWithResult` 後の失敗時に既存の kill + relayout cleanup を再利用するため |
| `internal/app/panelaunch/panelaunch_test.go` | slug/parser の表駆動テストと空 pane ID の no-op テストを追加（`:981`） | prefix の相互排他、親と末尾全体の数値検証、tmux 非呼び出しを固定するため |

</details>

## Risk

> [!WARNING]
> `make check` は commit `d861c50` で成功していますが、現在の runtime では enforceable read-only の `post-work-reviewer` を起動できず、broad review は未実施です。`internal/app/panelaunch` は class H のため、この PR は人手レビューが必要です。

## Test plan

- `go test ./internal/app/panelaunch` — 成功
- `git diff --check` — 成功
- `make check` — 成功（commit `d861c50`）

Plan: issue-orchestrator-pane / Task: panelaunch-helpers
