### PR TITLE
fix(tui): 長文プロンプトの切り詰めを防ぐ

### DIFF
--- a/cmd/fanout/tui_launch.go
+++ b/cmd/fanout/tui_launch.go
@@ -508,12 +508,16 @@ func launchOwnerProjectRoot(defaultRoot, sourceProjectRoot string) string {
 
 func manualPaneOptionsForTUI(prompt, agentName string) panelaunch.ManualOptions {
 	title := panelaunch.FirstPromptLine(prompt)
+	oversized := len(prompt) > panelaunch.MaxInlineManualPromptBytes
+	if oversized {
+		title = panelaunch.ShortIssueTitle(title)
+	}
 	opts := panelaunch.ManualOptions{
 		Title:  title,
 		Agent:  agentName,
 		Prompt: title,
 	}
-	if strings.Contains(prompt, "\n") {
+	if strings.Contains(prompt, "\n") || oversized {
 		opts.Body = prompt
 	}
 	return opts

--- a/cmd/fanout/tui_test.go
+++ b/cmd/fanout/tui_test.go
@@ -529,6 +529,13 @@ func TestTUINewPanePopupResultRoundTrip(t *testing.T) {
 			result: tuiNewPanePopupResult{Prompt: "Ship search", PlanFanout: true, Agents: []string{"claude"}},
 		},
 		{
+			name: "prompt mode preserves long pasted prompts",
+			result: tuiNewPanePopupResult{
+				Prompt: strings.Repeat("long pasted prompt line\n", 200) + "final line 201",
+				Agents: []string{"codex"},
+			},
+		},
+		{
 			name: "issue mode plan fan-out carries the worker agent",
 			result: tuiNewPanePopupResult{
 				Mode:         "issue",

--- a/cmd/fanout/tui_test.go
+++ b/cmd/fanout/tui_test.go
@@ -835,6 +835,29 @@ func TestManualPaneOptionsForTUIMultilinePromptUsesBriefingBody(t *testing.T) {
 	}
 }
 
+func TestManualPaneOptionsForTUILongSingleLineUsesBriefingBody(t *testing.T) {
+	prompt := strings.Repeat("x", panelaunch.MaxInlineManualPromptBytes+1)
+	opts := manualPaneOptionsForTUI(prompt, "codex")
+	wantTitle := strings.Repeat("x", 60)
+
+	if opts.Title != wantTitle || opts.Prompt != wantTitle {
+		t.Fatalf("long prompt title/prompt lengths = %d/%d, want bounded title length %d", len(opts.Title), len(opts.Prompt), len(wantTitle))
+	}
+	if opts.Body != prompt {
+		t.Fatalf("long prompt body length = %d, want %d", len(opts.Body), len(prompt))
+	}
+
+	cfg := manualPaneConfigForTUIAgent("codex")
+	cfg.DryRun = true
+	req := panelaunch.NewManualRequest(cfg, t.TempDir(), state.Store{}, hooks.EmptyConfig(), opts)
+	if req.BriefingPath == "" || !strings.Contains(req.BriefingBody, prompt) {
+		t.Fatalf("long Codex prompt briefing = path %q body length %d, want non-empty path containing %d-byte prompt", req.BriefingPath, len(req.BriefingBody), len(prompt))
+	}
+	if strings.Contains(req.Prompt, prompt) || !strings.Contains(req.Prompt, req.BriefingPath) {
+		t.Fatalf("long Codex prompt remained embedded in the launch argument: %d bytes", len(req.Prompt))
+	}
+}
+
 func TestManualPaneConfigForTUIAgentEnablesCodexPlanMode(t *testing.T) {
 	codex := manualPaneConfigForTUIAgent("codex")
 	if codex.Agent != "codex" || !codex.CodexPlanModeEnabled() {

--- a/internal/app/panelaunch/panelaunch_test.go
+++ b/internal/app/panelaunch/panelaunch_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/butaosuinu/fanout/internal/infra/settings"
 	"github.com/butaosuinu/fanout/internal/infra/state"
 	"github.com/butaosuinu/fanout/internal/infra/team"
+	"github.com/butaosuinu/fanout/internal/infra/tmuxrun"
 	"github.com/butaosuinu/fanout/internal/infra/worktree"
 )
 
@@ -280,7 +281,7 @@ func TestNewManualRequestCodexPlanModePreservesMultilinePrompt(t *testing.T) {
 	})
 
 	if req.BriefingPath != "" || req.BriefingBody != "" {
-		t.Fatalf("manual Codex Plan Mode should not use briefing file: path %q body %q", req.BriefingPath, req.BriefingBody)
+		t.Fatalf("small manual Codex Plan Mode prompt should stay inline: path %q body %q", req.BriefingPath, req.BriefingBody)
 	}
 	if !strings.Contains(req.Prompt, "Body:\nInspect API\n\nCheck handlers") {
 		t.Fatalf("manual plan prompt did not preserve multiline prompt:\n%s", req.Prompt)
@@ -294,6 +295,60 @@ func TestNewManualRequestCodexPlanModePreservesMultilinePrompt(t *testing.T) {
 	}
 	if !strings.Contains(cmd, "Body:\nInspect API\n\nCheck handlers") {
 		t.Fatalf("manual plan command did not preserve multiline prompt:\n%s", cmd)
+	}
+}
+
+func TestMaxInlineManualPromptFitsLinuxSingleArgumentBudget(t *testing.T) {
+	codexPlanMode := true
+	cfg := &cliflags.Config{Agent: "codex", DryRun: true, CodexPlanMode: &codexPlanMode}
+	prompt := strings.Repeat("'", MaxInlineManualPromptBytes)
+	req := NewManualRequest(cfg, "/repo", state.Store{}, hooks.EmptyConfig(), ManualOptions{
+		Title:  prompt,
+		Agent:  "codex",
+		Prompt: prompt,
+	})
+	command, err := buildAgentCommand(cfg, req, "fanout-go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	wrapper := tmuxrun.BuildPaneLaunchCommand(command)
+	const linuxMaxArgStringBytes = 32 * 4096
+	if got := len(wrapper) + 1; got >= linuxMaxArgStringBytes {
+		t.Fatalf("wrapped inline prompt = %d bytes including NUL, want less than Linux single-argument budget %d", got, linuxMaxArgStringBytes)
+	}
+}
+
+func TestNewAttachedRequestRoutesOversizedPromptThroughBriefing(t *testing.T) {
+	prompt := strings.Repeat("x", MaxInlineManualPromptBytes+1)
+	target := AttachTarget{
+		SourceParent:     ManualParentRef,
+		SourceLabel:      "source",
+		SourceBranchName: "feature/source",
+	}
+
+	for _, tc := range []struct {
+		name           string
+		cfg            *cliflags.Config
+		wantPlanPrompt bool
+	}{
+		{name: "claude", cfg: &cliflags.Config{Agent: "claude", DryRun: true}},
+		{name: "codex plan mode", cfg: func() *cliflags.Config {
+			planMode := true
+			return &cliflags.Config{Agent: "codex", DryRun: true, CodexPlanMode: &planMode}
+		}(), wantPlanPrompt: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := NewAttachedRequest(tc.cfg, t.TempDir(), state.Store{}, hooks.EmptyConfig(), prompt, "/repo/worktree", target)
+			if req.BriefingPath == "" || !strings.Contains(req.BriefingBody, prompt) {
+				t.Fatalf("briefing = path %q body length %d, want path containing full %d-byte prompt", req.BriefingPath, len(req.BriefingBody), len(prompt))
+			}
+			if strings.Contains(req.Prompt, prompt) || !strings.Contains(req.Prompt, req.BriefingPath) {
+				t.Fatalf("launch prompt should reference briefing without embedding payload: %d bytes", len(req.Prompt))
+			}
+			if got := strings.Contains(req.BriefingBody, "<proposed_plan>...</proposed_plan>"); got != tc.wantPlanPrompt {
+				t.Fatalf("briefing plan instructions = %t, want %t", got, tc.wantPlanPrompt)
+			}
+		})
 	}
 }
 

--- a/internal/app/panelaunch/request.go
+++ b/internal/app/panelaunch/request.go
@@ -22,6 +22,11 @@ import (
 	"github.com/butaosuinu/fanout/internal/infra/worktree"
 )
 
+// MaxInlineManualPromptBytes keeps a raw manual prompt far below Linux's
+// per-argument exec limit after plan-template expansion and two shell-quoting
+// layers. Larger prompts travel through a briefing file.
+const MaxInlineManualPromptBytes = 4 * 1024
+
 // fanoutTagPrefix opens the one-line child prompt tag "[fanout #N of #P]".
 // Its format pairs with team.FanoutTagRE / team.ParseFanoutTag
 // (internal/infra/team/detect.go); keep the two in sync.
@@ -157,7 +162,14 @@ func NewManualRequest(cfg *cliflags.Config, projectRoot string, store state.Stor
 		if strings.TrimSpace(body) == "" {
 			body = prompt
 		}
-		prompt = briefing.RenderManualPlan(title, body)
+		planPrompt := briefing.RenderManualPlan(title, body)
+		if len(body) > MaxInlineManualPromptBytes {
+			briefingPath = briefing.Path(projectRoot, number)
+			briefingBody = planPrompt
+			prompt = manualPromptWithBriefingAction(ShortIssueTitle(title), briefingPath, "investigate, then propose a plan")
+		} else {
+			prompt = planPrompt
+		}
 	} else if opts.Body != "" {
 		briefingPath = briefing.Path(projectRoot, number)
 		briefingBody = opts.Body
@@ -213,12 +225,23 @@ func NewAttachedRequest(cfg *cliflags.Config, projectRoot string, store state.St
 	if shortPrompt == "" {
 		shortPrompt = title
 	}
+	oversized := len(body) > MaxInlineManualPromptBytes
+	if oversized {
+		shortPrompt = ShortIssueTitle(shortPrompt)
+	}
 	briefingPath := ""
 	briefingBody := ""
 	switch {
 	case cfg.CodexPlanModeEnabled():
-		prompt = briefing.RenderManualPlan(title, body)
-	case strings.Contains(prompt, "\n"):
+		planPrompt := briefing.RenderManualPlan(title, body)
+		if oversized {
+			briefingPath = attachedBriefingPath(projectRoot, parentRef, target, number)
+			briefingBody = planPrompt
+			prompt = manualPromptWithBriefingAction(shortPrompt, briefingPath, "investigate, then propose a plan")
+		} else {
+			prompt = planPrompt
+		}
+	case strings.Contains(prompt, "\n") || oversized:
 		briefingPath = attachedBriefingPath(projectRoot, parentRef, target, number)
 		briefingBody = body
 		prompt = manualPromptWithBriefing(shortPrompt, briefingPath)

--- a/internal/ui/tui/newpane.go
+++ b/internal/ui/tui/newpane.go
@@ -356,7 +356,9 @@ func newNewPaneForm(defaultAgent string, width int) newPaneForm {
 	prompt.Placeholder = "Prompt"
 	prompt.Prompt = ""
 	prompt.ShowLineNumbers = false
-	prompt.CharLimit = 1000
+	// Long prompts are valid input; SetHeight controls only the visible viewport.
+	prompt.CharLimit = 0
+	prompt.MaxHeight = 0
 	prompt.SetWidth(width)
 	prompt.SetHeight(newPanePromptDefaultRows)
 	prompt.KeyMap.InsertNewline = key.NewBinding(

--- a/internal/ui/tui/newpane.go
+++ b/internal/ui/tui/newpane.go
@@ -93,8 +93,10 @@ type NewPanePromptOptions struct {
 const newPanePopupOpeningNotice = "opening new pane popup..."
 
 const (
-	newPanePromptDefaultRows = 6
-	newPanePromptMinRows     = 3
+	newPanePromptDefaultRows    = 6
+	newPanePromptMinRows        = 3
+	newPanePromptEditorMaxCells = 1000
+	newPanePromptEditorMaxLines = 99
 )
 
 // AttachTarget describes the recorded pane/worktree a new agent should share.
@@ -148,8 +150,14 @@ const (
 )
 
 type newPaneForm struct {
-	prompt     textarea.Model
-	agentCount map[string]int
+	prompt textarea.Model
+	// stagedPrompt holds a bracketed paste that is too large for Bubbles'
+	// textarea to render safely. The textarea stays empty while staged so View
+	// work remains bounded; submit still forwards the complete payload.
+	stagedPrompt      string
+	stagedPromptLines int
+	stagedPromptBytes int
+	agentCount        map[string]int
 	// promptAgentCount stashes the prompt-mode launch counts while a
 	// single-agent context (issue mode, plan fan-out) collapses agentCount to
 	// one selection; returning to plain prompt mode restores it. nil when
@@ -356,9 +364,10 @@ func newNewPaneForm(defaultAgent string, width int) newPaneForm {
 	prompt.Placeholder = "Prompt"
 	prompt.Prompt = ""
 	prompt.ShowLineNumbers = false
-	// Long prompts are valid input; SetHeight controls only the visible viewport.
-	prompt.CharLimit = 0
-	prompt.MaxHeight = 0
+	// Bubbles rebuilds every stored line and soft-wrap before clipping to the
+	// viewport. Oversized bracketed pastes are staged outside the textarea.
+	prompt.CharLimit = newPanePromptEditorMaxCells
+	prompt.MaxHeight = newPanePromptEditorMaxLines
 	prompt.SetWidth(width)
 	prompt.SetHeight(newPanePromptDefaultRows)
 	prompt.KeyMap.InsertNewline = key.NewBinding(
@@ -377,6 +386,58 @@ func newNewPaneForm(defaultAgent string, width int) newPaneForm {
 		workerIndex: defaultAgentIndex(defaultAgent),
 		focus:       newPaneFieldMain,
 	}
+}
+
+func (m model) updateNewPanePromptPaste(msg tea.KeyMsg) (model, tea.Cmd) {
+	prompt := m.newPane.prompt
+	if m.newPane.stagedPrompt != "" {
+		prompt.Reset()
+	}
+	// Apply the paste once without editor limits so Bubbles' sanitizer and
+	// cursor insertion semantics produce the exact payload we will submit.
+	prompt.CharLimit = 0
+	prompt.MaxHeight = 0
+	prompt, cmd := prompt.Update(msg)
+	if prompt.Length() > newPanePromptEditorMaxCells || prompt.LineCount() > newPanePromptEditorMaxLines {
+		value := prompt.Value()
+		m.newPane.prompt.Reset()
+		m.newPane.stagedPrompt = value
+		m.newPane.stagedPromptLines = strings.Count(value, "\n") + 1
+		m.newPane.stagedPromptBytes = len(value)
+		m.endCompletion()
+		return m, nil
+	}
+
+	prompt.CharLimit = newPanePromptEditorMaxCells
+	prompt.MaxHeight = newPanePromptEditorMaxLines
+	m.newPane.prompt = prompt
+	m.clearStagedPrompt()
+	m.endCompletion()
+	return m, cmd
+}
+
+func (m *model) clearStagedPrompt() {
+	m.newPane.stagedPrompt = ""
+	m.newPane.stagedPromptLines = 0
+	m.newPane.stagedPromptBytes = 0
+}
+
+func (m model) newPanePromptValue() string {
+	if m.newPane.stagedPrompt != "" {
+		return m.newPane.stagedPrompt
+	}
+	return m.newPane.prompt.Value()
+}
+
+func (m model) newPanePromptInputView() string {
+	if m.newPane.stagedPrompt == "" {
+		return m.newPane.prompt.View()
+	}
+	return fmt.Sprintf(
+		"Pasted prompt: %d lines / %d bytes\nCtrl+U clears; another paste replaces it",
+		m.newPane.stagedPromptLines,
+		m.newPane.stagedPromptBytes,
+	)
 }
 
 func (m *model) fitNewPanePromptHeight() {
@@ -467,6 +528,16 @@ func (m model) updateNewPane(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	if m.newPane.step == newPaneStepAssign {
 		return m.updateNewPaneAssign(msg)
 	}
+	if m.newPane.focus == newPaneFieldMain && m.newPane.mode == newPaneModePrompt {
+		if msg.String() == "ctrl+u" && m.newPane.stagedPrompt != "" {
+			m.clearStagedPrompt()
+			m.newPane.prompt.Reset()
+			return m, nil
+		}
+		if msg.Paste {
+			return m.updateNewPanePromptPaste(msg)
+		}
+	}
 	// While the @-completion popup is open it owns navigation/confirm/cancel
 	// keys; anything it does not handle (printable chars, backspace, cursor
 	// moves) falls through to normal editing with the updated completion state
@@ -543,6 +614,9 @@ func (m model) updateNewPane(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
 	switch {
 	case m.newPane.focus == newPaneFieldMain && m.newPane.mode == newPaneModePrompt:
+		if m.newPane.stagedPrompt != "" {
+			return m, nil
+		}
 		m.newPane.prompt, cmd = m.newPane.prompt.Update(msg)
 		// Open completion when '@' is typed at a word boundary. Inspecting the
 		// textarea after the insert keeps this robust to soft-wrapping.
@@ -779,7 +853,7 @@ func (m *model) submitNewPane() tea.Cmd {
 	if m.newPane.mode != newPaneModePrompt {
 		return m.submitNewPanePicker()
 	}
-	prompt := strings.TrimSpace(m.newPane.prompt.Value())
+	prompt := strings.TrimSpace(m.newPanePromptValue())
 	if prompt == "" {
 		m.setNewPaneErr("prompt is required")
 		return nil
@@ -938,7 +1012,7 @@ func (m model) newPaneView() string {
 			sections = append(sections, m.newPaneFieldView(newPaneFieldAgent, "Agent", m.agentSelectorView(), false))
 		}
 	default:
-		promptSection := m.newPaneFieldView(newPaneFieldMain, "Prompt", m.newPane.prompt.View(), true)
+		promptSection := m.newPaneFieldView(newPaneFieldMain, "Prompt", m.newPanePromptInputView(), true)
 		if m.newPane.focus == newPaneFieldMain && m.newPane.completing {
 			if popup := m.completionPopupView(); popup != "" {
 				promptSection += "\n" + popup

--- a/internal/ui/tui/newpane_complete_test.go
+++ b/internal/ui/tui/newpane_complete_test.go
@@ -292,6 +292,7 @@ func TestAcceptCompletionPreservesPrecedingText(t *testing.T) {
 
 func TestAcceptCompletionRefusesWhenOverCharLimit(t *testing.T) {
 	m := openCompletionModel(t, []string{"internal/ui/tui/newpane.go"})
+	m.newPane.prompt.CharLimit = 1000
 	// Fill the prompt to just under CharLimit, then start an @-token.
 	limit := m.newPane.prompt.CharLimit
 	m.newPane.prompt.SetValue(strings.Repeat("x", limit-3) + " ")
@@ -368,6 +369,7 @@ func TestFileIndexExcludesSpacePaths(t *testing.T) {
 
 func TestAcceptCompletionRefusesOverCharLimitFullWidth(t *testing.T) {
 	m := openCompletionModel(t, []string{"internal/ui/tui/newpane.go"})
+	m.newPane.prompt.CharLimit = 1000
 	// Full-width fill: rune count (499) is far under CharLimit but display width
 	// (~997) is near it, so a rune-count guard would wrongly allow the insert.
 	m.newPane.prompt.SetValue(strings.Repeat("あ", 498) + " ")

--- a/internal/ui/tui/newpane_complete_test.go
+++ b/internal/ui/tui/newpane_complete_test.go
@@ -292,7 +292,6 @@ func TestAcceptCompletionPreservesPrecedingText(t *testing.T) {
 
 func TestAcceptCompletionRefusesWhenOverCharLimit(t *testing.T) {
 	m := openCompletionModel(t, []string{"internal/ui/tui/newpane.go"})
-	m.newPane.prompt.CharLimit = 1000
 	// Fill the prompt to just under CharLimit, then start an @-token.
 	limit := m.newPane.prompt.CharLimit
 	m.newPane.prompt.SetValue(strings.Repeat("x", limit-3) + " ")
@@ -369,7 +368,6 @@ func TestFileIndexExcludesSpacePaths(t *testing.T) {
 
 func TestAcceptCompletionRefusesOverCharLimitFullWidth(t *testing.T) {
 	m := openCompletionModel(t, []string{"internal/ui/tui/newpane.go"})
-	m.newPane.prompt.CharLimit = 1000
 	// Full-width fill: rune count (499) is far under CharLimit but display width
 	// (~997) is near it, so a rune-count guard would wrongly allow the insert.
 	m.newPane.prompt.SetValue(strings.Repeat("あ", 498) + " ")

--- a/internal/ui/tui/tui_test.go
+++ b/internal/ui/tui/tui_test.go
@@ -4735,8 +4735,14 @@ func TestNewPaneFormSubmitsLongPastedPrompt(t *testing.T) {
 
 	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(longPrompt), Paste: true})
 	m = updated.(model)
-	if value := m.newPane.prompt.Value(); value != longPrompt {
-		t.Fatalf("pasted prompt was truncated: got %d bytes, want %d", len(value), len(longPrompt))
+	if value := m.newPane.stagedPrompt; value != longPrompt {
+		t.Fatalf("staged prompt was truncated: got %d bytes, want %d", len(value), len(longPrompt))
+	}
+	if value := m.newPane.prompt.Value(); value != "" {
+		t.Fatalf("textarea retained %d bytes of a staged prompt, want empty", len(value))
+	}
+	if view := m.newPaneView(); !strings.Contains(view, "Pasted prompt: 201 lines") || strings.Contains(view, "long pasted prompt line") {
+		t.Fatalf("staged prompt view should show only its summary:\n%s", view)
 	}
 
 	cmd := m.submitNewPane()
@@ -4746,6 +4752,44 @@ func TestNewPaneFormSubmitsLongPastedPrompt(t *testing.T) {
 	_ = cmd()
 	if got.Prompt != longPrompt {
 		t.Fatalf("submitted prompt was truncated: got %d bytes, want %d", len(got.Prompt), len(longPrompt))
+	}
+}
+
+func TestNewPaneFormStagesOversizedSingleLinePaste(t *testing.T) {
+	longPrompt := strings.Repeat("x", 100_000)
+	m := newModel(Options{DefaultAgent: "codex"})
+	m.openNewPaneForm()
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(longPrompt), Paste: true})
+	m = updated.(model)
+	if m.newPane.stagedPrompt != longPrompt {
+		t.Fatalf("staged prompt length = %d, want %d", len(m.newPane.stagedPrompt), len(longPrompt))
+	}
+	view := m.newPaneView()
+	if !strings.Contains(view, "Pasted prompt: 1 lines / 100000 bytes") || strings.Contains(view, longPrompt[:100]) {
+		t.Fatalf("oversized single-line view should stay bounded:\n%s", view)
+	}
+}
+
+func TestNewPaneFormStagedPasteCanBeReplacedAndCleared(t *testing.T) {
+	longPrompt := strings.Repeat("x", newPanePromptEditorMaxCells+1)
+	m := newModel(Options{DefaultAgent: "codex"})
+	m.openNewPaneForm()
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(longPrompt), Paste: true})
+	m = updated.(model)
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("replacement"), Paste: true})
+	m = updated.(model)
+	if m.newPane.stagedPrompt != "" || m.newPane.prompt.Value() != "replacement" {
+		t.Fatalf("replacement paste = staged %q textarea %q", m.newPane.stagedPrompt, m.newPane.prompt.Value())
+	}
+
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(longPrompt), Paste: true})
+	m = updated.(model)
+	updated, _ = m.Update(tea.KeyMsg{Type: tea.KeyCtrlU})
+	m = updated.(model)
+	if m.newPane.stagedPrompt != "" || m.newPane.prompt.Value() != "" {
+		t.Fatalf("Ctrl+U did not clear staged prompt: staged %d bytes textarea %q", len(m.newPane.stagedPrompt), m.newPane.prompt.Value())
 	}
 }
 

--- a/internal/ui/tui/tui_test.go
+++ b/internal/ui/tui/tui_test.go
@@ -4717,6 +4717,38 @@ func TestNewPaneFormSubmitsMultilinePrompt(t *testing.T) {
 	}
 }
 
+func TestNewPaneFormSubmitsLongPastedPrompt(t *testing.T) {
+	longPrompt := strings.Repeat("long pasted prompt line\n", 200) + "final line 201"
+	if lines := strings.Count(longPrompt, "\n") + 1; lines <= 200 || len(longPrompt) <= 1000 {
+		t.Fatalf("test prompt = %d lines / %d bytes, want more than 200 lines and 1000 bytes", lines, len(longPrompt))
+	}
+
+	var got LaunchRequest
+	m := newModel(Options{
+		DefaultAgent: "codex",
+		LaunchPane: func(req LaunchRequest) (LaunchResult, error) {
+			got = req
+			return LaunchResult{}, nil
+		},
+	})
+	m.openNewPaneForm()
+
+	updated, _ := m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune(longPrompt), Paste: true})
+	m = updated.(model)
+	if value := m.newPane.prompt.Value(); value != longPrompt {
+		t.Fatalf("pasted prompt was truncated: got %d bytes, want %d", len(value), len(longPrompt))
+	}
+
+	cmd := m.submitNewPane()
+	if cmd == nil {
+		t.Fatal("submitNewPane returned nil command")
+	}
+	_ = cmd()
+	if got.Prompt != longPrompt {
+		t.Fatalf("submitted prompt was truncated: got %d bytes, want %d", len(got.Prompt), len(longPrompt))
+	}
+}
+
 func TestNewPaneFormAcceptsCJKPromptInput(t *testing.T) {
 	var got LaunchRequest
 	m := newModel(Options{


### PR DESCRIPTION
## TL;DR

新規 Session の長文 paste を欠落なく保持し、200 行を超える prompt でも全文を起動処理へ渡します。表示負荷と OS の argv 上限も回避します。

## 変更内容

- 1000 cells / 99 logical lines を超える bracketed paste を textarea 外の `stagedPrompt` に全文保持
- staged 中は行数・byte 数だけを表示し、submit 時に完全な prompt を復元
- 複数行または 4 KiB 超の prompt を briefing に退避
- Codex Plan Mode と Attach 経路も長文を briefing 経由に統一
- 201 行 paste、100,000 byte 単一行 paste、popup JSON round-trip、Linux 単一引数 budget の回帰テストを追加

## 原因

Bubbles textarea の `CharLimit = 1000` と既定の `MaxHeight = 99` が超過分を無言で切り詰めていました。一方、両方を無制限にすると `textarea.View()` が全行・全 soft-wrap を毎回再構築し、長い単一行は tmux の単一 argv 上限にも到達します。

## 検証

- `go test ./internal/ui/tui ./cmd/fanout ./internal/app/panelaunch ./internal/infra/codexapp`
- `make check`
- 独立レビュー: findings なし

`post-work-review` driver は現在の実行基盤で reviewer sandbox を `read-only` に固定できないため marker 未作成です。

Review effort: 2